### PR TITLE
Fix binary install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Please see _'Development Status'_ for a listing of all crates and their capabili
 ### Binary Release
 
 ```sh
-curl -LSfs https://raw.githubusercontent.com/byron/git-oxide/master/ci/install.sh | \
-    sh -s -- --git byron/git-oxide --crate gix-max-termion
+curl -LSfs https://raw.githubusercontent.com/Byron/gitoxide/main/ci/install.sh | \
+    sh -s -- --git Byron/gitoxide --crate gix-max-termion
 ```
 
 See the [releases section][releases] for manual installation and various alternative builds that are _slimmer_ or _smaller_, depending


### PR DESCRIPTION
Seems like the repository has been renamed so the installation for the binary release didn't work. Updated to the current name.