### PR TITLE
[commitgraph] Implement commit-graph-verify plumbing command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,8 +699,8 @@ dependencies = [
  "byteorder",
  "filebuffer",
  "git-object",
- "quick-error 2.0.0",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytesize",
+ "git-commitgraph",
  "git-features",
  "git-object",
  "git-odb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,9 @@ dependencies = [
  "bstr",
  "byteorder",
  "filebuffer",
+ "git-features",
  "git-object",
+ "serde",
  "tempfile",
  "thiserror",
 ]

--- a/git-commitgraph/Cargo.toml
+++ b/git-commitgraph/Cargo.toml
@@ -12,14 +12,17 @@ include = ["src/**/*"]
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+serde1 = ["serde", "git-object/serde1"]
 
 [dependencies]
+git-features = { version = "^0.6.0", path = "../git-features" }
 git-object = { version = "^0.4.0", path = "../git-object" }
 
 bstr = { version = "0.2.13", default-features = false, features = ["std"] }
 byteorder = "1.2.3"
 filebuffer = "0.4.0"
+serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/git-commitgraph/Cargo.toml
+++ b/git-commitgraph/Cargo.toml
@@ -20,7 +20,7 @@ git-object = { version = "^0.4.0", path = "../git-object" }
 bstr = { version = "0.2.13", default-features = false, features = ["std"] }
 byteorder = "1.2.3"
 filebuffer = "0.4.0"
-quick-error = "2.0.0"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/git-commitgraph/src/file/access.rs
+++ b/git-commitgraph/src/file/access.rs
@@ -42,12 +42,10 @@ impl File {
     }
 
     pub fn iter_base_graph_ids(&self) -> impl Iterator<Item = borrowed::Id<'_>> {
-        let base_graphs_list = match self.base_graphs_list_offset {
-            Some(v) => &self.data[v..v + (SHA1_SIZE * self.base_graph_count as usize)],
-            None => &[],
-        };
+        let start = self.base_graphs_list_offset.unwrap_or(0);
+        let base_graphs_list = &self.data[start..start + (SHA1_SIZE * usize::from(self.base_graph_count))];
         base_graphs_list
-            .chunks_exact(SHA1_SIZE)
+            .chunks(SHA1_SIZE)
             .map(|bytes| borrowed::Id::try_from(bytes).expect("20 bytes SHA1 to be alright"))
     }
 

--- a/git-commitgraph/src/file/access.rs
+++ b/git-commitgraph/src/file/access.rs
@@ -59,7 +59,7 @@ impl File {
 
     // copied from git-odb/src/pack/index/access.rs
     pub fn lookup(&self, id: borrowed::Id<'_>) -> Option<file::Position> {
-        let first_byte = id.first_byte() as usize;
+        let first_byte = usize::from(id.first_byte());
         let mut upper_bound = self.fan[first_byte];
         let mut lower_bound = if first_byte != 0 { self.fan[first_byte - 1] } else { 0 };
 

--- a/git-commitgraph/src/file/access.rs
+++ b/git-commitgraph/src/file/access.rs
@@ -8,6 +8,10 @@ use std::{
 
 /// Access
 impl File {
+    pub fn base_graph_count(&self) -> u8 {
+        self.base_graph_count
+    }
+
     /// Returns the commit data for the commit located at the given lexigraphical position.
     ///
     /// `pos` must range from 0 to self.num_commits().

--- a/git-commitgraph/src/file/commit.rs
+++ b/git-commitgraph/src/file/commit.rs
@@ -77,7 +77,12 @@ impl<'a> Commit<'a> {
         }
     }
 
-    pub fn id(&self) -> borrowed::Id<'_> {
+    // Allow the return value to outlive this Commit object, as it only needs to be bound by the
+    // lifetime of the parent file.
+    pub fn id<'b>(&'b self) -> borrowed::Id<'a>
+    where
+        'a: 'b,
+    {
         self.file.id_at(self.pos)
     }
 
@@ -85,7 +90,12 @@ impl<'a> Commit<'a> {
         self.iter_parents().next().transpose()
     }
 
-    pub fn root_tree_id(&self) -> borrowed::Id<'_> {
+    // Allow the return value to outlive this Commit object, as it only needs to be bound by the
+    // lifetime of the parent file.
+    pub fn root_tree_id<'b>(&'b self) -> borrowed::Id<'a>
+    where
+        'a: 'b,
+    {
         self.root_tree_id
     }
 }

--- a/git-commitgraph/src/file/commit.rs
+++ b/git-commitgraph/src/file/commit.rs
@@ -4,38 +4,22 @@ use crate::{
 };
 use byteorder::{BigEndian, ByteOrder};
 use git_object::{borrowed, owned, SHA1_SIZE};
-use quick_error::quick_error;
 use std::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Formatter},
     slice::Chunks,
 };
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        ExtraEdgesListOverflow(commit: owned::Id) {
-            display(
-                "commit {}'s extra edges overflows the commit-graph file's extra edges list",
-                commit,
-            )
-        }
-        FirstParentIsExtraEdgeIndex(commit: owned::Id) {
-            display(
-                "commit {}'s first parent is an extra edge index, which is invalid",
-                commit,
-            )
-        }
-        MissingExtraEdgesList(commit: owned::Id) {
-            display(
-                "commit {} has extra edges, but commit-graph file has no extra edges list",
-                commit,
-            )
-        }
-        SecondParentWithoutFirstParent(commit: owned::Id) {
-            display("commit {} has a second parent but not a first parent", commit)
-        }
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("commit {0}'s extra edges overflows the commit-graph file's extra edges list")]
+    ExtraEdgesListOverflow(owned::Id),
+    #[error("commit {0}'s first parent is an extra edge index, which is invalid")]
+    FirstParentIsExtraEdgeIndex(owned::Id),
+    #[error("commit {0} has extra edges, but commit-graph file has no extra edges list")]
+    MissingExtraEdgesList(owned::Id),
+    #[error("commit {0} has a second parent but not a first parent")]
+    SecondParentWithoutFirstParent(owned::Id),
 }
 
 // Note that git's commit-graph-format.txt as of v2.28.0 gives an incorrect value 0x0700_0000 for

--- a/git-commitgraph/src/file/commit.rs
+++ b/git-commitgraph/src/file/commit.rs
@@ -90,6 +90,10 @@ impl<'a> Commit<'a> {
         self.iter_parents().next().transpose()
     }
 
+    pub fn position(&self) -> file::Position {
+        self.pos
+    }
+
     // Allow the return value to outlive this Commit object, as it only needs to be bound by the
     // lifetime of the parent file.
     pub fn root_tree_id<'b>(&'b self) -> borrowed::Id<'a>

--- a/git-commitgraph/src/file/init.rs
+++ b/git-commitgraph/src/file/init.rs
@@ -3,7 +3,6 @@ use bstr::ByteSlice;
 use byteorder::{BigEndian, ByteOrder};
 use filebuffer::FileBuffer;
 use git_object::SHA1_SIZE;
-use quick_error::quick_error;
 use std::{
     convert::{TryFrom, TryInto},
     ops::Range,
@@ -12,53 +11,38 @@ use std::{
 
 type ChunkId = [u8; 4];
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        BaseGraphMismatch(from_header: u8, from_chunk: u32) {
-            display(
-                "Commit-graph {} chunk contains {} base graphs, but commit-graph file header claims {} base graphs",
-                BASE_GRAPHS_LIST_CHUNK_ID.as_bstr(),
-                from_chunk,
-                from_header,
-            )
-        }
-        CommitCountMismatch(chunk1_id: ChunkId, chunk1_commits: u32, chunk2_id: ChunkId, chunk2_commits: u32) {
-            display(
-                "Commit-graph {:?} chunk contains {} commits, but {:?} chunk contains {} commits",
-                chunk1_id.as_bstr(),
-                chunk1_commits,
-                chunk2_id.as_bstr(),
-                chunk2_commits,
-            )
-        }
-        Corrupt(msg: String) {
-            display("{}", msg)
-        }
-        DuplicateChunk(id: ChunkId) {
-            display("Commit-graph file contains multiple {:?} chunks", id.as_bstr())
-        }
-        // This error case is disabled, as git allows extra garbage in the extra edges list.
-        // ExtraEdgesOverflow {
-        //     display("The last entry in commit-graph's extended edges list does is not marked as being terminal")
-        // }
-        InvalidChunkSize(id: ChunkId, msg: String) {
-            display("Commit-graph chunk {:?} has invalid size: {}", id.as_bstr(), msg)
-        }
-        Io(err: std::io::Error, path: std::path::PathBuf) {
-            display("Could not open commit-graph file at '{}'", path.display())
-            source(err)
-        }
-        MissingChunk(id: ChunkId) {
-            display("Missing required chunk {:?}", id.as_bstr())
-        }
-        UnsupportedHashVersion(version: u8) {
-            display("Commit-graph file uses unsupported hash version: {}", version)
-        }
-        UnsupportedVersion(version: u8) {
-            display("Unsupported commit-graph file version: {}", version)
-        }
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Commit-graph {:?} chunk contains {from_chunk} base graphs, but commit-graph file header claims {from_header} base graphs", BASE_GRAPHS_LIST_CHUNK_ID.as_bstr())]
+    BaseGraphMismatch { from_header: u8, from_chunk: u32 },
+    #[error("Commit-graph {:?} chunk contains {chunk1_commits} commits, but {:?} chunk contains {chunk2_commits} commits", .chunk1_id.as_bstr(), .chunk2_id.as_bstr())]
+    CommitCountMismatch {
+        chunk1_id: ChunkId,
+        chunk1_commits: u32,
+        chunk2_id: ChunkId,
+        chunk2_commits: u32,
+    },
+    #[error("{0}")]
+    Corrupt(String),
+    #[error("Commit-graph file contains multiple {:?} chunks", .0.as_bstr())]
+    DuplicateChunk(ChunkId),
+    // This error case is disabled, as git allows extra garbage in the extra edges list?
+    // #[error("The last entry in commit-graph's extended edges list does is not marked as being terminal")]
+    // ExtraEdgesOverflow,
+    #[error("Commit-graph chunk {:?} has invalid size: {msg}", .id.as_bstr())]
+    InvalidChunkSize { id: ChunkId, msg: String },
+    #[error("Could not open commit-graph file at '{}'", .path.display())]
+    Io {
+        #[source]
+        err: std::io::Error,
+        path: std::path::PathBuf,
+    },
+    #[error("Missing required chunk {:?}", .0.as_bstr())]
+    MissingChunk(ChunkId),
+    #[error("Commit-graph file uses unsupported hash version: {0}")]
+    UnsupportedHashVersion(u8),
+    #[error("Unsupported commit-graph file version: {0}")]
+    UnsupportedVersion(u8),
 }
 
 const CHUNK_LOOKUP_SIZE: usize = 12;
@@ -85,7 +69,10 @@ impl TryFrom<&Path> for File {
     type Error = Error;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        let data = FileBuffer::open(path).map_err(|e| Error::Io(e, path.to_owned()))?;
+        let data = FileBuffer::open(path).map_err(|e| Error::Io {
+            err: e,
+            path: path.to_owned(),
+        })?;
         let data_size = data.len();
         if data_size < MIN_FILE_SIZE {
             return Err(Error::Corrupt(
@@ -164,14 +151,18 @@ impl TryFrom<&Path> for File {
                 .expect("an offset small enough to fit a usize");
             ofs += 8;
 
-            let chunk_size: usize = next_chunk_offset
-                .checked_sub(chunk_offset)
-                .ok_or_else(|| Error::InvalidChunkSize(chunk_id, "size is negative".to_string()))?;
+            let chunk_size: usize =
+                next_chunk_offset
+                    .checked_sub(chunk_offset)
+                    .ok_or_else(|| Error::InvalidChunkSize {
+                        id: chunk_id,
+                        msg: "size is negative".to_string(),
+                    })?;
             if next_chunk_offset >= data_size {
-                return Err(Error::InvalidChunkSize(
-                    chunk_id,
-                    "chunk extends beyond end of file".to_string(),
-                ));
+                return Err(Error::InvalidChunkSize {
+                    id: chunk_id,
+                    msg: "chunk extends beyond end of file".to_string(),
+                });
             }
 
             match chunk_id {
@@ -180,14 +171,17 @@ impl TryFrom<&Path> for File {
                         return Err(Error::DuplicateChunk(chunk_id));
                     }
                     if chunk_size % SHA1_SIZE != 0 {
-                        return Err(Error::InvalidChunkSize(
-                            chunk_id,
-                            format!("chunk size {} is not a multiple of {}", chunk_size, SHA1_SIZE),
-                        ));
+                        return Err(Error::InvalidChunkSize {
+                            id: chunk_id,
+                            msg: format!("chunk size {} is not a multiple of {}", chunk_size, SHA1_SIZE),
+                        });
                     }
                     let chunk_base_graph_count = (chunk_size / SHA1_SIZE) as u32;
                     if chunk_base_graph_count != base_graph_count as u32 {
-                        return Err(Error::BaseGraphMismatch(base_graph_count, chunk_base_graph_count));
+                        return Err(Error::BaseGraphMismatch {
+                            from_chunk: chunk_base_graph_count,
+                            from_header: base_graph_count,
+                        });
                     }
                     base_graphs_list_offset = Some(chunk_offset);
                 }
@@ -196,13 +190,13 @@ impl TryFrom<&Path> for File {
                         return Err(Error::DuplicateChunk(chunk_id));
                     }
                     if chunk_size % COMMIT_DATA_ENTRY_SIZE != 0 {
-                        return Err(Error::InvalidChunkSize(
-                            chunk_id,
-                            format!(
+                        return Err(Error::InvalidChunkSize {
+                            id: chunk_id,
+                            msg: format!(
                                 "chunk size {} is not a multiple of {}",
                                 chunk_size, COMMIT_DATA_ENTRY_SIZE
                             ),
-                        ));
+                        });
                     }
                     commit_data_offset = Some(chunk_offset);
                     commit_data_count = (chunk_size / COMMIT_DATA_ENTRY_SIZE) as u32;
@@ -223,10 +217,10 @@ impl TryFrom<&Path> for File {
                     }
                     let expected_size = 4 * FAN_LEN;
                     if chunk_size != expected_size {
-                        return Err(Error::InvalidChunkSize(
-                            chunk_id,
-                            format!("expected chunk length {}, got {}", expected_size, chunk_size),
-                        ));
+                        return Err(Error::InvalidChunkSize {
+                            id: chunk_id,
+                            msg: format!("expected chunk length {}, got {}", expected_size, chunk_size),
+                        });
                     }
                     fan_offset = Some(chunk_offset);
                 }
@@ -235,13 +229,13 @@ impl TryFrom<&Path> for File {
                         return Err(Error::DuplicateChunk(chunk_id));
                     }
                     if chunk_size % OID_LOOKUP_ENTRY_SIZE != 0 {
-                        return Err(Error::InvalidChunkSize(
-                            chunk_id,
-                            format!(
+                        return Err(Error::InvalidChunkSize {
+                            id: chunk_id,
+                            msg: format!(
                                 "chunk size {} is not a multiple of {}",
                                 chunk_size, OID_LOOKUP_ENTRY_SIZE
                             ),
-                        ));
+                        });
                     }
                     oid_lookup_offset = Some(chunk_offset);
                     oid_lookup_count = (chunk_size / OID_LOOKUP_ENTRY_SIZE) as u32;
@@ -277,20 +271,20 @@ impl TryFrom<&Path> for File {
 
         let (fan, _) = read_fan(&data[fan_offset..]);
         if oid_lookup_count != fan[255] {
-            return Err(Error::CommitCountMismatch(
-                OID_FAN_CHUNK_ID,
-                fan[255],
-                OID_LOOKUP_CHUNK_ID,
-                oid_lookup_count,
-            ));
+            return Err(Error::CommitCountMismatch {
+                chunk1_id: OID_FAN_CHUNK_ID,
+                chunk1_commits: fan[255],
+                chunk2_id: OID_LOOKUP_CHUNK_ID,
+                chunk2_commits: oid_lookup_count,
+            });
         }
         if commit_data_count != fan[255] {
-            return Err(Error::CommitCountMismatch(
-                OID_FAN_CHUNK_ID,
-                fan[255],
-                COMMIT_DATA_CHUNK_ID,
-                commit_data_count,
-            ));
+            return Err(Error::CommitCountMismatch {
+                chunk1_id: OID_FAN_CHUNK_ID,
+                chunk1_commits: fan[255],
+                chunk2_id: COMMIT_DATA_CHUNK_ID,
+                chunk2_commits: commit_data_count,
+            });
         }
         Ok(File {
             base_graph_count,

--- a/git-commitgraph/src/file/mod.rs
+++ b/git-commitgraph/src/file/mod.rs
@@ -2,6 +2,8 @@
 mod access;
 pub mod commit;
 mod init;
+pub mod verify;
+
 pub use init::Error;
 
 pub use commit::Commit;

--- a/git-commitgraph/src/file/mod.rs
+++ b/git-commitgraph/src/file/mod.rs
@@ -1,7 +1,6 @@
 //! Operations on a single commit-graph file.
 mod access;
 pub mod commit;
-
 mod init;
 pub use init::Error;
 

--- a/git-commitgraph/src/file/verify.rs
+++ b/git-commitgraph/src/file/verify.rs
@@ -1,0 +1,167 @@
+use crate::{
+    file::{self, File},
+    GENERATION_NUMBER_INFINITY, GENERATION_NUMBER_MAX,
+};
+use bstr::ByteSlice;
+use git_object::{borrowed, owned, SHA1_SIZE};
+use std::cmp::{max, min};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::path::Path;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Commit(#[from] file::commit::Error),
+    #[error("commit at file position {pos} has invalid ID {id}")]
+    CommitId { id: owned::Id, pos: file::Position },
+    #[error("commit at file position {pos} with ID {id} is out of order relative to its predecessor with ID {predecessor_id}")]
+    CommitsOutOfOrder {
+        id: owned::Id,
+        pos: file::Position,
+        predecessor_id: owned::Id,
+    },
+    #[error("commit-graph filename should be {0}")]
+    Filename(String),
+    #[error("commit {id} has invalid generation {generation}")]
+    Generation { generation: u32, id: owned::Id },
+    #[error("checksum mismatch: expected {expected}, got {actual}")]
+    Mismatch { expected: owned::Id, actual: owned::Id },
+    #[error("commit {id} has invalid root tree ID {root_tree_id}")]
+    RootTreeId { id: owned::Id, root_tree_id: owned::Id },
+}
+
+// This is a separate type to let `traverse`'s caller use the same error type for its result and its
+// processor error type while also letting that error type contain file::verify::Error values.
+// Is there a better way? Should the caller's error type just use boxes to avoid recursive type
+// errors?
+#[derive(thiserror::Error, Debug)]
+pub enum EitherError<E1: std::error::Error + 'static, E2: std::error::Error + 'static> {
+    #[error(transparent)]
+    Internal(#[from] E1),
+    // Why can't I use #[from] here? Boo!
+    #[error("{0}")]
+    Processor(#[source] E2),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
+pub struct Outcome {
+    pub max_generation: u32,
+    pub max_parents: u32,
+    pub min_generation: u32,
+    pub num_commits: u32,
+    pub parent_counts: HashMap<u32, u32>,
+}
+
+impl File {
+    pub fn checksum(&self) -> borrowed::Id<'_> {
+        borrowed::Id::try_from(&self.data[self.data.len() - SHA1_SIZE..]).expect("file to be large enough for a hash")
+    }
+
+    pub fn traverse<'a, E, Processor>(&'a self, mut processor: Processor) -> Result<Outcome, EitherError<Error, E>>
+    where
+        E: std::error::Error + 'static,
+        Processor: FnMut(&file::Commit<'a>) -> Result<(), E>,
+    {
+        self.verify_checksum()?;
+        verify_split_chain_filename_hash(&self.path, self.checksum())?;
+
+        // This probably belongs in borrowed::Id itself?
+        let null_id = borrowed::Id::from(&[0u8; SHA1_SIZE]);
+
+        let mut stats = Outcome {
+            max_generation: 0,
+            max_parents: 0,
+            min_generation: GENERATION_NUMBER_INFINITY,
+            num_commits: self.num_commits(),
+            parent_counts: HashMap::new(),
+        };
+
+        // TODO: Verify self.fan values as we go.
+        let mut prev_id: borrowed::Id<'a> = null_id;
+        for commit in self.iter_commits() {
+            if commit.id() <= prev_id {
+                if commit.id() == null_id {
+                    return Err(Error::CommitId {
+                        pos: commit.position(),
+                        id: commit.id().into(),
+                    }
+                    .into());
+                }
+                return Err(Error::CommitsOutOfOrder {
+                    pos: commit.position(),
+                    id: commit.id().into(),
+                    predecessor_id: prev_id.into(),
+                }
+                .into());
+            }
+            if commit.root_tree_id() == null_id {
+                return Err(Error::RootTreeId {
+                    id: commit.id().into(),
+                    root_tree_id: commit.root_tree_id().into(),
+                }
+                .into());
+            }
+            if commit.generation() > GENERATION_NUMBER_MAX {
+                return Err(Error::Generation {
+                    generation: commit.generation(),
+                    id: commit.id().into(),
+                }
+                .into());
+            }
+
+            processor(&commit).map_err(EitherError::Processor)?;
+
+            stats.max_generation = max(stats.max_generation, commit.generation());
+            stats.min_generation = min(stats.min_generation, commit.generation());
+            let parent_count = commit
+                .iter_parents()
+                .try_fold(0u32, |acc, pos| pos.map(|_| acc + 1))
+                .map_err(Error::Commit)?;
+            *stats.parent_counts.entry(parent_count).or_insert(0) += 1;
+            prev_id = commit.id();
+        }
+
+        if stats.min_generation == GENERATION_NUMBER_INFINITY {
+            stats.min_generation = 0;
+        }
+
+        Ok(stats)
+    }
+
+    pub fn verify_checksum(&self) -> Result<owned::Id, Error> {
+        // TODO: Use/copy git_odb::hash::bytes_of_file.
+        let data_len_without_trailer = self.data.len() - SHA1_SIZE;
+        let mut hasher = git_features::hash::Sha1::default();
+        hasher.update(&self.data[..data_len_without_trailer]);
+        let actual = owned::Id::new_sha1(hasher.digest());
+
+        let expected = self.checksum();
+        if actual.to_borrowed() == expected {
+            Ok(actual)
+        } else {
+            Err(Error::Mismatch {
+                actual,
+                expected: expected.into(),
+            })
+        }
+    }
+}
+
+/// If the given path's filename matches "graph-{hash}.graph", check that `hash` matches the
+/// expected hash.
+fn verify_split_chain_filename_hash(path: impl AsRef<Path>, expected: borrowed::Id<'_>) -> Result<(), Error> {
+    let path = path.as_ref();
+    path.file_name()
+        .and_then(|filename| filename.to_str())
+        .and_then(|filename| filename.strip_suffix(".graph"))
+        .and_then(|stem| stem.strip_prefix("graph-"))
+        .map_or(Ok(()), |hex| match owned::Id::from_40_bytes_in_hex(hex.as_bytes()) {
+            Ok(actual) if actual.to_borrowed() == expected => Ok(()),
+            _ => Err(Error::Filename(format!(
+                "graph-{}.graph",
+                expected.to_sha1_hex().as_bstr()
+            ))),
+        })
+}

--- a/git-commitgraph/src/graph/access.rs
+++ b/git-commitgraph/src/graph/access.rs
@@ -42,7 +42,7 @@ impl Graph {
 
 /// Access fundamentals
 impl Graph {
-    fn lookup_by_id(&self, id: borrowed::Id<'_>) -> Option<LookupByIdResult<'_>> {
+    pub(crate) fn lookup_by_id(&self, id: borrowed::Id<'_>) -> Option<LookupByIdResult<'_>> {
         let mut current_file_start = 0;
         for file in &self.files {
             if let Some(lex_pos) = file.lookup(id) {
@@ -57,14 +57,15 @@ impl Graph {
         None
     }
 
-    fn lookup_by_pos(&self, pos: graph::Position) -> LookupByPositionResult<'_> {
+    pub(crate) fn lookup_by_pos(&self, pos: graph::Position) -> LookupByPositionResult<'_> {
         let mut remaining = pos.0;
-        for file in &self.files {
+        for (file_index, file) in self.files.iter().enumerate() {
             match remaining.checked_sub(file.num_commits()) {
                 Some(v) => remaining = v,
                 None => {
                     return LookupByPositionResult {
                         file,
+                        file_index,
                         pos: file::Position(remaining),
                     }
                 }
@@ -75,14 +76,15 @@ impl Graph {
 }
 
 #[derive(Clone)]
-struct LookupByIdResult<'a> {
+pub(crate) struct LookupByIdResult<'a> {
     pub file: &'a File,
     pub graph_pos: graph::Position,
     pub file_pos: file::Position,
 }
 
 #[derive(Clone)]
-struct LookupByPositionResult<'a> {
+pub(crate) struct LookupByPositionResult<'a> {
     pub file: &'a File,
+    pub file_index: usize,
     pub pos: file::Position,
 }

--- a/git-commitgraph/src/graph/init.rs
+++ b/git-commitgraph/src/graph/init.rs
@@ -82,8 +82,8 @@ impl Graph {
     }
 
     pub fn new(files: Vec<File>) -> Result<Self, Error> {
-        let num_commits: u64 = files.iter().map(|f| f.num_commits() as u64).sum();
-        if num_commits > MAX_COMMITS as u64 {
+        let num_commits: u64 = files.iter().map(|f| u64::from(f.num_commits())).sum();
+        if num_commits > u64::from(MAX_COMMITS) {
             return Err(Error::TooManyCommits(num_commits));
         }
 

--- a/git-commitgraph/src/graph/mod.rs
+++ b/git-commitgraph/src/graph/mod.rs
@@ -1,6 +1,7 @@
 //! Operations on a complete commit graph.
 mod access;
 mod init;
+pub mod verify;
 
 use crate::file::File;
 use std::fmt;

--- a/git-commitgraph/src/graph/verify.rs
+++ b/git-commitgraph/src/graph/verify.rs
@@ -1,0 +1,158 @@
+use crate::{
+    file::{self, commit},
+    graph, Graph, GENERATION_NUMBER_MAX,
+};
+use git_object::owned;
+use std::cmp::{max, min};
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::path::PathBuf;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error<E: std::error::Error + 'static> {
+    #[error("'{}' should have {expected} base graphs, but claims {actual} base graphs", .path.display())]
+    BaseGraphCount { actual: u8, expected: u8, path: PathBuf },
+    #[error("'{}' base graph at index {index} should have ID {expected} but is {actual}", .path.display())]
+    BaseGraphId {
+        actual: owned::Id,
+        expected: owned::Id,
+        index: u8,
+        path: PathBuf,
+    },
+    #[error(transparent)]
+    Commit(#[from] commit::Error),
+    #[error("{}: {err}", .path.display())]
+    File { err: file::verify::Error, path: PathBuf },
+    #[error("Commit {id}'s generation should be {expected} but is {actual}")]
+    Generation { actual: u32, expected: u32, id: owned::Id },
+    #[error(
+        "Commit {id} has parent position {parent_pos} that is out of range (should be in range 0-{max_valid_pos})"
+    )]
+    ParentOutOfRange {
+        id: owned::Id,
+        max_valid_pos: graph::Position,
+        parent_pos: graph::Position,
+    },
+    #[error("{0}")]
+    Processor(#[source] E),
+    #[error("Commit-graph should be composed of at most 256 files but actually contains {0} files")]
+    TooManyFiles(usize),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
+pub struct Outcome {
+    pub longest_path_length: Option<u32>,
+    pub num_commits: u32,
+    pub parent_counts: BTreeMap<u32, u32>,
+}
+
+impl Graph {
+    pub fn verify_integrity<E>(
+        &self,
+        mut processor: impl FnMut(&file::Commit<'_>) -> Result<(), E>,
+    ) -> Result<Outcome, Error<E>>
+    where
+        E: std::error::Error + 'static,
+    {
+        if self.files.len() > 256 {
+            // A file in a split chain can only have up to 255 base files.
+            return Err(Error::TooManyFiles(self.files.len()));
+        }
+
+        let mut stats = Outcome {
+            longest_path_length: None,
+            num_commits: 0,
+            parent_counts: BTreeMap::new(),
+        };
+        let mut max_generation = 0u32;
+
+        // TODO: Detect duplicate commit IDs across different files. Not sure how to do this without
+        //   a separate loop, e.g. self.iter_sorted_ids().
+
+        let mut file_start_pos = graph::Position(0);
+        for (file_index, file) in self.files.iter().enumerate() {
+            if usize::from(file.base_graph_count()) != file_index {
+                return Err(Error::BaseGraphCount {
+                    actual: file.base_graph_count(),
+                    expected: file_index
+                        .try_into()
+                        .expect("files.len() check to protect against this"),
+                    path: file.path().to_owned(),
+                });
+            }
+
+            for (base_graph_index, (expected, actual)) in self.files[..file_index]
+                .iter()
+                .map(|base_file| base_file.checksum())
+                .zip(file.iter_base_graph_ids())
+                .enumerate()
+            {
+                if actual != expected {
+                    return Err(Error::BaseGraphId {
+                        actual: actual.into(),
+                        expected: expected.into(),
+                        index: base_graph_index
+                            .try_into()
+                            .expect("files.len() check to protect against this"),
+                        path: file.path().to_owned(),
+                    });
+                }
+            }
+
+            let next_file_start_pos = graph::Position(file_start_pos.0 + file.num_commits());
+            let file_stats = file
+                .traverse(|commit| {
+                    let mut max_parent_generation = 0u32;
+                    for parent_pos in commit.iter_parents() {
+                        let parent_pos = parent_pos.map_err(Error::Commit)?;
+                        if parent_pos >= next_file_start_pos {
+                            return Err(Error::ParentOutOfRange {
+                                parent_pos,
+                                id: commit.id().into(),
+                                max_valid_pos: graph::Position(next_file_start_pos.0 - 1),
+                            });
+                        }
+                        let parent = self.commit_at(parent_pos);
+                        max_parent_generation = max(max_parent_generation, parent.generation());
+                    }
+
+                    // If the max parent generation is GENERATION_NUMBER_MAX, then this commit's
+                    // generation should be GENERATION_NUMBER_MAX too.
+                    let expected_generation = min(max_parent_generation + 1, GENERATION_NUMBER_MAX);
+                    if commit.generation() != expected_generation {
+                        return Err(Error::Generation {
+                            actual: commit.generation(),
+                            expected: expected_generation,
+                            id: commit.id().into(),
+                        });
+                    }
+
+                    processor(commit).map_err(Error::Processor)?;
+
+                    Ok(())
+                })
+                .map_err(|e| match e {
+                    file::verify::EitherError::Internal(err) => Error::File {
+                        err,
+                        path: file.path().to_owned(),
+                    },
+                    file::verify::EitherError::Processor(e) => e,
+                })?;
+
+            max_generation = max(max_generation, file_stats.max_generation);
+            stats.num_commits += file_stats.num_commits;
+            for (key, value) in file_stats.parent_counts.into_iter() {
+                *stats.parent_counts.entry(key).or_insert(0) += value;
+            }
+            file_start_pos = next_file_start_pos;
+        }
+
+        stats.longest_path_length = if max_generation < GENERATION_NUMBER_MAX {
+            Some(max_generation.saturating_sub(1))
+        } else {
+            None
+        };
+        Ok(stats)
+    }
+}

--- a/git-commitgraph/src/lib.rs
+++ b/git-commitgraph/src/lib.rs
@@ -11,3 +11,15 @@ pub const GENERATION_NUMBER_MAX: u32 = 0x3fff_ffff;
 
 /// The maximum number of commits that can be stored in a commit graph.
 pub const MAX_COMMITS: u32 = (1 << 30) + (1 << 29) + (1 << 28) - 1;
+
+// TODO: pub type ImpossibleVariantError = !;
+#[derive(Debug)]
+pub struct ImpossibleVariantError;
+
+impl std::error::Error for ImpossibleVariantError {}
+
+impl std::fmt::Display for ImpossibleVariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("this enum was constructed with an invalid variant")
+    }
+}

--- a/git-commitgraph/src/lib.rs
+++ b/git-commitgraph/src/lib.rs
@@ -6,5 +6,8 @@ pub mod graph;
 
 pub use graph::Graph;
 
+pub const GENERATION_NUMBER_INFINITY: u32 = 0xffff_ffff;
+pub const GENERATION_NUMBER_MAX: u32 = 0x3fff_ffff;
+
 /// The maximum number of commits that can be stored in a commit graph.
 pub const MAX_COMMITS: u32 = (1 << 30) + (1 << 29) + (1 << 28) - 1;

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 test = false
 
 [features]
-serde1 = ["git-object/serde1", "git-odb/serde1", "git-protocol/serde1", "serde_json", "serde"]
+serde1 = ["git-commitgraph/serde1", "git-object/serde1", "git-odb/serde1", "git-protocol/serde1", "serde_json", "serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -28,3 +28,4 @@ anyhow = "1.0.31"
 quick-error = "2.0.0"
 bytesize = "1.0.1"
 serde_json = { version = "1.0.56", optional = true }
+git-commitgraph = { version = "^0.1.2", path = "../git-commitgraph" }

--- a/gitoxide-core/src/commitgraph/mod.rs
+++ b/gitoxide-core/src/commitgraph/mod.rs
@@ -1,0 +1,1 @@
+pub mod verify;

--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -1,0 +1,36 @@
+use anyhow::{Context as AnyhowContext, Result};
+use std::{io, path::Path};
+
+/// A general purpose context for many operations provided here
+pub struct Context<W1: io::Write, W2: io::Write> {
+    /// A stream to which to output operation results
+    pub out: W1,
+    /// A stream to which to errors
+    pub err: W2,
+}
+
+impl Default for Context<Vec<u8>, Vec<u8>> {
+    fn default() -> Self {
+        Context {
+            out: Vec::new(),
+            err: Vec::new(),
+        }
+    }
+}
+
+pub fn graph_or_file<W1, W2>(
+    path: impl AsRef<Path>,
+    Context {
+        out: mut _out,
+        err: mut _err,
+    }: Context<W1, W2>,
+) -> Result<()>
+where
+    W1: io::Write,
+    W2: io::Write,
+{
+    // TODO: Handle `path` being objects/info, objects/info/commit-graph,
+    //   or objects/info/commit-graphs/graph-xyz.graph.
+    let _g = git_commitgraph::Graph::from_info_dir(path).with_context(|| "Could not open commit graph")?;
+    Err(anyhow::Error::msg("not implemented"))
+}

--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -1,20 +1,23 @@
+use crate::OutputFormat;
 use anyhow::{Context as AnyhowContext, Result};
-use git_commitgraph::Graph;
+use git_commitgraph::{graph::verify::Outcome, Graph};
 use std::{io, path::Path};
 
 /// A general purpose context for many operations provided here
 pub struct Context<W1: io::Write, W2: io::Write> {
+    /// A stream to which to output errors
+    pub err: W2,
     /// A stream to which to output operation results
     pub out: W1,
-    /// A stream to which to errors
-    pub err: W2,
+    pub output_statistics: Option<OutputFormat>,
 }
 
 impl Default for Context<Vec<u8>, Vec<u8>> {
     fn default() -> Self {
         Context {
-            out: Vec::new(),
             err: Vec::new(),
+            out: Vec::new(),
+            output_statistics: None,
         }
     }
 }
@@ -22,16 +25,49 @@ impl Default for Context<Vec<u8>, Vec<u8>> {
 pub fn graph_or_file<W1, W2>(
     path: impl AsRef<Path>,
     Context {
-        out: mut _out,
         err: mut _err,
+        mut out,
+        output_statistics,
     }: Context<W1, W2>,
-) -> Result<()>
+) -> Result<git_commitgraph::graph::verify::Outcome>
 where
     W1: io::Write,
     W2: io::Write,
 {
-    // TODO: Handle `path` being objects/info, objects/info/commit-graph,
-    //   or objects/info/commit-graphs/graph-xyz.graph.
-    let _g = Graph::at(path).with_context(|| "Could not open commit graph")?;
-    Err(anyhow::Error::msg("not implemented"))
+    let g = Graph::at(path).with_context(|| "Could not open commit graph")?;
+
+    fn dummy_processor(_commit: &git_commitgraph::file::Commit<'_>) -> std::result::Result<(), std::fmt::Error> {
+        Ok(())
+    }
+    let stats = g
+        .verify_integrity(dummy_processor)
+        .with_context(|| "Verification failure")?;
+
+    match output_statistics {
+        Some(OutputFormat::Human) => drop(print_statistics(&mut out, &stats)),
+        #[cfg(feature = "serde1")]
+        Some(OutputFormat::Json) => serde_json::to_writer_pretty(out, &stats)?,
+        _ => {}
+    }
+
+    Ok(stats)
+}
+
+fn print_statistics(out: &mut impl io::Write, stats: &Outcome) -> io::Result<()> {
+    writeln!(out, "number of commits with the given number of parents")?;
+    let mut parent_counts: Vec<_> = stats.parent_counts.iter().map(|(a, b)| (*a, *b)).collect();
+    parent_counts.sort_by_key(|e| e.0);
+    for (parent_count, commit_count) in parent_counts.into_iter() {
+        writeln!(out, "\t{:>2}: {}", parent_count, commit_count)?;
+    }
+    writeln!(out, "\t->: {}", stats.num_commits)?;
+
+    write!(out, "\nlongest path length between two commits: ")?;
+    if let Some(n) = stats.longest_path_length {
+        writeln!(out, "{}", n)?;
+    } else {
+        writeln!(out, "unknown")?;
+    }
+
+    Ok(())
 }

--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as AnyhowContext, Result};
+use git_commitgraph::Graph;
 use std::{io, path::Path};
 
 /// A general purpose context for many operations provided here
@@ -31,6 +32,6 @@ where
 {
     // TODO: Handle `path` being objects/info, objects/info/commit-graph,
     //   or objects/info/commit-graphs/graph-xyz.graph.
-    let _g = git_commitgraph::Graph::from_info_dir(path).with_context(|| "Could not open commit graph")?;
+    let _g = Graph::at(path).with_context(|| "Could not open commit graph")?;
     Err(anyhow::Error::msg("not implemented"))
 }

--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -37,6 +37,7 @@ impl FromStr for OutputFormat {
 mod protocol;
 pub use protocol::Protocol;
 
+pub mod commitgraph;
 pub mod pack;
 pub mod remote;
 pub mod repository;

--- a/src/plumbing/lean/main.rs
+++ b/src/plumbing/lean/main.rs
@@ -140,5 +140,17 @@ pub fn main() -> Result<()> {
             )
             .map(|_| ())
         }
+        SubCommands::CommitGraphVerify(CommitGraphVerify { path }) => {
+            use self::core::commitgraph::verify;
+
+            verify::graph_or_file(
+                path,
+                verify::Context {
+                    out: stdout(),
+                    err: stderr(),
+                },
+            )
+            .map(|_| ())
+        }
     }
 }

--- a/src/plumbing/lean/main.rs
+++ b/src/plumbing/lean/main.rs
@@ -140,14 +140,19 @@ pub fn main() -> Result<()> {
             )
             .map(|_| ())
         }
-        SubCommands::CommitGraphVerify(CommitGraphVerify { path }) => {
+        SubCommands::CommitGraphVerify(CommitGraphVerify { path, statistics }) => {
             use self::core::commitgraph::verify;
 
             verify::graph_or_file(
                 path,
                 verify::Context {
-                    out: stdout(),
                     err: stderr(),
+                    out: stdout(),
+                    output_statistics: if statistics {
+                        Some(core::OutputFormat::Human)
+                    } else {
+                        None
+                    },
                 },
             )
             .map(|_| ())

--- a/src/plumbing/lean/options.rs
+++ b/src/plumbing/lean/options.rs
@@ -32,6 +32,7 @@ pub enum SubCommands {
     IndexFromPack(IndexFromPack),
     RemoteRefList(RemoteRefList),
     PackReceive(PackReceive),
+    CommitGraphVerify(CommitGraphVerify),
 }
 
 /// Create an index from a packfile.
@@ -185,6 +186,14 @@ pub struct PackVerify {
     #[argh(switch, short = 's')]
     pub statistics: bool,
     /// the '.pack' or '.idx' file whose checksum to validate.
+    #[argh(positional)]
+    pub path: PathBuf,
+}
+
+/// Verify a commit graph
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "commit-graph-verify")]
+pub struct CommitGraphVerify {
     #[argh(positional)]
     pub path: PathBuf,
 }

--- a/src/plumbing/lean/options.rs
+++ b/src/plumbing/lean/options.rs
@@ -196,4 +196,8 @@ pub struct PackVerify {
 pub struct CommitGraphVerify {
     #[argh(positional)]
     pub path: PathBuf,
+
+    /// output statistical information about the pack
+    #[argh(switch, short = 's')]
+    pub statistics: bool,
 }

--- a/src/plumbing/pretty/main.rs
+++ b/src/plumbing/pretty/main.rs
@@ -256,14 +256,22 @@ pub fn main() -> Result<()> {
             },
         )
         .map(|_| ()),
-        Subcommands::CommitGraphVerify { path } => prepare_and_run(
+        Subcommands::CommitGraphVerify { path, statistics } => prepare_and_run(
             "commit-graph-verify",
             verbose,
             progress,
             progress_keep_open,
             None,
             move |_progress, out, err| {
-                core::commitgraph::verify::graph_or_file(path, core::commitgraph::verify::Context { out, err })
+                let output_statistics = if statistics { Some(format) } else { None };
+                core::commitgraph::verify::graph_or_file(
+                    path,
+                    core::commitgraph::verify::Context {
+                        err,
+                        out,
+                        output_statistics,
+                    },
+                )
             },
         )
         .map(|_| ()),

--- a/src/plumbing/pretty/main.rs
+++ b/src/plumbing/pretty/main.rs
@@ -256,6 +256,17 @@ pub fn main() -> Result<()> {
             },
         )
         .map(|_| ()),
+        Subcommands::CommitGraphVerify { path } => prepare_and_run(
+            "commit-graph-verify",
+            verbose,
+            progress,
+            progress_keep_open,
+            None,
+            move |_progress, out, err| {
+                core::commitgraph::verify::graph_or_file(path, core::commitgraph::verify::Context { out, err })
+            },
+        )
+        .map(|_| ()),
     }?;
     Ok(())
 }

--- a/src/plumbing/pretty/options.rs
+++ b/src/plumbing/pretty/options.rs
@@ -193,5 +193,8 @@ pub enum Subcommands {
         /// The 'objects/info/' dir, 'objects/info/commit-graphs' dir, or 'objects/info/commit-graph' file to validate.
         #[clap(parse(from_os_str))]
         path: PathBuf,
+        /// output statistical information about the pack
+        #[clap(long, short = 's')]
+        statistics: bool,
     },
 }

--- a/src/plumbing/pretty/options.rs
+++ b/src/plumbing/pretty/options.rs
@@ -186,4 +186,12 @@ pub enum Subcommands {
         #[clap(parse(from_os_str))]
         path: PathBuf,
     },
+    /// Verify the integrity of a commit graph
+    #[clap(setting = AppSettings::ColoredHelp)]
+    #[clap(setting = AppSettings::DisableVersion)]
+    CommitGraphVerify {
+        /// The 'objects/info/' dir, 'objects/info/commit-graphs' dir, or 'objects/info/commit-graph' file to validate.
+        #[clap(parse(from_os_str))]
+        path: PathBuf,
+    },
 }

--- a/tests/snapshots/plumbing/commit-graph-verify/statistics-json-success
+++ b/tests/snapshots/plumbing/commit-graph-verify/statistics-json-success
@@ -1,0 +1,8 @@
+{
+  "longest_path_length": 2,
+  "num_commits": 3,
+  "parent_counts": {
+    "0": 1,
+    "1": 2
+  }
+}

--- a/tests/snapshots/plumbing/commit-graph-verify/statistics-success
+++ b/tests/snapshots/plumbing/commit-graph-verify/statistics-success
@@ -1,0 +1,6 @@
+number of commits with the given number of parents
+	 0: 1
+	 1: 2
+	->: 3
+
+longest path length between two commits: 2

--- a/tests/stateless-journey.sh
+++ b/tests/stateless-journey.sh
@@ -476,3 +476,25 @@ snapshot="$snapshot/plumbing"
     )
   )
 )
+(when "running 'commit-graph-verify'"
+  snapshot="$snapshot/commit-graph-verify"
+  (small-repo-in-sandbox
+    (with "a valid and complete commit-graph file"
+      git commit-graph write --reachable
+      (with "statistics"
+        it "generates the correct output" && {
+          WITH_SNAPSHOT="$snapshot/statistics-success" \
+          expect_run $SUCCESSFULLY "$exe_plumbing" commit-graph-verify -s .git/objects/info
+        }
+      )
+      if test "$kind" = "max"; then
+      (with "statistics --format json"
+        it "generates the correct output" && {
+          WITH_SNAPSHOT="$snapshot/statistics-json-success" \
+          expect_run $SUCCESSFULLY "$exe_plumbing" --format json commit-graph-verify -s .git/objects/info
+        }
+      )
+      fi
+    )
+  )
+)


### PR DESCRIPTION
Commit graphs are optional, so commit-graph plumbing is guarded by a
`commitgraph` feature that is enabled by default.