### PR TITLE
Update error message for type name

### DIFF
--- a/git-object/src/types.rs
+++ b/git-object/src/types.rs
@@ -91,7 +91,7 @@ impl Kind {
 
 impl fmt::Display for Kind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(std::str::from_utf8(self.to_bytes()).expect("valid utf8 in kind name"))
+        f.write_str(std::str::from_utf8(self.to_bytes()).expect("invalid utf8 in kind name"))
     }
 }
 

--- a/git-object/src/types.rs
+++ b/git-object/src/types.rs
@@ -91,7 +91,7 @@ impl Kind {
 
 impl fmt::Display for Kind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(std::str::from_utf8(self.to_bytes()).expect("invalid utf8 in kind name"))
+        f.write_str(std::str::from_utf8(self.to_bytes()).expect("Converting Kind name to utf8"))
     }
 }
 


### PR DESCRIPTION
This change updates the error message in the `expect` call to display the correct message. If the `from_utf8` fails to unwrap it will be the result of _invalid_ utf8.