### PR TITLE
Make `stress` target runnable in more general circumstances.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,12 +134,14 @@ $(linux_repo):
 stress: ## Run various algorithms on big repositories
 	$(MAKE) -j3 $(linux_repo) $(rust_repo) release-lean
 	time ./target/release/gixp --verbose pack-verify --re-encode $(linux_repo)/objects/pack/*.idx
-	mkdir out && time ./target/release/gixp --verbose pack-index-from-data -p $(linux_repo)/objects/pack/*.pack out/
+	rm -Rf out; mkdir out && time ./target/release/gixp --verbose pack-index-from-data -p $(linux_repo)/objects/pack/*.pack out/
 	time ./target/release/gixp --verbose pack-verify out/*.idx
 
 	time ./target/release/gixp --verbose pack-verify --statistics $(rust_repo)/objects/pack/*.idx
 	time ./target/release/gixp --verbose pack-verify --algorithm less-memory $(rust_repo)/objects/pack/*.idx
 	time ./target/release/gixp --verbose pack-verify --re-encode $(rust_repo)/objects/pack/*.idx
+	# We must ensure there is exactly one pack file for the pack-explode *.idx globs to work.
+	git repack -Ad
 	time ./target/release/gixp --verbose pack-explode .git/objects/pack/*.idx
 
 	rm -Rf delme; mkdir delme && time ./target/release/gixp --verbose pack-explode .git/objects/pack/*.idx delme/


### PR DESCRIPTION
* If the `out/` directory already exists, delete it. Needed to run
  `stress` multiple times.
* If the gitoxide repo contains zero or multiple packs, repack it to
  contain exactly one pack. Needed when the gitoxide repo is not a fresh
  clone.