### PR TITLE
Add stress tests for `gixp commit-graph-verify` command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 # will have compiled files and executables
 target/
 
+/tests/fixtures/commit-graphs
 # repositories used for local testing
 /tests/fixtures/repos

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,50 @@ $(linux_repo):
 	mkdir -p $@
 	cd $@ && git init --bare && git remote add origin https://github.com/torvalds/linux && git fetch
 
+test_many_commits_1m_repo = tests/fixtures/repos/test-many-commits-1m.git
+$(test_many_commits_1m_repo):
+	mkdir -p $@
+	cd $@ && git init --bare && git remote add origin https://github.com/cirosantilli/test-many-commits-1m.git && git fetch
+
+## get all non-rc tags up to v5.8, oldest tag first (should have 78 tags)
+## -> convert to commit ids
+## -> write a new incremental commit-graph file for each commit id
+tests/fixtures/commit-graphs/linux/long-chain: $(linux_repo)
+	mkdir -p $@
+	rm -rf $(linux_repo)/objects/info/*graph*
+	set -x && cd $(linux_repo) && \
+		for tag in $$(git tag --list --merged v5.8 --sort=version:refname | grep -Fv -- -rc); do \
+			git show-ref -s "$$tag" | git commit-graph write --split=no-merge --stdin-commits; \
+		done
+	mv -f $(linux_repo)/objects/info/*graphs* $@
+	actual=$$(ls -1 $@/commit-graphs/*.graph | wc -l); \
+		if [ $$actual -ne 78 ]; then echo expected 78 commit-graph files, got $$actual; exit 1; fi
+
+tests/fixtures/commit-graphs/linux/single-file: $(linux_repo)
+	mkdir -p $@
+	rm -rf $(linux_repo)/objects/info/*graph*
+	cd $(linux_repo) && git show-ref -s v5.8 | git commit-graph write --stdin-commits
+	mv -f $(linux_repo)/objects/info/*graph* $@
+
+tests/fixtures/commit-graphs/rust/single-file: $(rust_repo)
+	mkdir -p $@
+	rm -rf $(rust_repo)/objects/info/*graph*
+	cd $(rust_repo) && git show-ref -s 1.47.0 | git commit-graph write --stdin-commits
+	mv -f $(rust_repo)/objects/info/*graph* $@
+
+tests/fixtures/commit-graphs/test-many-commits-1m/single-file: $(test_many_commits_1m_repo)
+	mkdir -p $@
+	rm -rf $(test_many_commits_1m_repo)/objects/info/*graph*
+	cd $(test_many_commits_1m_repo) \
+		&& echo f4d21576c13d917e1464d9bc1323a560a5b8595d | git commit-graph write --stdin-commits
+	mv -f $(test_many_commits_1m_repo)/objects/info/*graph* $@
+
+commit_graphs = \
+	tests/fixtures/commit-graphs/linux/long-chain \
+	tests/fixtures/commit-graphs/linux/single-file \
+	tests/fixtures/commit-graphs/rust/single-file \
+	tests/fixtures/commit-graphs/test-many-commits-1m/single-file
+
 ##@ on CI
 
 stress: ## Run various algorithms on big repositories
@@ -145,6 +189,14 @@ stress: ## Run various algorithms on big repositories
 	time ./target/release/gixp --verbose pack-explode .git/objects/pack/*.idx
 
 	rm -Rf delme; mkdir delme && time ./target/release/gixp --verbose pack-explode .git/objects/pack/*.idx delme/
+
+	$(MAKE) stress-commitgraph
+
+.PHONY: stress-commitgraph
+stress-commitgraph: release-lean $(commit_graphs)
+	set -x; for path in $(wordlist 2, 999, $^); do \
+		time ./target/release/gixp --verbose commit-graph-verify $$path; \
+	done
 
 ##@ Maintenance
 


### PR DESCRIPTION
The new `tests/fixtures/commit-graphs` fixtures are built using the
exact same set of commits each time even as their sources repos in
`tests/fixtures/repos` get newer commits. My hope there is to make
upcoming commit-graph benchmarks more consistent.