### PR TITLE
Implementing pack-gen

### DIFF
--- a/src/plumbing/lean/main.rs
+++ b/src/plumbing/lean/main.rs
@@ -46,6 +46,11 @@ pub fn main() -> Result<()> {
                 },
             )
         }
+        SubCommands::PackSend(options::PackSend { protocol, url }) => {
+            todo!();
+            // get a handle on some progress
+            // call core progress
+        }
         SubCommands::IndexFromPack(options::IndexFromPack {
             iteration_mode,
             pack_path,

--- a/src/plumbing/lean/options.rs
+++ b/src/plumbing/lean/options.rs
@@ -32,6 +32,7 @@ pub enum SubCommands {
     IndexFromPack(IndexFromPack),
     RemoteRefList(RemoteRefList),
     PackReceive(PackReceive),
+    PackSend(PackSend),
     CommitGraphVerify(CommitGraphVerify),
 }
 
@@ -110,6 +111,22 @@ pub struct PackReceive {
     /// If unset, they will be discarded.
     #[argh(positional)]
     pub directory: Option<PathBuf>,
+}
+
+/// Send a pack from client to a remote server
+/// This is the plumbing equivalent of git push
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "pack-send")]
+pub struct PackSend {
+    /// the protocol version to use. Valid values are 1 and 2
+    #[argh(option, short = 'p')]
+    pub protocol: Option<core::Protocol>,
+
+    /// the URLs or path to which to send the pack.
+    ///
+    /// See here for a list of supported URLs: https://www.git-scm.com/docs/git-clone#_git_urls
+    #[argh(positional)]
+    pub url: String,
 }
 
 /// Explode a pack into loose objects.


### PR DESCRIPTION
Hi, as far I understand, the current repository doesn't implement pack generation. (The third issue #3 is still open). So, before pack-send, we obviously need to generate packs first.

So, to begin implemention, I start by understanding the original C code, starting with [pack-objects.c](https://github.com/git/git/blob/master/builtin/pack-objects.c)? I have read the Git Internals part of the ProGit book, but it felt surface level in this context.

So, as apparent from the README, I should likely first look at these three tasks, starting with the first:

* [ ] create new pack
* [ ] create 'thin' pack
* [ ] Add support for zlib-ng for 2.5x compression performance and 20% faster decompression

Ideally, this functionality would be implemented in `git-odb/src/pack/data/encode.rs`.

Is this overall understanding correct?