### PR TITLE
[commitgraph] Tweak and expand documentation.

### DIFF
--- a/git-commitgraph/src/file/access.rs
+++ b/git-commitgraph/src/file/access.rs
@@ -9,7 +9,7 @@ use std::{
 
 /// Access
 impl File {
-    /// The amount of base graphs that this file depends on.
+    /// The number of base graphs that this file depends on.
     pub fn base_graph_count(&self) -> u8 {
         self.base_graph_count
     }

--- a/git-commitgraph/src/file/commit.rs
+++ b/git-commitgraph/src/file/commit.rs
@@ -1,3 +1,4 @@
+//! Low-level operations on individual commits.
 use crate::{
     file::{self, File},
     graph,

--- a/git-commitgraph/src/file/mod.rs
+++ b/git-commitgraph/src/file/mod.rs
@@ -2,12 +2,10 @@
 
 mod access;
 
-///
 pub mod commit;
 pub use commit::Commit;
 
 mod init;
-///
 pub mod verify;
 
 pub use init::Error;

--- a/git-commitgraph/src/file/verify.rs
+++ b/git-commitgraph/src/file/verify.rs
@@ -1,3 +1,4 @@
+//! Auxiliary types used in commit graph file verification methods.
 use crate::{
     file::{self, File},
     GENERATION_NUMBER_INFINITY, GENERATION_NUMBER_MAX,
@@ -42,15 +43,15 @@ pub enum Error<E: std::error::Error + 'static> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub struct Outcome {
-    /// The highest encountered [`file::Commit`] generation number.
+    /// The largest encountered [`file::Commit`] generation number.
     pub max_generation: u32,
     /// The smallest encountered [`file::Commit`] generation number.
     pub min_generation: u32,
-    /// The highest amount parents in a single [`file::Commit`].
+    /// The largest number of parents in a single [`file::Commit`].
     pub max_parents: u32,
-    /// The total amount of [`commits`][file::Commit] seen in the iteration.
+    /// The total number of [`commits`][file::Commit]s seen in the iteration.
     pub num_commits: u32,
-    /// A mapping of `parent-count -> amount of [commits][file::Commit] with that count`.
+    /// A mapping of `N -> number of commits with N parents`.
     pub parent_counts: HashMap<u32, u32>,
 }
 

--- a/git-commitgraph/src/graph/access.rs
+++ b/git-commitgraph/src/graph/access.rs
@@ -45,7 +45,7 @@ impl Graph {
         Some(self.lookup_by_id(id)?.graph_pos)
     }
 
-    /// Returns the amount of commits stored in this file.
+    /// Returns the number of commits stored in this file.
     pub fn num_commits(&self) -> u32 {
         self.files.iter().map(|f| f.num_commits()).sum()
     }

--- a/git-commitgraph/src/graph/mod.rs
+++ b/git-commitgraph/src/graph/mod.rs
@@ -1,7 +1,6 @@
 //! Operations on a complete commit graph.
 mod access;
 mod init;
-///
 pub mod verify;
 
 use crate::file::File;

--- a/git-commitgraph/src/graph/verify.rs
+++ b/git-commitgraph/src/graph/verify.rs
@@ -1,3 +1,4 @@
+//! Auxiliary types used by graph verification methods.
 use crate::{
     file::{self, commit},
     graph, Graph, GENERATION_NUMBER_MAX,
@@ -50,17 +51,19 @@ pub enum Error<E: std::error::Error + 'static> {
     TooManyFiles(usize),
 }
 
-/// Statistics gathered while verifying the integrity of the graph as returned by [`Graph::verify_integrity()]`.
+/// Statistics gathered while verifying the integrity of the graph as returned by [`Graph::verify_integrity()`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub struct Outcome {
-    /// The longest consecutive amount of commits in a chain of commits.
+    /// The length of the longest path between any two commits in this graph.
     ///
-    /// For example, a repository with 10 commits would have 10 as value.
+    /// For example, this will be `Some(9)` for a commit graph containing 10 linear commits.
+    /// This will be `Some(0)` for a commit graph containing 0 or 1 commits.
+    /// If the longest path length is too large to fit in a [u32], then this will be [None].
     pub longest_path_length: Option<u32>,
-    /// The total amount traversed commits.
+    /// The total number of commits traversed.
     pub num_commits: u32,
-    /// A mapping of `parent-count -> amount of [commits][file::Commit] with that count`.
+    /// A mapping of `N -> number of commits with N parents`.
     pub parent_counts: BTreeMap<u32, u32>,
 }
 

--- a/git-commitgraph/src/lib.rs
+++ b/git-commitgraph/src/lib.rs
@@ -1,11 +1,12 @@
 //! Read, verify, and traverse git commit graphs.
 //!
-//! A [commit graph][Graph] acts as a cache is a set of [graph files][file::File] each storing
-//! various commits in a way that accelerates lookups considerably compared to traversing the git history by usual means.
+//! A [commit graph][Graph] is an index of commits in the git commit history.
+//! The [Graph] stores commit data in a way that accelerates lookups considerably compared to
+//! traversing the git history by usual means.
 //!
-//! A [`Graph`] is generated as each [`File`][file::File] only contains a subset of all commits in the git commit
-//! history to avoid having to recreate the entire cache each time the cache should be updated, thus avoiding to traverse
-//! the git history that is already present in the [`Graph`].
+//! As generating the full commit graph from scratch can take some time, git may write new commits
+//! to separate [files][file::File] instead of overwriting the original file.
+//! Eventually, git will merge these files together as the number of files grows.
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms, missing_docs)]
 
@@ -16,7 +17,11 @@ pub use graph::Graph;
 
 /// The number of generations that are considered 'infinite' commit history.
 pub const GENERATION_NUMBER_INFINITY: u32 = 0xffff_ffff;
-/// The biggest possible amount of commits in the history of a repository.
+/// The largest valid generation number.
+///
+/// If a commit's real generation number is larger than this, the commit graph will cap the value to
+/// this number.
+/// The largest distinct generation number is `GENERATION_NUMBER_MAX - 1`.
 pub const GENERATION_NUMBER_MAX: u32 = 0x3fff_ffff;
 
 /// The maximum number of commits that can be stored in a commit graph.


### PR DESCRIPTION
* Use "number of" phrasing instead of "amount of."
* Describe the graph as an index instead of a cache.
* Add module-level documentation for `file::commit`, `file::verify`, and
  `graph::verify`.

Style-wise, I like to start new sentences on new lines to reduce the amount of reflow needed when updating comments, but I don't know whether that's acceptable in this project.