### PR TITLE
Config updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,8 +466,9 @@ dependencies = [
 
 [[package]]
 name = "dangerous"
-version = "0.7.0"
-source = "git+https://github.com/avitex/rust-dangerous#3b6863117353d3ee17113a99c1db19f6460f1731"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e95a55c47c2c5ce469fd39840be3ec8554765184a119cbcd20149dafaa3d75b4"
 
 [[package]]
 name = "dashmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,8 +467,7 @@ dependencies = [
 [[package]]
 name = "dangerous"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5718d28e9ff3fbcc721e2bfbfe1be4501cce62a06488b999b52a16fefafc24d7"
+source = "git+https://github.com/avitex/rust-dangerous#3b6863117353d3ee17113a99c1db19f6460f1731"
 
 [[package]]
 name = "dashmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dangerous"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5718d28e9ff3fbcc721e2bfbfe1be4501cce62a06488b999b52a16fefafc24d7"
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +650,7 @@ name = "git-config"
 version = "0.0.0"
 dependencies = [
  "bstr",
+ "dangerous",
  "quick-error",
 ]
 

--- a/git-config/Cargo.toml
+++ b/git-config/Cargo.toml
@@ -14,4 +14,5 @@ doctest = false
 
 [dependencies]
 bstr = { version = "0.2.13", default-features = false, features = ["std"] }
+dangerous = { version = "0.7.0", default-features = false, features = ["full-context", "retry"] }
 quick-error = "2.0.0"

--- a/git-config/Cargo.toml
+++ b/git-config/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 
 [dependencies]
 bstr = { version = "0.2.13", default-features = false, features = ["std"] }
-dangerous = { version = "0.7.0", default-features = false, features = ["full-context", "retry"], git = "https://github.com/avitex/rust-dangerous" }
+dangerous = { version = "0.9.0", default-features = false, features = ["full-backtrace"] }
 quick-error = "2.0.0"

--- a/git-config/Cargo.toml
+++ b/git-config/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 
 [dependencies]
 bstr = { version = "0.2.13", default-features = false, features = ["std"] }
-dangerous = { version = "0.7.0", default-features = false, features = ["full-context", "retry"] }
+dangerous = { version = "0.7.0", default-features = false, features = ["full-context", "retry"], git = "https://github.com/avitex/rust-dangerous" }
 quick-error = "2.0.0"

--- a/git-config/src/file/edit.rs
+++ b/git-config/src/file/edit.rs
@@ -1,4 +1,5 @@
-use crate::{borrowed, file::File, owned, Span};
+use crate::{borrowed, file::File, owned};
+use dangerous::Span;
 use std::io;
 
 /// Represents a possible edit to the git configuration file

--- a/git-config/src/file/mod.rs
+++ b/git-config/src/file/mod.rs
@@ -32,12 +32,7 @@ impl Token {
 pub struct File {
     buf: Vec<u8>,
     /// A config file as parsed into tokens, where each [`Token`] is one of the three relevant items in git config files.
-    tokens: Vec<Token>, // but how do we get fast lookups and proper value lookup based on decoded values?
-                        // On the fly is easier, otherwise we have to deal with a lookup cache of sorts and
-                        // many more allocations up front (which might be worth it only once we have measurements).
-                        // Cow<'a, _> would bind to our buffer so the cache can't be in this type.
-                        // Probably it could be the 'Config' type which handles multiple files and treats them as one,
-                        // and only if there is any need.
+    tokens: Vec<Token>,
 }
 
 impl File {

--- a/git-config/src/file/mod.rs
+++ b/git-config/src/file/mod.rs
@@ -1,7 +1,8 @@
-use crate::{borrowed, spanned, Span};
+use crate::{borrowed, spanned};
 use bstr::{BStr, ByteSlice};
+use dangerous::Span;
 
-#[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) enum Token {
     Section(spanned::Section),
     Entry(spanned::Entry),
@@ -28,7 +29,7 @@ impl Token {
 /// After reading a configuration file its contents is stored verbatim and indexed to allow retrieval
 /// of sections and entry values on demand. These are returned as [`borrowed`] items, which are read-only but
 /// can be transformed into editable items.
-#[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct File {
     buf: Vec<u8>,
     /// A config file as parsed into tokens, where each [`Token`] is one of the three relevant items in git config files.
@@ -37,7 +38,7 @@ pub struct File {
 
 impl File {
     pub(crate) fn bytes_at(&self, span: Span) -> &BStr {
-        &self.buf[span.to_range()].as_bstr()
+        span.of(self.buf.as_slice()).unwrap().as_bstr()
     }
 
     pub(crate) fn token(&self, index: usize) -> &Token {

--- a/git-config/src/lib.rs
+++ b/git-config/src/lib.rs
@@ -41,6 +41,8 @@ impl Span {
 pub mod file;
 pub use file::File;
 
+pub(crate) mod parse;
+
 /// A module with specialized value types as they exist within git config files.
 pub mod value;
 

--- a/git-config/src/lib.rs
+++ b/git-config/src/lib.rs
@@ -30,6 +30,15 @@ impl From<Span> for Range<usize> {
     }
 }
 
+impl From<Range<usize>> for Span {
+    fn from(Range { start, end }: Range<usize>) -> Self {
+        Span {
+            start,
+            end_inclusive: end - 1,
+        }
+    }
+}
+
 impl Span {
     /// Convert a span into the standard library range type.
     fn to_range(&self) -> Range<usize> {

--- a/git-config/src/lib.rs
+++ b/git-config/src/lib.rs
@@ -9,43 +9,6 @@
 //! Additionally it's a stated goal as well to apply such restrictions only when values are read and optionally allow
 //! a less limited character set. This opens up the git configuration format to other languages than English.
 
-use std::ops::Range;
-
-/// A span is a range into a set of bytes - see it as a selection into a Git config file.
-///
-/// Similar to [`std::ops::RangeInclusive`], but tailor made to work for us.
-/// There are various issues with std ranges, which we don't have to opt into for the simple Range-like item we need.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-struct Span {
-    pub start: usize,
-    pub end_inclusive: usize,
-}
-
-impl From<Span> for Range<usize> {
-    fn from(Span { start, end_inclusive }: Span) -> Self {
-        Range {
-            start,
-            end: end_inclusive + 1,
-        }
-    }
-}
-
-impl From<Range<usize>> for Span {
-    fn from(Range { start, end }: Range<usize>) -> Self {
-        Span {
-            start,
-            end_inclusive: end - 1,
-        }
-    }
-}
-
-impl Span {
-    /// Convert a span into the standard library range type.
-    fn to_range(&self) -> Range<usize> {
-        self.clone().into()
-    }
-}
-
 ///
 pub mod file;
 pub use file::File;

--- a/git-config/src/owned.rs
+++ b/git-config/src/owned.rs
@@ -1,5 +1,5 @@
-use crate::Span;
 use bstr::BString;
+use dangerous::Span;
 
 /// A key-value entry of a git-config file, like `name = value`
 pub struct Entry {

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -1,4 +1,5 @@
 use crate::file;
+use bstr::{BStr, ByteSlice};
 use dangerous::{BytesReader, Error};
 
 fn read_config<'i, E>(r: &mut BytesReader<'i, E>) -> Result<Vec<file::Token>, E>
@@ -14,33 +15,58 @@ enum ConsumeTo {
     EndOfLine,
 }
 
-fn skip_whitespace_or_comment<E>(r: &mut BytesReader<'_, E>, to_where: ConsumeTo) {
-    fn skip_comment<E>(r: &mut BytesReader<'_, E>) -> usize {
-        if r.peek_eq(b'#') {
-            r.take_while(|c| c != b'\n').len()
-        } else {
-            0
+fn skip_whitespace_or_comment<'a, E>(r: &mut BytesReader<'a, E>, to_where: ConsumeTo) -> Option<&'a BStr> {
+    fn skip_whitespace_or_comment<E>(r: &mut BytesReader<'_, E>, to_where: ConsumeTo) {
+        fn skip_comment<E>(r: &mut BytesReader<'_, E>) -> usize {
+            if r.peek_eq(b'#') {
+                r.take_while(|c| c != b'\n').len()
+            } else {
+                0
+            }
+        }
+
+        let (mut last, mut current) = (0, 0);
+        loop {
+            current += skip_comment(r);
+            current += r
+                .take_while(|c| {
+                    let iwb = c.is_ascii_whitespace();
+                    iwb && match to_where {
+                        ConsumeTo::NextToken => true,
+                        ConsumeTo::EndOfLine => c != b'\n',
+                    }
+                })
+                .len();
+            if last == current {
+                break;
+            }
+            last = current;
         }
     }
-
-    let (mut last, mut current) = (0, 0);
-    loop {
-        current += skip_comment(r);
-        current += r
-            .take_while(|c| {
-                let iwb = c.is_ascii_whitespace();
-                iwb && match to_where {
-                    ConsumeTo::NextToken => true,
-                    ConsumeTo::EndOfLine => c != b'\n',
-                }
-            })
-            .len();
-        if last == current {
-            break;
-        }
-        last = current;
+    let parsed = r
+        .take_consumed(|r| skip_whitespace_or_comment(r, to_where))
+        .as_dangerous();
+    if parsed.is_empty() {
+        None
+    } else {
+        Some(parsed.as_bstr())
     }
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    mod comments {
+        use crate::parse::{skip_whitespace_or_comment, ConsumeTo};
+        use bstr::ByteSlice;
+        use dangerous::Input;
+
+        #[test]
+        fn whitespace_skipping_whitespace() {
+            let i = b"     \n     \t ";
+            let (res, remaining) =
+                dangerous::input(i).read_infallible(|r| skip_whitespace_or_comment(r, ConsumeTo::NextToken));
+            assert!(remaining.is_empty());
+            assert_eq!(res, Some(i.as_bstr()));
+        }
+    }
+}

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -41,7 +41,7 @@ fn skip_whitespace_or_comment<'a, E>(r: &mut BytesReader<'a, E>, to_where: Consu
         loop {
             current += skip_comment(r);
             current += r
-                .take_while(|c| {
+                .take_while(|c: u8| {
                     let iwb = c.is_ascii_whitespace();
                     iwb && match to_where {
                         ConsumeTo::NextToken => true,

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -1,0 +1,46 @@
+use crate::file;
+use dangerous::{BytesReader, Error};
+
+fn read_config<'i, E>(r: &mut BytesReader<'i, E>) -> Result<Vec<file::Token>, E>
+where
+    E: Error<'i>,
+{
+    skip_whitespace_or_comment(r, ConsumeTo::NextToken);
+    unimplemented!("sections and values");
+}
+
+enum ConsumeTo {
+    NextToken,
+    EndOfLine,
+}
+
+fn skip_whitespace_or_comment<E>(r: &mut BytesReader<'_, E>, to_where: ConsumeTo) {
+    fn skip_comment<E>(r: &mut BytesReader<'_, E>) -> usize {
+        if r.peek_eq(b'#') {
+            r.take_while(|c| c != b'\n').len()
+        } else {
+            0
+        }
+    }
+
+    let (mut last, mut current) = (0, 0);
+    loop {
+        current += skip_comment(r);
+        current += r
+            .take_while(|c| {
+                let iwb = c.is_ascii_whitespace();
+                iwb && match to_where {
+                    ConsumeTo::NextToken => true,
+                    ConsumeTo::EndOfLine => c != b'\n',
+                }
+            })
+            .len();
+        if last == current {
+            break;
+        }
+        last = current;
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -7,14 +7,14 @@ fn config(bytes: &[u8]) -> Result<Vec<file::Token>, Expected<'_>> {
         E: Error<'i>,
     {
         let mut tokens = Vec::new();
-        skip_whitespace_or_comment(r, ConsumeTo::NextToken).map(|section| {
+        if let Some(section) = skip_whitespace_or_comment(r, ConsumeTo::NextToken) {
             tokens.push(spanned::Comment(
                 dangerous::input(section)
                     .span_of(&input)
                     .expect("range contained")
                     .into(),
             ))
-        });
+        };
         unimplemented!("sections and values");
     }
     let input = dangerous::input(bytes);

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -31,7 +31,7 @@ fn skip_whitespace_or_comment<'a, E>(r: &mut BytesReader<'a, E>, to_where: Consu
     fn skip_whitespace_or_comment<E>(r: &mut BytesReader<'_, E>, to_where: ConsumeTo) {
         fn skip_comment<E>(r: &mut BytesReader<'_, E>) -> usize {
             if r.peek_eq(b'#') {
-                r.take_while(|c| c != b'\n').len()
+                r.take_until_opt(b'\n').len()
             } else {
                 0
             }

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -58,17 +58,29 @@ mod tests {
         use crate::parse::{skip_whitespace_or_comment, ConsumeTo};
         use dangerous::Input;
 
-        #[test]
-        fn whitespace_only() {
-            let bytes = b"     \n     \t ";
-            let (res, remaining) =
-                dangerous::input(bytes).read_infallible(|r| skip_whitespace_or_comment(r, ConsumeTo::NextToken));
-            assert!(remaining.is_empty());
-            assert_eq!(
-                res.map(dangerous::input)
-                    .and_then(|s| s.span_of(&dangerous::input(bytes))),
-                Some(0..bytes.len())
-            );
+        macro_rules! decode_span {
+            ($name:ident, $input:literal, $range:expr, $explain:literal) => {
+                #[test]
+                fn $name() {
+                    let bytes = $input;
+                    let (res, remaining) = dangerous::input(bytes)
+                        .read_infallible(|r| skip_whitespace_or_comment(r, ConsumeTo::NextToken));
+                    assert!(remaining.is_empty(), $explain);
+                    assert_eq!(
+                        res.map(dangerous::input)
+                            .and_then(|s| s.span_of(&dangerous::input(bytes))),
+                        Some($range),
+                        $explain
+                    );
+                }
+            };
         }
+
+        decode_span!(
+            whitespace_only,
+            b"     \n     \t ",
+            0..13,
+            "it consumes newlines as well, taking everything"
+        );
     }
 }

--- a/git-config/src/parse.rs
+++ b/git-config/src/parse.rs
@@ -50,6 +50,9 @@ fn skip_whitespace_or_comment<'a, E>(r: &mut BytesReader<'a, E>, to_where: Consu
                 })
                 .len();
             if last == current {
+                if let ConsumeTo::EndOfLine = to_where {
+                    r.consume_opt(b'\n');
+                }
                 break;
             }
             last = current;
@@ -100,8 +103,8 @@ mod tests {
             no_comment_to_end_of_line,
             b"     \n     \t ",
             ConsumeTo::EndOfLine,
-            0..5,
-            "it consumes only a single line, EXCLUDING the EOF marker"
+            0..6,
+            "it consumes only a single line, including the EOF marker"
         );
 
         decode_span!(
@@ -116,7 +119,7 @@ mod tests {
             comment_to_end_of_line,
             b"# hi \n     \t ",
             ConsumeTo::EndOfLine,
-            0..5,
+            0..6,
             "comments are the same as whitespace"
         );
 

--- a/git-config/src/spanned.rs
+++ b/git-config/src/spanned.rs
@@ -1,9 +1,9 @@
-use crate::Span;
+use dangerous::Span;
 
 // we parse leading and trailing whitespace into comments, avoiding the notion of whitespace.
 // This means we auto-trim whitespace otherwise, which we a feature.
 // All whitespace is automatically an empty comment.
-#[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct Comment(pub(crate) Span);
 
 /// A section or sub-section (in case `sub_name` is `Some()`), i.e.
@@ -15,14 +15,14 @@ pub(crate) struct Comment(pub(crate) Span);
 ///
 /// [section "Sub-Section"]
 /// ```
-#[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct Section {
     pub(crate) name: Span,
     pub(crate) sub_name: Option<Span>,
 }
 
 /// A key-value entry of a git-config file, like `name = value`.
-#[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct Entry {
     pub(crate) name: Span,
     pub(crate) value: Option<Span>,

--- a/git-config/src/spanned.rs
+++ b/git-config/src/spanned.rs
@@ -4,7 +4,7 @@ use crate::Span;
 // This means we auto-trim whitespace otherwise, which we a feature.
 // All whitespace is automatically an empty comment.
 #[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
-pub(crate) struct Comment(Span);
+pub(crate) struct Comment(pub(crate) Span);
 
 /// A section or sub-section (in case `sub_name` is `Some()`), i.e.
 ///


### PR DESCRIPTION
@Byron 

I'm just starting to have a look now.

- [`dangerous::Span`](https://docs.rs/dangerous/0.9.0/dangerous/struct.Span.html) is now used instead. This actually is less error prone because ranges could be taken from the wrong offset. `dangerous::Span` internally holds pointer references to solve this!
- I've removed for now `PartialOrd/Ord` derives as I'm not sure what is semantic in the order, maybe you can help me here. `dangerous::Span` doesn't implement it because it doesn't make too much sense to me, which prevents derives. On a quick search, neither does `Range` https://github.com/rust-lang/rust/issues/75607 

I'll be looking a little more though this soon I promise!

On another note, I'm thinking of making a recommendation of only using `dangerous::input()` for the top level and not within sub parsers. I'll be explaining my reasoning soon :)