### PR TITLE
Remove almost all unsafe code from Tree.

### DIFF
--- a/git-odb/src/pack/index/traverse/indexed.rs
+++ b/git-odb/src/pack/index/traverse/indexed.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use super::{Error, SafetyCheck};
 use crate::pack::{
     self,
@@ -157,7 +159,7 @@ impl From<pack::index::Entry> for EntryWithDefault {
     }
 }
 
-fn digest_statistics(items: Vec<pack::tree::Item<EntryWithDefault>>) -> index::traverse::Outcome {
+fn digest_statistics(items: VecDeque<pack::tree::Item<EntryWithDefault>>) -> index::traverse::Outcome {
     let mut res = index::traverse::Outcome::default();
     let average = &mut res.average;
     for item in &items {

--- a/git-odb/src/pack/index/write/encode.rs
+++ b/git-odb/src/pack/index/write/encode.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 use byteorder::{BigEndian, WriteBytesExt};
 use git_features::progress::{self, Progress};
-use std::{cmp::Ordering, io};
+use std::{cmp::Ordering, collections::VecDeque, io};
 
 pub(crate) fn write_to(
     out: impl io::Write,
-    entries_sorted_by_oid: Vec<pack::tree::Item<pack::index::write::TreeEntry>>,
+    entries_sorted_by_oid: VecDeque<pack::tree::Item<pack::index::write::TreeEntry>>,
     pack_hash: &git_hash::ObjectId,
     kind: pack::index::Version,
     mut progress: impl Progress,
@@ -36,7 +36,7 @@ pub(crate) fn write_to(
     const HIGH_BIT: u32 = 0x8000_0000;
 
     let needs_64bit_offsets =
-        entries_sorted_by_oid.last().expect("at least one pack entry").offset > LARGE_OFFSET_THRESHOLD;
+        entries_sorted_by_oid.back().expect("at least one pack entry").offset > LARGE_OFFSET_THRESHOLD;
     let mut fan_out_be = [0u32; 256];
     progress.init(Some(4), progress::steps());
     let start = std::time::Instant::now();

--- a/git-odb/src/pack/index/write/mod.rs
+++ b/git-odb/src/pack/index/write/mod.rs
@@ -185,7 +185,7 @@ impl pack::index::File {
 
             {
                 let _progress = root_progress.add_child("sorting by id");
-                items.sort_by_key(|e| e.data.id);
+                items.make_contiguous().sort_by_key(|e| e.data.id);
             }
 
             root_progress.inc();

--- a/git-odb/src/pack/tree/iter.rs
+++ b/git-odb/src/pack/tree/iter.rs
@@ -3,191 +3,83 @@ use crate::{
     pack::tree::{Item, Tree},
 };
 
-/// All the **unsafe** bits to support parallel iteration with write access
-impl<T> Tree<T> {
-    #[allow(unsafe_code)]
-    /// # SAFETY
-    /// Called from node with is guaranteed to not be aliasing with any other node.
-    /// Note that we are iterating nodes that we are affecting here, but that only affects the
-    /// 'is_root' field fo the item, not the data field that we are writing here.
-    /// For all details see `from_node_take_entry()`.
-    unsafe fn put_data(&self, index: usize, data: T) {
-        let items_mut: &mut Vec<Item<T>> = &mut *(self.items.get());
-        items_mut.get_unchecked_mut(index).data = data;
-    }
-
-    #[allow(unsafe_code)]
-    /// # SAFETY
-    /// Similar to `from_node_put_data(…)`
-    unsafe fn offset(&self, index: usize) -> u64 {
-        let items: &Vec<Item<T>> = &*(self.items.get());
-        items.get_unchecked(index).offset
-    }
-
-    #[allow(unsafe_code)]
-    /// # SAFETY
-    /// Similar to `from_node_put_data(…)`
-    unsafe fn entry_slice(&self, index: usize) -> std::ops::Range<u64> {
-        let items: &Vec<Item<T>> = &*(self.items.get());
-        let start = items.get_unchecked(index).offset;
-        let end = items
-            .get(index + 1)
-            .map(|e| e.offset)
-            .or(self.pack_entries_end)
-            .expect("traversal(…) to have set this value (BUG)");
-        start..end
-    }
-
-    #[allow(unsafe_code)]
-    /// # SAFETY
-    /// A tree is a data structure without cycles, and we assure of that by verifying all input.
-    /// A node as identified by index can only be traversed once using the Chunks iterator.
-    /// When the iterator is created, this instance cannot be mutated anymore nor can it be read.
-    /// That iterator is only handed out once.
-    /// `Node` instances produced by it consume themselves when iterating their children, allowing them to be
-    /// used only once, recursively. Again, traversal is always forward and consuming, making it impossible to
-    /// alias multiple nodes in the tree.
-    /// It's safe for multiple threads to hold different chunks, as they are guaranteed to be non-overlapping and unique.
-    /// If the tree is accessed after iteration, it will panic as no mutation is allowed anymore, nor is
-    unsafe fn take_entry(&self, index: usize) -> (T, Vec<usize>)
-    where
-        T: Default,
-    {
-        let items_mut: &mut Vec<Item<T>> = &mut *(self.items.get());
-        let item = items_mut.get_unchecked_mut(index);
-        let children = std::mem::take(&mut item.children);
-        let data = std::mem::take(&mut item.data);
-        (data, children)
-    }
-
-    #[allow(unsafe_code)]
-    /// # SAFETY
-    /// As `take_entry(…)` - but this one only takes if the data of Node is a root
-    unsafe fn from_iter_take_entry_if_root(&self, index: usize) -> Option<(T, Vec<usize>)>
-    where
-        T: Default,
-    {
-        let items_mut: &mut Vec<Item<T>> = &mut *(self.items.get());
-        let item = items_mut.get_unchecked_mut(index);
-        if item.is_root {
-            let children = std::mem::take(&mut item.children);
-            let data = std::mem::take(&mut item.data);
-            Some((data, children))
-        } else {
-            None
-        }
-    }
-}
-
 /// Iteration
 impl<T> Tree<T> {
     /// Return an iterator over chunks of roots. Roots are not children themselves, they have no parents.
-    pub fn iter_root_chunks(&mut self, chunk_size: usize) -> Chunks<'_, T> {
-        Chunks {
-            tree: self,
-            chunk_size,
-            cursor: 0,
+    pub fn iter_root_chunks(&mut self, chunk_size: usize) -> impl Iterator<Item=Chunk<'_, T>> + '_ {
+        let (front, back) = self.items.as_mut_slices();
+        if front.len() != self.roots {
+            // This should not happen unless we added more nodes than were declared in the
+            // constructor.
+            panic!("item deque has been resized");
         }
+
+        front.chunks_mut(chunk_size).map(move |c| Chunk {
+            inner: c.iter_mut(),
+            children: back as *mut [Item<T>],
+        })
     }
 }
 
-/// An item returned by a [`Chunks`] iterator, allowing access to the `data` stored alongside nodes in a [`Tree`]
-pub struct Node<'a, T> {
-    tree: &'a Tree<T>,
-    index: usize,
-    children: Vec<usize>,
-    /// The custom data attached to each node of the tree whose ownership was transferred into the iteration.
-    pub data: T,
+/// A chunk returned by `iter_root_chunks`, which can be iterated over to get [`Node`]s.
+pub struct Chunk<'a, T> {
+    inner: std::slice::IterMut<'a, Item<T>>,
+    children: *mut [Item<T>],
 }
 
-impl<'a, T> Node<'a, T>
-where
-    T: Default,
-{
-    /// Returns the offset into the pack at which the `Node`s data is located.
-    pub fn offset(&self) -> u64 {
-        #[allow(unsafe_code)]
-        // SAFETY: The index is valid as it was controlled by `add_child(…)`, then see `take_entry(…)`
-        unsafe {
-            self.tree.offset(self.index)
-        }
-    }
+// SAFETY: The raw pointer is uniquely materialized in `Node::into_child_iter`.
+#[allow(unsafe_code)]
+unsafe impl<'a, T> Send for Chunk<'a, T> {}
 
-    /// Returns the slice into the data pack at which the pack entry is located.
-    pub fn entry_slice(&self) -> pack::data::EntryRange {
-        #[allow(unsafe_code)]
-        // SAFETY: The index is valid as it was controlled by `add_child(…)`, then see `take_entry(…)`
-        unsafe {
-            self.tree.entry_slice(self.index)
-        }
-    }
+impl<'a, T> Iterator for Chunk<'a, T> {
+    type Item = Node<'a, T>;
 
-    /// Write potentially changed `Node` data back into the [`Tree`] and transform this `Node` into an iterator
-    /// over its `Node`s children.
-    ///
-    /// Children are `Node`s referring to pack entries whose base object is this pack entry.
-    pub fn store_changes_then_into_child_iter(self) -> impl Iterator<Item = Node<'a, T>> {
-        #[allow(unsafe_code)]
-        // SAFETY: The index is valid as it was controlled by `add_child(…)`, then see `take_entry(…)`
-        unsafe {
-            self.tree.put_data(self.index, self.data)
-        };
-        let Self { tree, children, .. } = self;
-        children.into_iter().map(move |index| {
-            // SAFETY: The index is valid as it was controlled by `add_child(…)`, then see `take_entry(…)`
-            #[allow(unsafe_code)]
-            let (data, children) = unsafe { tree.take_entry(index) };
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|item| {
             Node {
-                tree,
-                index,
-                children,
-                data,
+                item,
+                children: self.children,
             }
         })
     }
 }
 
-/// An iterator over chunks of [`Node`]s in a [`Tree`]
-pub struct Chunks<'a, T> {
-    tree: &'a Tree<T>,
-    chunk_size: usize,
-    cursor: usize,
+/// An item returned by `iter_root_chunks`, allowing access to the `data` stored alongside nodes in a [`Tree`].
+pub struct Node<'a, T> {
+    item: &'a mut Item<T>,
+    children: *mut [Item<T>],
 }
 
-impl<'a, T> Iterator for Chunks<'a, T>
-where
-    T: Default,
-{
-    type Item = Vec<Node<'a, T>>;
+impl<'a, T> Node<'a, T> {
+    /// Returns the offset into the pack at which the `Node`s data is located.
+    pub fn offset(&self) -> u64 {
+        self.item.offset
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.cursor == self.tree.one_past_last_seen_root {
-            return None;
-        }
-        let mut items_remaining = self.chunk_size;
-        let mut res = Vec::with_capacity(self.chunk_size);
+    /// Returns the slice into the data pack at which the pack entry is located.
+    pub fn entry_slice(&self) -> pack::data::EntryRange {
+        self.item.offset..self.item.next_offset
+    }
 
-        while items_remaining > 0 && self.cursor < self.tree.one_past_last_seen_root {
-            // SAFETY: The index is valid as the cursor cannot surpass the amount of items. `one_past_last_seen_root`
-            // is guaranteed to be self.tree.items.len() at most, or smaller.
-            // Then see `take_entry_if_root(…)`
+    /// Returns the node data associated with this node.
+    pub fn data(&mut self) -> &mut T {
+        &mut self.item.data
+    }
+
+    /// Transform this `Node` into an iterator over its children.
+    ///
+    /// Children are `Node`s referring to pack entries whose base object is this pack entry.
+    pub fn into_child_iter(self) -> impl Iterator<Item = Node<'a, T>> + 'a {
+        let children = self.children;
+        self.item.children.iter().map(move |&index| {
+            // SAFETY: The children array is alive by the 'a lifetime.
+            // SAFETY: The index is a valid index into the children array.
+            // SAFETY: The resulting mutable pointer cannot be yielded by any other node.
             #[allow(unsafe_code)]
-            if let Some((data, children)) = unsafe { self.tree.from_iter_take_entry_if_root(self.cursor) } {
-                res.push(Node {
-                    tree: self.tree,
-                    index: self.cursor,
-                    children,
-                    data,
-                });
-                items_remaining -= 1;
+            Node {
+                item: unsafe { &mut *(children as *mut Item<T>).add(index) },
+                children,
             }
-            self.cursor += 1;
-        }
-
-        if res.is_empty() {
-            None
-        } else {
-            Some(res)
-        }
+        })
     }
 }

--- a/git-odb/src/pack/tree/iter.rs
+++ b/git-odb/src/pack/tree/iter.rs
@@ -6,7 +6,7 @@ use crate::{
 /// Iteration
 impl<T> Tree<T> {
     /// Return an iterator over chunks of roots. Roots are not children themselves, they have no parents.
-    pub fn iter_root_chunks(&mut self, chunk_size: usize) -> impl Iterator<Item=Chunk<'_, T>> + '_ {
+    pub fn iter_root_chunks(&mut self, chunk_size: usize) -> impl Iterator<Item = Chunk<'_, T>> + '_ {
         let (front, back) = self.items.as_mut_slices();
         if front.len() != self.roots {
             // This should not happen unless we added more nodes than were declared in the
@@ -35,11 +35,9 @@ impl<'a, T> Iterator for Chunk<'a, T> {
     type Item = Node<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|item| {
-            Node {
-                item,
-                children: self.children,
-            }
+        self.inner.next().map(|item| Node {
+            item,
+            children: self.children,
         })
     }
 }

--- a/git-odb/src/pack/tree/mod.rs
+++ b/git-odb/src/pack/tree/mod.rs
@@ -1,4 +1,4 @@
-use std::cell::UnsafeCell;
+use std::collections::VecDeque;
 
 /// Returned when using various methods on a [`Tree`]
 #[derive(thiserror::Error, Debug)]
@@ -23,7 +23,7 @@ pub enum Error {
 }
 
 mod iter;
-pub use iter::{Chunks, Node};
+pub use iter::{Chunk, Node};
 ///
 pub mod traverse;
 
@@ -34,26 +34,21 @@ pub mod from_offsets;
 pub struct Item<T> {
     /// The offset into the pack file at which the pack entry's data is located.
     pub offset: u64,
-    /// If true, this object may have children but is not a child itself. It's thus the root of a tree.
-    is_root: bool,
+    /// The offset of the next item in the pack file.
+    pub next_offset: u64,
     /// Data to store with each Item, effectively data associated with each entry in a pack.
     pub data: T,
     children: Vec<usize>,
 }
 /// A tree that allows one-time iteration over all nodes and their children, consuming it in the process,
 /// while being shareable among threads without a lock.
-/// It does this by making the run-time guarantee that iteration only happens once.
+/// It does this by making the guarantee that iteration only happens once.
 pub struct Tree<T> {
-    items: UnsafeCell<Vec<Item<T>>>,
-    last_added_offset: u64,
-    one_past_last_seen_root: usize,
-    pack_entries_end: Option<u64>,
+    /// Roots are first, then children.
+    items: VecDeque<Item<T>>,
+    roots: usize,
+    last_index: usize,
 }
-
-/// SAFETY: We solemnly swear…that this is sync because without the unsafe cell, it is also sync.
-/// But that's really the only reason why I would dare to know.
-#[allow(unsafe_code)]
-unsafe impl<T> Sync for Tree<T> {}
 
 impl<T> Tree<T> {
     /// Instantiate a empty tree capable of storing `num_objects` amounts of items.
@@ -62,69 +57,79 @@ impl<T> Tree<T> {
             return Err(Error::InvariantNonEmpty);
         }
         Ok(Tree {
-            items: UnsafeCell::new(Vec::with_capacity(num_objects)),
-            last_added_offset: 0,
-            one_past_last_seen_root: 0,
-            pack_entries_end: None,
+            items: VecDeque::with_capacity(num_objects),
+            roots: 0,
+            last_index: 0,
         })
     }
 
-    fn assert_is_incrementing(&mut self, offset: u64) -> Result<u64, Error> {
-        if offset > self.last_added_offset {
-            self.last_added_offset = offset;
-            Ok(offset)
-        } else {
-            Err(Error::InvariantIncreasingPackOffset {
-                last_pack_offset: self.last_added_offset,
+    fn assert_is_incrementing(&mut self, offset: u64) -> Result<(), Error> {
+        if self.items.is_empty() {
+            return Ok(());
+        }
+        let last_offset = self.items[self.last_index].offset;
+        if offset <= last_offset {
+            return Err(Error::InvariantIncreasingPackOffset {
+                last_pack_offset: last_offset,
                 pack_offset: offset,
-            })
+            });
+        }
+        self.items[self.last_index].next_offset = offset;
+        Ok(())
+    }
+
+    fn set_pack_entries_end(&mut self, pack_entries_end: u64) {
+        if !self.items.is_empty() {
+            self.items[self.last_index].next_offset = pack_entries_end;
         }
     }
 
     /// Add a new root node, one that only has children but is not a child itself, at the given pack `offset` and associate
     /// custom `data` with it.
     pub fn add_root(&mut self, offset: u64, data: T) -> Result<(), Error> {
-        // SAFETY: Because we passed the assertion above which implies no other access is possible as per
-        // standard borrow check rules.
-        #[allow(unsafe_code)]
-        let items = unsafe { &mut *(self.items.get()) };
-        let offset = self.assert_is_incrementing(offset)?;
-        items.push(Item {
+        self.assert_is_incrementing(offset)?;
+        self.last_index = 0;
+        self.items.push_front(Item {
             offset,
+            next_offset: 0,
             data,
-            is_root: true,
-            children: Default::default(),
+            children: Vec::new(),
         });
-        self.one_past_last_seen_root = items.len();
+        self.roots += 1;
         Ok(())
     }
 
     /// Add a child of the item at `base_offset` which itself resides at pack `offset` and associate custom `data` with it.
     pub fn add_child(&mut self, base_offset: u64, offset: u64, data: T) -> Result<(), Error> {
-        // SAFETY: Because we passed the assertion above which implies no other access is possible as per
-        // standard borrow check rules.
-        #[allow(unsafe_code)]
-        let items = unsafe { &mut *(self.items.get()) };
-        let offset = self.assert_is_incrementing(offset)?;
-        let base_index = items.binary_search_by_key(&base_offset, |e| e.offset).map_err(|_| {
-            Error::InvariantBasesBeforeDeltasNeedThem {
+        self.assert_is_incrementing(offset)?;
+        let (roots, children) = self.items.as_mut_slices();
+        if roots.len() != self.roots {
+            // This should not happen unless we added more nodes than were declared in the
+            // constructor.
+            panic!("item deque has been resized");
+        }
+        if let Ok(i) = children.binary_search_by_key(&base_offset, |i| i.offset) {
+            children[i].children.push(children.len());
+        } else if let Ok(i) = roots.binary_search_by(|i| base_offset.cmp(&i.offset)) {
+            roots[i].children.push(children.len());
+        } else {
+            return Err(Error::InvariantBasesBeforeDeltasNeedThem {
                 delta_pack_offset: offset,
                 base_pack_offset: base_offset,
-            }
-        })?;
-        let child_index = items.len();
-        items[base_index].children.push(child_index);
-        items.push(Item {
-            is_root: false,
+            });
+        }
+        self.last_index = self.items.len();
+        self.items.push_back(Item {
             offset,
+            next_offset: 0,
             data,
-            children: Default::default(),
+            children: Vec::new(),
         });
         Ok(())
     }
 
     /// Transform this `Tree` into its items.
-    pub fn into_items(self) -> Vec<Item<T>> {
-        self.items.into_inner()
+    pub fn into_items(self) -> VecDeque<Item<T>> {
+        self.items
     }
 }

--- a/git-odb/src/pack/tree/traverse/mod.rs
+++ b/git-odb/src/pack/tree/traverse/mod.rs
@@ -123,9 +123,7 @@ where
     P: Progress,
 {
     pub fn new(num_objects: usize, progress: &'a parking_lot::Mutex<P>, mut size_progress: P) -> Self {
-        progress
-            .lock()
-            .init(Some(num_objects), progress::count("objects"));
+        progress.lock().init(Some(num_objects), progress::count("objects"));
         size_progress.init(None, progress::bytes());
         Reducer {
             item_count: 0,

--- a/git-odb/src/pack/tree/traverse/resolve.rs
+++ b/git-odb/src/pack/tree/traverse/resolve.rs
@@ -6,7 +6,7 @@ use git_features::progress::{unit, Progress};
 use std::{cell::RefCell, collections::BTreeMap};
 
 pub(crate) fn deltas<T, F, P, MBFN, S, E>(
-    nodes: Vec<pack::tree::Node<'_, T>>,
+    nodes: pack::tree::Chunk<'_, T>,
     (bytes_buf, ref mut progress, state): &mut (Vec<u8>, P, S),
     resolve: F,
     modify_base: MBFN,
@@ -57,7 +57,7 @@ where
         };
 
         modify_base(
-            &mut base.data,
+            base.data(),
             progress,
             Context {
                 entry: &base_entry,
@@ -71,7 +71,7 @@ where
         num_objects += 1;
         decompressed_bytes += base_bytes.len() as u64;
         progress.inc();
-        for child in base.store_changes_then_into_child_iter() {
+        for child in base.into_child_iter() {
             let (mut child_entry, entry_end, delta_bytes) = decompress_from_resolver(child.entry_slice())?;
             let (base_size, consumed) = pack::data::delta::decode_header_size(&delta_bytes);
             let mut header_ofs = consumed;


### PR DESCRIPTION
The resulting code is significantly shorter and doesn't invoke UB[*]. An interesting side-effect is that we now process the roots in reverse order, which on my benchmark is a ~10% performance improvement due to processing blobs (which tend to be large and slow) first instead of last.

[*] The old code materialized the `Vec<Item<T>>` as a `&mut`, which is a big nono. Instant UB. Gotta stay in raw pointer space until you have an actually unique pointer.