### PR TITLE
Support pruning subgraphs from ancestor traversal.

### DIFF
--- a/git-traverse/src/commit.rs
+++ b/git-traverse/src/commit.rs
@@ -1,5 +1,6 @@
 ///
 pub mod ancestors {
+    use crate::commit::ancestors::predicates::AlwaysTrue;
     use git_hash::{oid, ObjectId};
     use git_object::immutable;
     use quick_error::quick_error;
@@ -41,12 +42,13 @@ pub mod ancestors {
     }
 
     /// An iterator over the ancestors one or more starting commits
-    pub struct Ancestors<Find, StateMut> {
+    pub struct Ancestors<Find, Predicate, StateMut> {
         find: Find,
+        predicate: Predicate,
         state: StateMut,
     }
 
-    impl<Find, StateMut> Ancestors<Find, StateMut>
+    impl<Find, StateMut> Ancestors<Find, predicates::AlwaysTrue, StateMut>
     where
         Find: for<'a> FnMut(&oid, &'a mut Vec<u8>) -> Option<immutable::CommitIter<'a>>,
         StateMut: BorrowMut<State>,
@@ -63,20 +65,76 @@ pub mod ancestors {
         /// * `tips`
         ///   * the starting points of the iteration, usually commits
         ///   * each commit they lead to will only be returned once, including the tip that started it
-        pub fn new(tips: impl IntoIterator<Item = impl Into<ObjectId>>, mut state: StateMut, find: Find) -> Self {
-            {
-                let state = state.borrow_mut();
-                state.clear();
-                state.next.extend(tips.into_iter().map(Into::into));
-                state.seen.extend(state.next.iter().cloned());
-            }
-            Ancestors { find, state }
+        pub fn new(tips: impl IntoIterator<Item = impl Into<ObjectId>>, state: StateMut, find: Find) -> Self {
+            Self::filtered_inner(tips, state, find, AlwaysTrue {})
         }
     }
 
-    impl<Find, StateMut> Iterator for Ancestors<Find, StateMut>
+    impl<Find, Predicate, StateMut> Ancestors<Find, predicates::FnMutWrapper<Predicate>, StateMut>
     where
         Find: for<'a> FnMut(&oid, &'a mut Vec<u8>) -> Option<immutable::CommitIter<'a>>,
+        Predicate: FnMut(&oid) -> bool,
+        StateMut: BorrowMut<State>,
+    {
+        /// Create a new instance with commit filtering enabled.
+        ///
+        /// * `find` - a way to lookup new object data during traversal by their ObjectId, writing their data into buffer and returning
+        ///    an iterator over commit tokens if the object is present and is a commit. Caching should be implemented within this function
+        ///    as needed. The return value is `Option<CommitIter>` which degenerates all error information. Not finding a commit should also
+        ///    be considered an errors as all objects in the commit graph should be present in the database. Hence [`Error::NotFound`] should
+        ///    be escalated into a more specific error if its encountered by the caller.
+        /// * `state` - all state used for the traversal. If multiple traversals are performed, allocations can be minimized by reusing
+        ///   this state.
+        /// * `tips`
+        ///   * the starting points of the iteration, usually commits
+        ///   * each commit they lead to will only be returned once, including the tip that started it
+        /// * `predicate` - indicate whether a given commit should be included in the result as well
+        ///   as whether its parent commits should be traversed.
+        pub fn filtered(
+            tips: impl IntoIterator<Item = impl Into<ObjectId>>,
+            state: StateMut,
+            find: Find,
+            predicate: Predicate,
+        ) -> Self
+        where
+            Predicate: FnMut(&oid) -> bool,
+        {
+            Self::filtered_inner(tips, state, find, predicates::FnMutWrapper { predicate })
+        }
+    }
+
+    impl<Find, Predicate, StateMut> Ancestors<Find, Predicate, StateMut>
+    where
+        Find: for<'a> FnMut(&oid, &'a mut Vec<u8>) -> Option<immutable::CommitIter<'a>>,
+        Predicate: predicates::OidPredicate,
+        StateMut: BorrowMut<State>,
+    {
+        fn filtered_inner(
+            tips: impl IntoIterator<Item = impl Into<ObjectId>>,
+            mut state: StateMut,
+            find: Find,
+            mut predicate: Predicate,
+        ) -> Self {
+            let tips = tips.into_iter();
+            {
+                let state = state.borrow_mut();
+                state.clear();
+                state.next.reserve(tips.size_hint().0);
+                for tip in tips.map(Into::into) {
+                    let was_inserted = state.seen.insert(tip);
+                    if was_inserted && predicate.call_mut(&tip) {
+                        state.next.push_back(tip);
+                    }
+                }
+            }
+            Self { find, predicate, state }
+        }
+    }
+
+    impl<Find, Predicate, StateMut> Iterator for Ancestors<Find, Predicate, StateMut>
+    where
+        Find: for<'a> FnMut(&oid, &'a mut Vec<u8>) -> Option<immutable::CommitIter<'a>>,
+        Predicate: predicates::OidPredicate,
         StateMut: BorrowMut<State>,
     {
         type Item = Result<ObjectId, Error>;
@@ -94,7 +152,7 @@ pub mod ancestors {
                             match token {
                                 Ok(immutable::commit::iter::Token::Parent { id }) => {
                                     let was_inserted = state.seen.insert(id);
-                                    if was_inserted {
+                                    if was_inserted && self.predicate.call_mut(&id) {
                                         state.next.push_back(id);
                                     }
                                 }
@@ -107,6 +165,63 @@ pub mod ancestors {
                 }
             }
             res.map(Ok)
+        }
+    }
+
+    mod predicates {
+        use super::*;
+
+        /// `FnMut`-like trait used for pruning commit subgraphs from the ancestors iterator.
+        ///
+        /// This trait only exists because:
+        /// 1. Predicate usage should be optional.
+        ///    The user should opt-in to using predicates via an alternate constructor or via the
+        ///    builder pattern.
+        /// 2. The default case (include all ancestors) should not increase the size of the
+        ///    [`Ancestors`] struct, nor should it require extra branches at runtime.
+        ///    So don't use boxed closures, `Option<impl FnMut...>`, or `fn(&oid) -> bool`.
+        ///    Instead, use a zero-sized type ([`AlwaysTrue`]) to handle the default case.
+        /// 3. Directly implementing `FnMut` is not yet supported in stable Rust.
+        /// 4. I could not get the compiler to accept [`Ancestors::new`] using a closure or static
+        ///    function as the default predicate. I don't think this is possible without using
+        ///    something like `typeof!(always_true)` (where `always_true` is a static function) as a
+        ///    type parameter.
+        pub trait OidPredicate {
+            /// Indicate whether the given commit and its parents should be visited by the
+            /// [`Ancestors`] iterator.
+            ///
+            /// Even if this method returns `false`, the commit's ancestors may still be visited if
+            /// they are reachable from another commit for which this method returns `true`.
+            /// If you still want to exclude those ancestors, then this method should also return
+            /// `false` for those ancestor commits.
+            fn call_mut(&mut self, oid: &oid) -> bool;
+        }
+
+        /// Default behavior to include all ancestor commits in the [`Ancestors`] iterator.
+        pub struct AlwaysTrue;
+
+        impl OidPredicate for AlwaysTrue {
+            #[inline(always)]
+            fn call_mut(&mut self, _: &oid) -> bool {
+                true
+            }
+        }
+
+        pub struct FnMutWrapper<P>
+        where
+            P: FnMut(&oid) -> bool,
+        {
+            pub predicate: P,
+        }
+
+        impl<P> OidPredicate for FnMutWrapper<P>
+        where
+            P: FnMut(&oid) -> bool,
+        {
+            #[inline(always)]
+            fn call_mut(&mut self, oid: &oid) -> bool {
+                (self.predicate)(oid)
+            }
         }
     }
 }

--- a/git-traverse/tests/commit/mod.rs
+++ b/git-traverse/tests/commit/mod.rs
@@ -1,6 +1,6 @@
 mod ancestor {
     use crate::hex_to_id;
-    use git_hash::ObjectId;
+    use git_hash::{oid, ObjectId};
     use git_odb::{linked::Db, pack, FindExt};
     use git_traverse::commit;
 
@@ -8,6 +8,34 @@ mod ancestor {
         let dir = git_testtools::scripted_fixture_repo_read_only("make_traversal_repo_for_commits.sh")?;
         let db = Db::at(dir.join(".git").join("objects"))?;
         Ok(db)
+    }
+
+    fn filtered_iter(
+        tips: impl IntoIterator<Item = impl Into<ObjectId>>,
+        predicate: impl FnMut(&oid) -> bool,
+    ) -> impl Iterator<Item = Result<ObjectId, commit::ancestors::Error>> {
+        let db = db().expect("db instantiation works as its definitely valid");
+        commit::Ancestors::filtered(
+            tips,
+            commit::ancestors::State::default(),
+            move |oid, buf| db.find_existing_commit_iter(oid, buf, &mut pack::cache::Never).ok(),
+            predicate,
+        )
+    }
+
+    fn check_filtered_traversal_with_shared_reference(
+        tips: &[&str],
+        expected: &[&str],
+        predicate: impl FnMut(&oid) -> bool,
+    ) -> crate::Result {
+        let tips: Vec<_> = tips.iter().copied().map(hex_to_id).collect();
+        let oids: Result<Vec<_>, _> = filtered_iter(tips.iter().cloned(), predicate).collect();
+        let expected: Vec<_> = tips
+            .into_iter()
+            .chain(expected.iter().map(|hex_id| hex_to_id(hex_id)))
+            .collect();
+        assert_eq!(oids?, expected);
+        Ok(())
     }
 
     fn new_iter(
@@ -85,6 +113,50 @@ mod ancestor {
                 "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7",
                 "134385f6d781b7e97062102c6a483440bfda2a03",
             ],
+        )
+    }
+
+    #[test]
+    fn filtered_commit_does_not_block_ancestors_reachable_from_another_commit() -> crate::Result {
+        // I don't see a use case for the predicate returning false for a commit but return true for
+        // at least one of its ancestors, so this test is kind of dubious. But we do want
+        // `Ancestors` to not eagerly blacklist all of a commit's ancestors when blacklisting that
+        // one commit, and this test happens to check that.
+        check_filtered_traversal_with_shared_reference(
+            &["01ec18a3ebf2855708ad3c9d244306bc1fae3e9b"],
+            &[
+                "efd9a841189668f1bab5b8ebade9cd0a1b139a37",
+                "ce2e8ffaa9608a26f7b21afc1db89cadb54fd353",
+                "9556057aee5abb06912922e9f26c46386a816822",
+                "17d78c64cef6c33a10a604573fd2c429e477fd63",
+                "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7",
+                "134385f6d781b7e97062102c6a483440bfda2a03",
+            ],
+            |id| id != hex_to_id("9152eeee2328073cf23dcf8e90c949170b711659"),
+        )
+    }
+
+    #[test]
+    fn predicate_only_called_once_even_if_fork_point() -> crate::Result {
+        // The `self.seen` check should come before the `self.predicate` check, as we don't know how
+        // expensive calling `self.predicate` may be.
+        let mut seen = false;
+        check_filtered_traversal_with_shared_reference(
+            &["01ec18a3ebf2855708ad3c9d244306bc1fae3e9b"],
+            &[
+                "efd9a841189668f1bab5b8ebade9cd0a1b139a37",
+                "ce2e8ffaa9608a26f7b21afc1db89cadb54fd353",
+                "9152eeee2328073cf23dcf8e90c949170b711659",
+            ],
+            move |id| {
+                if id == hex_to_id("9556057aee5abb06912922e9f26c46386a816822") {
+                    assert_eq!(seen, false);
+                    seen = true;
+                    false
+                } else {
+                    true
+                }
+            },
         )
     }
 }


### PR DESCRIPTION
This is meant to allow an upcoming `commit-graph write` command use the
existing traversal code to find new commits that haven't already been
indexed in an existing commit graph file.

It may also be useful for incremental pack generation.

I'm not exactly happy with the whole `OidPredicate` business, but I couldn't think of a better way.