### PR TITLE
Make negotiation fallible

### DIFF
--- a/git-protocol/src/fetch/function.rs
+++ b/git-protocol/src/fetch/function.rs
@@ -164,7 +164,7 @@ where
         progress.step();
         progress.set_name(format!("negotiate (round {})", round));
         round += 1;
-        let action = delegate.negotiate(&parsed_refs, &mut arguments, previous_response.as_ref());
+        let action = delegate.negotiate(&parsed_refs, &mut arguments, previous_response.as_ref())?;
         let mut reader = arguments.send(&mut transport, action == Action::Cancel).await?;
         if sideband_all {
             setup_remote_progress(&mut progress, &mut reader);

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -55,7 +55,12 @@ impl<W> protocol::fetch::DelegateBlocking for CloneDelegate<W> {
         Action::Continue
     }
 
-    fn negotiate(&mut self, refs: &[Ref], arguments: &mut Arguments, _previous: Option<&Response>) -> Action {
+    fn negotiate(
+        &mut self,
+        refs: &[Ref],
+        arguments: &mut Arguments,
+        _previous: Option<&Response>,
+    ) -> io::Result<Action> {
         for r in refs {
             let (path, id) = r.unpack();
             match self.ref_filter {
@@ -67,7 +72,7 @@ impl<W> protocol::fetch::DelegateBlocking for CloneDelegate<W> {
                 None => arguments.want(id),
             }
         }
-        Action::Cancel
+        Ok(Action::Cancel)
     }
 }
 

--- a/gitoxide-core/src/remote.rs
+++ b/gitoxide-core/src/remote.rs
@@ -34,7 +34,7 @@ pub mod refs {
             _refs: &[Ref],
             _arguments: &mut Arguments,
             _previous_result: Option<&Response>,
-        ) -> Action {
+        ) -> io::Result<Action> {
             unreachable!("not to be called due to Action::Close in `prepare_fetch`")
         }
     }


### PR DESCRIPTION
 Packfile negotiation needs to access the odb in order to figure out `have`s, which can fail.
