### PR TITLE
rustfmt: Reformat imports and module declarations more aggressively.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,5 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
 max_width = 120
+reorder_imports = true
+reorder_modules = true


### PR DESCRIPTION
This requires rustup nightly.


This is more of a "run it up the flagpole" PR, but it fits how I would like to organize `git-commitgraph` at least.