### PR TITLE
Add `make rustfmt` target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,3 +282,7 @@ force-update-assets: ## As update-assets, but will run git to update the baselin
 
 check-size: ## Run cargo-diet on all crates to see that they are still in bound
 	./etc/check-package-size.sh
+
+rustfmt: ## run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
+	cargo +nightly fmt --all -- --config-path rustfmt-nightly.toml
+	cargo +stable fmt --all -- --check

--- a/rustfmt-nightly.toml
+++ b/rustfmt-nightly.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+max_width = 120


### PR DESCRIPTION
This is intended to be run on occasion to let us take advantage of
rustfmt features available only in nightly while not requiring all
contributors and CI to use nightly rustfmt.

If the output of nightly rustfmt is not accepted by stable rustfmt, then
the recipe will intentionally fail. For now, we prefer to detect when
the two versions disagree on formatting rather than let nightly and
stable rustfmt stomp on each other.

Replaces #156.