### PR TITLE
Apply nightly rustfmt rules.

### DIFF
--- a/cargo-smart-release/src/command/release/cargo.rs
+++ b/cargo-smart-release/src/command/release/cargo.rs
@@ -1,7 +1,9 @@
-use super::{utils::will, Options};
+use std::process::Command;
+
 use anyhow::bail;
 use cargo_metadata::Package;
-use std::process::Command;
+
+use super::{utils::will, Options};
 
 pub(in crate::command::release_impl) fn publish_crate(
     publishee: &Package,

--- a/cargo-smart-release/src/command/release/git.rs
+++ b/cargo-smart-release/src/command/release/git.rs
@@ -1,6 +1,5 @@
-use super::{Context, Options};
-use crate::command::release_impl::tag_name_for;
-use crate::command::release_impl::utils::will;
+use std::{convert::TryInto, process::Command};
+
 use anyhow::{anyhow, bail};
 use bstr::ByteSlice;
 use cargo_metadata::{
@@ -20,7 +19,9 @@ use git_repository::{
     },
     Repository,
 };
-use std::{convert::TryInto, process::Command};
+
+use super::{Context, Options};
+use crate::command::release_impl::{tag_name_for, utils::will};
 
 pub(in crate::command::release_impl) fn has_changed_since_last_release(
     package: &Package,

--- a/cargo-smart-release/src/command/release/manifest.rs
+++ b/cargo-smart-release/src/command/release/manifest.rs
@@ -1,13 +1,15 @@
+use std::{collections::BTreeMap, str::FromStr};
+
+use anyhow::bail;
+use cargo_metadata::{Metadata, Package};
+use git_repository::hash::ObjectId;
+use semver::{Op, Version, VersionReq};
+
 use super::{
     cargo, git,
     utils::{names_and_versions, package_by_id, package_eq_dependency},
     Context, Options,
 };
-use anyhow::bail;
-use cargo_metadata::{Metadata, Package};
-use git_repository::hash::ObjectId;
-use semver::{Op, Version, VersionReq};
-use std::{collections::BTreeMap, str::FromStr};
 
 pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates(
     meta: &Metadata,

--- a/cargo-smart-release/src/command/release/mod.rs
+++ b/cargo-smart-release/src/command/release/mod.rs
@@ -1,8 +1,10 @@
-use crate::command::release::Options;
+use std::collections::BTreeSet;
+
 use anyhow::bail;
 use cargo_metadata::{camino::Utf8PathBuf, Dependency, DependencyKind, Metadata, Package, Version};
 use git_repository::{refs::packed, Repository};
-use std::collections::BTreeSet;
+
+use crate::command::release::Options;
 
 mod utils;
 use crates_index::Index;

--- a/experiments/diffing/src/main.rs
+++ b/experiments/diffing/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use anyhow::anyhow;
 use diff::tree::visit::{Action, Change};
 use git_repository::{
@@ -10,7 +12,6 @@ use git_repository::{
     refs::file::loose::reference::peel,
 };
 use rayon::prelude::*;
-use std::time::Instant;
 
 const GITOXIDE_CACHED_OBJECT_DATA_PER_THREAD_IN_BYTES: usize = 60_000_000;
 

--- a/experiments/hash-owned-borrowed/benches/usage.rs
+++ b/experiments/hash-owned-borrowed/benches/usage.rs
@@ -1,5 +1,6 @@
-use criterion::*;
 use std::borrow::Borrow;
+
+use criterion::*;
 
 fn use_owned_by_ref(id: &hash::Owned) {
     black_box(id);

--- a/experiments/object-access/src/main.rs
+++ b/experiments/object-access/src/main.rs
@@ -1,6 +1,7 @@
+use std::{path::Path, time::Instant};
+
 use anyhow::anyhow;
 use git_repository::{hash::ObjectId, odb, prelude::*, Repository};
-use std::{path::Path, time::Instant};
 
 const GITOXIDE_STATIC_CACHE_SIZE: usize = 64;
 const GITOXIDE_CACHED_OBJECT_DATA_PER_THREAD_IN_BYTES: usize = 60_000_000;

--- a/experiments/traversal/src/main.rs
+++ b/experiments/traversal/src/main.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
+
 use anyhow::anyhow;
 use dashmap::DashSet;
 use git_repository::{
@@ -7,10 +12,6 @@ use git_repository::{
     prelude::*,
     refs::file::loose::reference::peel,
     traverse::{tree, tree::visit::Action},
-};
-use std::{
-    collections::HashSet,
-    time::{Duration, Instant},
 };
 
 const GITOXIDE_STATIC_CACHE_SIZE: usize = 64;

--- a/git-actor/src/immutable/mod.rs
+++ b/git-actor/src/immutable/mod.rs
@@ -1,6 +1,7 @@
 //!
-use crate::Time;
 use bstr::BStr;
+
+use crate::Time;
 
 /// A signature is created by an actor at a certain time.
 ///

--- a/git-actor/src/immutable/signature.rs
+++ b/git-actor/src/immutable/signature.rs
@@ -1,8 +1,6 @@
 mod decode {
-    use btoi::btoi;
-
-    use crate::{immutable::Signature, Sign, Time};
     use bstr::ByteSlice;
+    use btoi::btoi;
     use nom::{
         branch::alt,
         bytes::complete::{tag, take, take_until, take_while_m_n},
@@ -11,6 +9,8 @@ mod decode {
         sequence::{terminated, tuple},
         IResult,
     };
+
+    use crate::{immutable::Signature, Sign, Time};
 
     const SPACE: &[u8] = b" ";
 
@@ -65,10 +65,14 @@ mod decode {
     #[cfg(test)]
     mod tests {
         mod parse_signature {
-            use crate::{immutable::signature, immutable::Signature, Sign, Time};
             use bstr::ByteSlice;
             use git_testtools::to_bstr_err;
             use nom::IResult;
+
+            use crate::{
+                immutable::{signature, Signature},
+                Sign, Time,
+            };
 
             fn decode(i: &[u8]) -> IResult<&[u8], Signature<'_>, nom::error::VerboseError<&[u8]>> {
                 signature::decode(i)

--- a/git-actor/src/signature.rs
+++ b/git-actor/src/signature.rs
@@ -14,10 +14,12 @@ mod convert {
 }
 
 mod write {
-    use crate::{Signature, SPACE};
+    use std::io;
+
     use bstr::{BStr, ByteSlice};
     use quick_error::quick_error;
-    use std::io;
+
+    use crate::{Signature, SPACE};
 
     quick_error! {
         /// The Error produced by [`Signature::write_to()`].

--- a/git-actor/src/types.rs
+++ b/git-actor/src/types.rs
@@ -1,5 +1,6 @@
-use crate::{Sign, Signature, Time, SPACE};
 use std::io;
+
+use crate::{Sign, Signature, Time, SPACE};
 
 impl Signature {
     /// An empty signature, similar to 'null'.

--- a/git-commitgraph/src/file/access.rs
+++ b/git-commitgraph/src/file/access.rs
@@ -1,10 +1,12 @@
-use crate::file::{self, commit::Commit, File, COMMIT_DATA_ENTRY_SIZE};
-use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 use std::{
     convert::TryInto,
     fmt::{Debug, Formatter},
     path::Path,
 };
+
+use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
+
+use crate::file::{self, commit::Commit, File, COMMIT_DATA_ENTRY_SIZE};
 
 /// Access
 impl File {

--- a/git-commitgraph/src/file/commit.rs
+++ b/git-commitgraph/src/file/commit.rs
@@ -1,14 +1,16 @@
 //! Low-level operations on individual commits.
-use crate::{
-    file::{self, File},
-    graph,
-};
-use byteorder::{BigEndian, ByteOrder};
-use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 use std::{
     convert::TryInto,
     fmt::{Debug, Formatter},
     slice::Chunks,
+};
+
+use byteorder::{BigEndian, ByteOrder};
+use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
+
+use crate::{
+    file::{self, File},
+    graph,
 };
 
 /// The error used in the [`file::commit`][self] module.

--- a/git-commitgraph/src/file/init.rs
+++ b/git-commitgraph/src/file/init.rs
@@ -1,13 +1,15 @@
-use crate::file::{File, COMMIT_DATA_ENTRY_SIZE, FAN_LEN, SIGNATURE};
-use bstr::ByteSlice;
-use byteorder::{BigEndian, ByteOrder};
-use filebuffer::FileBuffer;
-use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 use std::{
     convert::{TryFrom, TryInto},
     ops::Range,
     path::Path,
 };
+
+use bstr::ByteSlice;
+use byteorder::{BigEndian, ByteOrder};
+use filebuffer::FileBuffer;
+use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
+
+use crate::file::{File, COMMIT_DATA_ENTRY_SIZE, FAN_LEN, SIGNATURE};
 
 type ChunkId = [u8; 4];
 

--- a/git-commitgraph/src/file/mod.rs
+++ b/git-commitgraph/src/file/mod.rs
@@ -8,15 +8,15 @@ pub use commit::Commit;
 mod init;
 pub mod verify;
 
-pub use init::Error;
-
-use filebuffer::FileBuffer;
-use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 use std::{
     fmt::{Display, Formatter},
     ops::Range,
     path::PathBuf,
 };
+
+use filebuffer::FileBuffer;
+use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
+pub use init::Error;
 
 const COMMIT_DATA_ENTRY_SIZE: usize = SHA1_SIZE + 16;
 const FAN_LEN: usize = 256;

--- a/git-commitgraph/src/file/verify.rs
+++ b/git-commitgraph/src/file/verify.rs
@@ -1,14 +1,16 @@
 //! Auxiliary types used in commit graph file verification methods.
-use crate::{
-    file::{self, File},
-    GENERATION_NUMBER_INFINITY, GENERATION_NUMBER_MAX,
-};
-use bstr::ByteSlice;
-use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 use std::{
     cmp::{max, min},
     collections::HashMap,
     path::Path,
+};
+
+use bstr::ByteSlice;
+use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
+
+use crate::{
+    file::{self, File},
+    GENERATION_NUMBER_INFINITY, GENERATION_NUMBER_MAX,
 };
 
 /// The error used in [`File::traverse()`].

--- a/git-commitgraph/src/graph/init.rs
+++ b/git-commitgraph/src/graph/init.rs
@@ -1,11 +1,12 @@
-use crate::{
-    file::{self, File},
-    Graph, MAX_COMMITS,
-};
 use std::{
     convert::TryFrom,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
+};
+
+use crate::{
+    file::{self, File},
+    Graph, MAX_COMMITS,
 };
 
 /// The error used in the [`graph`][crate::graph] module.

--- a/git-commitgraph/src/graph/mod.rs
+++ b/git-commitgraph/src/graph/mod.rs
@@ -3,8 +3,9 @@ mod access;
 mod init;
 pub mod verify;
 
-use crate::file::File;
 use std::fmt;
+
+use crate::file::File;
 
 /// A complete commit graph.
 ///

--- a/git-commitgraph/src/graph/verify.rs
+++ b/git-commitgraph/src/graph/verify.rs
@@ -1,13 +1,14 @@
 //! Auxiliary types used by graph verification methods.
-use crate::{
-    file::{self, commit},
-    graph, Graph, GENERATION_NUMBER_MAX,
-};
 use std::{
     cmp::{max, min},
     collections::BTreeMap,
     convert::TryInto,
     path::PathBuf,
+};
+
+use crate::{
+    file::{self, commit},
+    graph, Graph, GENERATION_NUMBER_MAX,
 };
 
 /// The error used in [`verify_integrity()`][Graph::verify_integrity].

--- a/git-commitgraph/tests/access/mod.rs
+++ b/git-commitgraph/tests/access/mod.rs
@@ -1,5 +1,6 @@
-use crate::{check_common, inspect_refs, make_readonly_repo};
 use git_commitgraph::Graph;
+
+use crate::{check_common, inspect_refs, make_readonly_repo};
 
 #[test]
 fn single_parent() -> crate::Result {

--- a/git-commitgraph/tests/commitgraph.rs
+++ b/git-commitgraph/tests/commitgraph.rs
@@ -1,4 +1,3 @@
-use git_commitgraph::{graph::Position as GraphPosition, Graph};
 use std::{
     collections::{HashMap, HashSet},
     convert::{TryFrom, TryInto},
@@ -7,6 +6,8 @@ use std::{
     path::Path,
     process::Command,
 };
+
+use git_commitgraph::{graph::Position as GraphPosition, Graph};
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 

--- a/git-diff/src/tree/changes.rs
+++ b/git-diff/src/tree/changes.rs
@@ -1,11 +1,13 @@
+use std::{borrow::BorrowMut, collections::VecDeque};
+
+use git_hash::{oid, ObjectId};
+use git_object::immutable;
+use quick_error::quick_error;
+
 use crate::{
     tree,
     tree::{visit::Change, TreeInfoPair},
 };
-use git_hash::{oid, ObjectId};
-use git_object::immutable;
-use quick_error::quick_error;
-use std::{borrow::BorrowMut, collections::VecDeque};
 
 quick_error! {
     /// The error returned by [tree::Changes::needed_to_obtain()].

--- a/git-diff/src/tree/mod.rs
+++ b/git-diff/src/tree/mod.rs
@@ -1,6 +1,7 @@
+use std::collections::VecDeque;
+
 use git_hash::ObjectId;
 use git_object::immutable;
-use std::collections::VecDeque;
 
 /// The state required to visit [Changes] to be instantiated with `State::default()`.
 #[derive(Default, Clone)]

--- a/git-diff/src/tree/recorder.rs
+++ b/git-diff/src/tree/recorder.rs
@@ -1,10 +1,12 @@
-use crate::tree::visit;
+use std::collections::{BTreeMap, VecDeque};
+
 use git_hash::ObjectId;
 use git_object::{
     bstr::{BStr, BString, ByteSlice, ByteVec},
     tree,
 };
-use std::collections::{BTreeMap, VecDeque};
+
+use crate::tree::visit;
 
 /// A Change as observed by a call to [`visit(…)`][visit::Visit::visit()], enhanced with the path affected by the change.
 /// Its similar to [visit::Change] but includes the path that changed.

--- a/git-diff/tests/visit/mod.rs
+++ b/git-diff/tests/visit/mod.rs
@@ -3,8 +3,7 @@ mod changes {
         use git_diff::tree::{recorder, recorder::Change::*};
         use git_hash::{oid, ObjectId};
         use git_object::{bstr::ByteSlice, immutable, tree::EntryMode};
-        use git_odb::linked;
-        use git_odb::{pack, Find};
+        use git_odb::{linked, pack, Find};
 
         use crate::hex_to_id;
 

--- a/git-features/src/fs.rs
+++ b/git-features/src/fs.rs
@@ -9,8 +9,9 @@
 #[cfg(feature = "parallel")]
 ///
 pub mod walkdir {
-    pub use jwalk::{DirEntry as DirEntryGeneric, DirEntryIter as DirEntryIterGeneric, Error, WalkDir};
     use std::path::Path;
+
+    pub use jwalk::{DirEntry as DirEntryGeneric, DirEntryIter as DirEntryIterGeneric, Error, WalkDir};
 
     /// An alias for an uncustomized directory entry to match the one of the non-parallel version offered by `walkdir`.
     pub type DirEntry = DirEntryGeneric<((), ())>;
@@ -33,6 +34,7 @@ pub mod walkdir {
 ///
 pub mod walkdir {
     use std::path::Path;
+
     pub use walkdir::{DirEntry, Error, WalkDir};
 
     /// Instantiate a new directory iterator which will not skip hidden files.

--- a/git-features/src/hash.rs
+++ b/git-features/src/hash.rs
@@ -29,8 +29,9 @@ pub type Sha1Digest = [u8; 20];
 
 #[cfg(feature = "fast-sha1")]
 mod _impl {
-    use super::Sha1Digest;
     use sha1::Digest;
+
+    use super::Sha1Digest;
 
     /// A implementation of the Sha1 hash, which can be used once.
     #[derive(Default, Clone)]

--- a/git-features/src/io.rs
+++ b/git-features/src/io.rs
@@ -3,8 +3,9 @@
 /// A unidirectional pipe for bytes, analogous to a unix pipe. Available with the `io-pipe` feature toggle.
 #[cfg(feature = "io-pipe")]
 pub mod pipe {
-    use bytes::{Buf, BufMut, BytesMut};
     use std::io;
+
+    use bytes::{Buf, BufMut, BytesMut};
 
     /// The write-end of the pipe, receiving items to become available in the [`Reader`].
     ///

--- a/git-features/src/parallel/reduce.rs
+++ b/git-features/src/parallel/reduce.rs
@@ -212,6 +212,7 @@ mod stepped {
 }
 
 use std::marker::PhantomData;
+
 pub use stepped::Stepwise;
 
 /// An trait for aggregating items commonly produced in threads into a single result, without itself

--- a/git-features/src/progress.rs
+++ b/git-features/src/progress.rs
@@ -1,8 +1,10 @@
 //! Various `prodash` types along with various utilities for comfort.
 use std::io;
 
-pub use prodash::progress::{Discard, DoOrDiscard, Either, ThroughputOnDrop};
-pub use prodash::{unit, Progress, Unit};
+pub use prodash::{
+    progress::{Discard, DoOrDiscard, Either, ThroughputOnDrop},
+    unit, Progress, Unit,
+};
 
 /// A unit for displaying bytes with throughput and progress percentage.
 pub fn bytes() -> Option<Unit> {

--- a/git-features/src/zlib/stream/deflate/mod.rs
+++ b/git-features/src/zlib/stream/deflate/mod.rs
@@ -12,9 +12,11 @@ pub struct Write<W> {
 }
 
 mod impls {
-    use crate::zlib::stream::deflate;
-    use flate2::{Compress, Compression, FlushCompress, Status};
     use std::io;
+
+    use flate2::{Compress, Compression, FlushCompress, Status};
+
+    use crate::zlib::stream::deflate;
 
     impl<W> deflate::Write<W>
     where

--- a/git-features/src/zlib/stream/deflate/tests.rs
+++ b/git-features/src/zlib/stream/deflate/tests.rs
@@ -1,11 +1,13 @@
 mod deflate_stream {
-    use crate::zlib::stream::deflate;
-    use bstr::ByteSlice;
-    use flate2::Decompress;
     use std::{
         io,
         io::{Read, Write},
     };
+
+    use bstr::ByteSlice;
+    use flate2::Decompress;
+
+    use crate::zlib::stream::deflate;
 
     /// Provide streaming decompression using the `std::io::Read` trait.
     /// If `std::io::BufReader` is used, an allocation for the input buffer will be performed.

--- a/git-features/src/zlib/stream/inflate.rs
+++ b/git-features/src/zlib/stream/inflate.rs
@@ -1,5 +1,6 @@
-use flate2::{Decompress, FlushDecompress, Status};
 use std::{io, io::BufRead};
+
+use flate2::{Decompress, FlushDecompress, Status};
 
 /// The boxed variant is faster for what we do (moving the decompressor in and out a lot)
 pub struct ReadBoxed<R> {

--- a/git-features/tests/pipe.rs
+++ b/git-features/tests/pipe.rs
@@ -1,6 +1,7 @@
 mod io {
-    use git_features::io;
     use std::io::{BufRead, ErrorKind, Read, Write};
+
+    use git_features::io;
 
     #[test]
     fn threaded_read_to_end() {

--- a/git-hash/src/borrowed.rs
+++ b/git-hash/src/borrowed.rs
@@ -1,5 +1,6 @@
-use crate::{ObjectId, SIZE_OF_SHA1_DIGEST};
 use std::{convert::TryInto, fmt};
+
+use crate::{ObjectId, SIZE_OF_SHA1_DIGEST};
 
 /// A borrowed reference to a hash identifying objects.
 ///

--- a/git-hash/src/lib.rs
+++ b/git-hash/src/lib.rs
@@ -13,9 +13,11 @@ pub use owned::ObjectId;
 
 #[allow(missing_docs)]
 pub mod decode {
-    use crate::owned::ObjectId;
-    use quick_error::quick_error;
     use std::str::FromStr;
+
+    use quick_error::quick_error;
+
+    use crate::owned::ObjectId;
 
     quick_error! {
         /// An error returned by [`ObjectId::from_40_bytes_in_hex()`]

--- a/git-hash/src/owned.rs
+++ b/git-hash/src/owned.rs
@@ -1,5 +1,6 @@
-use crate::{borrowed::oid, SIZE_OF_SHA1_DIGEST};
 use std::{borrow::Borrow, fmt, io, ops::Deref};
+
+use crate::{borrowed::oid, SIZE_OF_SHA1_DIGEST};
 
 /// An owned hash identifying objects, most commonly Sha1
 #[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]

--- a/git-lock/src/acquire.rs
+++ b/git-lock/src/acquire.rs
@@ -1,11 +1,13 @@
-use crate::{backoff, File, Marker, DOT_LOCK_SUFFIX};
-use git_tempfile::{AutoRemove, ContainingDirectory};
-use quick_error::quick_error;
 use std::{
     fmt,
     path::{Path, PathBuf},
     time::Duration,
 };
+
+use git_tempfile::{AutoRemove, ContainingDirectory};
+use quick_error::quick_error;
+
+use crate::{backoff, File, Marker, DOT_LOCK_SUFFIX};
 
 /// Describe what to do if a lock cannot be obtained as it's already held elsewhere.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/git-lock/src/backoff.rs
+++ b/git-lock/src/backoff.rs
@@ -80,8 +80,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::convert::TryInto;
+
+    use super::*;
 
     const EXPECTED_TILL_SECOND: &[usize] = &[
         1usize, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400, 441, 484, 529,

--- a/git-lock/src/commit.rs
+++ b/git-lock/src/commit.rs
@@ -1,5 +1,6 @@
-use crate::{File, Marker};
 use std::path::PathBuf;
+
+use crate::{File, Marker};
 
 mod error {
     use std::{

--- a/git-lock/src/file.rs
+++ b/git-lock/src/file.rs
@@ -1,5 +1,6 @@
-use crate::{File, Marker, DOT_LOCK_SUFFIX};
 use std::path::{Path, PathBuf};
+
+use crate::{File, Marker, DOT_LOCK_SUFFIX};
 
 fn strip_lock_suffix(lock_path: &Path) -> PathBuf {
     lock_path.with_extension(lock_path.extension().map_or("".to_string(), |ext| {
@@ -37,8 +38,9 @@ impl File {
 }
 
 mod io_impls {
-    use super::File;
     use std::{io, io::SeekFrom};
+
+    use super::File;
 
     impl io::Write for File {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/git-lock/src/lib.rs
+++ b/git-lock/src/lib.rs
@@ -15,8 +15,9 @@
 //! * The limitations of `git-tempfile` apply.
 #![deny(missing_docs, unsafe_code, rust_2018_idioms)]
 
-use git_tempfile::handle::{Closed, Writable};
 use std::path::PathBuf;
+
+use git_tempfile::handle::{Closed, Writable};
 
 const DOT_LOCK_SUFFIX: &str = ".lock";
 

--- a/git-lock/tests/lock/file.rs
+++ b/git-lock/tests/lock/file.rs
@@ -1,7 +1,8 @@
 mod close {
 
-    use git_lock::acquire::Fail;
     use std::io::Write;
+
+    use git_lock::acquire::Fail;
 
     #[test]
     fn acquire_close_commit_to_existing_file() -> crate::Result {
@@ -86,8 +87,9 @@ mod commit {
 }
 
 mod acquire {
-    use git_lock::acquire;
     use std::io::{ErrorKind, Write};
+
+    use git_lock::acquire;
 
     fn fail_immediately() -> git_lock::acquire::Fail {
         acquire::Fail::Immediately

--- a/git-lock/tests/lock/marker.rs
+++ b/git-lock/tests/lock/marker.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod acquire {
-    use git_lock::acquire::Fail;
     use std::time::{Duration, Instant};
+
+    use git_lock::acquire::Fail;
 
     #[test]
     fn fail_mode_immediately_produces_a_descriptive_error() -> crate::Result {

--- a/git-object/src/immutable/commit/decode.rs
+++ b/git-object/src/immutable/commit/decode.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use nom::{
     branch::alt,
-    bytes::{complete::is_not, complete::tag},
+    bytes::complete::{is_not, tag},
     combinator::{all_consuming, opt},
-    error::context,
-    error::{ContextError, ParseError},
+    error::{context, ContextError, ParseError},
     multi::many0,
     IResult,
 };

--- a/git-object/src/immutable/commit/iter.rs
+++ b/git-object/src/immutable/commit/iter.rs
@@ -1,7 +1,5 @@
-use crate::{
-    bstr::ByteSlice,
-    immutable::{commit::decode, object, parse, parse::NL},
-};
+use std::borrow::Cow;
+
 use bstr::BStr;
 use git_hash::{oid, ObjectId};
 use nom::{
@@ -10,7 +8,11 @@ use nom::{
     combinator::{all_consuming, opt},
     error::context,
 };
-use std::borrow::Cow;
+
+use crate::{
+    bstr::ByteSlice,
+    immutable::{commit::decode, object, parse, parse::NL},
+};
 
 #[derive(Copy, Clone)]
 enum SignatureKind {

--- a/git-object/src/immutable/commit/mod.rs
+++ b/git-object/src/immutable/commit/mod.rs
@@ -1,5 +1,6 @@
-use smallvec::SmallVec;
 use std::borrow::Cow;
+
+use smallvec::SmallVec;
 
 use crate::{immutable::object, BStr};
 

--- a/git-object/src/immutable/tag.rs
+++ b/git-object/src/immutable/tag.rs
@@ -33,23 +33,20 @@ impl<'a> Tag<'a> {
 }
 
 mod decode {
-    use nom::bytes::complete::take_while;
     use nom::{
         branch::alt,
-        bytes::complete::{tag, take_until, take_while1},
+        bytes::complete::{tag, take_until, take_while, take_while1},
         character::is_alphabetic,
         combinator::{all_consuming, opt, recognize},
-        error::context,
+        error::{context, ContextError, ParseError},
         sequence::{preceded, tuple},
         IResult,
     };
 
-    use crate::immutable::Tag;
     use crate::{
-        immutable::{parse, parse::NL},
+        immutable::{parse, parse::NL, Tag},
         BStr, ByteSlice,
     };
-    use nom::error::{ContextError, ParseError};
 
     pub fn git_tag<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], Tag<'a>, E> {
         let (i, target) = context("object <40 lowercase hex char>", |i| {
@@ -132,19 +129,19 @@ mod decode {
 
 ///
 pub mod iter {
-    use crate::{
-        bstr::ByteSlice,
-        immutable::{object, parse, parse::NL, tag::decode},
-        Kind,
-    };
     use bstr::BStr;
     use git_hash::{oid, ObjectId};
-    use nom::error::ParseError;
     use nom::{
         bytes::complete::take_while1,
         character::is_alphabetic,
         combinator::{all_consuming, opt},
-        error::context,
+        error::{context, ParseError},
+    };
+
+    use crate::{
+        bstr::ByteSlice,
+        immutable::{object, parse, parse::NL, tag::decode},
+        Kind,
     };
 
     enum State {

--- a/git-object/src/immutable/tree.rs
+++ b/git-object/src/immutable/tree.rs
@@ -1,7 +1,8 @@
 use std::convert::TryFrom;
 
-use crate::{immutable::object, tree};
 use bstr::BStr;
+
+use crate::{immutable::object, tree};
 
 /// A directory snapshot containing files (blobs), directories (trees) and submodules (commits).
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
@@ -108,10 +109,6 @@ impl<'a> TryFrom<&'a [u8]> for tree::EntryMode {
 mod decode {
     use std::convert::TryFrom;
 
-    use crate::{
-        immutable::{parse::SPACE, tree::Entry, Tree},
-        tree,
-    };
     use bstr::ByteSlice;
     use nom::{
         bytes::complete::{tag, take, take_while1, take_while_m_n},
@@ -121,6 +118,11 @@ mod decode {
         multi::many0,
         sequence::terminated,
         IResult,
+    };
+
+    use crate::{
+        immutable::{parse::SPACE, tree::Entry, Tree},
+        tree,
     };
 
     const NULL: &[u8] = b"\0";

--- a/git-object/src/lib.rs
+++ b/git-object/src/lib.rs
@@ -3,10 +3,9 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms, missing_docs)]
 
-use bstr::{BStr, BString, ByteSlice};
-
 /// For convenience to allow using `bstr` without adding it to own cargo manifest.
 pub use bstr;
+use bstr::{BStr, BString, ByteSlice};
 
 pub mod immutable;
 pub mod mutable;

--- a/git-object/src/mutable/commit.rs
+++ b/git-object/src/mutable/commit.rs
@@ -1,10 +1,12 @@
+use std::io;
+
+use bstr::{BStr, BString, ByteSlice};
+use smallvec::SmallVec;
+
 use crate::{
     commit,
     mutable::{encode, NL},
 };
-use bstr::{BStr, BString, ByteSlice};
-use smallvec::SmallVec;
-use std::io;
 
 /// A mutable git commit, representing an annotated state of a working tree along with a reference to its historical commits.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]

--- a/git-object/src/mutable/encode.rs
+++ b/git-object/src/mutable/encode.rs
@@ -1,7 +1,9 @@
-use crate::mutable::{NL, SPACE};
+use std::io;
+
 use bstr::{BString, ByteSlice};
 use quick_error::quick_error;
-use std::io;
+
+use crate::mutable::{NL, SPACE};
 
 quick_error! {
     #[derive(Debug)]

--- a/git-object/src/mutable/object.rs
+++ b/git-object/src/mutable/object.rs
@@ -1,5 +1,6 @@
-use crate::mutable;
 use std::io;
+
+use crate::mutable;
 
 /// A mutable object representing [`Trees`][mutable::Tree], [`Blobs`][mutable::Blob], [`Commits`][mutable::Commit] or [`Tags`][mutable::Tag].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
@@ -68,8 +69,9 @@ impl Object {
 }
 
 mod convert {
-    use crate::mutable::{Blob, Commit, Object, Tag, Tree};
     use std::convert::TryFrom;
+
+    use crate::mutable::{Blob, Commit, Object, Tag, Tree};
 
     impl From<Tag> for Object {
         fn from(v: Tag) -> Self {

--- a/git-object/src/mutable/tag.rs
+++ b/git-object/src/mutable/tag.rs
@@ -1,7 +1,9 @@
-use crate::mutable::{encode, NL};
+use std::io;
+
 use bstr::{BStr, BString};
 use quick_error::quick_error;
-use std::io;
+
+use crate::mutable::{encode, NL};
 
 quick_error! {
     /// An Error used in [`Tag::write_to()`].

--- a/git-object/src/mutable/tag/tests.rs
+++ b/git-object/src/mutable/tag/tests.rs
@@ -1,7 +1,8 @@
 mod validated_name {
     mod invalid {
-        use super::super::super::*;
         use bstr::ByteSlice;
+
+        use super::super::super::*;
 
         #[test]
         fn only_dash() {
@@ -14,8 +15,9 @@ mod validated_name {
     }
 
     mod valid {
-        use super::super::super::*;
         use bstr::ByteSlice;
+
+        use super::super::super::*;
 
         #[test]
         fn version() {

--- a/git-object/src/mutable/tree.rs
+++ b/git-object/src/mutable/tree.rs
@@ -1,8 +1,9 @@
-use crate::{mutable::SPACE, tree::EntryMode};
+use std::{cmp::Ordering, io};
+
 use bstr::{BString, ByteSlice};
 use quick_error::quick_error;
-use std::cmp::Ordering;
-use std::io;
+
+use crate::{mutable::SPACE, tree::EntryMode};
 
 quick_error! {
     /// The Error used in [`Tree::write_to()`].

--- a/git-object/src/types.rs
+++ b/git-object/src/types.rs
@@ -1,5 +1,6 @@
-use quick_error::quick_error;
 use std::fmt;
+
+use quick_error::quick_error;
 
 /// The four types of objects that git differentiates.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]

--- a/git-object/tests/immutable/commit.rs
+++ b/git-object/tests/immutable/commit.rs
@@ -131,9 +131,10 @@ dS3aXZhRfaPqpdsWrMB9fY7ll+oyfw==
 =T+RI
 -----END PGP SIGNATURE-----";
 mod method {
-    use crate::{hex_to_id, immutable::fixture_bytes};
     use git_object::immutable::Commit;
     use pretty_assertions::assert_eq;
+
+    use crate::{hex_to_id, immutable::fixture_bytes};
 
     #[test]
     fn tree() -> crate::Result {
@@ -146,6 +147,11 @@ mod method {
 }
 
 mod iter {
+    use git_object::{
+        bstr::ByteSlice,
+        immutable::{commit::iter::Token, CommitIter},
+    };
+
     use crate::{
         hex_to_id,
         immutable::{
@@ -153,7 +159,6 @@ mod iter {
             fixture_bytes, linus_signature, signature,
         },
     };
-    use git_object::{bstr::ByteSlice, immutable::commit::iter::Token, immutable::CommitIter};
 
     #[test]
     fn newline_right_after_signature_multiline_header() -> crate::Result {
@@ -302,11 +307,12 @@ mod iter {
     }
 
     mod method {
+        use git_object::immutable::CommitIter;
+
         use crate::{
             hex_to_id,
             immutable::{fixture_bytes, signature},
         };
-        use git_object::immutable::CommitIter;
 
         #[test]
         fn tree_id() -> crate::Result {
@@ -337,12 +343,13 @@ mod iter {
 }
 
 mod from_bytes {
+    use git_object::{bstr::ByteSlice, immutable::Commit};
+    use smallvec::SmallVec;
+
     use crate::immutable::{
         commit::{LONG_MESSAGE, MERGE_TAG, SIGNATURE},
         fixture_bytes, linus_signature, signature,
     };
-    use git_object::{bstr::ByteSlice, immutable::Commit};
-    use smallvec::SmallVec;
 
     #[test]
     fn unsigned() -> crate::Result {

--- a/git-object/tests/immutable/mod.rs
+++ b/git-object/tests/immutable/mod.rs
@@ -1,5 +1,6 @@
-use git_actor::{Sign, Time};
 use std::path::PathBuf;
+
+use git_actor::{Sign, Time};
 
 mod commit;
 mod tag;

--- a/git-object/tests/immutable/tag.rs
+++ b/git-object/tests/immutable/tag.rs
@@ -1,9 +1,10 @@
 use git_object::{bstr::ByteSlice, immutable::Tag, Kind};
 
 mod method {
-    use crate::{hex_to_id, immutable::fixture_bytes};
     use git_object::immutable::Tag;
     use pretty_assertions::assert_eq;
+
+    use crate::{hex_to_id, immutable::fixture_bytes};
 
     #[test]
     fn target() -> crate::Result {
@@ -16,14 +17,15 @@ mod method {
 }
 
 mod iter {
-    use crate::{
-        hex_to_id,
-        immutable::{fixture_bytes, signature},
-    };
     use git_object::{
         bstr::ByteSlice,
         immutable::{tag::iter::Token, TagIter},
         Kind,
+    };
+
+    use crate::{
+        hex_to_id,
+        immutable::{fixture_bytes, signature},
     };
 
     #[test]
@@ -112,8 +114,9 @@ KLMHist5yj0sw1E4hDTyQa0=
 }
 
 mod from_bytes {
-    use crate::immutable::{fixture_bytes, signature, tag::tag_fixture};
     use git_object::{bstr::ByteSlice, immutable::Tag, Kind};
+
+    use crate::immutable::{fixture_bytes, signature, tag::tag_fixture};
 
     #[test]
     fn signed() -> crate::Result {

--- a/git-object/tests/immutable/tree.rs
+++ b/git-object/tests/immutable/tree.rs
@@ -1,10 +1,11 @@
 mod iter {
-    use crate::{hex_to_id, immutable::fixture_bytes};
     use git_object::{
         bstr::ByteSlice,
         immutable::{tree::Entry, TreeIter},
         tree,
     };
+
+    use crate::{hex_to_id, immutable::fixture_bytes};
 
     #[test]
     fn empty() {
@@ -59,12 +60,13 @@ mod iter {
 }
 
 mod from_bytes {
-    use crate::{hex_to_id, immutable::fixture_bytes};
     use git_object::{
         bstr::ByteSlice,
         immutable::{tree::Entry, Tree},
         tree,
     };
+
+    use crate::{hex_to_id, immutable::fixture_bytes};
 
     #[test]
     fn empty() -> crate::Result {

--- a/git-odb/src/alternate/mod.rs
+++ b/git-odb/src/alternate/mod.rs
@@ -16,8 +16,9 @@
 //! ```
 //!
 //! Based on the [canonical implementation](https://github.com/git/git/blob/master/sha1-file.c#L598:L609).
-use crate::store::compound;
 use std::{fs, io, path::PathBuf};
+
+use crate::store::compound;
 
 ///
 pub mod parse;

--- a/git-odb/src/alternate/parse.rs
+++ b/git-odb/src/alternate/parse.rs
@@ -1,6 +1,8 @@
-use crate::alternate::unquote;
-use git_object::bstr::ByteSlice;
 use std::{borrow::Cow, path::PathBuf};
+
+use git_object::bstr::ByteSlice;
+
+use crate::alternate::unquote;
 
 /// Returned as part of [`crate::alternate::Error::Parse`]
 #[derive(thiserror::Error, Debug)]

--- a/git-odb/src/alternate/unquote.rs
+++ b/git-odb/src/alternate/unquote.rs
@@ -1,6 +1,6 @@
+use std::{borrow::Cow, io::Read};
+
 use git_object::bstr::{BStr, BString, ByteSlice};
-use std::borrow::Cow;
-use std::io::Read;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -99,8 +99,9 @@ pub fn ansi_c(input: &BStr) -> Result<Cow<'_, BStr>, Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use git_object::bstr::ByteSlice;
+
+    use super::*;
 
     macro_rules! test {
         ($name:ident, $input:literal, $expected:literal) => {

--- a/git-odb/src/store/compound/find.rs
+++ b/git-odb/src/store/compound/find.rs
@@ -1,8 +1,9 @@
+use git_pack::data;
+
 use crate::{
     pack,
     store::{compound, loose},
 };
-use git_pack::data;
 
 /// Returned by [`compound::Store::find()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-odb/src/store/compound/write.rs
+++ b/git-odb/src/store/compound/write.rs
@@ -1,7 +1,8 @@
 use std::io::Read;
 
-use crate::store::{compound, loose};
 use git_object::{mutable, Kind};
+
+use crate::store::{compound, loose};
 
 impl crate::write::Write for compound::Store {
     type Error = loose::write::Error;

--- a/git-odb/src/store/linked/find.rs
+++ b/git-odb/src/store/linked/find.rs
@@ -1,13 +1,13 @@
-use git_hash::oid;
 use std::convert::TryInto;
 
-use crate::pack::Bundle;
+use git_hash::oid;
+use git_pack::{data::Object, find::Entry};
+
 use crate::{
     pack,
-    pack::bundle::Location,
+    pack::{bundle::Location, Bundle},
     store::{compound, linked},
 };
-use git_pack::{data::Object, find::Entry};
 
 impl linked::Store {
     /// Return true if the given object `id` is contained in the store.

--- a/git-odb/src/store/linked/init.rs
+++ b/git-odb/src/store/linked/init.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
-use crate::alternate;
-use crate::store::{compound, linked};
+use crate::{
+    alternate,
+    store::{compound, linked},
+};
 
 /// The error returned by [`linked::Store::at()`]
 #[derive(Debug, thiserror::Error)]

--- a/git-odb/src/store/linked/iter.rs
+++ b/git-odb/src/store/linked/iter.rs
@@ -1,8 +1,8 @@
-use git_hash::ObjectId;
 use std::{borrow::Borrow, option::Option::None, sync::Arc};
 
-use crate::store::linked;
-use crate::store::loose;
+use git_hash::ObjectId;
+
+use crate::store::{linked, loose};
 
 #[allow(clippy::large_enum_variant)]
 enum DbState {

--- a/git-odb/src/store/linked/write.rs
+++ b/git-odb/src/store/linked/write.rs
@@ -1,5 +1,6 @@
-use git_object::{mutable, Kind};
 use std::io::Read;
+
+use git_object::{mutable, Kind};
 
 use crate::store::{linked, loose};
 

--- a/git-odb/src/store/loose/find.rs
+++ b/git-odb/src/store/loose/find.rs
@@ -1,7 +1,9 @@
-use crate::store::loose::{sha1_path, Store, HEADER_READ_UNCOMPRESSED_BYTES};
+use std::{convert::TryInto, fs, io::Read, path::PathBuf};
+
 use git_features::zlib;
 use git_pack::{data, loose::object::header};
-use std::{convert::TryInto, fs, io::Read, path::PathBuf};
+
+use crate::store::loose::{sha1_path, Store, HEADER_READ_UNCOMPRESSED_BYTES};
 
 /// Returned by [`Store::find()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-odb/src/store/loose/iter.rs
+++ b/git-odb/src/store/loose/iter.rs
@@ -1,5 +1,6 @@
-use crate::store::loose::Store;
 use git_features::fs;
+
+use crate::store::loose::Store;
 
 /// Returned by [`Store::iter()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-odb/src/store/loose/write.rs
+++ b/git-odb/src/store/loose/write.rs
@@ -1,8 +1,10 @@
+use std::{fs, io, io::Write, path::PathBuf};
+
+use git_features::{hash, zlib::stream::deflate};
+use tempfile::NamedTempFile;
+
 use super::Store;
 use crate::store::loose;
-use git_features::{hash, zlib::stream::deflate};
-use std::{fs, io, io::Write, path::PathBuf};
-use tempfile::NamedTempFile;
 
 /// Returned by the [`crate::Write`] trait implementation of [`Store`]
 #[derive(thiserror::Error, Debug)]

--- a/git-odb/src/store/sink.rs
+++ b/git-odb/src/store/sink.rs
@@ -1,9 +1,10 @@
-use git_features::zlib::stream::deflate;
 use std::{
     cell::RefCell,
     convert::TryInto,
     io::{self, Write},
 };
+
+use git_features::zlib::stream::deflate;
 
 /// An object database equivalent to `/dev/null`, dropping all objects stored into it.
 ///

--- a/git-odb/src/write.rs
+++ b/git-odb/src/write.rs
@@ -1,5 +1,6 @@
-use git_object::mutable;
 use std::io;
+
+use git_object::mutable;
 
 /// Describe the capability to write git objects into an object store.
 pub trait Write {

--- a/git-odb/tests/odb/alternate/mod.rs
+++ b/git-odb/tests/odb/alternate/mod.rs
@@ -1,8 +1,9 @@
-use git_odb::alternate;
 use std::{
     fs, io,
     path::{Path, PathBuf},
 };
+
+use git_odb::alternate;
 
 pub fn alternate(
     objects_at: impl Into<PathBuf>,

--- a/git-odb/tests/odb/store/compound/mod.rs
+++ b/git-odb/tests/odb/store/compound/mod.rs
@@ -18,8 +18,7 @@ mod init {
 mod locate {
     use git_odb::compound::Store;
 
-    use crate::hex_to_id;
-    use crate::odb::store::compound::db;
+    use crate::{hex_to_id, odb::store::compound::db};
 
     fn can_locate(db: &Store, hex_id: &str) {
         let mut buf = vec![];

--- a/git-odb/tests/odb/store/linked/mod.rs
+++ b/git-odb/tests/odb/store/linked/mod.rs
@@ -33,8 +33,9 @@ mod iter {
 }
 
 mod locate {
-    use crate::{hex_to_id, odb::store::linked::db};
     use git_odb::{linked::Store, pack, Find};
+
+    use crate::{hex_to_id, odb::store::linked::db};
 
     fn can_locate(db: &Store, hex_id: &str) {
         let mut buf = vec![];
@@ -58,11 +59,11 @@ mod locate {
 }
 
 mod init {
-    use git_odb::linked;
     use std::convert::TryFrom;
 
-    use crate::odb::alternate::alternate;
-    use crate::odb::store::linked::db;
+    use git_odb::linked;
+
+    use crate::odb::{alternate::alternate, store::linked::db};
 
     #[test]
     fn multiple_linked_repositories_via_alternates() -> crate::Result {

--- a/git-odb/tests/odb/store/loose/backend.rs
+++ b/git-odb/tests/odb/store/loose/backend.rs
@@ -1,6 +1,5 @@
-use pretty_assertions::assert_eq;
-
 use git_odb::loose::Store;
+use pretty_assertions::assert_eq;
 
 use crate::{fixture_path, hex_to_id};
 

--- a/git-odb/tests/odb/store/sink/mod.rs
+++ b/git-odb/tests/odb/store/sink/mod.rs
@@ -1,5 +1,6 @@
-use crate::store::loose::backend::{locate_oid, object_ids};
 use git_odb::Write;
+
+use crate::store::loose::backend::{locate_oid, object_ids};
 
 #[test]
 fn write() -> Result<(), Box<dyn std::error::Error>> {

--- a/git-pack/src/bundle/mod.rs
+++ b/git-pack/src/bundle/mod.rs
@@ -8,8 +8,9 @@ mod find;
 pub mod write;
 
 mod verify {
-    use git_features::progress::Progress;
     use std::sync::{atomic::AtomicBool, Arc};
+
+    use git_features::progress::Progress;
 
     impl super::Bundle {
         /// Similar to [`crate::index::File::verify_integrity()`] but more convenient to call as the presence of the

--- a/git-pack/src/bundle/write/error.rs
+++ b/git-pack/src/bundle/write/error.rs
@@ -1,5 +1,6 @@
-use git_tempfile::handle::Writable;
 use std::io;
+
+use git_tempfile::handle::Writable;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/git-pack/src/bundle/write/mod.rs
+++ b/git-pack/src/bundle/write/mod.rs
@@ -1,13 +1,14 @@
-use filebuffer::FileBuffer;
-
-use crate::data;
-use git_features::{interrupt, progress, progress::Progress};
-use git_tempfile::{handle::Writable, AutoRemove, ContainingDirectory};
 use std::{
     io,
     path::{Path, PathBuf},
     sync::{atomic::AtomicBool, Arc},
 };
+
+use filebuffer::FileBuffer;
+use git_features::{interrupt, progress, progress::Progress};
+use git_tempfile::{handle::Writable, AutoRemove, ContainingDirectory};
+
+use crate::data;
 
 mod error;
 use error::Error;

--- a/git-pack/src/bundle/write/types.rs
+++ b/git-pack/src/bundle/write/types.rs
@@ -1,5 +1,6 @@
-use git_tempfile::handle::Writable;
 use std::{io, io::SeekFrom, path::PathBuf, sync::Arc};
+
+use git_tempfile::handle::Writable;
 
 /// Configuration for [write_to_directory][crate::Bundle::write_to_directory()] or
 /// [write_to_directory_eagerly][crate::Bundle::write_to_directory_eagerly()]

--- a/git-pack/src/cache.rs
+++ b/git-pack/src/cache.rs
@@ -1,5 +1,6 @@
-use git_object::Kind;
 use std::ops::DerefMut;
+
+use git_object::Kind;
 
 /// A trait to model putting objects at a given pack `offset` into a cache, and fetching them.
 ///

--- a/git-pack/src/data/entry/decode.rs
+++ b/git-pack/src/data/entry/decode.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use super::{BLOB, COMMIT, OFS_DELTA, REF_DELTA, SHA1_SIZE, TAG, TREE};
 use crate::data;
-use std::io;
 
 /// Decoding
 impl data::Entry {

--- a/git-pack/src/data/entry/header.rs
+++ b/git-pack/src/data/entry/header.rs
@@ -1,5 +1,6 @@
-use super::{BLOB, COMMIT, OFS_DELTA, REF_DELTA, TAG, TREE};
 use std::io;
+
+use super::{BLOB, COMMIT, OFS_DELTA, REF_DELTA, TAG, TREE};
 
 /// The header portion of a pack data entry, identifying the kind of stored object.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]

--- a/git-pack/src/data/file/decode_entry.rs
+++ b/git-pack/src/data/file/decode_entry.rs
@@ -1,11 +1,13 @@
+use std::{convert::TryInto, ops::Range};
+
+use git_features::zlib;
+use smallvec::SmallVec;
+
 use super::ResolvedBase;
 use crate::{
     cache,
     data::{delta, File},
 };
-use git_features::zlib;
-use smallvec::SmallVec;
-use std::{convert::TryInto, ops::Range};
 
 /// Returned by [`File::decompress_entry()`] and [`File::decode_entry()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/data/file/init.rs
+++ b/git-pack/src/data/file/init.rs
@@ -1,7 +1,12 @@
-use crate::data;
+use std::{
+    convert::{TryFrom, TryInto},
+    path::Path,
+};
+
 use filebuffer::FileBuffer;
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
-use std::{convert::TryFrom, convert::TryInto, path::Path};
+
+use crate::data;
 
 /// Instantiation
 impl data::File {

--- a/git-pack/src/data/file/verify.rs
+++ b/git-pack/src/data/file/verify.rs
@@ -1,7 +1,9 @@
-use crate::data::File;
+use std::sync::atomic::AtomicBool;
+
 use git_features::progress::Progress;
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
-use std::sync::atomic::AtomicBool;
+
+use crate::data::File;
 
 /// Returned by [`File::verify_checksum()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/data/header.rs
+++ b/git-pack/src/data/header.rs
@@ -1,5 +1,6 @@
-use crate::data;
 use byteorder::{BigEndian, ByteOrder};
+
+use crate::data;
 
 pub(crate) const N32_SIZE: usize = std::mem::size_of::<u32>();
 

--- a/git-pack/src/data/input/bytes_to_entries.rs
+++ b/git-pack/src/data/input/bytes_to_entries.rs
@@ -1,10 +1,12 @@
-use crate::data::input;
+use std::{fs, io};
+
 use git_features::{
     hash,
     hash::Sha1,
     zlib::{stream::inflate::ReadBoxed, Decompress},
 };
-use std::{fs, io};
+
+use crate::data::input;
 
 /// An iterator over [`Entries`][input::Entry] in a byte stream.
 ///

--- a/git-pack/src/data/input/entries_to_bytes.rs
+++ b/git-pack/src/data/input/entries_to_bytes.rs
@@ -1,6 +1,8 @@
-use crate::data::input;
-use git_features::hash;
 use std::iter::Peekable;
+
+use git_features::hash;
+
+use crate::data::input;
 
 /// An implementation of [`Iterator`] to write [encoded entries][input::Entry] to an inner implementation each time
 /// `next()` is called.

--- a/git-pack/src/data/input/entry.rs
+++ b/git-pack/src/data/input/entry.rs
@@ -1,5 +1,6 @@
-use crate::data::{self, entry::Header, input};
 use std::io::Write;
+
+use crate::data::{self, entry::Header, input};
 
 impl input::Entry {
     /// Create a new input entry from a given data `obj` set to be placed at the given `pack_offset`.

--- a/git-pack/src/data/input/lookup_ref_delta_objects.rs
+++ b/git-pack/src/data/input/lookup_ref_delta_objects.rs
@@ -1,6 +1,8 @@
-use crate::data::{self, entry::Header, input};
-use git_hash::ObjectId;
 use std::convert::TryInto;
+
+use git_hash::ObjectId;
+
+use crate::data::{self, entry::Header, input};
 
 /// An iterator to resolve thin packs on the fly.
 pub struct LookupRefDeltaObjectsIter<I, LFn> {

--- a/git-pack/src/data/mod.rs
+++ b/git-pack/src/data/mod.rs
@@ -2,7 +2,6 @@
 use std::{convert::TryInto, path::Path};
 
 use filebuffer::FileBuffer;
-
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 
 mod file;

--- a/git-pack/src/data/object.rs
+++ b/git-pack/src/data/object.rs
@@ -66,9 +66,11 @@ impl<'a> Object<'a> {
 
 /// Types supporting object hash verification
 pub mod verify {
-    use crate::loose;
-    use git_features::hash;
     use std::io;
+
+    use git_features::hash;
+
+    use crate::loose;
 
     /// Returned by [`crate::data::Object::verify_checksum()`]
     #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/data/output/bytes.rs
+++ b/git-pack/src/data/output/bytes.rs
@@ -1,6 +1,8 @@
-use crate::data::output;
-use git_features::hash;
 use std::io::Write;
+
+use git_features::hash;
+
+use crate::data::output;
 
 /// The error returned by `next()` in the [`FromEntriesIter`] iterator.
 #[allow(missing_docs)]

--- a/git-pack/src/data/output/count/iter_from_objects.rs
+++ b/git-pack/src/data/output/count/iter_from_objects.rs
@@ -1,9 +1,11 @@
-use crate::{data::output, find, FindExt};
+use std::sync::Arc;
+
 use dashmap::DashSet;
 use git_features::{parallel, progress::Progress};
 use git_hash::{oid, ObjectId};
 use git_object::immutable;
-use std::sync::Arc;
+
+use crate::{data::output, find, FindExt};
 
 /// Generate [`Count`][output::Count] from input `objects` with object expansion based on [`options`][Options]
 /// to learn which objects would be part of a pack.
@@ -522,10 +524,12 @@ mod types {
 pub use types::{Error, ObjectExpansion, Options, Outcome};
 
 mod reduce {
+    use std::marker::PhantomData;
+
+    use git_features::parallel;
+
     use super::Outcome;
     use crate::data::output;
-    use git_features::parallel;
-    use std::marker::PhantomData;
 
     pub struct Statistics<E> {
         total: Outcome,

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -1,5 +1,6 @@
-use crate::data;
 use git_hash::ObjectId;
+
+use crate::data;
 
 /// An item representing a future Entry in the leanest way possible.
 ///

--- a/git-pack/src/data/output/entry/iter_from_counts.rs
+++ b/git-pack/src/data/output/entry/iter_from_counts.rs
@@ -1,6 +1,8 @@
-use crate::data::{output, output::ChunkId};
-use git_features::{parallel, progress::Progress};
 use std::{cmp::Ordering, sync::Arc};
+
+use git_features::{parallel, progress::Progress};
+
+use crate::data::{output, output::ChunkId};
 
 /// Given a known list of object `counts`, calculate entries ready to be put into a data pack.
 ///
@@ -236,10 +238,12 @@ mod util {
 }
 
 mod reduce {
+    use std::marker::PhantomData;
+
+    use git_features::parallel;
+
     use super::{ChunkId, Outcome};
     use crate::data::output;
-    use git_features::parallel;
-    use std::marker::PhantomData;
 
     pub struct Statistics<E> {
         total: Outcome,

--- a/git-pack/src/data/output/entry/mod.rs
+++ b/git-pack/src/data/output/entry/mod.rs
@@ -1,7 +1,9 @@
-use crate::{data, data::output, find};
+use std::io::Write;
+
 use git_features::hash;
 use git_hash::ObjectId;
-use std::io::Write;
+
+use crate::{data, data::output, find};
 
 ///
 pub mod iter_from_counts;

--- a/git-pack/src/find.rs
+++ b/git-pack/src/find.rs
@@ -49,8 +49,9 @@ pub trait Find {
 }
 
 mod ext {
-    use crate::{data, find};
     use git_object::{immutable, Kind};
+
+    use crate::{data, find};
 
     macro_rules! make_obj_lookup {
         ($method:ident, $object_variant:path, $object_kind:path, $object_type:ty) => {
@@ -227,10 +228,11 @@ pub struct Entry<'a> {
 }
 
 mod find_impls {
-    use crate::bundle::Location;
-    use crate::{data::Object, find::Entry, Bundle};
-    use git_hash::oid;
     use std::ops::Deref;
+
+    use git_hash::oid;
+
+    use crate::{bundle::Location, data::Object, find::Entry, Bundle};
 
     impl<T> super::Find for std::sync::Arc<T>
     where

--- a/git-pack/src/index/access.rs
+++ b/git-pack/src/index/access.rs
@@ -1,7 +1,9 @@
-use crate::index::{self, FAN_LEN};
+use std::{convert::TryInto, mem::size_of};
+
 use byteorder::{BigEndian, ByteOrder};
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
-use std::{convert::TryInto, mem::size_of};
+
+use crate::index::{self, FAN_LEN};
 
 const N32_SIZE: usize = size_of::<u32>();
 const N64_SIZE: usize = size_of::<u64>();

--- a/git-pack/src/index/init.rs
+++ b/git-pack/src/index/init.rs
@@ -1,8 +1,10 @@
-use crate::index::{self, Version, FAN_LEN, V2_SIGNATURE};
+use std::{convert::TryFrom, mem::size_of, path::Path};
+
 use byteorder::{BigEndian, ByteOrder};
 use filebuffer::FileBuffer;
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
-use std::{convert::TryFrom, mem::size_of, path::Path};
+
+use crate::index::{self, Version, FAN_LEN, V2_SIGNATURE};
 
 /// Returned by [`index::File::at()`].
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/index/traverse/indexed.rs
+++ b/git-pack/src/index/traverse/indexed.rs
@@ -1,15 +1,17 @@
-use super::{Error, SafetyCheck};
-use crate::{
-    index::{self, util::index_entries_sorted_by_offset_ascending},
-    tree::traverse::Context,
-};
-use git_features::{parallel, progress::Progress};
 use std::{
     collections::VecDeque,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+};
+
+use git_features::{parallel, progress::Progress};
+
+use super::{Error, SafetyCheck};
+use crate::{
+    index::{self, util::index_entries_sorted_by_offset_ascending},
+    tree::traverse::Context,
 };
 
 /// Traversal with index

--- a/git-pack/src/index/traverse/mod.rs
+++ b/git-pack/src/index/traverse/mod.rs
@@ -1,9 +1,11 @@
-use crate::index;
+use std::sync::{atomic::AtomicBool, Arc};
+
 use git_features::{
     parallel,
     progress::{self, Progress},
 };
-use std::sync::{atomic::AtomicBool, Arc};
+
+use crate::index;
 
 ///
 mod indexed;
@@ -19,8 +21,9 @@ mod types;
 pub use types::{Algorithm, Outcome, SafetyCheck};
 
 mod options {
-    use crate::index::traverse::{Algorithm, SafetyCheck};
     use std::sync::{atomic::AtomicBool, Arc};
+
+    use crate::index::traverse::{Algorithm, SafetyCheck};
 
     /// Traversal options for [`traverse()`][crate::index::File::traverse()]
     #[derive(Debug, Clone)]

--- a/git-pack/src/index/traverse/reduce.rs
+++ b/git-pack/src/index/traverse/reduce.rs
@@ -1,9 +1,11 @@
-use crate::{data, index::traverse};
-use git_features::{parallel, progress::Progress};
 use std::{
     sync::atomic::{AtomicBool, Ordering},
     time::Instant,
 };
+
+use git_features::{parallel, progress::Progress};
+
+use crate::{data, index::traverse};
 
 fn add_decode_result(lhs: &mut data::decode_entry::Outcome, rhs: data::decode_entry::Outcome) {
     lhs.num_deltas += rhs.num_deltas;

--- a/git-pack/src/index/traverse/with_lookup.rs
+++ b/git-pack/src/index/traverse/with_lookup.rs
@@ -1,14 +1,17 @@
-use super::{Error, Reducer};
-use crate::{data, index, index::util};
+use std::sync::Arc;
+
 use git_features::{
     parallel::{self, in_parallel_if},
     progress::{self, unit, Progress},
 };
-use std::sync::Arc;
+
+use super::{Error, Reducer};
+use crate::{data, index, index::util};
 
 mod options {
-    use crate::index::traverse::SafetyCheck;
     use std::sync::{atomic::AtomicBool, Arc};
+
+    use crate::index::traverse::SafetyCheck;
 
     /// Traversal options for [`traverse()`][crate::index::File::traverse_with_lookup()]
     #[derive(Debug, Clone)]
@@ -33,8 +36,9 @@ mod options {
         }
     }
 }
-pub use options::Options;
 use std::sync::atomic::Ordering;
+
+pub use options::Options;
 
 /// Verify and validate the content of the index file
 impl index::File {

--- a/git-pack/src/index/util.rs
+++ b/git-pack/src/index/util.rs
@@ -1,5 +1,6 @@
-use git_features::progress::{self, Progress};
 use std::{io, time::Instant};
+
+use git_features::progress::{self, Progress};
 
 pub(crate) fn index_entries_sorted_by_offset_ascending(
     idx: &crate::index::File,

--- a/git-pack/src/index/verify.rs
+++ b/git-pack/src/index/verify.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicBool, Arc};
+
 use git_features::progress::{self, Progress};
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
 use git_object::{
@@ -7,7 +9,6 @@ use git_object::{
 };
 
 use crate::index;
-use std::{sync::atomic::AtomicBool, sync::Arc};
 
 /// Returned by [`index::File::verify_checksum()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/index/write/encode.rs
+++ b/git-pack/src/index/write/encode.rs
@@ -1,10 +1,12 @@
-use crate::index::{util::Count, V2_SIGNATURE};
+use std::{cmp::Ordering, collections::VecDeque, io};
+
 use byteorder::{BigEndian, WriteBytesExt};
 use git_features::{
     hash,
     progress::{self, Progress},
 };
-use std::{cmp::Ordering, collections::VecDeque, io};
+
+use crate::index::{util::Count, V2_SIGNATURE};
 
 pub(crate) fn write_to(
     out: impl io::Write,

--- a/git-pack/src/index/write/mod.rs
+++ b/git-pack/src/index/write/mod.rs
@@ -1,9 +1,11 @@
+use std::{convert::TryInto, io, sync::atomic::AtomicBool};
+
+use git_features::progress::{self, Progress};
+
 use crate::{
     loose,
     tree::{traverse::Context, Tree},
 };
-use git_features::progress::{self, Progress};
-use std::{convert::TryInto, io, sync::atomic::AtomicBool};
 
 mod encode;
 mod error;

--- a/git-pack/src/loose.rs
+++ b/git-pack/src/loose.rs
@@ -67,8 +67,9 @@ pub mod object {
         #[cfg(test)]
         mod tests {
             mod encode_decode_round_trip {
-                use crate::loose::object::header;
                 use git_object::bstr::ByteSlice;
+
+                use crate::loose::object::header;
 
                 #[test]
                 fn all() -> Result<(), Box<dyn std::error::Error>> {

--- a/git-pack/src/tree/from_offsets.rs
+++ b/git-pack/src/tree/from_offsets.rs
@@ -1,5 +1,3 @@
-use crate::{index::access::PackOffset, tree::Tree};
-use git_features::progress::{self, Progress};
 use std::{
     convert::TryFrom,
     fs, io,
@@ -7,6 +5,10 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
     time::Instant,
 };
+
+use git_features::progress::{self, Progress};
+
+use crate::{index::access::PackOffset, tree::Tree};
 
 /// Returned by [`Tree::from_offsets_in_pack()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/tree/traverse/mod.rs
+++ b/git-pack/src/tree/traverse/mod.rs
@@ -1,15 +1,17 @@
-use crate::{
-    data::EntryRange,
-    tree::{Item, Tree},
+use std::{
+    collections::VecDeque,
+    sync::atomic::{AtomicBool, Ordering},
 };
+
 use git_features::{
     parallel,
     parallel::in_parallel_if,
     progress::{self, Progress},
 };
-use std::{
-    collections::VecDeque,
-    sync::atomic::{AtomicBool, Ordering},
+
+use crate::{
+    data::EntryRange,
+    tree::{Item, Tree},
 };
 
 mod resolve;

--- a/git-pack/src/tree/traverse/resolve.rs
+++ b/git-pack/src/tree/traverse/resolve.rs
@@ -1,7 +1,14 @@
-use crate::{data::EntryRange, tree::traverse::Context, tree::traverse::Error};
-use git_features::progress::{unit, Progress};
-use git_features::zlib;
 use std::{cell::RefCell, collections::BTreeMap};
+
+use git_features::{
+    progress::{unit, Progress},
+    zlib,
+};
+
+use crate::{
+    data::EntryRange,
+    tree::traverse::{Context, Error},
+};
 
 pub(crate) fn deltas<T, F, P, MBFN, S, E>(
     nodes: crate::tree::Chunk<'_, T>,

--- a/git-pack/tests/pack/bundle.rs
+++ b/git-pack/tests/pack/bundle.rs
@@ -1,8 +1,9 @@
 mod locate {
-    use crate::{fixture_path, hex_to_id, pack::SMALL_PACK_INDEX};
     use bstr::ByteSlice;
     use git_object::Kind;
     use git_odb::pack;
+
+    use crate::{fixture_path, hex_to_id, pack::SMALL_PACK_INDEX};
 
     fn locate<'a>(hex_id: &str, out: &'a mut Vec<u8>) -> git_pack::data::Object<'a> {
         let bundle = pack::Bundle::at(fixture_path(SMALL_PACK_INDEX)).expect("pack and idx");
@@ -13,8 +14,9 @@ mod locate {
     }
 
     mod locate_and_verify {
-        use crate::{fixture_path, pack::PACKS_AND_INDICES};
         use git_odb::pack;
+
+        use crate::{fixture_path, pack::PACKS_AND_INDICES};
 
         #[test]
         fn all() -> Result<(), Box<dyn std::error::Error>> {
@@ -73,12 +75,16 @@ mod locate {
 }
 
 mod write_to_directory {
-    use crate::{fixture_path, pack::SMALL_PACK, pack::SMALL_PACK_INDEX};
+    use std::{fs, path::Path, sync::atomic::AtomicBool};
+
     use git_features::progress;
     use git_odb::pack;
-    use std::sync::atomic::AtomicBool;
-    use std::{fs, path::Path};
     use tempfile::TempDir;
+
+    use crate::{
+        fixture_path,
+        pack::{SMALL_PACK, SMALL_PACK_INDEX},
+    };
 
     fn expected_outcome() -> Result<pack::bundle::write::Outcome, Box<dyn std::error::Error>> {
         Ok(pack::bundle::write::Outcome {

--- a/git-pack/tests/pack/data/file.rs
+++ b/git-pack/tests/pack/data/file.rs
@@ -1,15 +1,19 @@
-use crate::fixture_path;
-use git_odb::pack;
 use std::convert::TryFrom;
+
+use git_odb::pack;
+
+use crate::fixture_path;
 
 fn pack_at(at: &str) -> pack::data::File {
     pack::data::File::try_from(fixture_path(at).as_path()).expect("valid pack file")
 }
 
 mod method {
-    use crate::{pack::data::file::pack_at, pack::SMALL_PACK};
-    use git_features::progress;
     use std::sync::atomic::AtomicBool;
+
+    use git_features::progress;
+
+    use crate::pack::{data::file::pack_at, SMALL_PACK};
 
     #[test]
     fn checksum() {
@@ -41,10 +45,13 @@ mod method {
 
 /// All hardcoded offsets are obtained via `git pack-verify --verbose  tests/fixtures/packs/pack-a2bf8e71d8c18879e499335762dd95119d93d9f1.idx`
 mod decode_entry {
-    use crate::{fixture_path, fixup, pack::data::file::pack_at, pack::SMALL_PACK};
     use bstr::ByteSlice;
-    use git_pack::cache;
-    use git_pack::data::ResolvedBase;
+    use git_pack::{cache, data::ResolvedBase};
+
+    use crate::{
+        fixture_path, fixup,
+        pack::{data::file::pack_at, SMALL_PACK},
+    };
 
     fn content_of(path: &str) -> Vec<u8> {
         fixup(std::fs::read(fixture_path(path)).expect("valid fixture"))
@@ -98,8 +105,9 @@ mod decode_entry {
 }
 
 mod decompress_entry {
-    use crate::{pack::data::file::pack_at, pack::SMALL_PACK};
     use git_object::bstr::ByteSlice;
+
+    use crate::pack::{data::file::pack_at, SMALL_PACK};
 
     #[test]
     fn commit() {

--- a/git-pack/tests/pack/data/header.rs
+++ b/git-pack/tests/pack/data/header.rs
@@ -1,5 +1,6 @@
-use crate::pack::fixture_path;
 use std::convert::TryInto;
+
+use crate::pack::fixture_path;
 
 #[test]
 fn encode_decode_roundtrip() -> crate::Result {

--- a/git-pack/tests/pack/data/input.rs
+++ b/git-pack/tests/pack/data/input.rs
@@ -1,7 +1,8 @@
 mod lookup_ref_delta_objects {
-    use crate::pack::hex_to_id;
     use git_hash::ObjectId;
     use git_pack::data::{self, entry::Header, input, input::LookupRefDeltaObjectsIter};
+
+    use crate::pack::hex_to_id;
 
     const D_A: &[u8] = b"a";
     const D_B: &[u8] = b"bb";

--- a/git-pack/tests/pack/data/output/count_and_entries.rs
+++ b/git-pack/tests/pack/data/output/count_and_entries.rs
@@ -1,9 +1,5 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 
-use crate::pack::{
-    data::output::{db, DbKind},
-    hex_to_id,
-};
 use git_features::{parallel::reduce::Finalize, progress};
 use git_odb::{compound, linked, pack, FindExt};
 use git_pack::data::{
@@ -11,7 +7,11 @@ use git_pack::data::{
     output::{count, entry},
 };
 use git_traverse::commit;
-use std::sync::atomic::AtomicBool;
+
+use crate::pack::{
+    data::output::{db, DbKind},
+    hex_to_id,
+};
 
 #[test]
 fn traversals() -> crate::Result {

--- a/git-pack/tests/pack/data/output/in_order_iter.rs
+++ b/git-pack/tests/pack/data/output/in_order_iter.rs
@@ -1,5 +1,6 @@
-use git_odb::data::output::InOrderIter;
 use std::convert::Infallible;
+
+use git_odb::data::output::InOrderIter;
 
 #[test]
 fn in_order_stays_in_order() {

--- a/git-pack/tests/pack/index.rs
+++ b/git-pack/tests/pack/index.rs
@@ -1,17 +1,18 @@
 mod file {
-    use crate::{
-        fixture_path, hex_to_id,
-        pack::{INDEX_V1, PACK_FOR_INDEX_V1},
-        pack::{SMALL_PACK, SMALL_PACK_INDEX},
-    };
     use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
     use git_object::{self as object};
     use git_odb::pack;
 
+    use crate::{
+        fixture_path, hex_to_id,
+        pack::{INDEX_V1, PACK_FOR_INDEX_V1, SMALL_PACK, SMALL_PACK_INDEX},
+    };
+
     mod method {
         mod v1 {
-            use crate::{fixture_path, pack::INDEX_V1};
             use git_pack::index;
+
+            use crate::{fixture_path, pack::INDEX_V1};
 
             #[test]
             fn lookup() -> Result<(), Box<dyn std::error::Error>> {
@@ -39,8 +40,9 @@ mod file {
         }
 
         mod v2 {
-            use crate::{fixture_path, pack::INDEX_V2};
             use git_pack::index;
+
+            use crate::{fixture_path, pack::INDEX_V2};
 
             #[test]
             fn lookup() -> Result<(), Box<dyn std::error::Error>> {
@@ -68,12 +70,14 @@ mod file {
         }
 
         mod any {
-            use crate::{fixture_path, pack::V2_PACKS_AND_INDICES};
+            use std::{fs, io, sync::atomic::AtomicBool};
+
             use filebuffer::FileBuffer;
             use git_features::progress;
             use git_odb::pack;
             use git_pack::data::{input, EntryRange};
-            use std::{fs, io, sync::atomic::AtomicBool};
+
+            use crate::{fixture_path, pack::V2_PACKS_AND_INDICES};
 
             #[test]
             fn write_to_stream() -> Result<(), Box<dyn std::error::Error>> {
@@ -180,12 +184,11 @@ mod file {
         }
     }
 
-    use crate::pack::{INDEX_V2, PACK_FOR_INDEX_V2};
     use common_macros::b_tree_map;
     use git_features::progress;
-    use git_pack::cache;
-    use git_pack::data::decode_entry::Outcome;
-    use git_pack::index;
+    use git_pack::{cache, data::decode_entry::Outcome, index};
+
+    use crate::pack::{INDEX_V2, PACK_FOR_INDEX_V2};
 
     static ALGORITHMS: &[index::traverse::Algorithm] = &[
         index::traverse::Algorithm::Lookup,

--- a/git-pack/tests/pack/iter.rs
+++ b/git-pack/tests/pack/iter.rs
@@ -10,12 +10,17 @@ fn size_of_entry() {
 }
 
 mod new_from_header {
-    use crate::{fixture_path, pack::SMALL_PACK, pack::V2_PACKS_AND_INDICES};
+    use std::fs;
+
     use git_odb::{
         pack,
         pack::data::input::{EntryDataMode, Mode},
     };
-    use std::fs;
+
+    use crate::{
+        fixture_path,
+        pack::{SMALL_PACK, V2_PACKS_AND_INDICES},
+    };
 
     #[test]
     fn header_encode() -> Result<(), Box<dyn std::error::Error>> {

--- a/git-pack/tests/pack/tree.rs
+++ b/git-pack/tests/pack/tree.rs
@@ -1,11 +1,13 @@
 mod method {
     mod from_offsets_in_pack {
+        use std::sync::atomic::AtomicBool;
+
+        use git_odb::pack;
+
         use crate::{
             fixture_path,
             pack::{INDEX_V1, PACK_FOR_INDEX_V1, SMALL_PACK, SMALL_PACK_INDEX},
         };
-        use git_odb::pack;
-        use std::sync::atomic::AtomicBool;
 
         #[test]
         fn v1() -> Result<(), Box<dyn std::error::Error>> {

--- a/git-packetline/src/decode.rs
+++ b/git-packetline/src/decode.rs
@@ -1,8 +1,7 @@
-use crate::{
-    PacketLine, {DELIMITER_LINE, FLUSH_LINE, MAX_DATA_LEN, MAX_LINE_LEN, RESPONSE_END_LINE, U16_HEX_BYTES},
-};
 use bstr::BString;
 use quick_error::quick_error;
+
+use crate::{PacketLine, DELIMITER_LINE, FLUSH_LINE, MAX_DATA_LEN, MAX_LINE_LEN, RESPONSE_END_LINE, U16_HEX_BYTES};
 
 quick_error! {
     /// The error used in the [`decode`][crate::decode] module

--- a/git-packetline/src/encode/async_io.rs
+++ b/git-packetline/src/encode/async_io.rs
@@ -1,12 +1,14 @@
-use super::u16_to_hex;
-use crate::{encode::Error, Channel, DELIMITER_LINE, ERR_PREFIX, FLUSH_LINE, MAX_DATA_LEN, RESPONSE_END_LINE};
-use futures_io::AsyncWrite;
-use futures_lite::AsyncWriteExt;
 use std::{
     io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures_io::AsyncWrite;
+use futures_lite::AsyncWriteExt;
+
+use super::u16_to_hex;
+use crate::{encode::Error, Channel, DELIMITER_LINE, ERR_PREFIX, FLUSH_LINE, MAX_DATA_LEN, RESPONSE_END_LINE};
 
 #[allow(missing_docs)]
 pin_project_lite::pin_project! {

--- a/git-packetline/src/encode/blocking_io.rs
+++ b/git-packetline/src/encode/blocking_io.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use super::u16_to_hex;
 use crate::{encode::Error, Channel, DELIMITER_LINE, ERR_PREFIX, FLUSH_LINE, MAX_DATA_LEN, RESPONSE_END_LINE};
-use std::io;
 
 /// Write a response-end message to `out`.
 pub fn response_end_to_write(mut out: impl io::Write) -> io::Result<usize> {

--- a/git-packetline/src/encode/mod.rs
+++ b/git-packetline/src/encode/mod.rs
@@ -1,5 +1,6 @@
-use crate::MAX_DATA_LEN;
 use quick_error::quick_error;
+
+use crate::MAX_DATA_LEN;
 
 quick_error! {
     /// The error returned by most functions in the [`encode`][crate::encode] module

--- a/git-packetline/src/immutable/async_io.rs
+++ b/git-packetline/src/immutable/async_io.rs
@@ -1,10 +1,12 @@
+use std::io;
+
+use futures_io::AsyncWrite;
+
 use crate::{
     encode,
     immutable::{Band, Error, Text},
     Channel, PacketLine,
 };
-use futures_io::AsyncWrite;
-use std::io;
 
 impl<'a> Band<'a> {
     /// Serialize this instance to `out`, returning the amount of bytes written.

--- a/git-packetline/src/immutable/blocking_io.rs
+++ b/git-packetline/src/immutable/blocking_io.rs
@@ -1,9 +1,10 @@
+use std::io;
+
 use crate::{
     encode,
     immutable::{Band, Error, Text},
     Channel, PacketLine,
 };
-use std::io;
 
 impl<'a> Band<'a> {
     /// Serialize this instance to `out`, returning the amount of bytes written.

--- a/git-packetline/src/immutable/mod.rs
+++ b/git-packetline/src/immutable/mod.rs
@@ -1,5 +1,6 @@
-use crate::{Channel, ERR_PREFIX};
 use bstr::BStr;
+
+use crate::{Channel, ERR_PREFIX};
 
 /// A borrowed packet line as it refers to a slice of data by reference.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]

--- a/git-packetline/src/read/async_io.rs
+++ b/git-packetline/src/read/async_io.rs
@@ -1,12 +1,14 @@
+use std::io;
+
+use bstr::ByteSlice;
+use futures_io::AsyncRead;
+use futures_lite::AsyncReadExt;
+
 use crate::{
     decode,
     read::{ExhaustiveOutcome, WithSidebands},
     PacketLine, StreamingPeekableIter, MAX_LINE_LEN, U16_HEX_BYTES,
 };
-use bstr::ByteSlice;
-use futures_io::AsyncRead;
-use futures_lite::AsyncReadExt;
-use std::io;
 
 /// Non-IO methods
 impl<T> StreamingPeekableIter<T>

--- a/git-packetline/src/read/blocking_io.rs
+++ b/git-packetline/src/read/blocking_io.rs
@@ -1,10 +1,12 @@
+use std::io;
+
+use bstr::ByteSlice;
+
 use crate::{
     decode,
     read::{ExhaustiveOutcome, WithSidebands},
     PacketLine, StreamingPeekableIter, MAX_LINE_LEN, U16_HEX_BYTES,
 };
-use bstr::ByteSlice;
-use std::io;
 
 /// Non-IO methods
 impl<T> StreamingPeekableIter<T>

--- a/git-packetline/src/read/sidebands/async_io.rs
+++ b/git-packetline/src/read/sidebands/async_io.rs
@@ -1,14 +1,16 @@
-use crate::{
-    decode,
-    immutable::{Band, Text},
-    PacketLine, StreamingPeekableIter, U16_HEX_BYTES,
-};
-use futures_io::{AsyncBufRead, AsyncRead};
-use futures_lite::ready;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
+};
+
+use futures_io::{AsyncBufRead, AsyncRead};
+use futures_lite::ready;
+
+use crate::{
+    decode,
+    immutable::{Band, Text},
+    PacketLine, StreamingPeekableIter, U16_HEX_BYTES,
 };
 
 type ReadLineResult<'a> = Option<std::io::Result<Result<PacketLine<'a>, decode::Error>>>;
@@ -188,8 +190,9 @@ where
     F: FnMut(bool, &[u8]) + Unpin,
 {
     fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
-        use futures_lite::FutureExt;
         use std::io;
+
+        use futures_lite::FutureExt;
         {
             let this = self.as_mut().get_mut();
             if this.pos >= this.cap {

--- a/git-packetline/src/read/sidebands/blocking_io.rs
+++ b/git-packetline/src/read/sidebands/blocking_io.rs
@@ -1,8 +1,9 @@
+use std::{io, io::BufRead};
+
 use crate::{
     immutable::{Band, Text},
     PacketLine, StreamingPeekableIter, U16_HEX_BYTES,
 };
-use std::{io, io::BufRead};
 
 /// An implementor of [`BufRead`][io::BufRead] yielding packet lines on each call to [`read_line()`][io::BufRead::read_line()].
 /// It's also possible to hide the underlying packet lines using the [`Read`][io::Read] implementation which is useful

--- a/git-packetline/src/write/async_io.rs
+++ b/git-packetline/src/write/async_io.rs
@@ -1,10 +1,12 @@
-use crate::{encode, MAX_DATA_LEN, U16_HEX_BYTES};
-use futures_io::AsyncWrite;
 use std::{
     io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures_io::AsyncWrite;
+
+use crate::{encode, MAX_DATA_LEN, U16_HEX_BYTES};
 
 pin_project_lite::pin_project! {
     /// An implementor of [`Write`][io::Write] which passes all input to an inner `Write` in packet line data encoding,

--- a/git-packetline/src/write/blocking_io.rs
+++ b/git-packetline/src/write/blocking_io.rs
@@ -1,5 +1,6 @@
-use crate::{MAX_DATA_LEN, U16_HEX_BYTES};
 use std::io;
+
+use crate::{MAX_DATA_LEN, U16_HEX_BYTES};
 
 /// An implementor of [`Write`][io::Write] which passes all input to an inner `Write` in packet line data encoding,
 /// one line per `write(…)` call or as many lines as it takes if the data doesn't fit into the maximum allowed line length.

--- a/git-packetline/tests/decode/mod.rs
+++ b/git-packetline/tests/decode/mod.rs
@@ -1,10 +1,11 @@
 mod streaming {
-    use crate::assert_err_display;
     use git_packetline::{
         decode::{self, streaming, Stream},
         immutable::Error,
         PacketLine,
     };
+
+    use crate::assert_err_display;
 
     fn assert_complete(
         res: Result<Stream, decode::Error>,
@@ -22,9 +23,10 @@ mod streaming {
     }
 
     mod round_trip {
-        use crate::decode::streaming::assert_complete;
         use bstr::ByteSlice;
         use git_packetline::{decode, decode::streaming, Channel, PacketLine};
+
+        use crate::decode::streaming::assert_complete;
 
         #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
         async fn trailing_line_feeds_are_removed_explicitly() -> crate::Result {

--- a/git-packetline/tests/encode/mod.rs
+++ b/git-packetline/tests/encode/mod.rs
@@ -1,11 +1,13 @@
 mod data_to_write {
-    use crate::assert_err_display;
+    #[cfg(feature = "blocking-io")]
+    use std::io;
+
     use bstr::ByteSlice;
     #[cfg(all(feature = "async-io", not(feature = "blocking-io")))]
     use futures_lite::io;
     use git_packetline::encode::data_to_write;
-    #[cfg(feature = "blocking-io")]
-    use std::io;
+
+    use crate::assert_err_display;
 
     #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
     async fn binary_and_non_binary() -> crate::Result {

--- a/git-packetline/tests/read/mod.rs
+++ b/git-packetline/tests/read/mod.rs
@@ -1,9 +1,10 @@
 mod sideband;
 
 pub mod streaming_peek_iter {
+    use std::{io, path::PathBuf};
+
     use bstr::ByteSlice;
     use git_packetline::PacketLine;
-    use std::{io, path::PathBuf};
 
     fn fixture_path(path: &str) -> PathBuf {
         PathBuf::from("tests/fixtures").join(path)

--- a/git-packetline/tests/read/sideband.rs
+++ b/git-packetline/tests/read/sideband.rs
@@ -1,17 +1,20 @@
-use crate::read::streaming_peek_iter::fixture_bytes;
+#[cfg(feature = "blocking-io")]
+use std::io::{BufRead, Read};
+
 use bstr::{BString, ByteSlice};
 #[cfg(all(not(feature = "blocking-io"), feature = "async-io"))]
 use futures_lite::io::AsyncReadExt;
 use git_odb::pack;
 use git_packetline::PacketLine;
-#[cfg(feature = "blocking-io")]
-use std::io::{BufRead, Read};
+
+use crate::read::streaming_peek_iter::fixture_bytes;
 
 #[cfg(all(not(feature = "blocking-io"), feature = "async-io"))]
 mod util {
+    use std::{io::Result, pin::Pin};
+
     use futures_io::{AsyncBufRead, AsyncRead};
     use futures_lite::{future, AsyncBufReadExt, AsyncReadExt};
-    use std::{io::Result, pin::Pin};
 
     pub struct BlockOn<T>(pub T);
 

--- a/git-packetline/tests/write/mod.rs
+++ b/git-packetline/tests/write/mod.rs
@@ -1,9 +1,10 @@
+#[cfg(feature = "blocking-io")]
+use std::io::Write;
+
 use bstr::ByteSlice;
 #[cfg(all(feature = "async-io", not(feature = "blocking-io")))]
 use futures_lite::prelude::*;
 use git_packetline::Writer;
-#[cfg(feature = "blocking-io")]
-use std::io::Write;
 
 const MAX_DATA_LEN: usize = 65516;
 const MAX_LINE_LEN: usize = 4 + MAX_DATA_LEN;

--- a/git-protocol/src/credentials.rs
+++ b/git-protocol/src/credentials.rs
@@ -1,9 +1,10 @@
-use git_transport::client;
-use quick_error::quick_error;
 use std::{
     io::{self, Write},
     process::{Command, Stdio},
 };
+
+use git_transport::client;
+use quick_error::quick_error;
 
 /// The result used in [`helper()`].
 pub type Result = std::result::Result<Option<Outcome>, Error>;

--- a/git-protocol/src/fetch/arguments/async_io.rs
+++ b/git-protocol/src/fetch/arguments/async_io.rs
@@ -1,6 +1,7 @@
-use crate::fetch::{Arguments, Command};
 use futures_lite::io::AsyncWriteExt;
 use git_transport::{client, client::TransportV2Ext};
+
+use crate::fetch::{Arguments, Command};
 
 impl Arguments {
     pub(crate) async fn send<'a, T: client::Transport + 'a>(

--- a/git-protocol/src/fetch/arguments/blocking_io.rs
+++ b/git-protocol/src/fetch/arguments/blocking_io.rs
@@ -1,6 +1,8 @@
-use crate::fetch::{Arguments, Command};
-use git_transport::{client, client::TransportV2Ext};
 use std::io::Write;
+
+use git_transport::{client, client::TransportV2Ext};
+
+use crate::fetch::{Arguments, Command};
 
 impl Arguments {
     pub(crate) fn send<'a, T: client::Transport + 'a>(

--- a/git-protocol/src/fetch/arguments/mod.rs
+++ b/git-protocol/src/fetch/arguments/mod.rs
@@ -1,5 +1,6 @@
-use bstr::{BStr, BString, ByteVec};
 use std::fmt;
+
+use bstr::{BStr, BString, ByteVec};
 
 /// The arguments passed to a server command.
 pub struct Arguments {
@@ -169,9 +170,10 @@ impl Arguments {
 
 #[cfg(any(feature = "blocking-client", feature = "async-client"))]
 mod shared {
-    use crate::fetch::Arguments;
     use bstr::{BString, ByteSlice};
     use git_transport::{client, client::MessageKind};
+
+    use crate::fetch::Arguments;
 
     impl Arguments {
         pub(in crate::fetch::arguments) fn prepare_v1(

--- a/git-protocol/src/fetch/command.rs
+++ b/git-protocol/src/fetch/command.rs
@@ -22,9 +22,10 @@ impl Command {
 
 #[cfg(any(test, feature = "async-client", feature = "blocking-client"))]
 mod with_io {
-    use crate::fetch::{agent, command::Feature, Command};
     use bstr::{BString, ByteSlice};
     use git_transport::client::Capabilities;
+
+    use crate::fetch::{agent, command::Feature, Command};
 
     impl Command {
         /// Only V2

--- a/git-protocol/src/fetch/delegate.rs
+++ b/git-protocol/src/fetch/delegate.rs
@@ -1,10 +1,12 @@
-use crate::fetch::{Arguments, Ref, Response};
-use bstr::BString;
-use git_transport::client::Capabilities;
 use std::{
     io,
     ops::{Deref, DerefMut},
 };
+
+use bstr::BString;
+use git_transport::client::Capabilities;
+
+use crate::fetch::{Arguments, Ref, Response};
 
 /// Defines what to do next after certain [`Delegate`] operations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
@@ -184,12 +186,14 @@ impl<T: DelegateBlocking> DelegateBlocking for &mut T {
 
 #[cfg(feature = "blocking-client")]
 mod blocking_io {
-    use crate::fetch::{DelegateBlocking, Ref, Response};
-    use git_features::progress::Progress;
     use std::{
         io::{self, BufRead},
         ops::DerefMut,
     };
+
+    use git_features::progress::Progress;
+
+    use crate::fetch::{DelegateBlocking, Ref, Response};
 
     /// The protocol delegate is the bare minimal interface needed to fully control the [`fetch`][crate::fetch()] operation.
     ///
@@ -243,11 +247,13 @@ pub use blocking_io::Delegate;
 
 #[cfg(feature = "async-client")]
 mod async_io {
-    use crate::fetch::{DelegateBlocking, Ref, Response};
+    use std::{io, ops::DerefMut};
+
     use async_trait::async_trait;
     use futures_io::AsyncBufRead;
     use git_features::progress::Progress;
-    use std::{io, ops::DerefMut};
+
+    use crate::fetch::{DelegateBlocking, Ref, Response};
 
     /// The protocol delegate is the bare minimal interface needed to fully control the [`fetch`][crate::fetch()] operation.
     ///

--- a/git-protocol/src/fetch/error.rs
+++ b/git-protocol/src/fetch/error.rs
@@ -1,10 +1,12 @@
+use std::io;
+
+use git_transport::client;
+use quick_error::quick_error;
+
 use crate::{
     credentials,
     fetch::{refs, response},
 };
-use git_transport::client;
-use quick_error::quick_error;
-use std::io;
 
 quick_error! {
     /// The error used in [`fetch()`][super::fetch].

--- a/git-protocol/src/fetch/refs.rs
+++ b/git-protocol/src/fetch/refs.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use bstr::BString;
 use quick_error::quick_error;
-use std::io;
 
 quick_error! {
     /// The error returned when parsing References/refs from the server response.
@@ -80,8 +81,9 @@ impl Ref {
 
 #[cfg(any(feature = "blocking-client", feature = "async-client"))]
 pub(crate) mod shared {
-    use crate::fetch::{refs, Ref};
     use bstr::{BString, ByteSlice};
+
+    use crate::fetch::{refs, Ref};
 
     impl From<InternalRef> for Ref {
         fn from(v: InternalRef) -> Self {
@@ -265,9 +267,10 @@ pub(crate) mod shared {
 
 #[cfg(feature = "async-client")]
 mod async_io {
-    use crate::fetch::{refs, Ref};
     use futures_io::AsyncBufRead;
     use futures_lite::AsyncBufReadExt;
+
+    use crate::fetch::{refs, Ref};
 
     /// Parse refs from the given input line by line. Protocol V2 is required for this to succeed.
     pub async fn from_v2_refs(in_refs: &mut (dyn AsyncBufRead + Unpin)) -> Result<Vec<Ref>, refs::Error> {
@@ -315,8 +318,9 @@ pub use async_io::{from_v1_refs_received_as_part_of_handshake_and_capabilities, 
 
 #[cfg(feature = "blocking-client")]
 mod blocking_io {
-    use crate::fetch::{refs, Ref};
     use std::io;
+
+    use crate::fetch::{refs, Ref};
 
     /// Parse refs from the given input line by line. Protocol V2 is required for this to succeed.
     pub fn from_v2_refs(in_refs: &mut dyn io::BufRead) -> Result<Vec<Ref>, refs::Error> {

--- a/git-protocol/src/fetch/response/async_io.rs
+++ b/git-protocol/src/fetch/response/async_io.rs
@@ -1,11 +1,13 @@
+use std::io;
+
+use futures_lite::AsyncBufReadExt;
+use git_transport::{client, Protocol};
+
 use crate::fetch::{
     response,
     response::{Acknowledgement, ShallowUpdate, WantedRef},
     Response,
 };
-use futures_lite::AsyncBufReadExt;
-use git_transport::{client, Protocol};
-use std::io;
 
 async fn parse_v2_section<T>(
     line: &mut String,

--- a/git-protocol/src/fetch/response/blocking_io.rs
+++ b/git-protocol/src/fetch/response/blocking_io.rs
@@ -1,10 +1,12 @@
+use std::io;
+
+use git_transport::{client, Protocol};
+
 use crate::fetch::{
     response,
     response::{Acknowledgement, ShallowUpdate, WantedRef},
     Response,
 };
-use git_transport::{client, Protocol};
-use std::io;
 
 fn parse_v2_section<T>(
     line: &mut String,

--- a/git-protocol/src/fetch/response/mod.rs
+++ b/git-protocol/src/fetch/response/mod.rs
@@ -1,8 +1,10 @@
-use crate::fetch::command::Feature;
+use std::io;
+
 use bstr::BString;
 use git_transport::{client, Protocol};
 use quick_error::quick_error;
-use std::io;
+
+use crate::fetch::command::Feature;
 
 quick_error! {
     /// The error used in the [response module][crate::fetch::response].

--- a/git-protocol/src/fetch/tests/arguments.rs
+++ b/git-protocol/src/fetch/tests/arguments.rs
@@ -1,6 +1,7 @@
-use crate::fetch;
 use bstr::ByteSlice;
 use git_transport::Protocol;
+
+use crate::fetch;
 
 fn arguments_v1(features: impl IntoIterator<Item = &'static str>) -> fetch::Arguments {
     fetch::Arguments::new(Protocol::V1, features.into_iter().map(|n| (n, None)).collect())
@@ -17,12 +18,13 @@ struct Transport<T> {
 
 #[cfg(feature = "blocking-client")]
 mod impls {
-    use crate::fetch::tests::arguments::Transport;
     use git_transport::{
         client,
         client::{Error, Identity, MessageKind, RequestWriter, SetServiceResponse, WriteMode},
         Protocol, Service,
     };
+
+    use crate::fetch::tests::arguments::Transport;
 
     impl<T: client::TransportWithoutIO> client::TransportWithoutIO for Transport<T> {
         fn set_identity(&mut self, identity: Identity) -> Result<(), Error> {
@@ -59,13 +61,14 @@ mod impls {
 
 #[cfg(feature = "async-client")]
 mod impls {
-    use crate::fetch::tests::arguments::Transport;
     use async_trait::async_trait;
     use git_transport::{
         client,
         client::{Error, Identity, MessageKind, RequestWriter, SetServiceResponse, WriteMode},
         Protocol, Service,
     };
+
+    use crate::fetch::tests::arguments::Transport;
     impl<T: client::TransportWithoutIO + Send> client::TransportWithoutIO for Transport<T> {
         fn set_identity(&mut self, identity: Identity) -> Result<(), Error> {
             self.inner.set_identity(identity)
@@ -122,8 +125,9 @@ fn id(hex: &str) -> git_hash::ObjectId {
 }
 
 mod v1 {
-    use crate::fetch::tests::arguments::{arguments_v1, id, transport};
     use bstr::ByteSlice;
+
+    use crate::fetch::tests::arguments::{arguments_v1, id, transport};
 
     #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
     async fn haves_and_wants_for_clone() {
@@ -207,8 +211,9 @@ mod v1 {
 }
 
 mod v2 {
-    use crate::fetch::tests::arguments::{arguments_v2, id, transport};
     use bstr::ByteSlice;
+
+    use crate::fetch::tests::arguments::{arguments_v2, id, transport};
 
     #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
     async fn haves_and_wants_for_clone_stateful() {

--- a/git-protocol/src/fetch/tests/command.rs
+++ b/git-protocol/src/fetch/tests/command.rs
@@ -119,8 +119,7 @@ mod v2 {
         mod validate {
             use bstr::ByteSlice;
 
-            use crate::fetch::tests::command::v2::capabilities;
-            use crate::fetch::Command;
+            use crate::fetch::{tests::command::v2::capabilities, Command};
 
             #[test]
             fn ref_prefixes_can_always_be_used() {

--- a/git-protocol/src/fetch/tests/refs.rs
+++ b/git-protocol/src/fetch/tests/refs.rs
@@ -1,8 +1,7 @@
-use crate::fetch::{refs, refs::shared::InternalRef, Ref};
-use git_transport::client;
-
 use git_testtools::hex_to_id as oid;
-use git_transport::client::Capabilities;
+use git_transport::{client, client::Capabilities};
+
+use crate::fetch::{refs, refs::shared::InternalRef, Ref};
 
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
 async fn extract_references_from_v2_refs() {

--- a/git-protocol/src/fetch_fn.rs
+++ b/git-protocol/src/fetch_fn.rs
@@ -1,7 +1,5 @@
-use crate::{
-    credentials,
-    fetch::{refs, Action, Arguments, Command, Delegate, Error, LsRefsAction, Response},
-};
+use std::io;
+
 use git_features::{progress, progress::Progress};
 use git_transport::{
     client,
@@ -9,7 +7,11 @@ use git_transport::{
     Service,
 };
 use maybe_async::maybe_async;
-use std::io;
+
+use crate::{
+    credentials,
+    fetch::{refs, Action, Arguments, Command, Delegate, Error, LsRefsAction, Response},
+};
 
 /// A way to indicate how to treat the connection underlying the transport, potentially allowing to reuse it.
 pub enum FetchConnection {

--- a/git-protocol/src/remote_progress.rs
+++ b/git-protocol/src/remote_progress.rs
@@ -1,10 +1,11 @@
+use std::convert::TryFrom;
+
 use bstr::ByteSlice;
 use nom::{
     bytes::complete::{tag, take_till, take_till1},
     combinator::{map_res, opt},
     sequence::{preceded, terminated},
 };
-use std::convert::TryFrom;
 
 /// The information usually found in remote progress messages as sent by a git server during
 /// fetch, clone and push operations.

--- a/git-protocol/tests/credentials/mod.rs
+++ b/git-protocol/tests/credentials/mod.rs
@@ -11,8 +11,9 @@ mod encode_message {
     }
 
     mod invalid {
-        use git_protocol::credentials;
         use std::io;
+
+        use git_protocol::credentials;
 
         #[test]
         fn contains_null() {
@@ -63,8 +64,9 @@ this=is-skipped-past-empty-line"
     }
 
     mod invalid {
-        use git_protocol::credentials;
         use std::io;
+
+        use git_protocol::credentials;
 
         #[test]
         fn null_in_key() -> crate::Result {

--- a/git-protocol/tests/fetch/mod.rs
+++ b/git-protocol/tests/fetch/mod.rs
@@ -1,6 +1,6 @@
-use bstr::{BString, ByteSlice};
 use std::io;
 
+use bstr::{BString, ByteSlice};
 use git_protocol::fetch::{self, Action, Arguments, LsRefsAction, Ref, Response};
 use git_transport::client::Capabilities;
 
@@ -132,13 +132,15 @@ impl fetch::DelegateBlocking for LsRemoteDelegate {
 
 #[cfg(feature = "blocking-client")]
 mod blocking_io {
-    use crate::fetch::{CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
+    use std::io;
+
     use git_features::progress::Progress;
     use git_protocol::{
         fetch,
         fetch::{Ref, Response},
     };
-    use std::io;
+
+    use crate::fetch::{CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
 
     impl fetch::Delegate for CloneDelegate {
         fn receive_pack(
@@ -187,7 +189,8 @@ mod blocking_io {
 
 #[cfg(feature = "async-client")]
 mod async_io {
-    use crate::fetch::{CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
+    use std::io;
+
     use async_trait::async_trait;
     use futures_io::AsyncBufRead;
     use git_features::progress::Progress;
@@ -195,7 +198,8 @@ mod async_io {
         fetch,
         fetch::{Ref, Response},
     };
-    use std::io;
+
+    use crate::fetch::{CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
 
     #[async_trait(?Send)]
     impl fetch::Delegate for CloneDelegate {

--- a/git-protocol/tests/fetch/response.rs
+++ b/git-protocol/tests/fetch/response.rs
@@ -12,7 +12,9 @@ fn id(hex: &str) -> git_hash::ObjectId {
 
 mod v1 {
     mod from_line_reader {
-        use crate::fetch::response::{id, mock_reader};
+        #[cfg(feature = "blocking-client")]
+        use std::io::Read;
+
         #[cfg(feature = "async-client")]
         use futures_lite::io::AsyncReadExt;
         use git_protocol::fetch::{
@@ -20,8 +22,8 @@ mod v1 {
             response::{Acknowledgement, ShallowUpdate},
         };
         use git_transport::Protocol;
-        #[cfg(feature = "blocking-client")]
-        use std::io::Read;
+
+        use crate::fetch::response::{id, mock_reader};
 
         #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
         async fn clone() -> crate::Result {
@@ -107,7 +109,9 @@ mod v1 {
 }
 mod v2 {
     mod from_line_reader {
-        use crate::fetch::response::{id, mock_reader};
+        #[cfg(feature = "blocking-client")]
+        use std::io::Read;
+
         #[cfg(feature = "async-client")]
         use futures_lite::io::AsyncReadExt;
         use git_protocol::fetch::{
@@ -115,8 +119,8 @@ mod v2 {
             response::{Acknowledgement, ShallowUpdate},
         };
         use git_transport::Protocol;
-        #[cfg(feature = "blocking-client")]
-        use std::io::Read;
+
+        use crate::fetch::response::{id, mock_reader};
 
         #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
         async fn clone() -> crate::Result {

--- a/git-protocol/tests/fetch/v1.rs
+++ b/git-protocol/tests/fetch/v1.rs
@@ -1,8 +1,9 @@
-use crate::fetch::{oid, transport, CloneDelegate, LsRemoteDelegate};
 use bstr::ByteSlice;
 use git_features::progress;
 use git_protocol::{fetch, FetchConnection};
 use git_transport::Protocol;
+
+use crate::fetch::{oid, transport, CloneDelegate, LsRemoteDelegate};
 
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
 async fn clone() -> crate::Result {

--- a/git-protocol/tests/fetch/v2.rs
+++ b/git-protocol/tests/fetch/v2.rs
@@ -1,8 +1,9 @@
-use crate::fetch::{oid, transport, CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
 use bstr::ByteSlice;
 use git_features::progress;
 use git_protocol::{fetch, FetchConnection};
 use git_transport::Protocol;
+
+use crate::fetch::{oid, transport, CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
 
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
 async fn clone_abort_prep() -> crate::Result {

--- a/git-ref/src/mutable.rs
+++ b/git-ref/src/mutable.rs
@@ -1,7 +1,9 @@
-use crate::Kind;
+use std::{borrow::Cow, convert::TryFrom, fmt, path::Path};
+
 use bstr::{BStr, BString, ByteSlice};
 use git_hash::{oid, ObjectId};
-use std::{borrow::Cow, convert::TryFrom, fmt, path::Path};
+
+use crate::Kind;
 
 /// Indicate that the given BString is a validate reference name or path that can be used as path on disk or written as target
 /// of a symbolic reference

--- a/git-ref/src/name.rs
+++ b/git-ref/src/name.rs
@@ -1,6 +1,12 @@
-use crate::{FullName, PartialName};
+use std::{
+    borrow::Cow,
+    convert::{Infallible, TryFrom},
+    path::Path,
+};
+
 use bstr::{BStr, ByteSlice};
-use std::{borrow::Cow, convert::Infallible, convert::TryFrom, path::Path};
+
+use crate::{FullName, PartialName};
 
 /// The error used in the [`PartialName`][super::PartialName]::try_from(…) implementations.
 pub type Error = git_validate::reference::name::Error;

--- a/git-ref/src/namespace.rs
+++ b/git-ref/src/namespace.rs
@@ -1,6 +1,8 @@
-use crate::{Namespace, PartialName};
-use bstr::{BStr, BString, ByteSlice, ByteVec};
 use std::{borrow::Cow, convert::TryInto, path::Path};
+
+use bstr::{BStr, BString, ByteSlice, ByteVec};
+
+use crate::{Namespace, PartialName};
 
 impl Namespace {
     /// Dissolve ourselves into the interior representation

--- a/git-ref/src/store/file/find.rs
+++ b/git-ref/src/store/file/find.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use bstr::ByteSlice;
-
 pub use error::Error;
 
 use crate::{

--- a/git-ref/src/store/file/log/iter.rs
+++ b/git-ref/src/store/file/log/iter.rs
@@ -1,5 +1,6 @@
-use crate::store::{file::log, file::log::iter::decode::LineNumber};
 use bstr::ByteSlice;
+
+use crate::store::file::{log, log::iter::decode::LineNumber};
 
 ///
 pub mod decode {

--- a/git-ref/src/store/file/log/line.rs
+++ b/git-ref/src/store/file/log/line.rs
@@ -1,5 +1,6 @@
-use crate::store::file::log::Line;
 use git_hash::ObjectId;
+
+use crate::store::file::log::Line;
 
 impl<'a> Line<'a> {
     /// The previous object id of the ref. It will be a null hash if there was no previous id as
@@ -15,16 +16,16 @@ impl<'a> Line<'a> {
 
 ///
 pub mod decode {
-    use crate::{file::log::Line, parse::hex_hash};
-
     use bstr::{BStr, ByteSlice};
     use nom::{
-        bytes::{complete::tag, complete::take_while},
+        bytes::complete::{tag, take_while},
         combinator::opt,
         error::{context, ContextError, ParseError},
         sequence::{terminated, tuple},
         IResult,
     };
+
+    use crate::{file::log::Line, parse::hex_hash};
 
     ///
     mod error {
@@ -110,10 +111,11 @@ pub mod decode {
 
     #[cfg(test)]
     mod test {
-        use super::*;
         use bstr::ByteSlice;
         use git_actor::{Sign, Time};
         use git_hash::ObjectId;
+
+        use super::*;
 
         fn hex_to_oid(hex: &str) -> ObjectId {
             ObjectId::from_hex(hex.as_bytes()).unwrap()
@@ -125,10 +127,10 @@ pub mod decode {
         }
 
         mod invalid {
-            use super::one;
-
             use git_testtools::to_bstr_err;
             use nom::error::VerboseError;
+
+            use super::one;
 
             #[test]
             fn completely_bogus_shows_error_with_context() {

--- a/git-ref/src/store/file/log/mod.rs
+++ b/git-ref/src/store/file/log/mod.rs
@@ -56,10 +56,12 @@ pub mod mutable {
     }
 
     mod write {
-        use super::Line;
+        use std::io;
+
         use bstr::{BStr, ByteSlice};
         use quick_error::quick_error;
-        use std::io;
+
+        use super::Line;
 
         quick_error! {
             /// The Error produced by [`Line::write_to()`] (but wrapped in an io error).

--- a/git-ref/src/store/file/loose/iter.rs
+++ b/git-ref/src/store/file/loose/iter.rs
@@ -1,13 +1,15 @@
-use crate::{
-    mutable::FullName,
-    store::file::{self, loose::Reference},
-};
-use bstr::ByteSlice;
-use git_features::fs::walkdir::DirEntryIter;
-use os_str_bytes::OsStrBytes;
 use std::{
     io::Read,
     path::{Path, PathBuf},
+};
+
+use bstr::ByteSlice;
+use git_features::fs::walkdir::DirEntryIter;
+use os_str_bytes::OsStrBytes;
+
+use crate::{
+    mutable::FullName,
+    store::file::{self, loose::Reference},
 };
 
 /// An iterator over all valid loose reference paths as seen from a particular base directory.
@@ -152,9 +154,11 @@ impl file::Store {
 ///
 pub mod loose {
     mod error {
-        use crate::file;
-        use quick_error::quick_error;
         use std::{io, path::PathBuf};
+
+        use quick_error::quick_error;
+
+        use crate::file;
 
         quick_error! {
             /// The error returned by [file::overlay::Loose] iteration.

--- a/git-ref/src/store/file/loose/reference/decode.rs
+++ b/git-ref/src/store/file/loose/reference/decode.rs
@@ -1,8 +1,5 @@
-use crate::{
-    mutable,
-    parse::{hex_hash, newline},
-    store::file::loose::Reference,
-};
+use std::convert::{TryFrom, TryInto};
+
 use bstr::BString;
 use git_hash::ObjectId;
 use nom::{
@@ -12,7 +9,12 @@ use nom::{
     IResult,
 };
 use quick_error::quick_error;
-use std::convert::{TryFrom, TryInto};
+
+use crate::{
+    mutable,
+    parse::{hex_hash, newline},
+    store::file::loose::Reference,
+};
 
 enum MaybeUnsafeState {
     Id(ObjectId),

--- a/git-ref/src/store/file/loose/reference/peel.rs
+++ b/git-ref/src/store/file/loose/reference/peel.rs
@@ -60,10 +60,11 @@ impl loose::Reference {
 
 ///
 pub mod to_id {
+    use std::{collections::BTreeSet, path::PathBuf};
+
     use bstr::BString;
     use git_hash::oid;
     use quick_error::quick_error;
-    use std::{collections::BTreeSet, path::PathBuf};
 
     use crate::{
         mutable::{FullName, Target},

--- a/git-ref/src/store/file/loose/reflog.rs
+++ b/git-ref/src/store/file/loose/reflog.rs
@@ -1,8 +1,9 @@
+use std::{convert::TryInto, io::Read, path::PathBuf};
+
 use crate::{
     store::{file, file::log},
     FullName,
 };
-use std::{convert::TryInto, io::Read, path::PathBuf};
 
 impl file::Store {
     /// Returns true if a reflog exists for the given reference `name`.
@@ -83,13 +84,15 @@ impl file::Store {
 
 ///
 pub mod create_or_update {
-    use crate::store::{file, file::WriteReflog};
-    use bstr::BStr;
-    use git_hash::{oid, ObjectId};
     use std::{
         io::Write,
         path::{Path, PathBuf},
     };
+
+    use bstr::BStr;
+    use git_hash::{oid, ObjectId};
+
+    use crate::store::{file, file::WriteReflog};
 
     impl file::Store {
         pub(crate) fn reflog_create_or_append(
@@ -210,8 +213,9 @@ pub mod create_or_update {
     mod tests;
 
     mod error {
-        use quick_error::quick_error;
         use std::path::PathBuf;
+
+        use quick_error::quick_error;
 
         quick_error! {
             /// The error returned when creating or appending to a reflog
@@ -236,8 +240,9 @@ pub mod create_or_update {
 }
 
 mod error {
-    use quick_error::quick_error;
     use std::io;
+
+    use quick_error::quick_error;
 
     quick_error! {
         /// The error returned by [crate::file::Store::reflog_iter()].

--- a/git-ref/src/store/file/overlay.rs
+++ b/git-ref/src/store/file/overlay.rs
@@ -1,13 +1,14 @@
-use crate::{
-    file::{loose, path_to_name, Reference},
-    mutable::FullName,
-    store::{file, packed},
-};
 use std::{
     cmp::Ordering,
     io::Read,
     iter::Peekable,
     path::{Path, PathBuf},
+};
+
+use crate::{
+    file::{loose, path_to_name, Reference},
+    mutable::FullName,
+    store::{file, packed},
 };
 
 /// An iterator stepping through sorted input of loose references and packed references, preferring loose refs over otherwise
@@ -147,10 +148,12 @@ impl file::Store {
 }
 
 mod error {
-    use crate::store::file;
+    use std::{io, path::PathBuf};
+
     use bstr::BString;
     use quick_error::quick_error;
-    use std::{io, path::PathBuf};
+
+    use crate::store::file;
 
     quick_error! {
         /// The error returned by the [`LooseThenPacked`][super::LooseThenPacked] iterator.

--- a/git-ref/src/store/file/packed.rs
+++ b/git-ref/src/store/file/packed.rs
@@ -33,8 +33,9 @@ impl file::Store {
 
 ///
 pub mod transaction {
-    use crate::store::packed;
     use quick_error::quick_error;
+
+    use crate::store::packed;
 
     quick_error! {
         /// The error returned by [`file::Store::packed_transaction`][crate::file::Store::packed_transaction()].

--- a/git-ref/src/store/file/reference.rs
+++ b/git-ref/src/store/file/reference.rs
@@ -1,16 +1,18 @@
+use std::convert::TryFrom;
+
+use bstr::ByteSlice;
+use git_hash::ObjectId;
+
 use crate::{
     file::loose::reference::logiter::must_be_io_err,
     mutable,
-    store::file,
     store::{
+        file,
         file::{log, loose},
         packed,
     },
     FullName, Namespace,
 };
-use bstr::ByteSlice;
-use git_hash::ObjectId;
-use std::convert::TryFrom;
 
 /// Either a loose or packed reference, depending on where it was found.
 #[derive(Debug)]

--- a/git-ref/src/store/file/transaction/commit.rs
+++ b/git-ref/src/store/file/transaction/commit.rs
@@ -151,9 +151,10 @@ impl<'s> Transaction<'s> {
     }
 }
 mod error {
-    use crate::store::{file, packed};
     use bstr::BString;
     use quick_error::quick_error;
+
+    use crate::store::{file, packed};
 
     quick_error! {
         /// The error returned by various [`Transaction`][super::Transaction] methods.

--- a/git-ref/src/store/file/transaction/mod.rs
+++ b/git-ref/src/store/file/transaction/mod.rs
@@ -1,10 +1,11 @@
+use bstr::BString;
+use git_hash::ObjectId;
+
 use crate::{
     store::{file, file::Transaction},
     transaction::RefEdit,
     Namespace,
 };
-use bstr::BString;
-use git_hash::ObjectId;
 
 /// A function receiving an object id to resolve, returning its decompressed bytes.
 ///

--- a/git-ref/src/store/file/transaction/prepare.rs
+++ b/git-ref/src/store/file/transaction/prepare.rs
@@ -3,8 +3,8 @@ use crate::{
     packed,
     store::{
         file,
-        file::loose,
         file::{
+            loose,
             transaction::{Edit, PackedRefs},
             Transaction,
         },
@@ -338,12 +338,13 @@ impl<'s> Transaction<'s> {
 }
 
 mod error {
+    use bstr::BString;
+    use quick_error::quick_error;
+
     use crate::{
         mutable::Target,
         store::{file, packed},
     };
-    use bstr::BString;
-    use quick_error::quick_error;
 
     quick_error! {
         /// The error returned by various [`Transaction`][super::Transaction] methods.

--- a/git-ref/src/store/packed/buffer.rs
+++ b/git-ref/src/store/packed/buffer.rs
@@ -17,9 +17,11 @@ impl AsRef<[u8]> for packed::Backing {
 
 ///
 pub mod open {
-    use crate::store::packed;
-    use filebuffer::FileBuffer;
     use std::path::PathBuf;
+
+    use filebuffer::FileBuffer;
+
+    use crate::store::packed;
 
     /// Initialization
     impl packed::Buffer {
@@ -77,8 +79,9 @@ pub mod open {
     }
 
     mod error {
-        use crate::packed;
         use quick_error::quick_error;
+
+        use crate::packed;
 
         quick_error! {
             /// The error returned by [`open()`][super::packed::Buffer::open()].
@@ -101,6 +104,7 @@ pub mod open {
             }
         }
     }
-    use crate::packed::Backing;
     pub use error::Error;
+
+    use crate::packed::Backing;
 }

--- a/git-ref/src/store/packed/decode.rs
+++ b/git-ref/src/store/packed/decode.rs
@@ -1,18 +1,18 @@
+use std::convert::TryFrom;
+
+use bstr::{BStr, ByteSlice};
+use nom::{
+    bytes::complete::{tag, take_while},
+    combinator::{map, map_res, opt},
+    error::{FromExternalError, ParseError},
+    sequence::{delimited, preceded, terminated, tuple},
+    IResult,
+};
+
 use crate::{
     parse::{hex_hash, newline},
     store::packed,
 };
-use bstr::{BStr, ByteSlice};
-use nom::combinator::map_res;
-use nom::error::FromExternalError;
-use nom::{
-    bytes::complete::{tag, take_while},
-    combinator::{map, opt},
-    error::ParseError,
-    sequence::{delimited, preceded, terminated, tuple},
-    IResult,
-};
-use std::convert::TryFrom;
 
 #[derive(Debug, PartialEq, Eq)]
 enum Peeled {

--- a/git-ref/src/store/packed/decode/tests.rs
+++ b/git-ref/src/store/packed/decode/tests.rs
@@ -1,11 +1,14 @@
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 mod reference {
-    use super::Result;
-    use crate::store::{packed, packed::decode};
-    use crate::FullName;
     use git_testtools::hex_to_id;
     use nom::error::VerboseError;
+
+    use super::Result;
+    use crate::{
+        store::{packed, packed::decode},
+        FullName,
+    };
 
     #[test]
     fn invalid() {
@@ -43,13 +46,14 @@ mod reference {
 }
 
 mod header {
+    use bstr::ByteSlice;
+    use git_testtools::to_bstr_err;
+
     use super::Result;
     use crate::store::packed::{
         decode,
         decode::{Header, Peeled},
     };
-    use bstr::ByteSlice;
-    use git_testtools::to_bstr_err;
 
     #[test]
     fn invalid() {

--- a/git-ref/src/store/packed/find.rs
+++ b/git-ref/src/store/packed/find.rs
@@ -1,6 +1,8 @@
-use crate::{store::packed, PartialName};
-use bstr::{BStr, BString, ByteSlice};
 use std::{borrow::Cow, convert::TryInto};
+
+use bstr::{BStr, BString, ByteSlice};
+
+use crate::{store::packed, PartialName};
 
 /// packed-refs specific functionality
 impl packed::Buffer {
@@ -97,8 +99,9 @@ impl packed::Buffer {
 }
 
 mod error {
-    use quick_error::quick_error;
     use std::convert::Infallible;
+
+    use quick_error::quick_error;
 
     quick_error! {
         /// The error returned by [`find()`][super::packed::Buffer::find()]

--- a/git-ref/src/store/packed/iter.rs
+++ b/git-ref/src/store/packed/iter.rs
@@ -1,5 +1,6 @@
-use crate::store::{packed, packed::decode};
 use bstr::{BString, ByteSlice};
+
+use crate::store::{packed, packed::decode};
 
 /// packed-refs specific functionality
 impl packed::Buffer {

--- a/git-ref/src/store/packed/mod.rs
+++ b/git-ref/src/store/packed/mod.rs
@@ -1,8 +1,10 @@
-use crate::{transaction::RefEdit, FullName};
+use std::path::PathBuf;
+
 use bstr::{BStr, BString};
 use filebuffer::FileBuffer;
 use git_hash::ObjectId;
-use std::path::PathBuf;
+
+use crate::{transaction::RefEdit, FullName};
 
 enum Backing {
     /// The buffer is loaded entirely in memory, along with the `offset` to the first record past the header.

--- a/git-ref/src/store/packed/transaction.rs
+++ b/git-ref/src/store/packed/transaction.rs
@@ -1,9 +1,10 @@
+use std::io::Write;
+
 use crate::{
     mutable::Target,
     store::{file::transaction::FindObjectFn, packed, packed::Edit},
     transaction::{Change, RefEdit},
 };
-use std::io::Write;
 
 pub(crate) const HEADER_LINE: &[u8] = b"# pack-refs with: peeled fully-peeled sorted \n";
 
@@ -264,8 +265,9 @@ pub mod prepare {
 
 ///
 pub mod commit {
-    use crate::store::packed;
     use quick_error::quick_error;
+
+    use crate::store::packed;
 
     quick_error! {
         /// The error used in [`Transaction::commit(…)`][super::packed::Transaction::commit()].

--- a/git-ref/src/target.rs
+++ b/git-ref/src/target.rs
@@ -1,6 +1,7 @@
-use crate::{Kind, Target};
 use bstr::BStr;
 use git_hash::oid;
+
+use crate::{Kind, Target};
 
 impl<'a> Target<'a> {
     /// Returns the kind of the target the ref is pointing to.

--- a/git-ref/src/transaction.rs
+++ b/git-ref/src/transaction.rs
@@ -12,9 +12,10 @@
 //!   - errors during preparations will cause a perfect rollback
 //! * prepared transactions are committed to finalize the change
 //!   - errors when committing while leave the ref store in an inconsistent, but operational state.
-use crate::mutable::{FullName, Target};
 use bstr::BString;
 use git_hash::ObjectId;
+
+use crate::mutable::{FullName, Target};
 
 /// A change to the reflog.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
@@ -134,11 +135,12 @@ pub enum RefLog {
 }
 
 mod ext {
+    use bstr::{BString, ByteVec};
+
     use crate::{
         transaction::{Change, LogChange, RefEdit, RefLog, Target},
         Namespace, PartialName,
     };
-    use bstr::{BString, ByteVec};
 
     /// An extension trait to perform commonly used operations on edits across different ref stores.
     pub trait RefEditsExt<T>

--- a/git-ref/tests/file/log.rs
+++ b/git-ref/tests/file/log.rs
@@ -144,9 +144,10 @@ mod iter {
         }
     }
     mod forward {
-        use crate::file::log::iter::reflog;
         use bstr::B;
         use git_hash::ObjectId;
+
+        use crate::file::log::iter::reflog;
 
         #[test]
         fn all_success() -> crate::Result {

--- a/git-ref/tests/file/reference.rs
+++ b/git-ref/tests/file/reference.rs
@@ -49,11 +49,13 @@ mod reflog {
 }
 
 mod peel {
-    use crate::{file, file::store_with_packed_refs};
+    use std::convert::TryFrom;
+
     use git_odb::Find;
     use git_ref::file::loose::reference::peel;
     use git_testtools::hex_to_id;
-    use std::convert::TryFrom;
+
+    use crate::{file, file::store_with_packed_refs};
 
     #[test]
     fn one_level() -> crate::Result {

--- a/git-ref/tests/file/store/find.rs
+++ b/git-ref/tests/file/store/find.rs
@@ -1,6 +1,7 @@
 mod existing {
-    use crate::file::store_at;
     use git_testtools::hex_to_id;
+
+    use crate::file::store_at;
 
     #[test]
     fn with_packed_refs() -> crate::Result {
@@ -18,8 +19,9 @@ mod loose {
     use crate::file::store;
 
     mod existing {
-        use crate::file::store;
         use std::path::Path;
+
+        use crate::file::store;
 
         #[test]
         fn success_and_failure() -> crate::Result {

--- a/git-ref/tests/file/store/iter.rs
+++ b/git-ref/tests/file/store/iter.rs
@@ -1,12 +1,15 @@
-use crate::file::{store, store_at, store_with_packed_refs};
-use bstr::ByteSlice;
-use git_testtools::hex_to_id;
 use std::convert::TryInto;
 
+use bstr::ByteSlice;
+use git_testtools::hex_to_id;
+
+use crate::file::{store, store_at, store_with_packed_refs};
+
 mod with_namespace {
-    use crate::file::store_at;
     use bstr::BString;
     use git_object::bstr::ByteSlice;
+
+    use crate::file::store_at;
 
     #[test]
     fn general_iteration_can_trivially_use_namespaces_as_prefixes() {

--- a/git-ref/tests/packed/find.rs
+++ b/git-ref/tests/packed/find.rs
@@ -1,9 +1,11 @@
+use std::convert::{TryFrom, TryInto};
+
+use git_ref::{packed, PartialName};
+
 use crate::{
     file::{store_at, store_with_packed_refs},
     packed::write_packed_refs_with,
 };
-use git_ref::{packed, PartialName};
-use std::convert::{TryFrom, TryInto};
 
 #[test]
 fn a_lock_file_would_not_be_a_valid_partial_name() {

--- a/git-ref/tests/packed/iter.rs
+++ b/git-ref/tests/packed/iter.rs
@@ -1,7 +1,9 @@
-use crate::file::{store_at, store_with_packed_refs};
+use std::convert::TryInto;
+
 use bstr::ByteSlice;
 use git_ref::packed;
-use std::convert::TryInto;
+
+use crate::file::{store_at, store_with_packed_refs};
 
 #[test]
 fn empty() -> crate::Result {

--- a/git-ref/tests/packed/open.rs
+++ b/git-ref/tests/packed/open.rs
@@ -1,7 +1,8 @@
-use crate::file::store_with_packed_refs;
-use crate::packed::write_packed_refs_with;
-use git_testtools::fixture_path;
 use std::path::Path;
+
+use git_testtools::fixture_path;
+
+use crate::{file::store_with_packed_refs, packed::write_packed_refs_with};
 
 #[test]
 fn sorted_buffer_works() {

--- a/git-ref/tests/transaction/mod.rs
+++ b/git-ref/tests/transaction/mod.rs
@@ -1,12 +1,12 @@
 mod refedit_ext {
+    use std::{cell::RefCell, collections::BTreeMap, convert::TryInto};
+
     use bstr::{BString, ByteSlice};
-    use git_ref::transaction::Create;
     use git_ref::{
         mutable::Target,
-        transaction::{Change, RefEdit, RefEditsExt, RefLog},
+        transaction::{Change, Create, RefEdit, RefEditsExt, RefLog},
         PartialName,
     };
-    use std::{cell::RefCell, collections::BTreeMap, convert::TryInto};
 
     #[derive(Default)]
     struct MockStore {
@@ -145,7 +145,8 @@ mod refedit_ext {
     }
 
     mod splitting {
-        use crate::transaction::refedit_ext::MockStore;
+        use std::{cell::Cell, convert::TryInto};
+
         use git_hash::ObjectId;
         use git_ref::{
             mutable::Target,
@@ -153,7 +154,8 @@ mod refedit_ext {
             FullName, PartialName,
         };
         use git_testtools::hex_to_id;
-        use std::{cell::Cell, convert::TryInto};
+
+        use crate::transaction::refedit_ext::MockStore;
 
         fn find<'a>(edits: &'a [RefEdit], name: &str) -> &'a RefEdit {
             let name: FullName = name.try_into().unwrap();

--- a/git-repository/examples/interrupt-handler-allows-graceful-shutdown.rs
+++ b/git-repository/examples/interrupt-handler-allows-graceful-shutdown.rs
@@ -1,5 +1,6 @@
-use git_repository::tempfile::{AutoRemove, ContainingDirectory};
 use std::path::Path;
+
+use git_repository::tempfile::{AutoRemove, ContainingDirectory};
 
 fn main() -> anyhow::Result<()> {
     git_repository::interrupt::init_handler(|| {})?;

--- a/git-repository/src/ext.rs
+++ b/git-repository/src/ext.rs
@@ -1,8 +1,9 @@
 mod tree {
+    use std::borrow::BorrowMut;
+
     use git_hash::oid;
     use git_object::immutable;
     use git_traverse::tree::breadthfirst;
-    use std::borrow::BorrowMut;
 
     pub trait Sealed {}
 

--- a/git-repository/src/init.rs
+++ b/git-repository/src/init.rs
@@ -1,10 +1,10 @@
-use quick_error::quick_error;
 use std::{
     fs::{self, OpenOptions},
     io::Write,
-    path::Path,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
+
+use quick_error::quick_error;
 
 quick_error! {
     #[derive(Debug)]

--- a/git-repository/src/interrupt.rs
+++ b/git-repository/src/interrupt.rs
@@ -52,12 +52,12 @@ mod init {
         Ok(())
     }
 }
-pub use init::init_handler;
-
 use std::{
     io,
     sync::atomic::{AtomicBool, Ordering},
 };
+
+pub use init::init_handler;
 
 /// A wrapper for an inner iterator which will check for interruptions on each iteration.
 pub struct Iter<I, EFN> {

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -72,10 +72,11 @@ pub mod interrupt;
 #[cfg(feature = "git-traverse")]
 pub mod ext;
 pub mod prelude {
-    #[cfg(all(feature = "git-traverse"))]
-    pub use crate::ext::*;
     pub use git_features::parallel::reduce::Finalize;
     pub use git_odb::{Find, FindExt, Write};
+
+    #[cfg(all(feature = "git-traverse"))]
+    pub use crate::ext::*;
 }
 
 pub mod init;

--- a/git-repository/src/path/discover.rs
+++ b/git-repository/src/path/discover.rs
@@ -1,12 +1,14 @@
-use crate::path;
 use std::{
     borrow::Cow,
     path::{Component, Path},
 };
 
+use crate::path;
+
 pub mod existing {
-    use quick_error::quick_error;
     use std::path::PathBuf;
+
+    use quick_error::quick_error;
 
     quick_error! {
         #[derive(Debug)]

--- a/git-repository/src/path/is_git.rs
+++ b/git-repository/src/path/is_git.rs
@@ -1,5 +1,6 @@
-use quick_error::quick_error;
 use std::path::{Path, PathBuf};
+
+use quick_error::quick_error;
 
 quick_error! {
     #[derive(Debug)]

--- a/git-repository/src/path/mod.rs
+++ b/git-repository/src/path/mod.rs
@@ -1,5 +1,6 @@
-use crate::Kind;
 use std::path::PathBuf;
+
+use crate::Kind;
 
 pub mod discover;
 pub mod is_git;

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -1,6 +1,7 @@
 mod init {
-    use crate::Repository;
     use std::path::Path;
+
+    use crate::Repository;
 
     impl Repository {
         /// Really just a sketch at this point to help guide the API.
@@ -13,9 +14,11 @@ mod init {
 }
 
 pub mod discover {
-    use crate::{path::discover, Repository};
-    use quick_error::quick_error;
     use std::path::Path;
+
+    use quick_error::quick_error;
+
+    use crate::{path::discover, Repository};
 
     quick_error! {
         #[derive(Debug)]

--- a/git-repository/tests/discover/mod.rs
+++ b/git-repository/tests/discover/mod.rs
@@ -1,6 +1,7 @@
 mod existing {
-    use git_repository::Kind;
     use std::path::{Component, PathBuf};
+
+    use git_repository::Kind;
 
     #[test]
     fn from_bare_git_dir() -> crate::Result {

--- a/git-tempfile/examples/delete-tempfiles-on-sigterm-interactive.rs
+++ b/git-tempfile/examples/delete-tempfiles-on-sigterm-interactive.rs
@@ -1,5 +1,6 @@
-use git_tempfile::{AutoRemove, ContainingDirectory};
 use std::path::PathBuf;
+
+use git_tempfile::{AutoRemove, ContainingDirectory};
 
 fn main() -> std::io::Result<()> {
     let filepath = PathBuf::new().join("writable-tempfile.ext");

--- a/git-tempfile/examples/delete-tempfiles-on-sigterm.rs
+++ b/git-tempfile/examples/delete-tempfiles-on-sigterm.rs
@@ -1,8 +1,9 @@
-use git_tempfile::{AutoRemove, ContainingDirectory};
 use std::{
     io::{stdout, Write},
     path::PathBuf,
 };
+
+use git_tempfile::{AutoRemove, ContainingDirectory};
 
 fn main() -> std::io::Result<()> {
     let filepath = PathBuf::new().join("tempfile.ext");

--- a/git-tempfile/src/forksafe.rs
+++ b/git-tempfile/src/forksafe.rs
@@ -1,7 +1,8 @@
-use crate::{handle, AutoRemove};
-use std::io::Write;
-use std::path::Path;
+use std::{io::Write, path::Path};
+
 use tempfile::{NamedTempFile, TempPath};
+
+use crate::{handle, AutoRemove};
 
 enum TempfileOrTemppath {
     Tempfile(NamedTempFile),

--- a/git-tempfile/src/fs/create_dir.rs
+++ b/git-tempfile/src/fs/create_dir.rs
@@ -26,8 +26,9 @@ impl Default for Retries {
 }
 
 mod error {
-    use crate::fs::create_dir::Retries;
     use std::{fmt, path::Path};
+
+    use crate::fs::create_dir::Retries;
 
     /// The error returned by [all()][super::all()].
     #[allow(missing_docs)]

--- a/git-tempfile/src/handle.rs
+++ b/git-tempfile/src/handle.rs
@@ -1,7 +1,9 @@
 //!
-use crate::{AutoRemove, ContainingDirectory, ForksafeTempfile, Handle, NEXT_MAP_INDEX, REGISTER};
 use std::{io, path::Path};
+
 use tempfile::{NamedTempFile, TempPath};
+
+use crate::{AutoRemove, ContainingDirectory, ForksafeTempfile, Handle, NEXT_MAP_INDEX, REGISTER};
 
 /// Marker to signal the Registration is an open file able to be written to.
 #[derive(Debug)]
@@ -175,8 +177,9 @@ impl Handle<Writable> {
 }
 
 mod io_impls {
-    use super::{Handle, Writable};
     use std::{io, io::SeekFrom};
+
+    use super::{Handle, Writable};
 
     impl io::Write for Handle<Writable> {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -203,15 +206,17 @@ mod io_impls {
 
 ///
 pub mod persist {
+    use std::path::Path;
+
     use crate::{
         handle::{expect_none, Closed, Writable},
         Handle, REGISTER,
     };
-    use std::path::Path;
 
     mod error {
-        use crate::Handle;
         use std::fmt::{self, Debug, Display};
+
+        use crate::Handle;
 
         /// The error returned by various [`persist(…)`][Handle<crate::handle::Writable>::persist()] methods
         #[derive(Debug)]

--- a/git-tempfile/src/handler.rs
+++ b/git-tempfile/src/handler.rs
@@ -42,8 +42,9 @@ pub(crate) fn cleanup_tempfiles_windows() {
 
 #[cfg(test)]
 mod tests {
-    use crate::{AutoRemove, ContainingDirectory};
     use std::path::Path;
+
+    use crate::{AutoRemove, ContainingDirectory};
 
     fn filecount_in(path: impl AsRef<Path>) -> usize {
         std::fs::read_dir(path).expect("valid dir").count()

--- a/git-tempfile/src/lib.rs
+++ b/git-tempfile/src/lib.rs
@@ -26,14 +26,15 @@
 //! [signal-hook]: https://docs.rs/signal-hook
 #![deny(missing_docs, unsafe_code, rust_2018_idioms)]
 
-use dashmap::DashMap;
-use once_cell::sync::Lazy;
 use std::{
     io,
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::atomic::AtomicUsize,
 };
+
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
 
 mod fs;
 pub use fs::{create_dir, remove_dir};

--- a/git-tempfile/tests/tempfile/fs/create_dir.rs
+++ b/git-tempfile/tests/tempfile/fs/create_dir.rs
@@ -13,8 +13,10 @@ mod all {
 mod iter {
     pub use std::io::ErrorKind::*;
 
-    use git_tempfile::create_dir;
-    use git_tempfile::create_dir::{Error::*, Retries};
+    use git_tempfile::{
+        create_dir,
+        create_dir::{Error::*, Retries},
+    };
 
     #[test]
     fn an_existing_directory_causes_immediate_success() -> crate::Result {

--- a/git-tempfile/tests/tempfile/fs/remove_dir.rs
+++ b/git-tempfile/tests/tempfile/fs/remove_dir.rs
@@ -1,6 +1,7 @@
 mod empty_upwards_until_boundary {
-    use git_tempfile::remove_dir;
     use std::{io, path::Path};
+
+    use git_tempfile::remove_dir;
 
     #[test]
     fn boundary_must_contain_target_dir() -> crate::Result {
@@ -126,8 +127,9 @@ mod empty_depth_first {
 /// We assume that all checks above also apply to the iterator, so won't repeat them here
 /// Test outside interference only
 mod iter {
-    use git_tempfile::remove_dir;
     use std::io;
+
+    use git_tempfile::remove_dir;
 
     #[test]
     fn racy_directory_creation_during_deletion_always_wins_immediately() -> crate::Result {

--- a/git-tempfile/tests/tempfile/handle.rs
+++ b/git-tempfile/tests/tempfile/handle.rs
@@ -171,11 +171,12 @@ mod at_path {
 }
 
 mod new {
-    use git_tempfile::{AutoRemove, ContainingDirectory};
     use std::{
         io::{ErrorKind, Write},
         path::Path,
     };
+
+    use git_tempfile::{AutoRemove, ContainingDirectory};
 
     fn filecount_in(path: impl AsRef<Path>) -> usize {
         std::fs::read_dir(path).expect("valid dir").count()

--- a/git-transport/src/client/async_io/bufread_ext.rs
+++ b/git-transport/src/client/async_io/bufread_ext.rs
@@ -1,12 +1,14 @@
-use crate::{
-    client::{Error, MessageKind},
-    Protocol,
-};
-use async_trait::async_trait;
-use futures_io::{AsyncBufRead, AsyncRead};
 use std::{
     io,
     ops::{Deref, DerefMut},
+};
+
+use async_trait::async_trait;
+use futures_io::{AsyncBufRead, AsyncRead};
+
+use crate::{
+    client::{Error, MessageKind},
+    Protocol,
 };
 
 /// A function `f(is_error, text)` receiving progress or error information.

--- a/git-transport/src/client/async_io/request.rs
+++ b/git-transport/src/client/async_io/request.rs
@@ -1,11 +1,13 @@
-use crate::client::{ExtendedBufRead, MessageKind, WriteMode};
-use futures_io::AsyncWrite;
-use pin_project_lite::pin_project;
 use std::{
     io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures_io::AsyncWrite;
+use pin_project_lite::pin_project;
+
+use crate::client::{ExtendedBufRead, MessageKind, WriteMode};
 
 pin_project! {
     /// A [`Write`][io::Write] implementation optimized for writing packet lines.

--- a/git-transport/src/client/async_io/traits.rs
+++ b/git-transport/src/client/async_io/traits.rs
@@ -1,11 +1,13 @@
+use std::ops::DerefMut;
+
+use async_trait::async_trait;
+use bstr::BString;
+use futures_lite::io::AsyncWriteExt;
+
 use crate::{
     client::{Capabilities, Error, ExtendedBufRead, MessageKind, TransportWithoutIO, WriteMode},
     Protocol, Service,
 };
-use async_trait::async_trait;
-use bstr::BString;
-use futures_lite::io::AsyncWriteExt;
-use std::ops::DerefMut;
 
 /// The response of the [`handshake()`][Transport::handshake()] method.
 pub struct SetServiceResponse<'a> {

--- a/git-transport/src/client/blocking_io/bufread_ext.rs
+++ b/git-transport/src/client/blocking_io/bufread_ext.rs
@@ -1,10 +1,11 @@
-use crate::{
-    client::{Error, MessageKind},
-    Protocol,
-};
 use std::{
     io,
     ops::{Deref, DerefMut},
+};
+
+use crate::{
+    client::{Error, MessageKind},
+    Protocol,
 };
 /// A function `f(is_error, text)` receiving progress or error information.
 pub type HandleProgress = Box<dyn FnMut(bool, &[u8])>;

--- a/git-transport/src/client/blocking_io/connect.rs
+++ b/git-transport/src/client/blocking_io/connect.rs
@@ -1,6 +1,5 @@
-use crate::client::Transport;
-
 pub use crate::client::non_io_types::connect::Error;
+use crate::client::Transport;
 
 /// A general purpose connector connecting to a repository identified by the given `url`.
 ///

--- a/git-transport/src/client/blocking_io/http/curl/mod.rs
+++ b/git-transport/src/client/blocking_io/http/curl/mod.rs
@@ -1,9 +1,11 @@
-use crate::client::blocking_io::http;
-use git_features::io;
 use std::{
     sync::mpsc::{Receiver, SyncSender},
     thread,
 };
+
+use git_features::io;
+
+use crate::client::blocking_io::http;
 
 mod remote;
 

--- a/git-transport/src/client/blocking_io/http/curl/remote.rs
+++ b/git-transport/src/client/blocking_io/http/curl/remote.rs
@@ -1,6 +1,3 @@
-use crate::client::blocking_io::http;
-use curl::easy::Easy2;
-use git_features::io::pipe;
 use std::{
     io,
     io::{Read, Write},
@@ -8,6 +5,11 @@ use std::{
     thread,
     time::Duration,
 };
+
+use curl::easy::Easy2;
+use git_features::io::pipe;
+
+use crate::client::blocking_io::http;
 
 #[derive(Default)]
 struct Handler {

--- a/git-transport/src/client/blocking_io/http/traits.rs
+++ b/git-transport/src/client/blocking_io/http/traits.rs
@@ -1,5 +1,6 @@
-use quick_error::quick_error;
 use std::io;
+
+use quick_error::quick_error;
 
 quick_error! {
     /// The error used by the [Http] trait.

--- a/git-transport/src/client/blocking_io/request.rs
+++ b/git-transport/src/client/blocking_io/request.rs
@@ -1,5 +1,6 @@
-use crate::client::{ExtendedBufRead, MessageKind, WriteMode};
 use std::io;
+
+use crate::client::{ExtendedBufRead, MessageKind, WriteMode};
 
 /// A [`Write`][io::Write] implementation optimized for writing packet lines.
 /// A type implementing `Write` for packet lines, which when done can be transformed into a `Read` for

--- a/git-transport/src/client/blocking_io/ssh.rs
+++ b/git-transport/src/client/blocking_io/ssh.rs
@@ -1,9 +1,9 @@
-use bstr::BString;
-use quick_error::quick_error;
 use std::borrow::Cow;
 
-use crate::client::blocking_io;
-use crate::Protocol;
+use bstr::BString;
+use quick_error::quick_error;
+
+use crate::{client::blocking_io, Protocol};
 
 quick_error! {
     /// The error used in [`connect()`].
@@ -95,8 +95,7 @@ pub fn connect(
 mod tests {
     use bstr::ByteSlice;
 
-    use crate::client::blocking_io::ssh::connect;
-    use crate::Protocol;
+    use crate::{client::blocking_io::ssh::connect, Protocol};
 
     #[test]
     fn connect_with_tilde_in_path() {

--- a/git-transport/src/client/blocking_io/traits.rs
+++ b/git-transport/src/client/blocking_io/traits.rs
@@ -1,9 +1,11 @@
+use std::{io, io::Write, ops::DerefMut};
+
+use bstr::BString;
+
 use crate::{
     client::{Capabilities, Error, ExtendedBufRead, MessageKind, TransportWithoutIO, WriteMode},
     Protocol, Service,
 };
-use bstr::BString;
-use std::{io, io::Write, ops::DerefMut};
 
 /// The response of the [`handshake()`][Transport::handshake()] method.
 pub struct SetServiceResponse<'a> {

--- a/git-transport/src/client/capabilities.rs
+++ b/git-transport/src/client/capabilities.rs
@@ -1,9 +1,11 @@
+use std::io;
+
+use bstr::{BStr, BString, ByteSlice};
+use quick_error::quick_error;
+
 #[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use crate::client;
 use crate::Protocol;
-use bstr::{BStr, BString, ByteSlice};
-use quick_error::quick_error;
-use std::io;
 
 quick_error! {
     /// The error used in [`Capabilities::from_bytes()`] and [`Capabilities::from_lines()`].
@@ -167,8 +169,9 @@ impl Capabilities {
 #[cfg(feature = "blocking-client")]
 ///
 pub mod recv {
-    use crate::{client, client::Capabilities, Protocol};
     use std::{io, io::BufRead};
+
+    use crate::{client, client::Capabilities, Protocol};
 
     /// Success outcome of [`Capabilities::from_lines_with_version_detection`].
     pub struct Outcome<'a> {
@@ -230,9 +233,10 @@ pub mod recv {
 #[allow(missing_docs)]
 ///
 pub mod recv {
-    use crate::{client, client::Capabilities, Protocol};
     use futures_io::{AsyncBufRead, AsyncRead};
     use futures_lite::{AsyncBufReadExt, StreamExt};
+
+    use crate::{client, client::Capabilities, Protocol};
 
     /// Success outcome of [`Capabilities::from_lines_with_version_detection`].
     pub struct Outcome<'a> {

--- a/git-transport/src/client/git/async_io.rs
+++ b/git-transport/src/client/git/async_io.rs
@@ -1,12 +1,13 @@
-use crate::{
-    client::{self, capabilities, git, Capabilities, SetServiceResponse},
-    Protocol, Service,
-};
 use async_trait::async_trait;
 use bstr::BString;
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_lite::AsyncWriteExt;
 use git_packetline::PacketLine;
+
+use crate::{
+    client::{self, capabilities, git, Capabilities, SetServiceResponse},
+    Protocol, Service,
+};
 
 impl<R, W> client::TransportWithoutIO for git::Connection<R, W>
 where

--- a/git-transport/src/client/git/blocking_io.rs
+++ b/git-transport/src/client/git/blocking_io.rs
@@ -1,10 +1,12 @@
+use std::{io, io::Write};
+
+use bstr::BString;
+use git_packetline::PacketLine;
+
 use crate::{
     client::{self, capabilities, git, Capabilities, SetServiceResponse},
     Protocol, Service,
 };
-use bstr::BString;
-use git_packetline::PacketLine;
-use std::{io, io::Write};
 
 impl<R, W> client::TransportWithoutIO for git::Connection<R, W>
 where
@@ -144,9 +146,10 @@ pub mod connect {
         net::{TcpStream, ToSocketAddrs},
     };
 
-    use crate::client::git;
     use bstr::BString;
     use quick_error::quick_error;
+
+    use crate::client::git;
     quick_error! {
         /// The error used in [`connect()`].
         #[derive(Debug)]

--- a/git-transport/src/client/git/mod.rs
+++ b/git-transport/src/client/git/mod.rs
@@ -1,5 +1,6 @@
-use crate::Protocol;
 use bstr::BString;
+
+use crate::Protocol;
 
 /// The way to connect to a process speaking the `git` protocol.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -43,8 +44,9 @@ impl<R, W> Connection<R, W> {
 }
 
 mod message {
-    use crate::{Protocol, Service};
     use bstr::{BString, ByteVec};
+
+    use crate::{Protocol, Service};
 
     pub fn connect(
         service: Service,

--- a/git-transport/src/client/non_io_types.rs
+++ b/git-transport/src/client/non_io_types.rs
@@ -79,10 +79,11 @@ pub(crate) mod connect {
 }
 
 mod error {
+    use bstr::BString;
+
     use crate::client::capabilities;
     #[cfg(feature = "http-client-curl")]
     use crate::client::http;
-    use bstr::BString;
 
     #[cfg(feature = "http-client-curl")]
     type HttpError = http::Error;

--- a/git-transport/src/client/traits.rs
+++ b/git-transport/src/client/traits.rs
@@ -1,10 +1,11 @@
+use std::ops::{Deref, DerefMut};
+
 #[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use crate::client::{MessageKind, RequestWriter, WriteMode};
 use crate::{
     client::{Error, Identity},
     Protocol,
 };
-use std::ops::{Deref, DerefMut};
 
 /// This trait represents all transport related functions that don't require any input/output to be done which helps
 /// implementation to share more code across blocking and async programs.

--- a/git-transport/tests/client/blocking_io/http/mock.rs
+++ b/git-transport/tests/client/blocking_io/http/mock.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use bstr::ByteVec;
-
 use git_transport::{
     client::{http, TransportWithoutIO},
     Protocol,

--- a/git-transport/tests/client/blocking_io/http/mod.rs
+++ b/git-transport/tests/client/blocking_io/http/mod.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use bstr::ByteSlice;
-
 use git_transport::{
     client::{self, http, Identity, SetServiceResponse, Transport, TransportV2Ext, TransportWithoutIO},
     Protocol, Service,

--- a/git-transport/tests/client/git.rs
+++ b/git-transport/tests/client/git.rs
@@ -1,12 +1,13 @@
-#[cfg(feature = "async-client")]
-use futures_lite::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
 #[cfg(feature = "blocking-client")]
 use std::io::{BufRead, Write};
-
-use std::ops::Deref;
+use std::{
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
 
 use bstr::ByteSlice;
-
+#[cfg(feature = "async-client")]
+use futures_lite::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
 use git_transport::{
     client,
     client::{git, Transport, TransportV2Ext, TransportWithoutIO},
@@ -14,7 +15,6 @@ use git_transport::{
 };
 
 use crate::fixture_bytes;
-use std::sync::{Arc, Mutex};
 
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
 async fn handshake_v1_and_request() -> crate::Result {

--- a/git-traverse/src/commit.rs
+++ b/git-traverse/src/commit.rs
@@ -1,12 +1,13 @@
 ///
 pub mod ancestors {
-    use git_hash::{oid, ObjectId};
-    use git_object::immutable;
-    use quick_error::quick_error;
     use std::{
         borrow::BorrowMut,
         collections::{BTreeSet, VecDeque},
     };
+
+    use git_hash::{oid, ObjectId};
+    use git_object::immutable;
+    use quick_error::quick_error;
 
     quick_error! {
         /// The error is part of the item returned by the [Ancestors] iterator.

--- a/git-traverse/src/tree/breadthfirst.rs
+++ b/git-traverse/src/tree/breadthfirst.rs
@@ -1,8 +1,10 @@
-use crate::tree::visit::Visit;
+use std::{borrow::BorrowMut, collections::VecDeque};
+
 use git_hash::{oid, ObjectId};
 use git_object::{immutable, tree};
 use quick_error::quick_error;
-use std::{borrow::BorrowMut, collections::VecDeque};
+
+use crate::tree::visit::Visit;
 
 quick_error! {
     /// The error is part of the item returned by the [`traverse()`] function.

--- a/git-traverse/src/tree/recorder.rs
+++ b/git-traverse/src/tree/recorder.rs
@@ -1,10 +1,12 @@
-use crate::{tree::visit, tree::visit::Action};
+use std::collections::VecDeque;
+
 use git_hash::ObjectId;
 use git_object::{
     bstr::{BStr, BString, ByteSlice, ByteVec},
     immutable, tree,
 };
-use std::collections::VecDeque;
+
+use crate::tree::{visit, visit::Action};
 
 /// An owned entry as observed by a call to [`visit_(tree|nontree)(…)`][visit::Visit::visit_tree()], enhanced with the full path to it.
 /// Otherwise similar to [`immutable::tree::Entry`][git_object::immutable::tree::Entry].

--- a/git-traverse/src/tree/visit.rs
+++ b/git-traverse/src/tree/visit.rs
@@ -1,5 +1,4 @@
-use git_object::bstr::BStr;
-use git_object::immutable;
+use git_object::{bstr::BStr, immutable};
 
 /// What to do after an entry was [recorded][Visit::visit_tree()].
 #[derive(Clone, Copy, PartialOrd, PartialEq, Ord, Eq, Hash)]

--- a/git-traverse/tests/commit/mod.rs
+++ b/git-traverse/tests/commit/mod.rs
@@ -1,7 +1,6 @@
 mod ancestor {
     use git_hash::{oid, ObjectId};
-    use git_odb::linked::Store;
-    use git_odb::{pack, FindExt};
+    use git_odb::{linked::Store, pack, FindExt};
     use git_traverse::commit;
 
     use crate::hex_to_id;

--- a/git-url/src/expand_path.rs
+++ b/git-url/src/expand_path.rs
@@ -1,7 +1,8 @@
 //! Functions for expanding repository paths.
+use std::path::{Path, PathBuf};
+
 use bstr::{BStr, BString, ByteSlice};
 use quick_error::quick_error;
-use std::path::{Path, PathBuf};
 
 /// Whether a repository is resolving for the current user, or the given one.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]

--- a/git-url/src/lib.rs
+++ b/git-url/src/lib.rs
@@ -2,11 +2,12 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
-use bstr::ByteSlice;
 use std::{
     convert::TryFrom,
     fmt::{self, Write},
 };
+
+use bstr::ByteSlice;
 
 ///
 pub mod parse;

--- a/git-url/src/parse.rs
+++ b/git-url/src/parse.rs
@@ -1,7 +1,9 @@
-use crate::Scheme;
+use std::borrow::Cow;
+
 use bstr::ByteSlice;
 use quick_error::quick_error;
-use std::borrow::Cow;
+
+use crate::Scheme;
 
 quick_error! {
     /// The Error returned by [`parse()`]

--- a/git-url/tests/expand_user/mod.rs
+++ b/git-url/tests/expand_user/mod.rs
@@ -1,6 +1,7 @@
+use std::path::Path;
+
 use bstr::ByteSlice;
 use git_url::{expand_path, expand_path::ForUser};
-use std::path::Path;
 
 #[cfg(windows)]
 fn expected_path() -> std::path::PathBuf {

--- a/git-url/tests/parse/file.rs
+++ b/git-url/tests/parse/file.rs
@@ -1,5 +1,6 @@
-use crate::parse::{assert_url_and, assert_url_roundtrip, url};
 use git_url::Scheme;
+
+use crate::parse::{assert_url_and, assert_url_roundtrip, url};
 
 #[test]
 fn file_path_with_protocol() -> crate::Result {
@@ -67,8 +68,9 @@ fn interior_relative_file_path_without_protocol() -> crate::Result {
 }
 
 mod windows {
-    use crate::parse::{assert_url_and, assert_url_roundtrip, url};
     use git_url::Scheme;
+
+    use crate::parse::{assert_url_and, assert_url_roundtrip, url};
 
     #[test]
     fn file_path_without_protocol() -> crate::Result {

--- a/git-url/tests/parse/mod.rs
+++ b/git-url/tests/parse/mod.rs
@@ -35,8 +35,9 @@ mod invalid;
 mod ssh;
 
 mod radicle {
-    use crate::parse::{assert_url_roundtrip, url};
     use git_url::Scheme;
+
+    use crate::parse::{assert_url_roundtrip, url};
 
     #[test]
     fn basic() -> crate::Result {
@@ -45,8 +46,9 @@ mod radicle {
 }
 
 mod http {
-    use crate::parse::{assert_url_roundtrip, url};
     use git_url::Scheme;
+
+    use crate::parse::{assert_url_roundtrip, url};
 
     #[test]
     fn username_expansion_is_unsupported() -> crate::Result {
@@ -64,8 +66,9 @@ mod http {
     }
 }
 mod git {
-    use crate::parse::{assert_url_roundtrip, url};
     use git_url::Scheme;
+
+    use crate::parse::{assert_url_roundtrip, url};
 
     #[test]
     fn username_expansion_with_username() -> crate::Result {

--- a/git-url/tests/parse/ssh.rs
+++ b/git-url/tests/parse/ssh.rs
@@ -1,5 +1,6 @@
-use crate::parse::{assert_url_and, assert_url_roundtrip, url};
 use git_url::Scheme;
+
+use crate::parse::{assert_url_and, assert_url_roundtrip, url};
 
 #[test]
 fn without_user_and_without_port() -> crate::Result {

--- a/git-validate/src/reference.rs
+++ b/git-validate/src/reference.rs
@@ -1,7 +1,8 @@
 ///
 pub mod name {
-    use quick_error::quick_error;
     use std::convert::Infallible;
+
+    use quick_error::quick_error;
 
     quick_error! {
         /// The error used in [name()][super::name()] and [name_partial()][super::name_partial()]

--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -1,7 +1,9 @@
-use crate::OutputFormat;
+use std::{io, path::Path};
+
 use anyhow::{Context as AnyhowContext, Result};
 use git_commitgraph::{graph::verify::Outcome, Graph};
-use std::{io, path::Path};
+
+use crate::OutputFormat;
 
 /// A general purpose context for many operations provided here
 pub struct Context<W1: io::Write, W2: io::Write> {

--- a/gitoxide-core/src/hours.rs
+++ b/gitoxide-core/src/hours.rs
@@ -1,8 +1,3 @@
-use anyhow::{anyhow, bail};
-use bstr::BString;
-use git_repository::{actor, interrupt, object, odb, odb::pack, prelude::*, progress, Progress};
-use itertools::Itertools;
-use rayon::prelude::*;
 use std::{
     collections::{hash_map::Entry, HashMap},
     ffi::OsStr,
@@ -12,6 +7,12 @@ use std::{
     path::Path,
     time::Instant,
 };
+
+use anyhow::{anyhow, bail};
+use bstr::BString;
+use git_repository::{actor, interrupt, object, odb, odb::pack, prelude::*, progress, Progress};
+use itertools::Itertools;
+use rayon::prelude::*;
 
 /// Additional configuration for the hours estimation functionality.
 pub struct Context<W> {

--- a/gitoxide-core/src/net.rs
+++ b/gitoxide-core/src/net.rs
@@ -20,8 +20,9 @@ impl FromStr for Protocol {
 
 #[cfg(any(feature = "blocking-client", feature = "async-client"))]
 mod impls {
-    use super::Protocol;
     use git_repository::protocol::transport;
+
+    use super::Protocol;
 
     impl From<Protocol> for transport::Protocol {
         fn from(v: Protocol) -> Self {
@@ -42,16 +43,20 @@ impl Default for Protocol {
 }
 #[cfg(feature = "async-client")]
 mod async_io {
+    use std::{io, time::Duration};
+
     use async_net::TcpStream;
     use futures_lite::FutureExt;
     use git_repository::{
         object::bstr::BString,
         protocol::{
             transport,
-            transport::{client, client::connect::Error, client::git},
+            transport::{
+                client,
+                client::{connect::Error, git},
+            },
         },
     };
-    use std::{io, time::Duration};
 
     async fn git_connect(
         host: &str,
@@ -100,8 +105,8 @@ mod async_io {
         })
     }
 }
-#[cfg(feature = "async-client")]
-pub use self::async_io::connect;
-
 #[cfg(feature = "blocking-client")]
 pub use git_repository::protocol::transport::connect;
+
+#[cfg(feature = "async-client")]
+pub use self::async_io::connect;

--- a/gitoxide-core/src/organize.rs
+++ b/gitoxide-core/src/organize.rs
@@ -1,6 +1,7 @@
+use std::path::{Path, PathBuf};
+
 use git_config::file::GitConfig;
 use git_repository::{object::bstr::ByteSlice, progress, Progress};
-use std::path::{Path, PathBuf};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Mode {

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -1,4 +1,5 @@
-use crate::OutputFormat;
+use std::{ffi::OsStr, io, path::Path, str::FromStr, sync::Arc, time::Instant};
+
 use anyhow::anyhow;
 use git_repository::{
     hash,
@@ -9,7 +10,8 @@ use git_repository::{
     prelude::{Finalize, FindExt},
     progress, traverse, Progress,
 };
-use std::{ffi::OsStr, io, path::Path, str::FromStr, sync::Arc, time::Instant};
+
+use crate::OutputFormat;
 
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=2;
 

--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -6,8 +6,6 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use quick_error::quick_error;
-
 use git_repository::{
     hash,
     hash::ObjectId,
@@ -15,6 +13,7 @@ use git_repository::{
     odb::{loose, pack, Write},
     progress, Progress,
 };
+use quick_error::quick_error;
 
 #[derive(PartialEq, Debug)]
 pub enum SafetyCheck {

--- a/gitoxide-core/src/pack/index.rs
+++ b/gitoxide-core/src/pack/index.rs
@@ -1,7 +1,8 @@
-use crate::OutputFormat;
+use std::{fs, io, path::PathBuf, str::FromStr, sync::atomic::AtomicBool};
+
 use git_repository::{odb::pack, Progress};
-use std::sync::atomic::AtomicBool;
-use std::{fs, io, path::PathBuf, str::FromStr};
+
+use crate::OutputFormat;
 
 #[derive(PartialEq, Debug)]
 pub enum IterationMode {

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -1,4 +1,9 @@
-use crate::{remote::refs::JsonRef, OutputFormat};
+use std::{
+    io,
+    path::PathBuf,
+    sync::{atomic::AtomicBool, Arc},
+};
+
 use git_repository::{
     hash::ObjectId,
     object::bstr::{BString, ByteSlice},
@@ -10,7 +15,8 @@ use git_repository::{
         transport::client::Capabilities,
     },
 };
-use std::{io, path::PathBuf, sync::atomic::AtomicBool, sync::Arc};
+
+use crate::{remote::refs::JsonRef, OutputFormat};
 
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
 
@@ -78,14 +84,16 @@ impl<W> protocol::fetch::DelegateBlocking for CloneDelegate<W> {
 
 #[cfg(feature = "blocking-client")]
 mod blocking_io {
-    use super::{receive_pack_blocking, CloneDelegate, Context};
-    use crate::net;
+    use std::{io, io::BufRead, path::PathBuf};
+
     use git_repository::{
         protocol,
         protocol::fetch::{Ref, Response},
         Progress,
     };
-    use std::{io, io::BufRead, path::PathBuf};
+
+    use super::{receive_pack_blocking, CloneDelegate, Context};
+    use crate::net;
 
     impl<W: io::Write> protocol::fetch::Delegate for CloneDelegate<W> {
         fn receive_pack(
@@ -137,8 +145,8 @@ pub use blocking_io::receive;
 
 #[cfg(feature = "async-client")]
 mod async_io {
-    use super::{print, receive_pack_blocking, write_raw_refs, CloneDelegate, Context};
-    use crate::{net, OutputFormat};
+    use std::{io, io::BufRead, path::PathBuf};
+
     use async_trait::async_trait;
     use futures_io::AsyncBufRead;
     use git_repository::{
@@ -148,7 +156,9 @@ mod async_io {
         protocol::fetch::{Ref, Response},
         Progress,
     };
-    use std::{io, io::BufRead, path::PathBuf};
+
+    use super::{print, receive_pack_blocking, write_raw_refs, CloneDelegate, Context};
+    use crate::{net, OutputFormat};
 
     #[async_trait(?Send)]
     impl<W: io::Write + Send + 'static> protocol::fetch::Delegate for CloneDelegate<W> {

--- a/gitoxide-core/src/pack/verify.rs
+++ b/gitoxide-core/src/pack/verify.rs
@@ -1,4 +1,10 @@
-use crate::OutputFormat;
+use std::{
+    io,
+    path::Path,
+    str::FromStr,
+    sync::{atomic::AtomicBool, Arc},
+};
+
 use anyhow::{anyhow, Context as AnyhowContext, Result};
 use bytesize::ByteSize;
 use git_repository::{
@@ -7,14 +13,9 @@ use git_repository::{
     odb::{pack, pack::index},
     progress, Progress,
 };
-use std::{
-    io,
-    path::Path,
-    str::FromStr,
-    sync::{atomic::AtomicBool, Arc},
-};
-
 pub use index::verify::Mode;
+
+use crate::OutputFormat;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum Algorithm {

--- a/gitoxide-core/src/remote.rs
+++ b/gitoxide-core/src/remote.rs
@@ -1,5 +1,4 @@
 pub mod refs {
-    use crate::OutputFormat;
     use git_repository::{
         protocol,
         protocol::{
@@ -7,6 +6,8 @@ pub mod refs {
             transport,
         },
     };
+
+    use crate::OutputFormat;
 
     pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=2;
 
@@ -41,8 +42,8 @@ pub mod refs {
 
     #[cfg(feature = "async-client")]
     mod async_io {
-        use super::{Context, LsRemotes};
-        use crate::{net, remote::refs::print, OutputFormat};
+        use std::io;
+
         use async_trait::async_trait;
         use futures_io::AsyncBufRead;
         use git_repository::{
@@ -50,7 +51,9 @@ pub mod refs {
             protocol::fetch::{Ref, Response},
             Progress,
         };
-        use std::io;
+
+        use super::{Context, LsRemotes};
+        use crate::{net, remote::refs::print, OutputFormat};
 
         #[async_trait(?Send)]
         impl protocol::fetch::Delegate for LsRemotes {
@@ -109,16 +112,18 @@ pub mod refs {
 
     #[cfg(feature = "blocking-client")]
     mod blocking_io {
-        #[cfg(feature = "serde1")]
-        use super::JsonRef;
-        use super::{print, Context, LsRemotes};
-        use crate::{net, OutputFormat};
+        use std::io;
+
         use git_repository::{
             protocol,
             protocol::fetch::{Ref, Response},
             Progress,
         };
-        use std::io;
+
+        #[cfg(feature = "serde1")]
+        use super::JsonRef;
+        use super::{print, Context, LsRemotes};
+        use crate::{net, OutputFormat};
 
         impl protocol::fetch::Delegate for LsRemotes {
             fn receive_pack(

--- a/gitoxide-core/src/repository.rs
+++ b/gitoxide-core/src/repository.rs
@@ -1,5 +1,6 @@
-use anyhow::{Context as AnyhowContext, Result};
 use std::path::PathBuf;
+
+use anyhow::{Context as AnyhowContext, Result};
 
 pub fn init(directory: Option<PathBuf>) -> Result<()> {
     git_repository::init::repository(directory.unwrap_or_default()).with_context(|| "Repository initialization failed")

--- a/src/plumbing/lean/main.rs
+++ b/src/plumbing/lean/main.rs
@@ -1,10 +1,3 @@
-use crate::{
-    plumbing::lean::options::{self, Args, SubCommands},
-    shared::lean::prepare,
-};
-use anyhow::Result;
-use git_features::progress::DoOrDiscard;
-use gitoxide_core::{self as core, OutputFormat};
 use std::{
     io::{self, stderr, stdin, stdout},
     path::PathBuf,
@@ -12,6 +5,15 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+};
+
+use anyhow::Result;
+use git_features::progress::DoOrDiscard;
+use gitoxide_core::{self as core, OutputFormat};
+
+use crate::{
+    plumbing::lean::options::{self, Args, SubCommands},
+    shared::lean::prepare,
 };
 #[cfg(all(feature = "gitoxide-core-blocking-client", feature = "gitoxide-core-async-client"))]
 compile_error!("Please set only one of the client networking options.");

--- a/src/plumbing/lean/options.rs
+++ b/src/plumbing/lean/options.rs
@@ -1,6 +1,7 @@
+use std::{ffi::OsString, path::PathBuf};
+
 use argh::FromArgs;
 use gitoxide_core as core;
-use std::{ffi::OsString, path::PathBuf};
 
 #[derive(FromArgs)]
 #[argh(name = "gix-plumbing")]

--- a/src/plumbing/pretty/main.rs
+++ b/src/plumbing/pretty/main.rs
@@ -1,12 +1,3 @@
-use anyhow::Result;
-use clap::Clap;
-use gitoxide_core as core;
-
-use crate::{
-    plumbing::pretty::options::{Args, Subcommands},
-    shared::pretty::prepare_and_run,
-};
-use gitoxide_core::pack::verify;
 use std::{
     io::{stdin, BufReader},
     path::PathBuf,
@@ -14,6 +5,16 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+};
+
+use anyhow::Result;
+use clap::Clap;
+use gitoxide_core as core;
+use gitoxide_core::pack::verify;
+
+use crate::{
+    plumbing::pretty::options::{Args, Subcommands},
+    shared::pretty::prepare_and_run,
 };
 
 pub fn main() -> Result<()> {

--- a/src/plumbing/pretty/options.rs
+++ b/src/plumbing/pretty/options.rs
@@ -1,7 +1,7 @@
+use std::{ffi::OsString, path::PathBuf};
+
 use clap::{AppSettings, Clap};
 use gitoxide_core as core;
-use std::ffi::OsString;
-use std::path::PathBuf;
 
 #[derive(Debug, Clap)]
 #[clap(name = "gix-plumbing", about = "The git underworld", version = clap::crate_version!())]

--- a/src/porcelain/main.rs
+++ b/src/porcelain/main.rs
@@ -1,14 +1,16 @@
-use crate::{
-    porcelain::options::{Args, EstimateHours, Subcommands, ToolCommands},
-    shared::pretty::prepare_and_run,
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
 };
+
 use anyhow::Result;
 use clap::Clap;
 use git_features::progress::DoOrDiscard;
 use gitoxide_core as core;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+
+use crate::{
+    porcelain::options::{Args, EstimateHours, Subcommands, ToolCommands},
+    shared::pretty::prepare_and_run,
 };
 
 pub fn main() -> Result<()> {

--- a/src/porcelain/options.rs
+++ b/src/porcelain/options.rs
@@ -1,6 +1,6 @@
+use std::{ffi::OsString, path::PathBuf};
+
 use clap::{AppSettings, Clap};
-use std::ffi::OsString;
-use std::path::PathBuf;
 
 #[derive(Debug, Clap)]
 #[clap(about = "The rusty git", version = clap::crate_version!())]
@@ -104,8 +104,9 @@ pub struct EstimateHours {
 }
 
 mod validator {
-    use anyhow::Context;
     use std::{ffi::OsStr, path::PathBuf};
+
+    use anyhow::Context;
 
     fn is_repo_inner(dir: &OsStr) -> anyhow::Result<()> {
         let git_dir = PathBuf::from(dir).join(".git");

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -66,12 +66,14 @@ pub mod lean {
 
 #[cfg(feature = "pretty-cli")]
 pub mod pretty {
-    use crate::shared::ProgressRange;
-    use anyhow::{anyhow, Result};
     use std::{
         io::{stderr, stdout, Write},
         panic::UnwindSafe,
     };
+
+    use anyhow::{anyhow, Result};
+
+    use crate::shared::ProgressRange;
 
     pub fn prepare_and_run<T: Send + 'static>(
         name: &str,

--- a/tests/snapshots/panic-behaviour/expected-failure
+++ b/tests/snapshots/panic-behaviour/expected-failure
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'something went very wrong', src/porcelain/main.rs:33:42
+thread 'main' panicked at 'something went very wrong', src/porcelain/main.rs:35:42
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/snapshots/panic-behaviour/expected-failure-in-thread
+++ b/tests/snapshots/panic-behaviour/expected-failure-in-thread
@@ -1,2 +1,2 @@
-thread '<unnamed>' panicked at 'something went very wrong', src/porcelain/main.rs:33:42
+thread '<unnamed>' panicked at 'something went very wrong', src/porcelain/main.rs:35:42
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/snapshots/panic-behaviour/expected-failure-in-thread-with-progress
+++ b/tests/snapshots/panic-behaviour/expected-failure-in-thread-with-progress
@@ -1,3 +1,3 @@
-[?1049h[?25lthread '<unnamed>' panicked at 'something went very wrong', src/porcelain/main.rs:33:42
+[?1049h[?25lthread '<unnamed>' panicked at 'something went very wrong', src/porcelain/main.rs:35:42
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 [?25h[?1049lError: receiving on a closed channel

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -1,9 +1,13 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+pub use bstr;
 use bstr::{BStr, ByteSlice};
 use nom::error::VerboseError;
 use once_cell::sync::Lazy;
-use std::{collections::BTreeMap, path::Path, path::PathBuf, sync::Mutex};
-
-pub use bstr;
 pub use tempfile;
 
 static SCRIPT_IDENTITY: Lazy<Mutex<BTreeMap<PathBuf, u32>>> = Lazy::new(|| Mutex::new(BTreeMap::new()));


### PR DESCRIPTION
Applied via `make rustfmt`, which enables these nightly-only rules:
```
group_imports = "StdExternalCrate"
imports_granularity = "Crate"
```