### PR TITLE
Count objects performance improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,8 +2664,7 @@ checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 [[package]]
 name = "uluru"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308dcc9d947b227796f851adb99936fb060681a89c002c9c1928404a3b6c2d72"
+source = "git+https://github.com/Byron/uluru?branch=master#43fed348af8c391419354a0829e67e44a6a24f8a"
 dependencies = [
  "arrayvec",
 ]

--- a/git-features/src/interrupt.rs
+++ b/git-features/src/interrupt.rs
@@ -36,9 +36,7 @@ where
     type Item = Result<I::Item, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.make_err.is_none() {
-            return None;
-        }
+        self.make_err.as_ref()?;
         if self.should_interrupt.load(Ordering::Relaxed) {
             return Some(Err(self.make_err.take().expect("no bug")()));
         }

--- a/git-features/src/interrupt.rs
+++ b/git-features/src/interrupt.rs
@@ -10,7 +10,6 @@ pub struct Iter<'a, I, EFN> {
     pub inner: I,
     make_err: Option<EFN>,
     should_interrupt: &'a AtomicBool,
-    is_done: bool,
 }
 
 impl<'a, I, EFN, E> Iter<'a, I, EFN>
@@ -25,7 +24,6 @@ where
             inner,
             make_err: Some(make_err),
             should_interrupt,
-            is_done: false,
         }
     }
 }
@@ -38,17 +36,16 @@ where
     type Item = Result<I::Item, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.is_done {
+        if self.make_err.is_none() {
             return None;
         }
         if self.should_interrupt.load(Ordering::Relaxed) {
-            self.is_done = true;
             return Some(Err(self.make_err.take().expect("no bug")()));
         }
         match self.inner.next() {
             Some(next) => Some(Ok(next)),
             None => {
-                self.is_done = true;
+                self.make_err = None;
                 None
             }
         }

--- a/git-features/src/parallel/mod.rs
+++ b/git-features/src/parallel/mod.rs
@@ -35,11 +35,11 @@
 #[cfg(feature = "parallel")]
 mod in_parallel;
 #[cfg(feature = "parallel")]
-pub use in_parallel::*;
+pub use in_parallel::{in_parallel, join};
 
 mod serial;
 #[cfg(not(feature = "parallel"))]
-pub use serial::*;
+pub use serial::{in_parallel, join};
 
 mod eager_iter;
 pub use eager_iter::{EagerIter, EagerIterIf};

--- a/git-features/src/parallel/serial.rs
+++ b/git-features/src/parallel/serial.rs
@@ -1,7 +1,7 @@
 use crate::parallel::Reduce;
 
-#[cfg(not(feature = "parallel"))]
 /// Runs `left` and then `right`, one after another, returning their output when both are done.
+#[cfg(not(feature = "parallel"))]
 pub fn join<O1: Send, O2: Send>(left: impl FnOnce() -> O1 + Send, right: impl FnOnce() -> O2 + Send) -> (O1, O2) {
     (left(), right())
 }

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -48,7 +48,7 @@ itoa = "0.4.6"
 bytesize = "1.0.1"
 parking_lot = { version = "0.11.0", default-features = false }
 thiserror = "1.0.26"
-uluru = { version = "2.2.0", optional = true }
+uluru = { version = "2.2.0", optional = true, git = "https://github.com/Byron/uluru", features = ["std"], branch = "master"}
 memory-lru = { version = "0.1.0", optional = true }
 dashmap = "4.0.2"
 

--- a/git-pack/src/cache.rs
+++ b/git-pack/src/cache.rs
@@ -106,17 +106,28 @@ pub mod lru {
         /// The cache must be small as the search is 'naive' and the underlying data structure is a linked list.
         /// Values of 64 seem to improve performance.
         #[derive(Default)]
-        pub struct StaticLinkedList<const SIZE: usize>(uluru::LRUCache<Entry, SIZE>);
+        pub struct StaticLinkedList<const SIZE: usize>(uluru::LRUCache<Entry, SIZE>, Vec<Vec<u8>>);
 
         impl<const SIZE: usize> DecodeEntry for StaticLinkedList<SIZE> {
             fn put(&mut self, pack_id: u32, offset: u64, data: &[u8], kind: git_object::Kind, compressed_size: usize) {
-                self.0.insert(Entry {
+                if let Some(previous) = self.0.insert(Entry {
                     offset,
                     pack_id,
-                    data: Vec::from(data),
+                    data: self
+                        .1
+                        .pop()
+                        .map(|mut v| {
+                            v.clear();
+                            v.resize(data.len(), 0);
+                            v.copy_from_slice(data);
+                            v
+                        })
+                        .unwrap_or_else(|| Vec::from(data)),
                     kind,
                     compressed_size,
-                })
+                }) {
+                    self.1.push(previous.data)
+                }
             }
 
             fn get(&mut self, pack_id: u32, offset: u64, out: &mut Vec<u8>) -> Option<(git_object::Kind, usize)> {

--- a/git-pack/src/data/output/count/iter_from_objects.rs
+++ b/git-pack/src/data/output/count/iter_from_objects.rs
@@ -7,6 +7,9 @@ use git_object::immutable;
 
 use crate::{data::output, find, FindExt};
 
+/// The return type used by [`objects()`].
+pub type Result<E> = std::result::Result<(Vec<output::Count>, Outcome), Error<E>>;
+
 /// Generate [`Count`][output::Count]s from input `objects` with object expansion based on [`options`][Options]
 /// to learn which objects would would constitute a pack. This step is required to know exactly how many objects would
 /// be in a pack while keeping data around to avoid minimize object database access.
@@ -35,7 +38,7 @@ pub fn objects<Find, Iter, Oid, Cache>(
         input_object_expansion,
         chunk_size,
     }: Options,
-) -> Result<(Vec<output::Count>, Outcome), Error<find::existing::Error<Find::Error>>>
+) -> Result<find::existing::Error<Find::Error>>
 where
     Find: crate::Find + Send + Sync,
     <Find as crate::Find>::Error: Send,

--- a/git-pack/src/data/output/count/iter_from_objects.rs
+++ b/git-pack/src/data/output/count/iter_from_objects.rs
@@ -252,6 +252,248 @@ where
     )
 }
 
+/// Generate [`Count`][output::Count]s from input `objects` with object expansion based on [`options`][Options]
+/// to learn which objects would would constitute a pack. This step is required to know exactly how many objects would
+/// be in a pack while keeping data around to avoid minimize object database access.
+///
+/// A [`Count`][output::Count] object maintains enough state to greatly accelerate future access of packed objects.
+///
+/// * `db` - the object store to use for accessing objects.
+/// * `make_cache` - a function to create thread-local pack caches
+/// * `objects_ids`
+///   * A list of objects ids to add to the pack. Duplication checks are performed so no object is ever added to a pack twice.
+///   * Objects may be expanded based on the provided [`options`][Options]
+/// * `progress`
+///   * a way to obtain progress information
+/// * `options`
+///   * more configuration
+pub fn objects<Find, Iter, Oid, Cache>(
+    db: Find,
+    make_cache: impl Fn() -> Cache + Send + Sync,
+    objects_ids: Iter,
+    progress: impl Progress,
+    Options {
+        thread_limit,
+        input_object_expansion,
+        chunk_size,
+    }: Options,
+) -> Result<(Vec<output::Count>, Outcome), Error<find::existing::Error<Find::Error>>>
+where
+    Find: crate::Find + Send + Sync,
+    <Find as crate::Find>::Error: Send,
+    Iter: Iterator<Item = Oid> + Send,
+    Oid: AsRef<oid> + Send,
+    Cache: crate::cache::DecodeEntry,
+{
+    let lower_bound = objects_ids.size_hint().0;
+    let (chunk_size, thread_limit, _) = parallel::optimize_chunk_size_and_thread_limit(
+        chunk_size,
+        if lower_bound == 0 { None } else { Some(lower_bound) },
+        thread_limit,
+        None,
+    );
+    let chunks = util::Chunks {
+        iter: objects_ids,
+        size: chunk_size,
+    };
+    let seen_objs = dashmap::DashSet::<ObjectId>::new();
+    let progress = parking_lot::Mutex::new(progress);
+
+    parallel::in_parallel(
+        chunks,
+        thread_limit,
+        {
+            move |n| {
+                (
+                    Vec::new(),   // object data buffer
+                    Vec::new(),   // object data buffer 2 to hold two objects at a time
+                    make_cache(), // cache to speed up pack operations
+                    {
+                        let mut p = progress.lock().add_child(format!("thread {}", n));
+                        p.init(None, git_features::progress::count("objects"));
+                        p
+                    },
+                )
+            }
+        },
+        {
+            move |oids: Vec<Oid>, (buf1, buf2, cache, progress)| {
+                use ObjectExpansion::*;
+                let mut out = Vec::new();
+                let mut tree_traversal_state = git_traverse::tree::breadthfirst::State::default();
+                let mut tree_diff_state = git_diff::tree::State::default();
+                let mut parent_commit_ids = Vec::new();
+                let mut traverse_delegate = tree::traverse::AllUnseen::new(&seen_objs);
+                let mut changes_delegate = tree::changes::AllNew::new(&seen_objs);
+                let mut outcome = Outcome::default();
+                let stats = &mut outcome;
+
+                for id in oids.into_iter() {
+                    let id = id.as_ref();
+                    let obj = db.find_existing(id, buf1, cache)?;
+                    stats.input_objects += 1;
+                    match input_object_expansion {
+                        TreeAdditionsComparedToAncestor => {
+                            use git_object::Kind::*;
+                            let mut obj = obj;
+                            let mut id = id.to_owned();
+
+                            loop {
+                                push_obj_count_unique(&mut out, &seen_objs, &id, &obj, progress, stats, false);
+                                match obj.kind {
+                                    Tree | Blob => break,
+                                    Tag => {
+                                        id = immutable::TagIter::from_bytes(obj.data)
+                                            .target_id()
+                                            .expect("every tag has a target");
+                                        obj = db.find_existing(id, buf1, cache)?;
+                                        stats.expanded_objects += 1;
+                                        continue;
+                                    }
+                                    Commit => {
+                                        let current_tree_iter = {
+                                            let mut commit_iter = immutable::CommitIter::from_bytes(obj.data);
+                                            let tree_id = commit_iter.tree_id().expect("every commit has a tree");
+                                            parent_commit_ids.clear();
+                                            for token in commit_iter {
+                                                match token {
+                                                    Ok(immutable::commit::iter::Token::Parent { id }) => {
+                                                        parent_commit_ids.push(id)
+                                                    }
+                                                    Ok(_) => break,
+                                                    Err(err) => return Err(Error::CommitDecode(err)),
+                                                }
+                                            }
+                                            let obj = db.find_existing(tree_id, buf1, cache)?;
+                                            push_obj_count_unique(
+                                                &mut out, &seen_objs, &tree_id, &obj, progress, stats, true,
+                                            );
+                                            immutable::TreeIter::from_bytes(obj.data)
+                                        };
+
+                                        let objects = if parent_commit_ids.is_empty() {
+                                            traverse_delegate.clear();
+                                            git_traverse::tree::breadthfirst(
+                                                current_tree_iter,
+                                                &mut tree_traversal_state,
+                                                |oid, buf| {
+                                                    stats.decoded_objects += 1;
+                                                    db.find_existing_tree_iter(oid, buf, cache).ok()
+                                                },
+                                                &mut traverse_delegate,
+                                            )
+                                            .map_err(Error::TreeTraverse)?;
+                                            &traverse_delegate.objects
+                                        } else {
+                                            for commit_id in &parent_commit_ids {
+                                                let parent_tree_id = {
+                                                    let parent_commit_obj = db.find_existing(commit_id, buf2, cache)?;
+
+                                                    push_obj_count_unique(
+                                                        &mut out,
+                                                        &seen_objs,
+                                                        commit_id,
+                                                        &parent_commit_obj,
+                                                        progress,
+                                                        stats,
+                                                        true,
+                                                    );
+                                                    immutable::CommitIter::from_bytes(parent_commit_obj.data)
+                                                        .tree_id()
+                                                        .expect("every commit has a tree")
+                                                };
+                                                let parent_tree = {
+                                                    let parent_tree_obj =
+                                                        db.find_existing(parent_tree_id, buf2, cache)?;
+                                                    push_obj_count_unique(
+                                                        &mut out,
+                                                        &seen_objs,
+                                                        &parent_tree_id,
+                                                        &parent_tree_obj,
+                                                        progress,
+                                                        stats,
+                                                        true,
+                                                    );
+                                                    immutable::TreeIter::from_bytes(parent_tree_obj.data)
+                                                };
+
+                                                changes_delegate.clear();
+                                                git_diff::tree::Changes::from(Some(parent_tree))
+                                                    .needed_to_obtain(
+                                                        current_tree_iter.clone(),
+                                                        &mut tree_diff_state,
+                                                        |oid, buf| {
+                                                            stats.decoded_objects += 1;
+                                                            db.find_existing_tree_iter(oid, buf, cache).ok()
+                                                        },
+                                                        &mut changes_delegate,
+                                                    )
+                                                    .map_err(Error::TreeChanges)?;
+                                            }
+                                            &changes_delegate.objects
+                                        };
+                                        for id in objects.iter() {
+                                            out.push(id_to_count(&db, buf2, id, progress, stats));
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        TreeContents => {
+                            use git_object::Kind::*;
+                            let mut id: ObjectId = id.into();
+                            let mut obj = obj;
+                            loop {
+                                push_obj_count_unique(&mut out, &seen_objs, &id, &obj, progress, stats, false);
+                                match obj.kind {
+                                    Tree => {
+                                        traverse_delegate.clear();
+                                        git_traverse::tree::breadthfirst(
+                                            git_object::immutable::TreeIter::from_bytes(obj.data),
+                                            &mut tree_traversal_state,
+                                            |oid, buf| {
+                                                stats.decoded_objects += 1;
+                                                db.find_existing_tree_iter(oid, buf, cache).ok()
+                                            },
+                                            &mut traverse_delegate,
+                                        )
+                                        .map_err(Error::TreeTraverse)?;
+                                        for id in traverse_delegate.objects.iter() {
+                                            out.push(id_to_count(&db, buf1, id, progress, stats));
+                                        }
+                                        break;
+                                    }
+                                    Commit => {
+                                        id = immutable::CommitIter::from_bytes(obj.data)
+                                            .tree_id()
+                                            .expect("every commit has a tree");
+                                        stats.expanded_objects += 1;
+                                        obj = db.find_existing(id, buf1, cache)?;
+                                        continue;
+                                    }
+                                    Blob => break,
+                                    Tag => {
+                                        id = immutable::TagIter::from_bytes(obj.data)
+                                            .target_id()
+                                            .expect("every tag has a target");
+                                        stats.expanded_objects += 1;
+                                        obj = db.find_existing(id, buf1, cache)?;
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        AsIs => push_obj_count_unique(&mut out, &seen_objs, id, &obj, progress, stats, false),
+                    }
+                }
+                Ok((out, outcome))
+            }
+        },
+        reduce::Statistics2::default(),
+    )
+}
+
 mod tree {
     pub mod changes {
         use dashmap::DashSet;
@@ -431,7 +673,7 @@ mod types {
         pub expanded_objects: usize,
         /// The amount of fully decoded objects. These are the most expensive as they are fully decoded
         pub decoded_objects: usize,
-        /// The total amount of objects seed. Should be `expanded_objects + input_objects`.
+        /// The total amount of encountered objects. Should be `expanded_objects + input_objects`.
         pub total_objects: usize,
     }
 
@@ -561,6 +803,41 @@ mod reduce {
 
         fn finalize(self) -> Result<Self::Output, Self::Error> {
             Ok(self.total)
+        }
+    }
+
+    pub struct Statistics2<E> {
+        total: Outcome,
+        counts: Vec<output::Count>,
+        _err: PhantomData<E>,
+    }
+
+    impl<E> Default for Statistics2<E> {
+        fn default() -> Self {
+            Statistics2 {
+                total: Default::default(),
+                counts: Default::default(),
+                _err: PhantomData::default(),
+            }
+        }
+    }
+
+    impl<Error> parallel::Reduce for Statistics2<Error> {
+        type Input = Result<(Vec<output::Count>, Outcome), Error>;
+        type FeedProduce = ();
+        type Output = (Vec<output::Count>, Outcome);
+        type Error = Error;
+
+        fn feed(&mut self, item: Self::Input) -> Result<Self::FeedProduce, Self::Error> {
+            let (counts, mut stats) = item?;
+            stats.total_objects = counts.len();
+            self.total.aggregate(stats);
+            self.counts.extend(counts);
+            Ok(())
+        }
+
+        fn finalize(self) -> Result<Self::Output, Self::Error> {
+            Ok((self.counts, self.total))
         }
     }
 }

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -27,4 +27,4 @@ impl Count {
 
 ///
 pub mod iter_from_objects;
-pub use iter_from_objects::objects;
+pub use iter_from_objects::{objects, objects_unthreaded};

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -27,4 +27,4 @@ impl Count {
 
 ///
 pub mod iter_from_objects;
-pub use iter_from_objects::iter_from_objects;
+pub use iter_from_objects::{iter_from_objects, objects};

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -27,4 +27,4 @@ impl Count {
 
 ///
 pub mod iter_from_objects;
-pub use iter_from_objects::{iter_from_objects, objects};
+pub use iter_from_objects::objects;

--- a/git-pack/tests/pack/data/output/count_and_entries.rs
+++ b/git-pack/tests/pack/data/output/count_and_entries.rs
@@ -12,6 +12,7 @@ use crate::pack::{
     data::output::{db, DbKind},
     hex_to_id,
 };
+use std::convert::Infallible;
 
 #[test]
 fn traversals() -> crate::Result {
@@ -250,7 +251,8 @@ fn traversals() -> crate::Result {
                 } else {
                     "e3fb53cbb4c346d48732a24f09cf445e49bc63d6"
                 })))
-                .filter(|o| !o.is_null()),
+                .filter(|o| !o.is_null())
+                .map(Ok::<_, Infallible>),
             progress::Discard,
             &AtomicBool::new(false),
             count::iter_from_objects::Options {

--- a/git-pack/tests/pack/data/output/count_and_entries.rs
+++ b/git-pack/tests/pack/data/output/count_and_entries.rs
@@ -252,6 +252,7 @@ fn traversals() -> crate::Result {
                 })))
                 .filter(|o| !o.is_null()),
             progress::Discard,
+            &AtomicBool::new(false),
             count::iter_from_objects::Options {
                 input_object_expansion: expansion_mode,
                 thread_limit: deterministic_count_needs_single_thread,

--- a/git-pack/tests/pack/data/output/count_and_entries.rs
+++ b/git-pack/tests/pack/data/output/count_and_entries.rs
@@ -240,7 +240,7 @@ fn traversals() -> crate::Result {
         }
 
         let deterministic_count_needs_single_thread = Some(1);
-        let mut counts_iter = output::count::iter_from_objects(
+        let (counts, stats) = output::count::objects(
             db.clone(),
             || pack::cache::Never,
             commits
@@ -257,13 +257,7 @@ fn traversals() -> crate::Result {
                 thread_limit: deterministic_count_needs_single_thread,
                 ..Default::default()
             },
-        );
-        let counts: Vec<_> = counts_iter
-            .by_ref()
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .flatten()
-            .collect();
+        )?;
         let actual_count = counts.iter().fold(ObjectCount::default(), |mut c, e| {
             let mut buf = Vec::new();
             if let Some(obj) = db.find_existing(e.id, &mut buf, &mut pack::cache::Never).ok() {
@@ -275,7 +269,6 @@ fn traversals() -> crate::Result {
         let counts_len = counts.len();
         assert_eq!(counts_len, expected_obj_count.total());
 
-        let stats = counts_iter.finalize()?;
         assert_eq!(stats, expected_counts_outcome);
         assert_eq!(stats.total_objects, expected_obj_count.total());
 

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -218,7 +218,7 @@ where
         ))
     };
 
-    let mut entries_progress = progress.add_child("consumed");
+    let mut entries_progress = progress.add_child("consuming");
     entries_progress.init(Some(num_objects), progress::count("entries"));
     let mut write_progress = progress.add_child("writing");
     write_progress.init(None, progress::bytes());


### PR DESCRIPTION
The current implementation suffers for being more flexible than it needs to be.

For one, it's implemented as iterator even though that's not required as counts are never streamed.
Secondly, it is forced to use thread-safe data structures which greatly slow down operation in a
single thread.

* [x] Rewrite multi-threaded counting to not be an iterator but use scoped thread parallelism instead with cancellation support. That way some indirections through arcs can be removed and overall we will probably get faster as we don't have to send small vectors around just to combine them into a big one later. **Also review how input is presented, allow an Option/Result to handle errors there**. Otherwise people are forced to panic or iterate everything in advance.
* [x] **a single-threaded version** of counting to avoid dashmap tax (as Mutex<HashSet> is 12s faster than dashmap already with a single thread) to get en-par or better than git in this case - fast insertions are key.

Unfortunately, it didn't get noticeably faster - using a RefCell in 40s of time about 2s go to the RefCell. PackCaches currently do a lot of allocations (and throw them away when the LRU portion kicks in), which could be improved with a free-list. But to do that, it requires support in the statically allocated version.

Furthermore it might be possible to improve cache efficiency by caching whole objects even though my strong feeling is that this won't do much as objects are never visited twice when traversing trees. When handling tree diffs, a better cache is definitely possible though, but that's out of scope here.