### PR TITLE
Improving counting performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "218d6bd3dde8e442a975fa1cd233c0e5fded7596bccfe39f58eca98d22421e0a"
+
+[[package]]
 name = "cmake"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1135,7 @@ dependencies = [
  "btoi",
  "byteorder",
  "bytesize",
+ "clru",
  "common_macros",
  "dashmap",
  "filebuffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "git-pack"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "bstr",
  "btoi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,6 @@ dependencies = [
  "git-traverse",
  "hex",
  "itoa",
- "memory-lru",
  "parking_lot 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "smallvec",

--- a/git-odb/Cargo.toml
+++ b/git-odb/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 git-features = { version = "^0.16.0", path = "../git-features", features = ["rustsha1", "walkdir", "zlib"] }
 git-hash = { version = "^0.5.0", path = "../git-hash" }
 git-object = { version ="0.12.0", path = "../git-object" }
-git-pack = { version ="0.8.0", path = "../git-pack" }
+git-pack = { version ="^0.9.0", path = "../git-pack" }
 
 btoi = "0.4.2"
 tempfile = "3.1.0"

--- a/git-odb/src/store/compound/init.rs
+++ b/git-odb/src/store/compound/init.rs
@@ -38,6 +38,8 @@ impl compound::Store {
                         p.extension().unwrap_or_default() == "idx"
                             && p.file_name().unwrap_or_default().to_string_lossy().starts_with("pack-")
                     })
+                    // TODO: make this configurable, git for instance sorts by modification date
+                    //       https://github.com/libgit2/libgit2/blob/main/src/odb_pack.c#L41-L158
                     .map(|(p, md)| pack::Bundle::at(p).map(|b| (b, md.len())))
                     .collect::<Result<Vec<_>, _>>()?;
                 packs_and_sizes.sort_by_key(|e| e.1);

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 pack-cache-lru-static = ["uluru"]
-pack-cache-lru-dynamic = ["memory-lru"]
+pack-cache-lru-dynamic = ["clru", "memory-lru"]
 serde1 = ["serde", "git-object/serde1"]
 internal-testing-git-features-parallel = ["git-features/parallel"]
 internal-testing-to-avoid-being-run-by-cargo-test-all = []
@@ -50,6 +50,7 @@ parking_lot = { version = "0.11.0", default-features = false }
 thiserror = "1.0.26"
 uluru = { version = "3.0.0", optional = true }
 memory-lru = { version = "0.1.0", optional = true }
+clru = { version = "0.5.0", optional = true }
 dashmap = "4.0.2"
 
 [dev-dependencies]

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 pack-cache-lru-static = ["uluru"]
-pack-cache-lru-dynamic = ["clru", "memory-lru"]
+pack-cache-lru-dynamic = ["clru"]
 serde1 = ["serde", "git-object/serde1"]
 internal-testing-git-features-parallel = ["git-features/parallel"]
 internal-testing-to-avoid-being-run-by-cargo-test-all = []
@@ -49,7 +49,6 @@ bytesize = "1.0.1"
 parking_lot = { version = "0.11.0", default-features = false }
 thiserror = "1.0.26"
 uluru = { version = "3.0.0", optional = true }
-memory-lru = { version = "0.1.0", optional = true }
 clru = { version = "0.5.0", optional = true }
 dashmap = "4.0.2"
 

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-pack"
-version = "0.8.2"
+version = "0.9.0"
 repository = "https://github.com/Byron/gitoxide"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT/Apache-2.0"

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -17,6 +17,7 @@ pub struct Count {
 
 /// Specifies how the pack location was handled during counting
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum PackLocation {
     /// We did not lookup this object
     NotLookedUp,

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -12,7 +12,33 @@ pub struct Count {
     /// The hash of the object to write
     pub id: ObjectId,
     /// A way to locate a pack entry in the object database, only available if the object is in a pack.
-    pub entry_pack_location: Option<crate::bundle::Location>,
+    pub entry_pack_location: PackLocation,
+}
+
+/// Specifies how the pack location was handled during counting
+#[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
+pub enum PackLocation {
+    /// We did not lookup this object
+    NotLookedUp,
+    /// The object was looked up and there may be a location in a pack, along with enty information
+    LookedUp(Option<crate::bundle::Location>),
+}
+
+impl PackLocation {
+    /// Directly go through to LookedUp variant, panic otherwise
+    pub fn is_none(&self) -> bool {
+        match self {
+            PackLocation::LookedUp(opt) => opt.is_none(),
+            PackLocation::NotLookedUp => unreachable!("must have been resolved"),
+        }
+    }
+    /// Directly go through to LookedUp variant, panic otherwise
+    pub fn as_ref(&self) -> Option<&crate::bundle::Location> {
+        match self {
+            PackLocation::LookedUp(opt) => opt.as_ref(),
+            PackLocation::NotLookedUp => unreachable!("must have been resolved"),
+        }
+    }
 }
 
 impl Count {
@@ -20,7 +46,7 @@ impl Count {
     pub fn from_data(oid: impl Into<ObjectId>, obj: &data::Object<'_>) -> Self {
         Count {
             id: oid.into(),
-            entry_pack_location: obj.pack_location.clone(),
+            entry_pack_location: PackLocation::LookedUp(obj.pack_location.clone()),
         }
     }
 }

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -26,5 +26,5 @@ impl Count {
 }
 
 ///
-pub mod iter_from_objects;
-pub use iter_from_objects::{objects, objects_unthreaded};
+pub mod objects;
+pub use objects::{objects, objects_unthreaded};

--- a/git-pack/src/data/output/count/objects.rs
+++ b/git-pack/src/data/output/count/objects.rs
@@ -318,7 +318,7 @@ where
 
 mod tree {
     pub mod changes {
-        use crate::data::output::count::iter_from_objects::util::InsertImmutable;
+        use crate::data::output::count::objects::util::InsertImmutable;
         use git_diff::tree::{
             visit::{Action, Change},
             Visit,
@@ -374,7 +374,7 @@ mod tree {
     }
 
     pub mod traverse {
-        use crate::data::output::count::iter_from_objects::util::InsertImmutable;
+        use crate::data::output::count::objects::util::InsertImmutable;
         use git_hash::ObjectId;
         use git_object::{bstr::BStr, immutable::tree::Entry};
         use git_traverse::tree::visit::{Action, Visit};

--- a/git-pack/src/data/output/count/objects.rs
+++ b/git-pack/src/data/output/count/objects.rs
@@ -463,7 +463,8 @@ fn id_to_count<Find: crate::Find>(
     statistics.expanded_objects += 1;
     output::Count {
         id: id.to_owned(),
-        entry_pack_location: db.location_by_oid(id, buf),
+        // entry_pack_location: db.location_by_oid(id, buf),
+        entry_pack_location: None,
     }
 }
 

--- a/git-pack/src/data/output/count/objects.rs
+++ b/git-pack/src/data/output/count/objects.rs
@@ -463,8 +463,7 @@ fn id_to_count<Find: crate::Find>(
     statistics.expanded_objects += 1;
     output::Count {
         id: id.to_owned(),
-        // entry_pack_location: db.location_by_oid(id, buf),
-        entry_pack_location: None,
+        entry_pack_location: db.location_by_oid(id, buf),
     }
 }
 

--- a/git-pack/tests/pack/data/output/count_and_entries.rs
+++ b/git-pack/tests/pack/data/output/count_and_entries.rs
@@ -90,7 +90,7 @@ fn traversals() -> crate::Result {
         allow_thin_pack,
     ) in [
         (
-            count::iter_from_objects::ObjectExpansion::AsIs,
+            count::objects::ObjectExpansion::AsIs,
             Count {
                 trees: 0,
                 commits: 15,
@@ -105,7 +105,7 @@ fn traversals() -> crate::Result {
                 blobs: 0,
                 tags: 1,
             },
-            output::count::iter_from_objects::Outcome {
+            output::count::objects::Outcome {
                 input_objects: 16,
                 expanded_objects: 0,
                 decoded_objects: 16,
@@ -122,7 +122,7 @@ fn traversals() -> crate::Result {
             false,
         ),
         (
-            count::iter_from_objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
+            count::objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
             Count {
                 trees: 3,
                 commits: 2, // todo: why more?
@@ -137,7 +137,7 @@ fn traversals() -> crate::Result {
                 blobs: 96,
                 tags: 0,
             },
-            output::count::iter_from_objects::Outcome {
+            output::count::objects::Outcome {
                 input_objects: 1,
                 expanded_objects: 102,
                 decoded_objects: 18,
@@ -154,7 +154,7 @@ fn traversals() -> crate::Result {
             true,
         ),
         (
-            count::iter_from_objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
+            count::objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
             Count {
                 trees: 5,
                 commits: 2, // todo: why more?
@@ -169,7 +169,7 @@ fn traversals() -> crate::Result {
                 blobs: 96,
                 tags: 0,
             },
-            output::count::iter_from_objects::Outcome {
+            output::count::objects::Outcome {
                 input_objects: 1,
                 expanded_objects: 102,
                 decoded_objects: 18,
@@ -186,10 +186,10 @@ fn traversals() -> crate::Result {
             false,
         ),
         (
-            count::iter_from_objects::ObjectExpansion::TreeContents,
+            count::objects::ObjectExpansion::TreeContents,
             whole_pack,
             whole_pack_obj_count,
-            output::count::iter_from_objects::Outcome {
+            output::count::objects::Outcome {
                 input_objects: 16,
                 expanded_objects: 852,
                 decoded_objects: 57,
@@ -206,10 +206,10 @@ fn traversals() -> crate::Result {
             false,
         ),
         (
-            count::iter_from_objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
+            count::objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
             whole_pack,
             whole_pack_obj_count,
-            output::count::iter_from_objects::Outcome {
+            output::count::objects::Outcome {
                 input_objects: 16,
                 expanded_objects: 866,
                 decoded_objects: 208,
@@ -255,7 +255,7 @@ fn traversals() -> crate::Result {
                 .map(Ok::<_, Infallible>),
             progress::Discard,
             &AtomicBool::new(false),
-            count::iter_from_objects::Options {
+            count::objects::Options {
                 input_object_expansion: expansion_mode,
                 thread_limit: deterministic_count_needs_single_thread,
                 ..Default::default()

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -42,7 +42,7 @@ git-odb = { version ="0.20.0", path = "../git-odb" }
 git-hash = { version = "^0.5.0", path = "../git-hash" }
 git-object = { version ="0.12.0", path = "../git-object" }
 git-actor = { version ="0.3.1", path = "../git-actor" }
-git-pack = { version ="0.8.0", path = "../git-pack" }
+git-pack = { version ="^0.9.0", path = "../git-pack" }
 
 git-url = { version = "0.3.0", path = "../git-url", optional = true }
 git-traverse = { version ="0.7.0", path = "../git-traverse", optional = true }

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -176,7 +176,7 @@ where
             if may_use_multiple_threads {
                 Box::new(pack::cache::Never) as Box<dyn DecodeEntry>
             } else {
-                Box::new(pack::cache::lru::MemoryCappedHashmap::new(512 * 1024 * 1024)) as Box<dyn DecodeEntry>
+                Box::new(pack::cache::lru::MemoryCappedHashmap2::new(512 * 1024 * 1024)) as Box<dyn DecodeEntry>
                 // todo: Make that configurable
             }
         };

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -210,6 +210,7 @@ where
         counts.shrink_to_fit();
         counts
     };
+    todo!("figure out performance issues");
 
     progress.inc();
     let num_objects = counts.len();

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -176,7 +176,7 @@ where
             if may_use_multiple_threads {
                 Box::new(pack::cache::Never) as Box<dyn DecodeEntry>
             } else {
-                Box::new(pack::cache::lru::MemoryCappedHashmap2::new(512 * 1024 * 1024)) as Box<dyn DecodeEntry>
+                Box::new(pack::cache::lru::MemoryCappedHashmap::new(512 * 1024 * 1024)) as Box<dyn DecodeEntry>
                 // todo: Make that configurable
             }
         };

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -210,7 +210,6 @@ where
         counts.shrink_to_fit();
         counts
     };
-    todo!("figure out performance issues");
 
     progress.inc();
     let num_objects = counts.len();

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -49,9 +49,9 @@ impl FromStr for ObjectExpansion {
     }
 }
 
-impl From<ObjectExpansion> for pack::data::output::count::iter_from_objects::ObjectExpansion {
+impl From<ObjectExpansion> for pack::data::output::count::objects::ObjectExpansion {
     fn from(v: ObjectExpansion) -> Self {
-        use pack::data::output::count::iter_from_objects::ObjectExpansion::*;
+        use pack::data::output::count::objects::ObjectExpansion::*;
         match v {
             ObjectExpansion::None => AsIs,
             ObjectExpansion::TreeTraversal => TreeContents,
@@ -190,7 +190,7 @@ where
                 input,
                 progress,
                 &interrupt::IS_INTERRUPTED,
-                pack::data::output::count::iter_from_objects::Options {
+                pack::data::output::count::objects::Options {
                     thread_limit,
                     chunk_size,
                     input_object_expansion,
@@ -300,7 +300,7 @@ fn print(stats: Statistics, format: OutputFormat, out: impl std::io::Write) -> a
 fn human_output(
     Statistics {
         counts:
-            pack::data::output::count::iter_from_objects::Outcome {
+            pack::data::output::count::objects::Outcome {
                 input_objects,
                 expanded_objects,
                 decoded_objects,
@@ -343,7 +343,7 @@ fn human_output(
 #[derive(Default)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 struct Statistics {
-    counts: pack::data::output::count::iter_from_objects::Outcome,
+    counts: pack::data::output::count::objects::Outcome,
     entries: pack::data::output::entry::iter_from_counts::Outcome,
 }
 


### PR DESCRIPTION
Currently single-threaded object counting during pack generation is 3x slower than when git does it. It takes git about 52s to count the linux kernel pack by tree traversal while gitoxide takes 160s on a single thread. All this while we know that `gitoxide`'s pack access performance is en-par or even faster than the one in git.

Obviously there must be something here that causes this behaviour, here are a few ideas:

* [x] tree traversal doesn't store the information of decoded trees, even though it could and should. Down to ~140s
* [x] every traversed object is looked up currently during counting, which causes its entry to be decoded. This should be postponed to the 'entry' stage, which is multi-threaded. This decreases the time from 160s to 108s. Now counting ends after 100s.

I think it's worth noting that `gitoxide` does seemingly a little more than counting as it records some pack information that can later be used for faster entry lookups. Thus I have trouble imagining that it's going to be any faster than this in single-threaded mode. Overall, writing a pack of 3.6GB takes around 104 seconds on an M1 MacBook Air. It took 97s with a 1GB pack lookup cache instead of 512MB (with 58.12% efficiency instead of 52%)

```
➜  gitoxide git:(counting-performance) ✗ cargo build --release --no-default-features --features lean,cache-efficiency-debug --bin gixp && /usr/bin/time -lp ./target/release/gixp -v pack-create -r ../../torvalds/linux HEAD --statistics
   Compiling git-pack v0.9.0 (/Users/byron/dev/github.com/Byron/gitoxide/git-pack)
   Compiling git-odb v0.20.2 (/Users/byron/dev/github.com/Byron/gitoxide/git-odb)
   Compiling git-repository v0.7.2 (/Users/byron/dev/github.com/Byron/gitoxide/git-repository)
   Compiling gitoxide-core v0.10.2 (/Users/byron/dev/github.com/Byron/gitoxide/gitoxide-core)
   Compiling gitoxide v0.8.2 (/Users/byron/dev/github.com/Byron/gitoxide)
    Finished release [optimized] target(s) in 37.26s
MemoryCappedHashmap(536870912B)[600002824108]: 3561558 / 6849380 (hits/misses) = 52.00%, puts = 5868531
 12:03:44 counting done 8.1M objects in 91.66s (88.6k objects/s)
 12:03:50 resolving done 8.1M counts in 5.33s (1.5M counts/s)
 12:03:51   sorting done 8.1M counts in 0.89s (9.2M counts/s)
7765ddef2a3a30fc81eff9a19c228f21efbfb249.pack[================>----------------]
counting phaseries
        input objects                  1015172===============================>-]
        expanded objects               7118452   ===   ===   ===   ===   ===   ]
        decoded objects                5864317
        total objects                  0
generation phase
        decoded and recompressed       26507
        pack-to-pack copies            8097502
        missing objects                0
 12:03:56   writing done 3.6GB in 5.51s (651.0MB/s)
 12:03:56 consuming done 8.1M entries in 5.51s (1.5M entries/s)
real 104.05
user 101.44
sys 14.62
          2634465280  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              437169  page reclaims
              560051  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                  65  voluntary context switches
              671311  involuntary context switches
        701160684628  instructions retired
        347450406272  cycles elapsed
          1686633344  peak memory footprint
```

For the same task, here is git. Note that git builds a better pack and it's Organges vs. Apples, but it's all we got a 3.10GiB pack in 137s .

```
➜  gitoxide git:(counting-performance) echo HEAD | /usr/bin/time -lp  git -C ../../torvalds/linux/.git   pack-objects --all-progress --stdout --revs >/dev/null
Enumerating objects: 8124009, done.
Counting objects: 100% (8124009/8124009), done.
Delta compression using up to 8 threads
Compressing objects: 100% (1321393/1321393), done.
Writing objects: 100% (8124009/8124009), 3.19 GiB | 54.35 MiB/s, done.
Total 8124009 (delta 6755648), reused 8120773 (delta 6752412), pack-reused 0
real 136.75
user 60.84
sys 12.45
          2413199360  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
             1365706  page reclaims
              859771  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                 135  signals received
                  87  voluntary context switches
              722739  involuntary context switches
        525791099498  instructions retired
        225718777412  cycles elapsed
          2012098816  peak memory footprintl
```

Now there is one avenue left to explore:

* [x] memory capped cache access performance isn't optimal, even though the cache hit rate is at about 52% it does a lot of cache trashing. There should be a free list to reduce allocator pressure.

Shortest time noe 86s for counting and 98s for everything. 44s and 50s with multi threaded counting.

Now we are talking!