### PR TITLE
cleanup and init a bare repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "parking_lot",
  "quick-error",
  "signal-hook",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,6 @@ dependencies = [
  "git-url",
  "git-validate",
  "parking_lot",
- "quick-error",
  "signal-hook",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "quick-error",
  "signal-hook",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "git-actor",
+ "git-config",
  "git-diff",
  "git-features",
  "git-hash",

--- a/git-config/src/parser.rs
+++ b/git-config/src/parser.rs
@@ -1367,7 +1367,7 @@ fn take_spaces(i: &[u8]) -> IResult<&[u8], &str> {
 
 fn take_newline(i: &[u8]) -> IResult<&[u8], (&str, usize)> {
     let mut counter = 0;
-    let (i, v) = take_while(|c| (c as char).is_ascii() && is_newline(c))(i)?;
+    let (i, v) = take_while(|c| (c as char).is_ascii() && (c == b'\r' || is_newline(c)))(i)?;
     counter += v.len();
     if v.is_empty() {
         Err(nom::Err::Error(NomError {

--- a/git-config/src/parser.rs
+++ b/git-config/src/parser.rs
@@ -834,9 +834,7 @@ impl<'a> Parser<'a> {
     /// frontmatter
     #[inline]
     pub fn take_frontmatter(&mut self) -> Vec<Event<'a>> {
-        let mut to_return = vec![];
-        std::mem::swap(&mut self.frontmatter, &mut to_return);
-        to_return
+        std::mem::take(&mut self.frontmatter)
     }
 
     /// Returns the parsed sections from the parser. Consider

--- a/git-config/tests/fixtures/repo-config.crlf
+++ b/git-config/tests/fixtures/repo-config.crlf
@@ -1,0 +1,14 @@
+; hello
+# world
+
+[core]
+	repositoryformatversion = 0
+	bare = true
+[other]
+	repositoryformatversion = 0
+
+	bare = true
+
+# before section with newline
+[foo]
+	repositoryformatversion = 0

--- a/git-config/tests/integration_tests/file_integeration_test.rs
+++ b/git-config/tests/integration_tests/file_integeration_test.rs
@@ -1,7 +1,6 @@
-use std::{borrow::Cow, convert::TryFrom};
+use std::{borrow::Cow, convert::TryFrom, path::Path};
 
 use git_config::{file::GitConfig, values::*};
-use std::path::Path;
 
 #[test]
 fn parse_config_with_windows_line_endings_successfully() -> crate::Result {

--- a/git-config/tests/integration_tests/file_integeration_test.rs
+++ b/git-config/tests/integration_tests/file_integeration_test.rs
@@ -1,6 +1,14 @@
 use std::{borrow::Cow, convert::TryFrom};
 
 use git_config::{file::GitConfig, values::*};
+use std::path::Path;
+
+#[test]
+fn parse_config_with_windows_line_endings_successfully() {
+    GitConfig::open(Path::new("tests").join("fixtures").join("repo-config.crlf"))
+        .map_err(|err| err.to_string())
+        .unwrap();
+}
 
 /// Asserts we can cast into all variants of our type
 #[test]

--- a/git-config/tests/integration_tests/file_integeration_test.rs
+++ b/git-config/tests/integration_tests/file_integeration_test.rs
@@ -4,15 +4,14 @@ use git_config::{file::GitConfig, values::*};
 use std::path::Path;
 
 #[test]
-fn parse_config_with_windows_line_endings_successfully() {
-    GitConfig::open(Path::new("tests").join("fixtures").join("repo-config.crlf"))
-        .map_err(|err| err.to_string())
-        .unwrap();
+fn parse_config_with_windows_line_endings_successfully() -> crate::Result {
+    GitConfig::open(Path::new("tests").join("fixtures").join("repo-config.crlf"))?;
+    Ok(())
 }
 
 /// Asserts we can cast into all variants of our type
 #[test]
-fn get_value_for_all_provided_values() -> Result<(), Box<dyn std::error::Error>> {
+fn get_value_for_all_provided_values() -> crate::Result {
     let config = r#"
         [core]
             bool-explicit = false
@@ -80,7 +79,7 @@ fn get_value_for_all_provided_values() -> Result<(), Box<dyn std::error::Error>>
 /// There was a regression where lookup would fail because we only checked the
 /// last section entry for any given section and subsection
 #[test]
-fn get_value_looks_up_all_sections_before_failing() -> Result<(), Box<dyn std::error::Error>> {
+fn get_value_looks_up_all_sections_before_failing() -> crate::Result {
     let config = r#"
         [core]
             bool-explicit = false
@@ -106,7 +105,7 @@ fn get_value_looks_up_all_sections_before_failing() -> Result<(), Box<dyn std::e
 }
 
 #[test]
-fn section_names_are_case_insensitive() -> Result<(), Box<dyn std::error::Error>> {
+fn section_names_are_case_insensitive() -> crate::Result {
     let config = "[core] bool-implicit";
     let file = GitConfig::try_from(config)?;
     assert!(file.value::<Boolean>("core", None, "bool-implicit").is_ok());
@@ -119,7 +118,7 @@ fn section_names_are_case_insensitive() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[test]
-fn value_names_are_case_insensitive() -> Result<(), Box<dyn std::error::Error>> {
+fn value_names_are_case_insensitive() -> crate::Result {
     let config = "[core]
         a = true
         A = false";

--- a/git-config/tests/integration_tests/main.rs
+++ b/git-config/tests/integration_tests/main.rs
@@ -4,5 +4,7 @@
 // TL;DR single mod makes integration tests faster to compile, test, and with
 // less build artifacts.
 
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
 mod file_integeration_test;
 mod parser_integration_tests;

--- a/git-config/tests/integration_tests/parser_integration_tests.rs
+++ b/git-config/tests/integration_tests/parser_integration_tests.rs
@@ -211,9 +211,18 @@ fn newline_events_are_merged() {
 #[test]
 fn error() {
     let input = "[core] a=b\n 4a=3";
-    println!("{}", parse_from_str(input).unwrap_err());
+    assert_eq!(
+        parse_from_str(input).unwrap_err().to_string(),
+        "Got an unexpected token on line 2 while trying to parse a config name: '4a=3'"
+    );
     let input = "[core] a=b\n =3";
-    println!("{}", parse_from_str(input).unwrap_err());
+    assert_eq!(
+        parse_from_str(input).unwrap_err().to_string(),
+        "Got an unexpected token on line 2 while trying to parse a config name: '=3'"
+    );
     let input = "[core";
-    println!("{}", parse_from_str(input).unwrap_err());
+    assert_eq!(
+        parse_from_str(input).unwrap_err().to_string(),
+        "Got an unexpected token on line 1 while trying to parse a section header: '[core'"
+    );
 }

--- a/git-pack/src/bundle/init.rs
+++ b/git-pack/src/bundle/init.rs
@@ -1,8 +1,9 @@
-use crate::Bundle;
 use std::{
     convert::TryFrom,
     path::{Path, PathBuf},
 };
+
+use crate::Bundle;
 
 /// Returned by [`Bundle::at()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/bundle/mod.rs
+++ b/git-pack/src/bundle/mod.rs
@@ -29,8 +29,9 @@ pub mod write;
 mod verify {
     use std::sync::{atomic::AtomicBool, Arc};
 
-    use crate::Bundle;
     use git_features::progress::Progress;
+
+    use crate::Bundle;
 
     impl Bundle {
         /// Similar to [`crate::index::File::verify_integrity()`] but more convenient to call as the presence of the

--- a/git-pack/src/cache/delta/from_offsets.rs
+++ b/git-pack/src/cache/delta/from_offsets.rs
@@ -8,8 +8,7 @@ use std::{
 
 use git_features::progress::{self, Progress};
 
-use crate::cache::delta::Tree;
-use crate::index::access::PackOffset;
+use crate::{cache::delta::Tree, index::access::PackOffset};
 
 /// Returned by [`Tree::from_offsets_in_pack()`]
 #[derive(thiserror::Error, Debug)]

--- a/git-pack/src/cache/delta/traverse/mod.rs
+++ b/git-pack/src/cache/delta/traverse/mod.rs
@@ -9,8 +9,10 @@ use git_features::{
     progress::{self, Progress},
 };
 
-use crate::cache::delta::{Item, Tree};
-use crate::data::EntryRange;
+use crate::{
+    cache::delta::{Item, Tree},
+    data::EntryRange,
+};
 
 mod resolve;
 

--- a/git-pack/src/cache/delta/traverse/resolve.rs
+++ b/git-pack/src/cache/delta/traverse/resolve.rs
@@ -5,8 +5,10 @@ use git_features::{
     zlib,
 };
 
-use crate::cache::delta::traverse::{Context, Error};
-use crate::data::EntryRange;
+use crate::{
+    cache::delta::traverse::{Context, Error},
+    data::EntryRange,
+};
 
 pub(crate) fn deltas<T, F, P, MBFN, S, E>(
     nodes: crate::cache::delta::Chunk<'_, T>,

--- a/git-pack/src/data/entry/mod.rs
+++ b/git-pack/src/data/entry/mod.rs
@@ -1,5 +1,6 @@
-use crate::data::Entry;
 use git_hash::SIZE_OF_SHA1_DIGEST as SHA1_SIZE;
+
+use crate::data::Entry;
 
 const _TYPE_EXT1: u8 = 0;
 const COMMIT: u8 = 1;

--- a/git-pack/src/data/object.rs
+++ b/git-pack/src/data/object.rs
@@ -1,7 +1,8 @@
 //! Contains a borrowed Object bound to a buffer holding its decompressed data.
 
-use crate::data::Object;
 use git_object::{BlobRef, CommitRef, CommitRefIter, ObjectRef, TagRef, TagRefIter, TreeRef, TreeRefIter};
+
+use crate::data::Object;
 
 impl<'a> Object<'a> {
     /// Constructs a new data object from `kind` and `data`.

--- a/git-pack/src/data/output/count/mod.rs
+++ b/git-pack/src/data/output/count/mod.rs
@@ -1,6 +1,6 @@
-use crate::data;
-use crate::data::output::Count;
 use git_hash::ObjectId;
+
+use crate::{data, data::output::Count};
 
 /// Specifies how the pack location was handled during counting
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]

--- a/git-pack/src/index/traverse/indexed.rs
+++ b/git-pack/src/index/traverse/indexed.rs
@@ -8,10 +8,11 @@ use std::{
 
 use git_features::{parallel, progress::Progress};
 
-use crate::cache::delta::traverse::Context;
-use crate::index::{self, util::index_entries_sorted_by_offset_ascending};
-
 use super::{Error, SafetyCheck};
+use crate::{
+    cache::delta::traverse::Context,
+    index::{self, util::index_entries_sorted_by_offset_ascending},
+};
 
 /// Traversal with index
 impl index::File {

--- a/git-pack/src/index/write/mod.rs
+++ b/git-pack/src/index/write/mod.rs
@@ -3,8 +3,10 @@ use std::{convert::TryInto, io, sync::atomic::AtomicBool};
 pub use error::Error;
 use git_features::progress::{self, Progress};
 
-use crate::cache::delta::{traverse::Context, Tree};
-use crate::loose;
+use crate::{
+    cache::delta::{traverse::Context, Tree},
+    loose,
+};
 
 mod encode;
 mod error;

--- a/git-repository/CHANGELOG.md
+++ b/git-repository/CHANGELOG.md
@@ -1,3 +1,15 @@
+### v0.9.0 (2021-08-??)
+
+#### New
+
+- `init()`
+- `Repository::init()`
+
+#### Breaking
+- **renames / moves**
+    - `path::Path` to `Path`
+    - `init::repository()` -> `init::into()`
+
 ### v0.8.1 (2021-08-28)
 
 - Introduce `EasyArcExclusive` type, now available thanks to `parking_lot` 0.11.2

--- a/git-repository/CHANGELOG.md
+++ b/git-repository/CHANGELOG.md
@@ -8,7 +8,7 @@
 #### Breaking
 - **renames / moves**
     - `path::Path` to `Path`
-    - `init::repository()` -> `init::into()`
+    - `init::repository()` -> `path::create::into()`
 
 ### v0.8.1 (2021-08-28)
 

--- a/git-repository/CHANGELOG.md
+++ b/git-repository/CHANGELOG.md
@@ -3,14 +3,15 @@
 #### New
 
 - `init()`
-- `Repository::init()`
+- `init_bare()`
+- `Repository::init(Kind)`
 - `open()`
 - `Repository::open()`
 
 #### Breaking
-- **renames / moves**
+- **renames / moves / Signature Changes**
     - `path::Path` to `Path`
-    - `init::repository()` -> `path::create::into()`
+    - `init::repository(dir)` -> `path::create::into(dir, **Kind**)`
 
 ### v0.8.1 (2021-08-28)
 

--- a/git-repository/CHANGELOG.md
+++ b/git-repository/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `init()`
 - `Repository::init()`
+- `open()`
+- `Repository::open()`
 
 #### Breaking
 - **renames / moves**

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -54,6 +54,7 @@ git-features = { version = "^0.16.0", path = "../git-features", features = ["pro
 
 signal-hook = { version = "0.3.9", default-features = false }
 quick-error = "2.0.0"
+thiserror = "1.0.26"
 parking_lot = { version = "0.11.2", features = ["arc_lock"] }
 
 [dev-dependencies]

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -39,6 +39,7 @@ git-tempfile = { version ="^1.0.0", path = "../git-tempfile" }
 git-lock = { version ="^1.0.0", path = "../git-lock" }
 git-validate = { version = "^0.5.0", path = "../git-validate" }
 
+git-config = { version ="^0.1.0", path = "../git-config" }
 git-odb = { version ="^0.21.0", path = "../git-odb" }
 git-hash = { version = "^0.5.0", path = "../git-hash" }
 git-object = { version ="^0.13.0", path = "../git-object" }

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -53,7 +53,6 @@ git-diff = { version ="^0.9.0", path = "../git-diff", optional = true }
 git-features = { version = "^0.16.0", path = "../git-features", features = ["progress"] }
 
 signal-hook = { version = "0.3.9", default-features = false }
-quick-error = "2.0.0"
 thiserror = "1.0.26"
 parking_lot = { version = "0.11.2", features = ["arc_lock"] }
 

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -59,3 +59,4 @@ parking_lot = { version = "0.11.2", features = ["arc_lock"] }
 git-testtools = { path = "../tests/tools" }
 signal-hook = { version = "0.3.9", default-features = false }
 anyhow = "1"
+tempfile = "3.2.0"

--- a/git-repository/src/assets/baseline-init/config
+++ b/git-repository/src/assets/baseline-init/config
@@ -1,2 +1,3 @@
 [core]
 	repositoryformatversion = 0
+	bare = {bare-value}

--- a/git-repository/src/easy/borrow.rs
+++ b/git-repository/src/easy/borrow.rs
@@ -1,18 +1,11 @@
 #![allow(missing_docs)]
 pub mod state {
-    use quick_error::quick_error;
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            Borrow(err: std::cell::BorrowError) {
-                display("A state member could not be borrowed")
-                from()
-            }
-            BorrowMut(err: std::cell::BorrowMutError) {
-                display("A state member could not be mutably borrowed")
-                from()
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error("A state member could not be borrowed")]
+        Borrow(#[from] std::cell::BorrowError),
+        #[error("A state member could not be mutably borrowed")]
+        BorrowMut(#[from] std::cell::BorrowMutError),
     }
 
     pub type Result<T> = std::result::Result<T, Error>;

--- a/git-repository/src/easy/object/mod.rs
+++ b/git-repository/src/easy/object/mod.rs
@@ -60,30 +60,20 @@ where
 
 pub mod find {
     use git_odb as odb;
-    use quick_error::quick_error;
 
     use crate::easy;
 
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            Find(err: OdbError) {
-                display("An error occurred while trying to find an object")
-                from()
-                source(err)
-            }
-            BorrowState(err: easy::borrow::state::Error) {
-                display("BUG: Part of interior state could not be borrowed.")
-                from()
-                source(err)
-            }
-            BorrowRepo(err: easy::borrow::repo::Error) {
-                display("BUG: The repository could not be borrowed")
-                from()
-            }
-        }
-    }
     pub(crate) type OdbError = odb::compound::find::Error;
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        Find(#[from] OdbError),
+        #[error("BUG: Part of interior state could not be borrowed.")]
+        BorrowState(#[from] easy::borrow::state::Error),
+        #[error("BUG: The repository could not be borrowed")]
+        BorrowRepo(#[from] easy::borrow::repo::Error),
+    }
 
     pub mod existing {
         use git_odb as odb;

--- a/git-repository/src/easy/reference.rs
+++ b/git-repository/src/easy/reference.rs
@@ -137,52 +137,31 @@ where
 
 pub mod find {
     use git_ref as refs;
-    use quick_error::quick_error;
 
     use crate::easy;
 
     pub mod existing {
-        use quick_error::quick_error;
 
         use crate::easy::reference::find;
 
-        quick_error! {
-            #[derive(Debug)]
-            pub enum Error {
-                Find(err: find::Error) {
-                    display("An error occurred when trying to find a reference")
-                    from()
-                    source(err)
-                }
-                NotFound {
-                    display("The reference did not exist even though that was expected")
-                }
-            }
+        #[derive(Debug, thiserror::Error)]
+        pub enum Error {
+            #[error(transparent)]
+            Find(#[from] find::Error),
+            #[error("The reference did not exist even though that was expected")]
+            NotFound,
         }
     }
 
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            Find(err: refs::file::find::Error) {
-                display("An error occurred when trying to find a reference")
-                from()
-                source(err)
-            }
-            PackedRefsOpen(err: refs::packed::buffer::open::Error) {
-                display("The packed-refs file could not be opened")
-                from()
-                source(err)
-            }
-            BorrowState(err: easy::borrow::state::Error) {
-                display("BUG: Part of interior state could not be borrowed.")
-                from()
-                source(err)
-            }
-            BorrowRepo(err: easy::borrow::repo::Error) {
-                display("BUG: The repository could not be borrowed")
-                from()
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        Find(#[from] refs::file::find::Error),
+        #[error(transparent)]
+        PackedRefsOpen(#[from] refs::packed::buffer::open::Error),
+        #[error("BUG: Part of interior state could not be borrowed.")]
+        BorrowState(#[from] easy::borrow::state::Error),
+        #[error("BUG: The repository could not be borrowed")]
+        BorrowRepo(#[from] easy::borrow::repo::Error),
     }
 }

--- a/git-repository/src/easy/reference.rs
+++ b/git-repository/src/easy/reference.rs
@@ -25,65 +25,37 @@ pub(crate) enum Backing {
 
 pub mod edit {
     use git_ref as refs;
-    use quick_error::quick_error;
 
     use crate::easy;
 
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            FileTransactionPrepare(err: refs::file::transaction::prepare::Error) {
-                display("Could not prepare the file transaction")
-                from()
-                source(err)
-            }
-            FileTransactionCommit(err: refs::file::transaction::commit::Error) {
-                display("Could not commit the file transaction")
-                from()
-                source(err)
-            }
-            NameValidation(err: git_validate::reference::name::Error) {
-                display("The reference name is invalid")
-                from()
-                source(err)
-            }
-            BorrowRepo(err: easy::borrow::repo::Error) {
-                display("BUG: The repository could not be borrowed")
-                from()
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        FileTransactionPrepare(#[from] refs::file::transaction::prepare::Error),
+        #[error(transparent)]
+        FileTransactionCommit(#[from] refs::file::transaction::commit::Error),
+        #[error(transparent)]
+        NameValidation(#[from] git_validate::reference::name::Error),
+        #[error("BUG: The repository could not be borrowed")]
+        BorrowRepo(#[from] easy::borrow::repo::Error),
     }
 }
 
 pub mod peel_to_oid_in_place {
     use git_ref as refs;
-    use quick_error::quick_error;
 
     use crate::easy;
 
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            LoosePeelToId(err: refs::file::loose::reference::peel::to_id::Error) {
-                display("Could not peel loose reference")
-                from()
-                source(err)
-            }
-            PackedRefsOpen(err: refs::packed::buffer::open::Error) {
-                display("The packed-refs file could not be opened")
-                from()
-                source(err)
-            }
-            BorrowState(err: easy::borrow::state::Error) {
-                display("BUG: Part of interior state could not be borrowed.")
-                from()
-                source(err)
-            }
-            BorrowRepo(err: easy::borrow::repo::Error) {
-                display("BUG: The repository could not be borrowed")
-                from()
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        LoosePeelToId(#[from] refs::file::loose::reference::peel::to_id::Error),
+        #[error(transparent)]
+        PackedRefsOpen(#[from] refs::packed::buffer::open::Error),
+        #[error("BUG: Part of interior state could not be borrowed.")]
+        BorrowState(#[from] easy::borrow::state::Error),
+        #[error("BUG: The repository could not be borrowed")]
+        BorrowRepo(#[from] easy::borrow::repo::Error),
     }
 }
 

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -125,7 +125,7 @@ pub mod prelude {
 pub mod path;
 
 mod repository;
-pub use repository::{discover, from_path, init};
+pub use repository::{discover, from_path, init, open};
 
 /// A repository path which either points to a work tree or the `.git` repository itself.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -152,11 +152,12 @@ pub struct Repository {
     pub odb: git_odb::linked::Store,
     #[cfg(not(feature = "unstable"))]
     pub(crate) odb: git_odb::linked::Store,
-    /// TODO: git-config should be here - it's read a lot but not written much in must applications, so shouldn't be in `State`.
-    ///       Probably it's best reload it on signal (in servers) or refresh it when it's known to have been changed similar to how
-    ///       packs are refreshed. This would be `git_config::fs::Config` when ready.
     /// The path to the worktree at which to find checked out files
     pub work_tree: Option<PathBuf>,
+    // TODO: git-config should be here - it's read a lot but not written much in must applications, so shouldn't be in `State`.
+    //       Probably it's best reload it on signal (in servers) or refresh it when it's known to have been changed similar to how
+    //       packs are refreshed. This would be `git_config::fs::Config` when ready.
+    // pub(crate) config: git_config::file::GitConfig<'static>,
 }
 
 /// A handle to a `Repository` for use when the repository needs to be shared, providing state for one `ObjectRef` at a time, , created with [`Repository::into_easy()`].

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -122,12 +122,10 @@ pub mod prelude {
 }
 
 ///
-pub mod init;
-
-///
 pub mod path;
-///
-pub mod repository;
+
+mod repository;
+pub use repository::{discover, from_path, init};
 
 /// A repository path which either points to a work tree or the `.git` repository itself.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -46,6 +46,13 @@
 //!   extension traits can't apply internally if if it is implemented, but must be part of the external interface. This is only
 //!   relevant for code within `git-repository`
 //!
+//! ### Terminology
+//!
+//! #### WorkingTree and WorkTree
+//!
+//! When reading the documentation of the canonical git-worktree program one gets the impression work tree and working tree are used
+//! interchangeably. We use the term _work tree_ only and try to do so consistently as its shorter and assumed to be the same.
+//!
 //! # Cargo-features
 //!
 //! ## With the optional "unstable" cargo feature
@@ -102,7 +109,6 @@ pub use git_tempfile as tempfile;
 pub use git_traverse as traverse;
 #[cfg(all(feature = "unstable", feature = "git-url"))]
 pub use git_url as url;
-pub use path::Path;
 
 pub mod interrupt;
 
@@ -122,6 +128,15 @@ pub mod init;
 pub mod path;
 ///
 pub mod repository;
+
+/// A repository path which either points to a work tree or the `.git` repository itself.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Path {
+    /// The currently checked out or nascent work tree of a git repository.
+    WorkTree(PathBuf),
+    /// The git repository itself
+    Repository(PathBuf),
+}
 
 /// A instance with access to everything a git repository entails, best imagined as container for _most_ for system resources required
 /// to interact with a `git` repository which are loaded in once the instance is created.
@@ -230,4 +245,9 @@ impl Kind {
 /// See [Repository::discover()].
 pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, repository::discover::Error> {
     Repository::discover(directory)
+}
+
+/// See [Repository::init()].
+pub fn init(directory: impl AsRef<std::path::Path>) -> Result<Repository, repository::init::Error> {
+    Repository::init(directory)
 }

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -248,7 +248,12 @@ pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, re
 
 /// See [Repository::init()].
 pub fn init(directory: impl AsRef<std::path::Path>) -> Result<Repository, repository::init::Error> {
-    Repository::init(directory)
+    Repository::init(directory, Kind::WorkTree)
+}
+
+/// See [Repository::init()].
+pub fn init_bare(directory: impl AsRef<std::path::Path>) -> Result<Repository, repository::init::Error> {
+    Repository::init(directory, Kind::Bare)
 }
 
 /// See [Repository::open()].

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -249,3 +249,8 @@ pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, re
 pub fn init(directory: impl AsRef<std::path::Path>) -> Result<Repository, repository::init::Error> {
     Repository::init(directory)
 }
+
+/// See [Repository::open()].
+pub fn open(directory: impl Into<std::path::PathBuf>) -> Result<Repository, repository::open::Error> {
+    Repository::open(directory)
+}

--- a/git-repository/src/path/create.rs
+++ b/git-repository/src/path/create.rs
@@ -31,22 +31,22 @@ quick_error! {
 
 const GIT_DIR_NAME: &str = ".git";
 
-const TPL_INFO_EXCLUDE: &[u8] = include_bytes!("./assets/baseline-init/info/exclude");
-const TPL_HOOKS_APPLYPATCH_MSG: &[u8] = include_bytes!("./assets/baseline-init/hooks/applypatch-msg.sample");
-const TPL_HOOKS_COMMIT_MSG: &[u8] = include_bytes!("./assets/baseline-init/hooks/commit-msg.sample");
-const TPL_HOOKS_FSMONITOR_WATCHMAN: &[u8] = include_bytes!("./assets/baseline-init/hooks/fsmonitor-watchman.sample");
-const TPL_HOOKS_POST_UPDATE: &[u8] = include_bytes!("./assets/baseline-init/hooks/post-update.sample");
-const TPL_HOOKS_PRE_APPLYPATCH: &[u8] = include_bytes!("./assets/baseline-init/hooks/pre-applypatch.sample");
-const TPL_HOOKS_PRE_COMMIT: &[u8] = include_bytes!("./assets/baseline-init/hooks/pre-commit.sample");
-const TPL_HOOKS_PRE_MERGE_COMMIT: &[u8] = include_bytes!("./assets/baseline-init/hooks/pre-merge-commit.sample");
-const TPL_HOOKS_PRE_PUSH: &[u8] = include_bytes!("./assets/baseline-init/hooks/pre-push.sample");
-const TPL_HOOKS_PRE_REBASE: &[u8] = include_bytes!("./assets/baseline-init/hooks/pre-rebase.sample");
-const TPL_HOOKS_PRE_RECEIVE: &[u8] = include_bytes!("./assets/baseline-init/hooks/pre-receive.sample");
-const TPL_HOOKS_PREPARE_COMMIT_MSG: &[u8] = include_bytes!("./assets/baseline-init/hooks/prepare-commit-msg.sample");
-const TPL_HOOKS_UPDATE: &[u8] = include_bytes!("./assets/baseline-init/hooks/update.sample");
-const TPL_CONFIG: &[u8] = include_bytes!("./assets/baseline-init/config");
-const TPL_DESCRIPTION: &[u8] = include_bytes!("./assets/baseline-init/description");
-const TPL_HEAD: &[u8] = include_bytes!("./assets/baseline-init/HEAD");
+const TPL_INFO_EXCLUDE: &[u8] = include_bytes!("../assets/baseline-init/info/exclude");
+const TPL_HOOKS_APPLYPATCH_MSG: &[u8] = include_bytes!("../assets/baseline-init/hooks/applypatch-msg.sample");
+const TPL_HOOKS_COMMIT_MSG: &[u8] = include_bytes!("../assets/baseline-init/hooks/commit-msg.sample");
+const TPL_HOOKS_FSMONITOR_WATCHMAN: &[u8] = include_bytes!("../assets/baseline-init/hooks/fsmonitor-watchman.sample");
+const TPL_HOOKS_POST_UPDATE: &[u8] = include_bytes!("../assets/baseline-init/hooks/post-update.sample");
+const TPL_HOOKS_PRE_APPLYPATCH: &[u8] = include_bytes!("../assets/baseline-init/hooks/pre-applypatch.sample");
+const TPL_HOOKS_PRE_COMMIT: &[u8] = include_bytes!("../assets/baseline-init/hooks/pre-commit.sample");
+const TPL_HOOKS_PRE_MERGE_COMMIT: &[u8] = include_bytes!("../assets/baseline-init/hooks/pre-merge-commit.sample");
+const TPL_HOOKS_PRE_PUSH: &[u8] = include_bytes!("../assets/baseline-init/hooks/pre-push.sample");
+const TPL_HOOKS_PRE_REBASE: &[u8] = include_bytes!("../assets/baseline-init/hooks/pre-rebase.sample");
+const TPL_HOOKS_PRE_RECEIVE: &[u8] = include_bytes!("../assets/baseline-init/hooks/pre-receive.sample");
+const TPL_HOOKS_PREPARE_COMMIT_MSG: &[u8] = include_bytes!("../assets/baseline-init/hooks/prepare-commit-msg.sample");
+const TPL_HOOKS_UPDATE: &[u8] = include_bytes!("../assets/baseline-init/hooks/update.sample");
+const TPL_CONFIG: &[u8] = include_bytes!("../assets/baseline-init/config");
+const TPL_DESCRIPTION: &[u8] = include_bytes!("../assets/baseline-init/description");
+const TPL_HEAD: &[u8] = include_bytes!("../assets/baseline-init/HEAD");
 
 struct PathCursor<'a>(&'a mut PathBuf);
 

--- a/git-repository/src/path/is_git.rs
+++ b/git-repository/src/path/is_git.rs
@@ -29,7 +29,8 @@ pub fn is_bare(git_dir: impl AsRef<Path>) -> bool {
     !git_dir.as_ref().join("index").exists()
 }
 
-/// What constitutes a valid git repository, and what's yet to be implemented.
+/// What constitutes a valid git repository, and what's yet to be implemented, returning the guessed repository kind
+/// purely based on the presence of files. Note that the git-config ultimately decides what's bare.
 ///
 /// * [x] a valid head
 /// * [ ] git common directory

--- a/git-repository/src/path/mod.rs
+++ b/git-repository/src/path/mod.rs
@@ -34,12 +34,6 @@ impl Path {
         }
     }
 
-    pub fn into_repository_directory(self) -> PathBuf {
-        match self {
-            Path::WorkTree(path) => path.join(".git"),
-            Path::Repository(path) => path,
-        }
-    }
     pub fn into_repository_and_work_tree_directories(self) -> (PathBuf, Option<PathBuf>) {
         match self {
             crate::Path::WorkTree(working_tree) => (working_tree.join(".git"), Some(working_tree)),

--- a/git-repository/src/path/mod.rs
+++ b/git-repository/src/path/mod.rs
@@ -1,17 +1,11 @@
 #![allow(missing_docs)]
 use std::path::PathBuf;
 
-use crate::Kind;
+use crate::{Kind, Path};
 
 pub mod discover;
 pub mod is_git;
 pub use is_git::{is_bare, is_git};
-
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum Path {
-    WorkTree(PathBuf),
-    Repository(PathBuf),
-}
 
 impl AsRef<std::path::Path> for Path {
     fn as_ref(&self) -> &std::path::Path {
@@ -40,6 +34,12 @@ impl Path {
         match self {
             Path::WorkTree(path) => path.join(".git"),
             Path::Repository(path) => path,
+        }
+    }
+    pub fn into_repository_and_work_tree_directories(self) -> (PathBuf, Option<PathBuf>) {
+        match self {
+            crate::Path::WorkTree(working_tree) => (working_tree.join(".git"), Some(working_tree)),
+            crate::Path::Repository(repository) => (repository, None),
         }
     }
 }

--- a/git-repository/src/path/mod.rs
+++ b/git-repository/src/path/mod.rs
@@ -1,11 +1,15 @@
 #![allow(missing_docs)]
+
 use std::path::PathBuf;
+
+pub use is_git::{is_bare, is_git};
 
 use crate::{Kind, Path};
 
+///
+pub mod create;
 pub mod discover;
 pub mod is_git;
-pub use is_git::{is_bare, is_git};
 
 impl AsRef<std::path::Path> for Path {
     fn as_ref(&self) -> &std::path::Path {

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -55,7 +55,7 @@ pub mod init {
     quick_error! {
         #[derive(Debug)]
         pub enum Error {
-            Init(err: crate::init::Error) {
+            Init(err: crate::path::create::Error) {
                 display("Failed to initialize a new repository")
                 from()
                 source(err)
@@ -78,7 +78,7 @@ pub mod init {
         /// Fails without action if there is already a `.git` repository inside of `directory`, but
         /// won't mind if the `directory` otherwise is non-empty.
         pub fn init(directory: impl AsRef<Path>) -> Result<Self, Error> {
-            let path = crate::init::into(directory.as_ref())?;
+            let path = crate::path::create::into(directory.as_ref())?;
             Ok(path.try_into()?)
         }
     }

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -136,8 +136,8 @@ pub mod init {
         ///
         /// Fails without action if there is already a `.git` repository inside of `directory`, but
         /// won't mind if the `directory` otherwise is non-empty.
-        pub fn init(directory: impl AsRef<Path>) -> Result<Self, Error> {
-            let path = crate::path::create::into(directory.as_ref())?;
+        pub fn init(directory: impl AsRef<Path>, kind: crate::Kind) -> Result<Self, Error> {
+            let path = crate::path::create::into(directory.as_ref(), kind)?;
             Ok(path.try_into()?)
         }
     }

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -20,8 +20,9 @@ mod access {
 }
 
 pub mod from_path {
-    use crate::Path;
     use std::convert::TryFrom;
+
+    use crate::Path;
 
     pub type Error = git_odb::linked::init::Error;
 
@@ -47,8 +48,9 @@ pub mod from_path {
 }
 
 pub mod init {
-    use quick_error::quick_error;
     use std::path::Path;
+
+    use quick_error::quick_error;
 
     quick_error! {
         #[derive(Debug)]
@@ -66,8 +68,9 @@ pub mod init {
         }
     }
 
-    use crate::Repository;
     use std::convert::TryInto;
+
+    use crate::Repository;
 
     impl Repository {
         /// Create a repository with work-tree within `directory`, creating intermediate directories as needed.
@@ -82,12 +85,11 @@ pub mod init {
 }
 
 pub mod discover {
-    use std::path::Path;
+    use std::{convert::TryInto, path::Path};
 
     use quick_error::quick_error;
 
     use crate::{path::discover, Repository};
-    use std::convert::TryInto;
 
     quick_error! {
         #[derive(Debug)]

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -35,10 +35,11 @@ pub mod from_path {
 }
 
 pub mod open {
-    use crate::Repository;
+    use std::path::PathBuf;
 
     use git_config::values::Boolean;
-    use std::path::PathBuf;
+
+    use crate::Repository;
 
     #[derive(Debug, thiserror::Error)]
     pub enum Error {
@@ -95,9 +96,9 @@ pub mod open {
 }
 
 pub mod init {
+    use std::{convert::TryInto, path::Path};
+
     use crate::Repository;
-    use std::convert::TryInto;
-    use std::path::Path;
 
     #[derive(Debug, thiserror::Error)]
     pub enum Error {
@@ -120,8 +121,9 @@ pub mod init {
 }
 
 pub mod discover {
-    use crate::{path::discover, Repository};
     use std::{convert::TryInto, path::Path};
+
+    use crate::{path::discover, Repository};
 
     #[derive(Debug, thiserror::Error)]
     pub enum Error {

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -38,28 +38,16 @@ pub mod open {
     use crate::Repository;
 
     use git_config::values::Boolean;
-    use quick_error::quick_error;
     use std::path::PathBuf;
 
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            Config(err: git_config::parser::ParserOrIoError<'static>) {
-                display("The git configuration file could not be read")
-                from()
-                source(err)
-            }
-            NotARepository(err: crate::path::is_git::Error) {
-                display("The provided path doesn't appear to be a git repository")
-                from()
-                source(err)
-            }
-            ObjectStoreInitialization(err: git_odb::linked::init::Error) {
-                display("Could not initialize the object database")
-                from()
-                source(err)
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        Config(#[from] git_config::parser::ParserOrIoError<'static>),
+        #[error(transparent)]
+        NotARepository(#[from] crate::path::is_git::Error),
+        #[error(transparent)]
+        ObjectStoreInitialization(#[from] git_odb::linked::init::Error),
     }
 
     impl Repository {

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -95,29 +95,17 @@ pub mod open {
 }
 
 pub mod init {
+    use crate::Repository;
+    use std::convert::TryInto;
     use std::path::Path;
 
-    use quick_error::quick_error;
-
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            Init(err: crate::path::create::Error) {
-                display("Failed to initialize a new repository")
-                from()
-                source(err)
-            }
-            Open(err: crate::open::Error) {
-                display("Could not open repository")
-                from()
-                source(err)
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        Init(#[from] crate::path::create::Error),
+        #[error(transparent)]
+        Open(#[from] crate::open::Error),
     }
-
-    use std::convert::TryInto;
-
-    use crate::Repository;
 
     impl Repository {
         /// Create a repository with work-tree within `directory`, creating intermediate directories as needed.
@@ -132,26 +120,15 @@ pub mod init {
 }
 
 pub mod discover {
+    use crate::{path::discover, Repository};
     use std::{convert::TryInto, path::Path};
 
-    use quick_error::quick_error;
-
-    use crate::{path::discover, Repository};
-
-    quick_error! {
-        #[derive(Debug)]
-        pub enum Error {
-            Discover(err: discover::existing::Error) {
-                display("Could not find a valid git repository directory")
-                from()
-                source(err)
-            }
-            Open(err: crate::open::Error) {
-                display("Could not open repository")
-                from()
-                source(err)
-            }
-        }
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        Discover(#[from] discover::existing::Error),
+        #[error(transparent)]
+        Open(#[from] crate::open::Error),
     }
 
     impl Repository {

--- a/git-repository/tests/discover/mod.rs
+++ b/git-repository/tests/discover/mod.rs
@@ -32,7 +32,7 @@ mod existing {
         let path = git_repository::path::discover::existing(&dir)?;
         assert_eq!(path.kind(), Kind::WorkTree);
         assert_eq!(
-            path.into_repository_directory(),
+            path.into_repository_and_work_tree_directories().0,
             dir,
             "the .git dir is directly returned if valid"
         );

--- a/git-repository/tests/init/mod.rs
+++ b/git-repository/tests/init/mod.rs
@@ -1,5 +1,4 @@
 #[test]
-#[ignore]
 fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
     let tmp = tempfile::tempdir()?;
     let repo = git_repository::init(tmp.path())?;
@@ -14,7 +13,10 @@ fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
         "there is a work tree by default"
     );
     assert_eq!(git_repository::open(repo.git_dir())?, repo);
-    git_repository::open(repo.work_tree.expect("non-bare repo"))?;
+    assert_eq!(
+        git_repository::open(repo.work_tree.as_ref().expect("non-bare repo"))?,
+        repo
+    );
     Ok(())
 }
 

--- a/git-repository/tests/init/mod.rs
+++ b/git-repository/tests/init/mod.rs
@@ -1,30 +1,63 @@
-#[test]
-fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
-    let tmp = tempfile::tempdir()?;
-    let repo = git_repository::init(tmp.path())?;
-    assert_eq!(
-        repo.work_tree.as_deref(),
-        Some(tmp.path()),
-        "there is a work tree by default"
-    );
-    assert_eq!(
-        repo.git_dir(),
-        tmp.path().join(".git"),
-        "there is a work tree by default"
-    );
-    assert_eq!(git_repository::open(repo.git_dir())?, repo);
-    assert_eq!(
-        git_repository::open(repo.work_tree.as_ref().expect("non-bare repo"))?,
-        repo
-    );
-    Ok(())
+mod bare {
+    #[test]
+    fn init_into_empty_directory_creates_a_dot_git_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = git_repository::init_bare(tmp.path()).unwrap();
+        assert_eq!(repo.kind(), git_repository::Kind::Bare);
+        assert!(
+            repo.work_tree.is_none(),
+            "a worktree isn't present in bare repositories"
+        );
+        assert_eq!(
+            repo.git_dir(),
+            tmp.path(),
+            "the repository is placed into the directory itself"
+        );
+        assert_eq!(git_repository::open(repo.git_dir()).unwrap(), repo);
+    }
+
+    #[test]
+    fn init_into_non_empty_directory_is_not_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("existing.txt"), b"I was here before you").unwrap();
+
+        assert_eq!(
+            git_repository::init_bare(tmp.path()).unwrap_err().to_string(),
+            "Failed to initialize a new repository"
+        );
+    }
 }
 
-#[test]
-fn init_into_non_empty_directory_is_allowed() -> crate::Result {
-    let tmp = tempfile::tempdir()?;
-    std::fs::write(tmp.path().join("existing.txt"), b"I was here before you")?;
+mod non_bare {
+    #[test]
+    fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
+        let tmp = tempfile::tempdir()?;
+        let repo = git_repository::init(tmp.path())?;
+        assert_eq!(repo.kind(), git_repository::Kind::WorkTree);
+        assert_eq!(
+            repo.work_tree.as_deref(),
+            Some(tmp.path()),
+            "there is a work tree by default"
+        );
+        assert_eq!(
+            repo.git_dir(),
+            tmp.path().join(".git"),
+            "there is a work tree by default"
+        );
+        assert_eq!(git_repository::open(repo.git_dir())?, repo);
+        assert_eq!(
+            git_repository::open(repo.work_tree.as_ref().expect("non-bare repo"))?,
+            repo
+        );
+        Ok(())
+    }
 
-    git_repository::init(tmp.path())?;
-    Ok(())
+    #[test]
+    fn init_into_non_empty_directory_is_allowed() -> crate::Result {
+        let tmp = tempfile::tempdir()?;
+        std::fs::write(tmp.path().join("existing.txt"), b"I was here before you")?;
+
+        git_repository::init(tmp.path())?;
+        Ok(())
+    }
 }

--- a/git-repository/tests/init/mod.rs
+++ b/git-repository/tests/init/mod.rs
@@ -21,10 +21,10 @@ mod bare {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("existing.txt"), b"I was here before you").unwrap();
 
-        assert_eq!(
-            git_repository::init_bare(tmp.path()).unwrap_err().to_string(),
-            "Failed to initialize a new repository"
-        );
+        assert!(git_repository::init_bare(tmp.path())
+            .unwrap_err()
+            .to_string()
+            .starts_with("Refusing to initialize the non-empty directory as"),);
     }
 }
 

--- a/git-repository/tests/init/mod.rs
+++ b/git-repository/tests/init/mod.rs
@@ -1,0 +1,25 @@
+#[test]
+fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
+    let tmp = tempfile::tempdir()?;
+    let repo = git_repository::init(tmp.path())?;
+    assert_eq!(
+        repo.work_tree.as_deref(),
+        Some(tmp.path()),
+        "there is a work tree by default"
+    );
+    assert_eq!(
+        repo.git_dir(),
+        tmp.path().join(".git"),
+        "there is a work tree by default"
+    );
+    Ok(())
+}
+
+#[test]
+fn init_into_non_empty_directory_is_allowed() -> crate::Result {
+    let tmp = tempfile::tempdir()?;
+    std::fs::write(tmp.path().join("existing.txt"), b"I was here before you")?;
+
+    git_repository::init(tmp.path())?;
+    Ok(())
+}

--- a/git-repository/tests/init/mod.rs
+++ b/git-repository/tests/init/mod.rs
@@ -1,4 +1,5 @@
 #[test]
+#[ignore]
 fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
     let tmp = tempfile::tempdir()?;
     let repo = git_repository::init(tmp.path())?;
@@ -12,6 +13,8 @@ fn init_into_empty_directory_creates_a_dot_git_dir() -> crate::Result {
         tmp.path().join(".git"),
         "there is a work tree by default"
     );
+    assert_eq!(git_repository::open(repo.git_dir())?, repo);
+    git_repository::open(repo.work_tree.expect("non-bare repo"))?;
     Ok(())
 }
 

--- a/git-repository/tests/repo.rs
+++ b/git-repository/tests/repo.rs
@@ -9,5 +9,6 @@ fn repo(name: &str) -> crate::Result<Repository> {
 
 mod access;
 mod discover;
+mod init;
 mod object;
 mod reference;

--- a/gitoxide-core/src/repository.rs
+++ b/gitoxide-core/src/repository.rs
@@ -3,6 +3,6 @@ use std::path::PathBuf;
 use anyhow::{Context as AnyhowContext, Result};
 
 pub fn init(directory: Option<PathBuf>) -> Result<git_repository::Path> {
-    git_repository::path::create::into(directory.unwrap_or_default())
+    git_repository::path::create::into(directory.unwrap_or_default(), git_repository::Kind::WorkTree)
         .with_context(|| "Repository initialization failed")
 }

--- a/gitoxide-core/src/repository.rs
+++ b/gitoxide-core/src/repository.rs
@@ -3,5 +3,6 @@ use std::path::PathBuf;
 use anyhow::{Context as AnyhowContext, Result};
 
 pub fn init(directory: Option<PathBuf>) -> Result<git_repository::Path> {
-    git_repository::init::into(directory.unwrap_or_default()).with_context(|| "Repository initialization failed")
+    git_repository::path::create::into(directory.unwrap_or_default())
+        .with_context(|| "Repository initialization failed")
 }

--- a/gitoxide-core/src/repository.rs
+++ b/gitoxide-core/src/repository.rs
@@ -2,6 +2,6 @@ use std::path::PathBuf;
 
 use anyhow::{Context as AnyhowContext, Result};
 
-pub fn init(directory: Option<PathBuf>) -> Result<()> {
-    git_repository::init::repository(directory.unwrap_or_default()).with_context(|| "Repository initialization failed")
+pub fn init(directory: Option<PathBuf>) -> Result<git_repository::Path> {
+    git_repository::init::into(directory.unwrap_or_default()).with_context(|| "Repository initialization failed")
 }

--- a/src/porcelain/main.rs
+++ b/src/porcelain/main.rs
@@ -34,7 +34,7 @@ pub fn main() -> Result<()> {
             crate::shared::STANDARD_RANGE,
             move |_progress, _out, _err| panic!("something went very wrong"),
         ),
-        Subcommands::Init { directory } => core::repository::init(directory),
+        Subcommands::Init { directory } => core::repository::init(directory).map(|_| ()),
         Subcommands::Tools(tool) => match tool {
             ToolCommands::EstimateHours(EstimateHours {
                 working_dir,

--- a/tests/fixtures/baseline-init/config
+++ b/tests/fixtures/baseline-init/config
@@ -1,2 +1,0 @@
-[core]
-	repositoryformatversion = 0

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -145,6 +145,7 @@ title "Porcelain ${kind}"
           }
 
           it "matches the output of baseline git init" && {
+            rm .git/config # this one is altered, ignore
             expect_snapshot "$fixtures/baseline-init" .git
           }
 
@@ -167,6 +168,7 @@ title "Porcelain ${kind}"
           }
 
           it "matches the output of baseline git init" && {
+            rm $DIR/.git/config # this one is altered, ignore
             expect_snapshot "$fixtures/baseline-init" $DIR/.git
           }
 


### PR DESCRIPTION
This time we can still get around using a full-blown git-config implementation as well.

* [x] refactor and some tests
* [x] repository open()
* [x] use thiserror in favor of quickerror (thanks to transparent errors and it being used already in dependency tree)
* [x] init bare
* [x] get git-config parsing to work on windows
