### PR TITLE
transport err typing

### DIFF
--- a/etc/check-package-size.sh
+++ b/etc/check-package-size.sh
@@ -36,4 +36,4 @@ echo "in root: gitoxide CLI"
 (enter git-packetline && indent cargo diet -n --package-size-limit 15KB)
 (enter git-repository && indent cargo diet -n --package-size-limit 50KB)
 (enter git-transport && indent cargo diet -n --package-size-limit 30KB)
-(enter gitoxide-core && indent cargo diet -n --package-size-limit 20KB)
+(enter gitoxide-core && indent cargo diet -n --package-size-limit 25KB)

--- a/git-packetline/src/read/async_io.rs
+++ b/git-packetline/src/read/async_io.rs
@@ -56,9 +56,16 @@ where
                         return (true, stopped_at, None);
                     } else if fail_on_err_lines {
                         if let Some(err) = line.check_error() {
-                            let err = err.0.as_bstr().to_string();
+                            let err = err.0.as_bstr().to_owned();
                             buf.clear();
-                            return (true, None, Some(Err(io::Error::new(io::ErrorKind::Other, err))));
+                            return (
+                                true,
+                                None,
+                                Some(Err(io::Error::new(
+                                    io::ErrorKind::Other,
+                                    crate::read::Error { message: err },
+                                ))),
+                            );
                         }
                     }
                     let len = line

--- a/git-packetline/src/read/blocking_io.rs
+++ b/git-packetline/src/read/blocking_io.rs
@@ -53,9 +53,16 @@ where
                         return (true, stopped_at, None);
                     } else if fail_on_err_lines {
                         if let Some(err) = line.check_error() {
-                            let err = err.0.as_bstr().to_string();
+                            let err = err.0.as_bstr().to_owned();
                             buf.clear();
-                            return (true, None, Some(Err(io::Error::new(io::ErrorKind::Other, err))));
+                            return (
+                                true,
+                                None,
+                                Some(Err(io::Error::new(
+                                    io::ErrorKind::Other,
+                                    crate::read::Error { message: err },
+                                ))),
+                            );
                         }
                     }
                     let len = line

--- a/git-packetline/src/read/mod.rs
+++ b/git-packetline/src/read/mod.rs
@@ -9,6 +9,28 @@ type ExhaustiveOutcome<'a> = (
     Option<std::io::Result<Result<PacketLineRef<'a>, crate::decode::Error>>>, // actual method result
 );
 
+mod error {
+    use bstr::BString;
+    use std::fmt::{Debug, Display, Formatter};
+
+    /// The error representing an ERR packet line, as possibly wrapped into an `std::io::Error` in
+    /// [`read_line(…)`][super::StreamingPeekableIter::read_line()].
+    #[derive(Debug)]
+    pub struct Error {
+        /// The contents of the ERR line, with `ERR` portion stripped.
+        pub message: BString,
+    }
+
+    impl Display for Error {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            Display::fmt(&self.message, f)
+        }
+    }
+
+    impl std::error::Error for Error {}
+}
+pub use error::Error;
+
 impl<T> StreamingPeekableIter<T> {
     /// Return a new instance from `read` which will stop decoding packet lines when receiving one of the given `delimiters`.
     pub fn new(read: T, delimiters: &'static [PacketLineRef<'static>]) -> Self {

--- a/git-packetline/tests/read/sideband.rs
+++ b/git-packetline/tests/read/sideband.rs
@@ -193,10 +193,15 @@ async fn handling_of_err_lines() {
     let mut buf = [0u8; 2];
     let mut reader = rd.as_read();
     let res = reader.read(buf.as_mut()).await;
+    let err = res.unwrap_err();
+    assert_eq!(err.to_string(), "e", "it respects errors and passes them on");
     assert_eq!(
-        res.unwrap_err().to_string(),
+        err.into_inner()
+            .expect("inner err")
+            .downcast::<git_packetline::read::Error>()
+            .expect("it's this type")
+            .message,
         "e",
-        "it respects errors and passes them on"
     );
     let res = reader.read(buf.as_mut()).await;
     assert_eq!(

--- a/git-protocol/tests/fixtures/v2/fetch-err-line.response
+++ b/git-protocol/tests/fixtures/v2/fetch-err-line.response
@@ -1,0 +1,1 @@
+001bERR segmentation fault

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -85,6 +85,7 @@
 //! * [`interrupt`]
 //! * [`protocol`]
 //!   * [`transport`][protocol::transport]
+//!     * [`packetline`][protocol::transport::packetline]
 //!
 #![deny(missing_docs, unsafe_code, rust_2018_idioms)]
 

--- a/git-transport/src/lib.rs
+++ b/git-transport/src/lib.rs
@@ -5,6 +5,8 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms, missing_docs)]
 
+pub use git_packetline as packetline;
+
 /// The version of the way client and server communicate.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]

--- a/src/plumbing/lean/main.rs
+++ b/src/plumbing/lean/main.rs
@@ -92,6 +92,7 @@ pub fn main() -> Result<()> {
             protocol,
             url,
             directory,
+            refs,
             refs_directory,
         }) => {
             let (_handle, progress) = prepare(verbose, "pack-receive", core::pack::receive::PROGRESS_RANGE);
@@ -100,6 +101,7 @@ pub fn main() -> Result<()> {
                 &url,
                 directory,
                 refs_directory,
+                refs.into_iter().map(|s| s.into()).collect(),
                 DoOrDiscard::from(progress),
                 core::pack::receive::Context {
                     thread_limit,

--- a/src/plumbing/lean/options.rs
+++ b/src/plumbing/lean/options.rs
@@ -102,7 +102,7 @@ pub struct PackReceive {
     /// the directory into which to write references. Existing files will be overwritten.
     ///
     /// Note that the directory will be created if needed.
-    #[argh(option, short = 'r')]
+    #[argh(option, short = 'd')]
     pub refs_directory: Option<PathBuf>,
 
     /// the URLs or path from which to receive the pack.
@@ -110,6 +110,12 @@ pub struct PackReceive {
     /// See here for a list of supported URLs: https://www.git-scm.com/docs/git-clone#_git_urls
     #[argh(positional)]
     pub url: String,
+
+    /// if set once or more times, these references will be fetched instead of all advertised ones.
+    ///
+    /// Note that this requires a reasonably modern git server.
+    #[argh(option, long = "reference", short = 'r')]
+    pub refs: Vec<String>,
 
     /// the directory into which to write the received pack and index.
     ///

--- a/src/plumbing/pretty/main.rs
+++ b/src/plumbing/pretty/main.rs
@@ -83,6 +83,7 @@ pub fn main() -> Result<()> {
             protocol,
             url,
             directory,
+            refs,
             refs_directory,
         } => prepare_and_run(
             "pack-receive",
@@ -96,6 +97,7 @@ pub fn main() -> Result<()> {
                     &url,
                     directory,
                     refs_directory,
+                    refs.into_iter().map(|r| r.into()).collect(),
                     git_features::progress::DoOrDiscard::from(progress),
                     core::pack::receive::Context {
                         thread_limit,

--- a/src/plumbing/pretty/options.rs
+++ b/src/plumbing/pretty/options.rs
@@ -90,13 +90,19 @@ pub enum Subcommands {
         /// the directory into which to write references. Existing files will be overwritten.
         ///
         /// Note that the directory will be created if needed.
-        #[clap(long, short = 'r')]
+        #[clap(long, short = 'd')]
         refs_directory: Option<PathBuf>,
 
         /// The URLs or path from which to receive the pack.
         ///
         /// See here for a list of supported URLs: <https://www.git-scm.com/docs/git-clone#_git_urls>
         url: String,
+
+        /// If set once or more times, these references will be fetched instead of all advertised ones.
+        ///
+        /// Note that this requires a reasonably modern git server.
+        #[clap(long = "reference", short = 'r')]
+        refs: Vec<String>,
 
         /// The directory into which to write the received pack and index.
         ///

--- a/tests/journey/gixp.sh
+++ b/tests/journey/gixp.sh
@@ -118,10 +118,18 @@ title "gixp pack-receive"
       launch-git-daemon
       (with "version 1"
         (with "NO output directory"
-          it "generates the correct output" && {
-            WITH_SNAPSHOT="$snapshot/file-v-any-no-output" \
-            expect_run $SUCCESSFULLY "$exe_plumbing" pack-receive -p 1 git://localhost/
-          }
+          (with "no wanted refs"
+            it "generates the correct output" && {
+              WITH_SNAPSHOT="$snapshot/file-v-any-no-output" \
+              expect_run $SUCCESSFULLY "$exe_plumbing" pack-receive -p 1 git://localhost/
+            }
+          )
+          (with "wanted refs"
+            it "generates the correct output" && {
+              WITH_SNAPSHOT="$snapshot/file-v-any-no-output-wanted-ref-p1" \
+              expect_run $WITH_FAILURE "$exe_plumbing" pack-receive -p 1 git://localhost/ -r =refs/heads/main
+            }
+          )
         )
         (with "output directory"
           mkdir out
@@ -133,10 +141,18 @@ title "gixp pack-receive"
       )
       (with "version 2"
         (with "NO output directory"
-          it "generates the correct output" && {
-            WITH_SNAPSHOT="$snapshot/file-v-any-no-output" \
-            expect_run $SUCCESSFULLY "$exe_plumbing" pack-receive -p 2 git://localhost/
-          }
+          (with "NO wanted refs"
+            it "generates the correct output" && {
+              WITH_SNAPSHOT="$snapshot/file-v-any-no-output" \
+              expect_run $SUCCESSFULLY "$exe_plumbing" pack-receive -p 2 git://localhost/
+            }
+          )
+          (with "wanted refs"
+            it "generates the correct output" && {
+              WITH_SNAPSHOT="$snapshot/file-v-any-no-output-single-ref" \
+              expect_run $WITH_FAILURE "$exe_plumbing" pack-receive -p 2 git://localhost/ -r refs/heads/main
+            }
+          )
         )
         (with "output directory"
           it "generates the correct output" && {

--- a/tests/snapshots/plumbing/pack-receive/file-v-any-no-output-single-ref
+++ b/tests/snapshots/plumbing/pack-receive/file-v-any-no-output-single-ref
@@ -1,0 +1,4 @@
+Error: Could not access repository or failed to read streaming pack file
+
+Caused by:
+    Want to get specific refs, but remote doesn't support this capability

--- a/tests/snapshots/plumbing/pack-receive/file-v-any-no-output-wanted-ref-p1
+++ b/tests/snapshots/plumbing/pack-receive/file-v-any-no-output-wanted-ref-p1
@@ -1,0 +1,4 @@
+Error: Could not access repository or failed to read streaming pack file
+
+Caused by:
+    Want to get specific refs, but remote doesn't support this capability


### PR DESCRIPTION
Fix for #200 

* [x] structured error in git-packetline
* [x] a flag to use ref-in-want in order to reproduce the issue on a high level - fails to reproduce as the current test suite operates with servers who don't support this feature at all. Unless there is a way to want invalid SHA1s, it's hard to trigger an error.
* [x] cause a packet-line based error
* [ ] obtain underlying packetline errors from io errors