### PR TITLE
Simplification of `header_field_multi_line` and its invocation.

### DIFF
--- a/git-object/src/commit/write.rs
+++ b/git-object/src/commit/write.rs
@@ -1,7 +1,5 @@
 use std::io;
 
-use bstr::ByteSlice;
-
 use crate::{encode, encode::NL, Commit, CommitRef, Kind};
 
 impl crate::WriteTo for Commit {
@@ -17,12 +15,7 @@ impl crate::WriteTo for Commit {
             encode::header_field(b"encoding", encoding, &mut out)?;
         }
         for (name, value) in &self.extra_headers {
-            let has_newline = value.find_byte(b'\n').is_some();
-            if has_newline {
-                encode::header_field_multi_line(name, value, &mut out)?;
-            } else {
-                encode::trusted_header_field(name, value, &mut out)?;
-            }
+            encode::header_field_multi_line(name, value, &mut out)?;
         }
         out.write_all(NL)?;
         out.write_all(&self.message)
@@ -46,12 +39,7 @@ impl<'a> crate::WriteTo for CommitRef<'a> {
             encode::header_field(b"encoding", encoding, &mut out)?;
         }
         for (name, value) in &self.extra_headers {
-            let has_newline = value.find_byte(b'\n').is_some();
-            if has_newline {
-                encode::header_field_multi_line(name, value, &mut out)?;
-            } else {
-                encode::trusted_header_field(name, value, &mut out)?;
-            }
+            encode::header_field_multi_line(name, value, &mut out)?;
         }
         out.write_all(NL)?;
         out.write_all(self.message)


### PR DESCRIPTION
Just a simple "cleanup" I saw while reading the code: 

* `EmptyValue` is already used by `header_field` and seems suitable for the same case here, the way it was previously called there was no way the value could be empty but since `header_field_multi_line` is already fallible it seems odd to make it panic.
* Swapped `lines` for `split_str`, avoids the terminal edge case which might be a tad slower (as it writes an empty string) but doesn't seem like it should be too critical.
* Somewhat similarly simplifies `write_to` by removing the condition entirely (should work because of the fix to (1), `header_field_multi_line` starts by writing a single header then writes the followup so it should work fine for both cases).