### PR TITLE
thread-local loose ref namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "git-hash",
  "jwalk",
  "num_cpus",
+ "parking_lot",
  "prodash",
  "quick-error",
  "sha-1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,9 @@ futures-lite = { version = "1.12.0", optional = true, default-features = false, 
 [profile.release]
 overflow-checks = false
 lto = "fat"
-panic = 'abort'
+# this bloats files but assures destructors are called, important for tempfiles. One day I hope we
+# can wire up the 'abrt' signal handler so tempfiles will be removed in case of panics.
+panic = 'unwind'
 codegen-units = 1
 incremental = false
 build-override = { opt-level = 0 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ gitoxide-core-tools = ["gitoxide-core/organize", "gitoxide-core/estimate-hours"]
 gitoxide-core-blocking-client = ["gitoxide-core/blocking-client"]
 gitoxide-core-async-client = ["gitoxide-core/async-client", "futures-lite"]
 http-client-curl = ["git-transport-for-configuration-only/http-client-curl"]
-fast = ["git-features/parallel", "git-features/fast-sha1", "git-features/zlib-ng-compat"]
+fast = ["git-features/threading", "git-features/parallel", "git-features/fast-sha1", "git-features/zlib-ng-compat"]
 
 pretty-cli = ["clap",
     "gitoxide-core/serde1",

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ check: ## Build all code in suitable configurations
 			   && cargo check
 	cd git-features && cargo check --all-features \
 			   && cargo check --features parallel \
+			   && cargo check --features threading \
 			   && cargo check --features rustsha1 \
 			   && cargo check --features fast-sha1 \
 			   && cargo check --features progress \

--- a/cargo-features.md
+++ b/cargo-features.md
@@ -106,6 +106,9 @@ All feature toggles are additive.
     * Use scoped threads and channels to parallelize common workloads on multiple objects. If enabled, it is used everywhere
       where it makes sense.
     * As caches are likely to be used and instantiated per thread, more memory will be used on top of the costs for threads.
+* **threading**
+    * If set, the `threading` module will contain thread-safe primitives for shared ownership and mutation, otherwise these will be their single threaded counterparts.
+    * This way, single-threaded applications don't have to pay for threaded primitives.
 * **crc32**
     * provide a proven and fast `crc32` implementation.
 * **io-pipe**

--- a/git-config/src/file/git_config.rs
+++ b/git-config/src/file/git_config.rs
@@ -171,7 +171,7 @@ impl<'event> GitConfig<'event> {
 
         let mut paths = vec![];
 
-        if let Err(_) = env::var("GIT_CONFIG_NO_SYSTEM") {
+        if env::var("GIT_CONFIG_NO_SYSTEM").is_err() {
             if let Ok(git_config_system) = env::var("GIT_CONFIG_SYSTEM") {
                 paths.push(PathBuf::from(git_config_system))
             } else {

--- a/git-config/src/file/git_config.rs
+++ b/git-config/src/file/git_config.rs
@@ -165,7 +165,7 @@ impl<'event> GitConfig<'event> {
     /// Constructs a `git-config` from the default cascading sequence.
     /// This is neither zero-alloc nor zero-copy.
     ///
-    /// See https://git-scm.com/docs/git-config#FILES for details.
+    /// See <https://git-scm.com/docs/git-config#FILES> for details.
     pub fn from_env_paths() -> Result<Self, ParserOrIoError<'static>> {
         use std::env;
 

--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -13,6 +13,7 @@ test = false
 
 [features]
 default = []
+threading = ["parking_lot"]
 progress = ["prodash"]
 parallel = ["crossbeam-utils", "crossbeam-channel", "num_cpus", "jwalk"]
 fast-sha1 = ["sha-1"]
@@ -50,6 +51,10 @@ required-features = ["io-pipe"]
 
 [dependencies]
 git-hash = { version ="^0.8.0", path = "../git-hash" }
+
+
+# 'threading' feature
+parking_lot = { version = "0.11.0", default-features = false, optional = true }
 
 # 'parallel' feature
 crossbeam-utils = { version = "0.8.5", optional = true }

--- a/git-features/src/lib.rs
+++ b/git-features/src/lib.rs
@@ -19,6 +19,7 @@ pub mod io;
 pub mod parallel;
 #[cfg(feature = "progress")]
 pub mod progress;
+pub mod threading;
 ///
 #[cfg(feature = "zlib")]
 pub mod zlib;

--- a/git-features/src/threading.rs
+++ b/git-features/src/threading.rs
@@ -1,0 +1,74 @@
+//! Type definitions for putting shared ownership and synchronized mutation behind the `threading` feature toggle.
+//!
+//! That way, single-threaded applications will not have to use thread-safe primitives, and simply do not specify the 'threading' feature.
+
+#[cfg(feature = "threading")]
+mod _impl {
+    use std::sync::Arc;
+
+    /// A reference counted pointer type for shared ownership.
+    pub type OwnShared<T> = Arc<T>;
+    /// A synchronization primitive which can start read-only and transition to support mutation.
+    pub type MutableOnDemand<T> = parking_lot::RwLock<T>;
+
+    /// Get an upgradable shared reference through a [`MutableOnDemand`] for read-only access.
+    ///
+    /// This access can be upgraded using [`upgrade_ref_to_mut()`].
+    pub fn get_ref_upgradeable<T>(v: &MutableOnDemand<T>) -> parking_lot::RwLockUpgradableReadGuard<'_, T> {
+        v.upgradable_read()
+    }
+
+    /// Get a shared reference through a [`MutableOnDemand`] for read-only access.
+    pub fn get_ref<T>(v: &MutableOnDemand<T>) -> parking_lot::RwLockReadGuard<'_, T> {
+        v.read()
+    }
+
+    /// Get a mutable reference through a [`MutableOnDemand`] for read-write access.
+    pub fn get_mut<T>(v: &MutableOnDemand<T>) -> parking_lot::RwLockWriteGuard<'_, T> {
+        v.write()
+    }
+
+    /// Upgrade a handle previously obtained with [`get_ref_upgradeable()`] to support mutation.
+    pub fn upgrade_ref_to_mut<T>(
+        v: parking_lot::RwLockUpgradableReadGuard<'_, T>,
+    ) -> parking_lot::RwLockWriteGuard<'_, T> {
+        parking_lot::RwLockUpgradableReadGuard::upgrade(v)
+    }
+}
+
+#[cfg(not(feature = "threading"))]
+mod _impl {
+    use std::{
+        cell::{Ref, RefCell, RefMut},
+        rc::Rc,
+    };
+
+    /// A reference counted pointer type for shared ownership.
+    pub type OwnShared<T> = Rc<T>;
+    /// A synchronization primitive which can start read-only and transition to support mutation.
+    pub type MutableOnDemand<T> = RefCell<T>;
+
+    /// Get an upgradable shared reference through a [`MutableOnDemand`] for read-only access.
+    ///
+    /// This access can be upgraded using [`upgrade_ref_to_mut()`].
+    pub fn get_ref_upgradeable<T>(v: &RefCell<T>) -> RefMut<'_, T> {
+        v.borrow_mut()
+    }
+
+    /// Get a shared reference through a [`MutableOnDemand`] for read-only access.
+    pub fn get_mut<T>(v: &RefCell<T>) -> RefMut<'_, T> {
+        v.borrow_mut()
+    }
+
+    /// Get a mutable reference through a [`MutableOnDemand`] for read-write access.
+    pub fn get_ref<T>(v: &RefCell<T>) -> Ref<'_, T> {
+        v.borrow()
+    }
+
+    /// Upgrade a handle previously obtained with [`get_ref_upgradeable()`] to support mutation.
+    pub fn upgrade_ref_to_mut<T>(v: RefMut<'_, T>) -> RefMut<'_, T> {
+        v
+    }
+}
+
+pub use _impl::*;

--- a/git-packetline/src/encode/async_io.rs
+++ b/git-packetline/src/encode/async_io.rs
@@ -10,7 +10,6 @@ use futures_lite::AsyncWriteExt;
 use super::u16_to_hex;
 use crate::{encode::Error, Channel, DELIMITER_LINE, ERR_PREFIX, FLUSH_LINE, MAX_DATA_LEN, RESPONSE_END_LINE};
 
-#[allow(missing_docs)]
 pin_project_lite::pin_project! {
     /// A way of writing packet lines asynchronously.
     pub struct LineWriter<'a, W> {

--- a/git-repository/src/easy/impls.rs
+++ b/git-repository/src/easy/impls.rs
@@ -103,6 +103,10 @@ impl<'repo> easy::Access for EasyShared<'repo> {
     fn state(&self) -> &easy::State {
         &self.state
     }
+
+    fn state_mut(&mut self) -> &mut easy::State {
+        &mut self.state
+    }
 }
 
 impl easy::Access for Easy {
@@ -121,6 +125,10 @@ impl easy::Access for Easy {
     fn state(&self) -> &easy::State {
         &self.state
     }
+
+    fn state_mut(&mut self) -> &mut easy::State {
+        &mut self.state
+    }
 }
 
 impl easy::Access for EasyArc {
@@ -136,6 +144,10 @@ impl easy::Access for EasyArc {
     fn state(&self) -> &easy::State {
         &self.state
     }
+
+    fn state_mut(&mut self) -> &mut easy::State {
+        &mut self.state
+    }
 }
 
 impl easy::Access for EasyArcExclusive {
@@ -150,5 +162,9 @@ impl easy::Access for EasyArcExclusive {
     }
     fn state(&self) -> &easy::State {
         &self.state
+    }
+
+    fn state_mut(&mut self) -> &mut easy::State {
+        &mut self.state
     }
 }

--- a/git-repository/src/easy/impls.rs
+++ b/git-repository/src/easy/impls.rs
@@ -6,9 +6,10 @@ use crate::{easy, Easy, EasyArc, EasyArcExclusive, EasyShared, Repository};
 
 impl From<Repository> for Easy {
     fn from(repo: Repository) -> Self {
+        let state = easy::State::from(&repo);
         Easy {
             repo: Rc::new(repo),
-            state: Default::default(),
+            state,
         }
     }
 }
@@ -31,18 +32,20 @@ impl TryFrom<EasyArc> for Repository {
 
 impl From<Repository> for EasyArc {
     fn from(repo: Repository) -> Self {
+        let state = easy::State::from(&repo);
         EasyArc {
             repo: Arc::new(repo),
-            state: Default::default(),
+            state,
         }
     }
 }
 
 impl From<Repository> for EasyArcExclusive {
     fn from(repo: Repository) -> Self {
+        let state = easy::State::from(&repo);
         EasyArcExclusive {
             repo: Arc::new(parking_lot::RwLock::new(repo)),
-            state: Default::default(),
+            state,
         }
     }
 }
@@ -66,7 +69,7 @@ impl Repository {
     pub fn to_easy(&self) -> EasyShared<'_> {
         EasyShared {
             repo: self,
-            state: Default::default(),
+            state: self.into(),
         }
     }
     /// Transform this instance into an [`Easy`], offering shared immutable access to the repository, for the current thread.

--- a/git-repository/src/easy/mod.rs
+++ b/git-repository/src/easy/mod.rs
@@ -114,7 +114,7 @@ pub struct State {
     /// As the packed-buffer may hold onto a memory map, so ideally this State is freed after use instead of keeping it around
     /// for too long. At least `packed_refs` is lazily initialized.
     packed_refs: RefCell<reference::packed::ModifieablePackedRefsBuffer>,
-    refs: git_ref::file::Store,
+    refs: crate::RefStore,
     pack_cache: RefCell<PackCache>,
     object_cache: RefCell<Option<object::cache::MemoryCappedHashmap>>,
     buf: RefCell<Vec<u8>>,
@@ -148,6 +148,9 @@ pub trait Access {
     /// relevant for long-running applications that make changes to the repository.
     fn repo_mut(&self) -> borrow::repo::Result<Self::RepoRefMut>;
 
-    /// Return a shared borrow of the repository state, with support for interior mutability.
+    /// Return a shared borrow of the repository state.
     fn state(&self) -> &State;
+
+    /// Return a shared borrow of the repository state.
+    fn state_mut(&mut self) -> &mut State;
 }

--- a/git-repository/src/easy/mod.rs
+++ b/git-repository/src/easy/mod.rs
@@ -114,6 +114,7 @@ pub struct State {
     /// As the packed-buffer may hold onto a memory map, so ideally this State is freed after use instead of keeping it around
     /// for too long. At least `packed_refs` is lazily initialized.
     packed_refs: RefCell<reference::packed::ModifieablePackedRefsBuffer>,
+    refs: git_ref::file::Store,
     pack_cache: RefCell<PackCache>,
     object_cache: RefCell<Option<object::cache::MemoryCappedHashmap>>,
     buf: RefCell<Vec<u8>>,

--- a/git-repository/src/easy/reference/errors.rs
+++ b/git-repository/src/easy/reference/errors.rs
@@ -1,22 +1,4 @@
 ///
-pub mod namespace {
-    ///
-    pub mod set {
-        use crate::easy;
-
-        /// The error returned by [ReferenceAccessExt::set_namespace(…)][easy::ext::ReferenceAccessExt::set_namespace()].
-        #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
-        pub enum Error {
-            #[error(transparent)]
-            BorrowRepoMut(#[from] easy::borrow::repo::Error),
-            #[error(transparent)]
-            NameValidation(#[from] git_validate::refname::Error),
-        }
-    }
-}
-
-///
 pub mod edit {
     use crate::easy;
 

--- a/git-repository/src/easy/reference/mod.rs
+++ b/git-repository/src/easy/reference/mod.rs
@@ -14,7 +14,7 @@ pub mod iter;
 mod errors;
 use std::{borrow::Borrow, cell::RefMut, marker::PhantomData};
 
-pub use errors::{edit, find, namespace, peel};
+pub use errors::{edit, find, peel};
 
 use crate::ext::ObjectIdExt;
 
@@ -78,8 +78,8 @@ where
         let state = self.access.state();
         let mut pack_cache = state.try_borrow_mut_pack_cache()?;
         let oid = self.inner.peel_to_id_in_place(
-            &repo.refs,
-            state.assure_packed_refs_uptodate(&repo.refs)?.buffer.as_ref(),
+            &state.refs,
+            state.assure_packed_refs_uptodate()?.buffer.as_ref(),
             |oid, buf| {
                 repo.odb
                     .try_find(oid, buf, pack_cache.deref_mut())

--- a/git-repository/src/easy/state.rs
+++ b/git-repository/src/easy/state.rs
@@ -1,8 +1,6 @@
 //!
 use std::cell::{Ref, RefCell, RefMut};
 
-use git_ref::file;
-
 use crate::{easy, easy::borrow, Repository};
 
 impl Clone for easy::State {
@@ -12,8 +10,8 @@ impl Clone for easy::State {
 }
 
 // TODO: Expand this as needed as more higher-level stores exist (i.e. odb)
-impl From<git_ref::file::Store> for easy::State {
-    fn from(refs: git_ref::file::Store) -> Self {
+impl From<crate::RefStore> for easy::State {
+    fn from(refs: crate::RefStore) -> Self {
         easy::State {
             packed_refs: RefCell::new(Default::default()),
             #[cfg(not(feature = "max-performance"))]
@@ -36,10 +34,9 @@ impl From<&Repository> for easy::State {
 impl easy::State {
     pub(crate) fn assure_packed_refs_uptodate(
         &self,
-        file: &file::Store,
     ) -> Result<Ref<'_, easy::reference::packed::ModifieablePackedRefsBuffer>, easy::reference::packed::Error> {
         let mut packed_refs = self.packed_refs.try_borrow_mut()?;
-        packed_refs.assure_packed_refs_uptodate(file)?;
+        packed_refs.assure_packed_refs_uptodate(&self.refs)?;
         drop(packed_refs);
         Ok(self.packed_refs.try_borrow()?)
     }

--- a/git-repository/src/easy/state.rs
+++ b/git-repository/src/easy/state.rs
@@ -3,16 +3,17 @@ use std::cell::{Ref, RefCell, RefMut};
 
 use git_ref::file;
 
-use crate::{easy, easy::borrow};
+use crate::{easy, easy::borrow, Repository};
 
 impl Clone for easy::State {
     fn clone(&self) -> Self {
-        easy::State { ..Default::default() }
+        self.refs.clone().into()
     }
 }
 
-impl Default for easy::State {
-    fn default() -> Self {
+// TODO: Expand this as needed as more higher-level stores exist (i.e. odb)
+impl From<git_ref::file::Store> for easy::State {
+    fn from(refs: git_ref::file::Store) -> Self {
         easy::State {
             packed_refs: RefCell::new(Default::default()),
             #[cfg(not(feature = "max-performance"))]
@@ -21,7 +22,14 @@ impl Default for easy::State {
             pack_cache: RefCell::new(Box::new(git_pack::cache::lru::StaticLinkedList::<64>::default())),
             object_cache: RefCell::new(None),
             buf: RefCell::new(vec![]),
+            refs,
         }
+    }
+}
+
+impl From<&Repository> for easy::State {
+    fn from(repo: &Repository) -> Self {
+        repo.refs.clone().into()
     }
 }
 

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -154,6 +154,9 @@ pub mod path;
 mod repository;
 pub use repository::{discover, init, open};
 
+/// The standard type for a store to handle git references.
+pub type RefStore = git_ref::file::Store;
+
 /// A repository path which either points to a work tree or the `.git` repository itself.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Path {
@@ -173,7 +176,7 @@ pub enum Path {
 /// Namely, this is an object database, a reference database to point to objects.
 pub struct Repository {
     /// A store for references to point at objects
-    pub refs: git_ref::file::Store,
+    pub refs: RefStore,
     /// A store for objects that contain data
     #[cfg(feature = "unstable")]
     pub odb: git_odb::linked::Store,

--- a/git-repository/src/path/is.rs
+++ b/git-repository/src/path/is.rs
@@ -35,7 +35,7 @@ pub fn git(git_dir: impl AsRef<Path>) -> Result<crate::Kind, Error> {
     let dot_git = git_dir.as_ref();
 
     {
-        let refs = git_ref::file::Store::at(&dot_git, Default::default());
+        let refs = crate::RefStore::at(&dot_git, Default::default());
         let head = refs.find_loose("HEAD")?;
         if head.name.as_bstr() != "HEAD" {
             return Err(Error::MisplacedHead {

--- a/git-repository/src/repository.rs
+++ b/git-repository/src/repository.rs
@@ -101,7 +101,7 @@ pub mod open {
 
             Ok(crate::Repository {
                 odb: git_odb::linked::Store::at(git_dir.join("objects"))?,
-                refs: git_ref::file::Store::at(
+                refs: crate::RefStore::at(
                     git_dir,
                     if worktree_dir.is_none() {
                         git_ref::file::WriteReflog::Disable

--- a/git-repository/tests/easy/ext/reference.rs
+++ b/git-repository/tests/easy/ext/reference.rs
@@ -14,7 +14,7 @@ mod set_namespace {
             15,
             "there are plenty of references in the default namespace"
         );
-        assert!(repo.namespace()?.is_none(), "no namespace is set initially");
+        assert!(repo.namespace().is_none(), "no namespace is set initially");
         assert!(repo.set_namespace("foo")?.is_none(), "there is no previous namespace");
 
         assert_eq!(
@@ -67,9 +67,9 @@ mod set_namespace {
             "namespaces are transparent"
         );
 
-        let previous_ns = repo.clear_namespace()?.expect("namespace set");
+        let previous_ns = repo.clear_namespace().expect("namespace set");
         assert_eq!(previous_ns.as_bstr(), "refs/namespaces/foo/");
-        assert!(repo.clear_namespace()?.is_none(), "it doesn't invent namespaces");
+        assert!(repo.clear_namespace().is_none(), "it doesn't invent namespaces");
 
         assert_eq!(
             repo.references()?.all()?.count(),


### PR DESCRIPTION
Related to #263 

#### Tasks

* [x] `git-features` with compile-time switchable primitives
* ~~make namespace a parameter in loose ref db~~
   - They are essentially stateless already, and having an instance per thread (including the namespace) is the way to go and much easier than carrying through another parameter.
* [x] update git-repository `Easy` state to keep a copy of the whole loose DB instead - this is similar to having a handle to the more general store later.