### PR TITLE
Test/git traverse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 /tests/fixtures/repos
 
 **/generated/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ target/
 # repositories used for local testing
 /tests/fixtures/repos
 
-**/generated/
-.idea
+**/generated-do-not-edit/

--- a/git-traverse/tests/fixtures/make_traversal_repo_for_commits.sh
+++ b/git-traverse/tests/fixtures/make_traversal_repo_for_commits.sh
@@ -3,6 +3,7 @@ set -eu -o pipefail
 
 git init -q
 git config commit.gpgsign false
+git config merge.ff false
 
 git checkout -q -b main
 git commit -q --allow-empty -m c1

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -74,7 +74,7 @@ pub fn scripted_fixture_repo_read_only_with_args(
             crc_digest.finalize()
         })
         .to_owned();
-    let script_result_directory = fixture_path(Path::new("generated").join(format!("{}", script_identity)));
+    let script_result_directory = fixture_path(Path::new("generated-do-not-edit").join(format!("{}", script_identity)));
     if !script_result_directory.is_dir() {
         std::fs::create_dir_all(&script_result_directory)?;
         let script_absolute_path = std::env::current_dir()?.join(script_path);


### PR DESCRIPTION
- Ensure a merge commit is created in the git-traverse test fixture by adding `git config merge.ff false` in the fixture script. 
- ~~Ensure the test fixture is re-created on each test run~~
- Rename fixture directory to `generated-do-not-edit` 

closes #268