### PR TITLE
fix(core/organize): keep non "git" repository name extensions

### DIFF
--- a/gitoxide-core/src/organize.rs
+++ b/gitoxide-core/src/organize.rs
@@ -177,7 +177,11 @@ fn handle(
             match kind {
                 RepoKind::Bare => path,
                 RepoKind::WorkingTree => {
-                    path.set_extension("");
+                    if let Some(ext) = path.extension() {
+                        if ext == "git" {
+                            path.set_extension("");
+                        }
+                    }
                     path
                 }
             }


### PR DESCRIPTION
When converting a remote URL to a destination directory name,
keep extension strings if they are not equal to "git". For example,
https://github.com/jonhoo/rust-for-rustaceans.com should _not_ have the
extension stripped from its directory name.