### PR TITLE
feat(git-config:subsections): implement a draft for subsection fetching

### DIFF
--- a/git-config/src/file/git_config.rs
+++ b/git-config/src/file/git_config.rs
@@ -463,6 +463,70 @@ impl<'event> GitConfig<'event> {
             .collect()
     }
 
+    /// Get all sections that match the provided name. Returning the section header and body.
+    ///
+    /// # Example
+    ///
+    /// Provided the following config:
+    /// ```plain
+    /// [url "ssh://git@github.com/"]
+    ///     insteadOf = https://github.com/
+    /// [url "ssh://git@bitbucket.org"]
+    ///     insteadOf = https://bitbucket.org/
+    /// ```
+    /// Calling this method will yield all section bodies and their header:
+    ///
+    /// ```rust
+    /// use git_config::file::{GitConfig, GitConfigError};
+    /// use git_config::parser::Key;
+    /// use std::borrow::Cow;
+    /// use std::convert::TryFrom;
+    /// use nom::AsBytes;
+    ///
+    /// let input = r#"
+    /// [url "ssh://git@github.com/"]
+    ///    insteadOf = https://github.com/
+    /// [url "ssh://git@bitbucket.org"]
+    ///    insteadOf = https://bitbucket.org/
+    /// "#;
+    /// let config = GitConfig::try_from(input).unwrap();
+    /// let url = config.sections_by_name_with_header("url");
+    /// assert_eq!(url.len(), 2);
+    ///
+    /// for (i, (header, body)) in url.iter().enumerate() {
+    ///     let url = header.subsection_name.as_ref();
+    ///     let instead_of = body.value(&Key::from("insteadOf"));
+    ///
+    ///     // todo(unstable-order): the order is not always the same, so `i` cannot be used here
+    ///     if instead_of.as_ref().unwrap().as_ref().as_bytes().eq("https://github.com/".as_bytes()) {
+    ///         assert_eq!(instead_of.unwrap().as_ref(), "https://github.com/".as_bytes());
+    ///         assert_eq!(url.unwrap().as_ref(), "ssh://git@github.com/");
+    ///     } else {
+    ///         assert_eq!(instead_of.unwrap().as_ref(), "https://bitbucket.org/".as_bytes());
+    ///         assert_eq!(url.unwrap().as_ref(), "ssh://git@bitbucket.org");
+    ///     }
+    /// }
+    /// ```
+    pub fn sections_by_name_with_header<'lookup>(
+        &self,
+        section_name: &'lookup str,
+    ) -> Vec<(&ParsedSectionHeader<'event>, &SectionBody<'event>)> {
+        self.get_section_ids_by_name(section_name)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|id| {
+                (
+                    self.section_headers
+                        .get(&id)
+                        .expect("section doesn't have a section header??"),
+                    self.sections
+                        .get(&id)
+                        .expect("section doesn't have id from from lookup"),
+                )
+            })
+            .collect()
+    }
+
     /// Adds a new section to config. If a subsection name was provided, then
     /// the generated header will use the modern subsection syntax. Returns a
     /// reference to the new section for immediate editing.

--- a/git-config/tests/integration_tests/file_integeration_test.rs
+++ b/git-config/tests/integration_tests/file_integeration_test.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use std::{borrow::Cow, convert::TryFrom, path::Path};
 
 use git_config::{file::GitConfig, values::*};
@@ -7,36 +6,6 @@ use git_config::{file::GitConfig, values::*};
 fn parse_config_with_windows_line_endings_successfully() -> crate::Result {
     GitConfig::open(Path::new("tests").join("fixtures").join("repo-config.crlf"))?;
     Ok(())
-}
-
-#[test]
-fn foobar() {
-    use git_config::file::GitConfig;
-    use git_config::parser::Key;
-
-    let input = r#"
-[url "ssh://git@github.com/"]
-    insteadOf = https://github.com/
-[url "ssh://git@bitbucket.org"]
-    insteadOf = https://bitbucket.org/
-"#;
-    let config = GitConfig::try_from(input).unwrap();
-    let url = config.sections_by_name("url");
-    assert_eq!(url.len(), 2);
-
-    for (i, u) in url.iter().enumerate() {
-        let instead_of = u.value(&Key::from("insteadOf"));
-
-        // todo(sub-section-name)
-        dbg!(u);
-        // assert_eq!(xxxxx, "ssh://git@github.com/")
-
-        if i == 1 {
-            assert_eq!(instead_of.unwrap().deref(), "https://github.com/".as_bytes())
-        } else {
-            assert_eq!(instead_of.unwrap().as_ref(), "https://bitbucket.org/".as_bytes())
-        }
-    }
 }
 
 /// Asserts we can cast into all variants of our type


### PR DESCRIPTION
- introduce method `sections_by_name_with_header` to allow iterating over tuples of
  section header and section body
- remove the integration test in favor of a doctest
- doctest is also a comprehensive usage example
- leave a todo note to illustrate the inconsitent order issue, so sections
  do not always arrive in the same order
- fixes #319