### PR TITLE
derive PartialEq on ResolvedGitConfig

### DIFF
--- a/git-config/src/file/resolved.rs
+++ b/git-config/src/file/resolved.rs
@@ -19,6 +19,7 @@ enum ResolvedTreeNode<'event> {
 /// not remember comments nor whitespace. Additionally, values are normalized
 /// upon creation, so it's not possible to retrieve the original value.
 #[allow(clippy::module_name_repetitions)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct ResolvedGitConfig<'data>(HashMap<SectionLookupTuple<'data>, HashMap<Key<'data>, Cow<'data, [u8]>>>);
 
 type SectionLookupTuple<'data> = (SectionHeaderName<'data>, Option<Cow<'data, str>>);


### PR DESCRIPTION
I have two separate solutions that generate git config. I would like to compare that config file generated by those two is logically identical.