### PR TITLE
run both windows toolchains (#298)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           command: check
           args: --all --bins --tests --examples
+      - name: "Test ref (crossterm)"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package git-ref
       - name: "Test (crossterm)"
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
       run: make tests
 
   build-and-test-on-windows:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            rust: stable-gnu
+          - target: x86_64-pc-windows-msvc
+            rust: stable-msvc
     name: Windows
     runs-on: windows-2019
     steps:
@@ -39,7 +46,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: "Check default features build on windows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             rust: stable-msvc
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,9 @@ miniz_oxide = { opt-level = 3 }
 sha-1 = { opt-level = 3 }
 sha1_smol = { opt-level = 3 }
 
+[profile.dev]
+opt-level = 1
+
 [profile.release]
 overflow-checks = false
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,9 +108,6 @@ miniz_oxide = { opt-level = 3 }
 sha-1 = { opt-level = 3 }
 sha1_smol = { opt-level = 3 }
 
-[profile.dev]
-opt-level = 1
-
 [profile.release]
 overflow-checks = false
 lto = "fat"


### PR DESCRIPTION
Try to reproduce the [vergen issue](https://github.com/Byron/vergen/runs/5845150345?check_suite_focus=true#step:10:506).

```
Err` value: The ref file could not be read in full
Caused by:
    The filename, directory name, or volume label syntax is incorrect. (os error 123)', src\gen.rs:673:76
```