### PR TITLE
git-glob windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,16 @@ Follow linked crate name for detailed status. Please note that all crates follow
 Crates that seem feature complete and need to see some more use before they can be released as 1.0.
 
 * [git-mailmap](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-mailmap)
+* [git-chunk](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-chunk)
 
 ### Initial Development
 * **usable**
   * [git-actor](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-actor)
   * [git-hash](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-hash)
-  * [git-chunk](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-chunk)
   * [git-object](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-object)
   * [git-validate](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-validate)
   * [git-url](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-url)
+  * [git-glob](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-glob)
   * [git-packetline](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-packetline)
   * [git-transport](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-transport)
   * [git-protocol](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-protocol)
@@ -119,7 +120,6 @@ Crates that seem feature complete and need to see some more use before they can 
   * [git-revision](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-revision)
   * [git-attributes](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-attributes)
   * [git-quote](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-quote)
-  * [git-glob](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-glob)
 * **idea**
   * [git-note](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-note)
   * [git-pathspec](https://github.com/Byron/gitoxide/blob/main/crate-status.md#git-pathspec)

--- a/crate-status.md
+++ b/crate-status.md
@@ -8,8 +8,8 @@
     * [ ] Some examples
 
 ### git-chunk
-* [ ] decode the chunk file table of contents and provide convenient API
-* [ ] write the table of contents
+* [x] decode the chunk file table of contents and provide convenient API
+* [x] write the table of contents
 
 ### git-object
 * *decode (zero-copy)* borrowed objects
@@ -232,8 +232,8 @@ A mechanism to associate metadata with any object, and keep revisions of it usin
 * [ ] CRUD for git notes
 
 ### git-glob
-* [ ] parse pattern
-* [ ] a type for pattern matching
+* [x] parse pattern
+* [x] a type for pattern matching of paths and non-paths, optionally case-insensitively.
 
 ### git-worktree
 * handle the working tree/checkout

--- a/git-glob/src/pattern.rs
+++ b/git-glob/src/pattern.rs
@@ -28,6 +28,7 @@ bitflags! {
 /// Describes whether to match a path case sensitively or not.
 ///
 /// Used in [Pattern::matches_repo_relative_path()].
+#[derive(Debug, PartialOrd, PartialEq, Copy, Clone, Hash, Ord, Eq)]
 pub enum Case {
     /// The case affects the match
     Sensitive,
@@ -84,7 +85,7 @@ impl Pattern {
             return false;
         }
 
-        let flags = wildmatch::Mode::SLASH_IS_LITERAL
+        let flags = wildmatch::Mode::NO_MATCH_SLASH_LITERAL
             | match case {
                 Case::Fold => wildmatch::Mode::IGNORE_CASE,
                 Case::Sensitive => wildmatch::Mode::empty(),

--- a/git-glob/tests/fixtures/make_baseline.sh
+++ b/git-glob/tests/fixtures/make_baseline.sh
@@ -155,17 +155,3 @@ aBcDeFg  abcdefg
 aBcDeFg  ABCDEFG
 aBcDeFg  AbCdEfG
 EOF
-
-# nmatches OS specific
-# unix
-#    "abc\\def" "abc/def"
-
-
-# windows only
-# abc[/]def "abc/def"
-# abc\def  "abc/def"
-
-# empty string is not a valid path-spec
-#** " "
-#{} " "
-#{,} " "

--- a/git-glob/tests/fixtures/make_baseline.sh
+++ b/git-glob/tests/fixtures/make_baseline.sh
@@ -7,11 +7,11 @@ git config commit.gpgsign false
 git config core.autocrlf false
 git config core.ignorecase false
 
-while read -r pattern nomatch; do
-  echo "$pattern" "$nomatch"
+while read -r pattern value; do
+  echo "$pattern" "$value"
   echo "$pattern" > .gitignore
-  git check-ignore -vn "$nomatch" 2>&1 || :
-done <<EOF >>git-baseline.nmatch
+  echo "$value" | git check-ignore -vn --stdin 2>&1 || :
+done <<EOF >git-baseline.nmatch
 */\ XXX/\
 */\\ XXX/\
 /*foo bar/foo
@@ -68,11 +68,15 @@ foo/** foo
 abc[/]def abc/def
 EOF
 
-while read -r pattern match; do
-  echo "$pattern" "$match"
+while read -r pattern value; do
+  echo "$pattern" "$value"
   echo "$pattern" > .gitignore
-  git check-ignore -vn "$match" 2>&1 || :
-done <<EOF >>git-baseline.match
+  echo "$value" | git check-ignore -vn --stdin 2>&1 || :
+done <<EOF >git-baseline.match
+\a  a
+\\\[a-z] \a
+\\\? \a
+\\\* \\
 /*foo.txt barfoo.txt
 *foo.txt bar/foo.txt
 *.c mozilla-sha1/sha1.c
@@ -141,11 +145,11 @@ abc/def abc/def
 EOF
 
 git config core.ignorecase true
-while read -r pattern match; do
-  echo "$pattern" "$match"
+while read -r pattern value; do
+  echo "$pattern" "$value"
   echo "$pattern" > .gitignore
-  git check-ignore -vn "$match" 2>&1 || :
-done <<EOF >>git-baseline.match-icase
+  echo "$value" | git check-ignore -vn --stdin 2>&1 || :
+done <<EOF >git-baseline.match-icase
 aBcDeFg  aBcDeFg
 aBcDeFg  abcdefg
 aBcDeFg  ABCDEFG
@@ -153,26 +157,13 @@ aBcDeFg  AbCdEfG
 EOF
 
 # nmatches OS specific
-# windows
-#    "abc?def" "abc\\def"
 # unix
 #    "abc\\def" "abc/def"
 
 
-# matches OS specific
-
-# unix only
-# "\\a"  "a"
-#"abc\\def"  "abc/def"
-#"abc?def"  "abc/def"
-# \[a-z] \a
-# \? \a
-# \* \\
-
 # windows only
-# "abc[/]def" "abc/def"
-# "abc\\def"  "abc/def"
-#"abc?def"  "abc\\def"
+# abc[/]def "abc/def"
+# abc\def  "abc/def"
 
 # empty string is not a valid path-spec
 #** " "

--- a/git-glob/tests/matching/mod.rs
+++ b/git-glob/tests/matching/mod.rs
@@ -46,22 +46,13 @@ fn compare_baseline_with_ours() {
     let dir = git_testtools::scripted_fixture_repo_read_only("make_baseline.sh").unwrap();
     let (mut total_matches, mut total_correct, mut panics) = (0, 0, 0);
     let mut mismatches = Vec::new();
-    for (input_file, mut expected_matches, case, invert_expectation_on_other_os) in &[
-        ("git-baseline.match", true, pattern::Case::Sensitive, false),
-        ("git-baseline.nmatch", false, pattern::Case::Sensitive, false),
-        ("git-baseline.match-icase", true, pattern::Case::Fold, false),
-        // (
-        //     "git-baseline-unix.match",
-        //     true,
-        //     pattern::Case::Sensitive,
-        //     if cfg!(unix) { false } else { true },
-        // ),
+    for (input_file, expected_matches, case) in &[
+        ("git-baseline.match", true, pattern::Case::Sensitive),
+        ("git-baseline.nmatch", false, pattern::Case::Sensitive),
+        ("git-baseline.match-icase", true, pattern::Case::Fold),
     ] {
         let input = std::fs::read(dir.join(*input_file)).unwrap();
         let mut seen = BTreeSet::default();
-        if *invert_expectation_on_other_os {
-            expected_matches = !expected_matches;
-        }
 
         for m @ GitMatch {
             pattern,
@@ -72,7 +63,7 @@ fn compare_baseline_with_ours() {
             total_matches += 1;
             assert!(seen.insert(m), "duplicate match entry: {:?}", m);
             assert_eq!(
-                is_match, expected_matches,
+                is_match, *expected_matches,
                 "baseline for matches must be {} - check baseline and git version: {:?}",
                 expected_matches, m
             );

--- a/git-glob/tests/matching/mod.rs
+++ b/git-glob/tests/matching/mod.rs
@@ -46,9 +46,22 @@ fn compare_baseline_with_ours() {
     let dir = git_testtools::scripted_fixture_repo_read_only("make_baseline.sh").unwrap();
     let (mut total_matches, mut total_correct, mut panics) = (0, 0, 0);
     let mut mismatches = Vec::new();
-    for (input_file, expected_matches) in &[("git-baseline.match", true), ("git-baseline.nmatch", false)] {
+    for (input_file, mut expected_matches, case, invert_expectation_on_other_os) in &[
+        ("git-baseline.match", true, pattern::Case::Sensitive, false),
+        ("git-baseline.nmatch", false, pattern::Case::Sensitive, false),
+        ("git-baseline.match-icase", true, pattern::Case::Fold, false),
+        // (
+        //     "git-baseline-unix.match",
+        //     true,
+        //     pattern::Case::Sensitive,
+        //     if cfg!(unix) { false } else { true },
+        // ),
+    ] {
         let input = std::fs::read(dir.join(*input_file)).unwrap();
         let mut seen = BTreeSet::default();
+        if *invert_expectation_on_other_os {
+            expected_matches = !expected_matches;
+        }
 
         for m @ GitMatch {
             pattern,
@@ -58,13 +71,18 @@ fn compare_baseline_with_ours() {
         {
             total_matches += 1;
             assert!(seen.insert(m), "duplicate match entry: {:?}", m);
+            assert_eq!(
+                is_match, expected_matches,
+                "baseline for matches must be {} - check baseline and git version: {:?}",
+                expected_matches, m
+            );
             match std::panic::catch_unwind(|| {
                 let pattern = pat(pattern);
                 pattern.matches_repo_relative_path(
                     value,
                     basename_start_pos(value),
                     false, // TODO: does it make sense to pretend it is a dir and see what happens?
-                    pattern::Case::Sensitive,
+                    *case,
                 )
             }) {
                 Ok(actual_match) => {


### PR DESCRIPTION
On windows patterns seem to handle backslashes differently. Figure out where that happens and make sure we can reproduce it.

Bring in OS-specific tests as well which are still disabled in the baseline test.

### Tasks

* ~~add OS specific tests to `git-glob`~~
* [x] cleanup