### PR TITLE
ci-speedups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,33 +9,25 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: Swatinem/rust-cache@v1
-    - name: Setup dependencies (ubuntu)
-      if: startsWith(matrix.os, 'ubuntu')
+    - name: Setup dependencies
       run:
         sudo apt-get install tree
-    - name: Setup dependencies (macos)
-      if: startsWith(matrix.os, 'macos')
-      run:
-        brew install tree openssl
-    - run: git lfs fetch && git lfs checkout
-      if: startsWith(matrix.os, 'macos')
     - name: test
       env:
         CI: true
       run: make tests
 
-  build-and-test-on-windows:
-    name: Windows
-    runs-on: windows-2019
+  test-fast:
+    strategy:
+      matrix:
+        os:
+          - windows-2019
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -44,7 +36,12 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - name: "Check default features build on windows"
+      - name: Setup dependencies (macos)
+        if: startsWith(matrix.os, 'macos')
+        run:
+          brew install tree openssl
+      - name: "Check default features build"
+        if: startsWith(matrix.os, 'windows')
         uses: actions-rs/cargo@v1
         with:
           command: check
@@ -58,6 +55,7 @@ jobs:
         run: cargo nextest run --all
       - name: "Install prerequisites"
         run: vcpkg install  zlib:x64-windows-static-md
+        if: startsWith(matrix.os, 'windows')
       - name: "Installation from crates.io"
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,12 @@ jobs:
           command: check
           args: --all --bins --tests --examples
       - run: git lfs fetch && git lfs checkout
-      - name: "Test (crossterm)"
-        uses: actions-rs/cargo@v1
+      - uses: taiki-e/install-action@v1
         with:
-          command: test
-          args: --all
+          tool: nextest
+          version: 0.9
+      - name: "Test (nextest)"
+        run: cargo nextest run --all
       - name: "Install prerequisites"
         run: vcpkg install  zlib:x64-windows-static-md
       - name: "Installation from crates.io"


### PR DESCRIPTION
Try to use nextest for windows and possibly on Mac as well.

That way, overall runtime should go down to 20 minutes, which is the time it takes linux to run (sometimes it's 17min even).

Currently MacOS takes 30 minutes due to slow builds, but it's questionable whether it adds anything as it's basically unix.