### PR TITLE
git-repository: `describe` does not return more recent tag, in case of duplicate tags

### DIFF
--- a/git-object/src/commit/ref_iter.rs
+++ b/git-object/src/commit/ref_iter.rs
@@ -77,7 +77,6 @@ impl<'a> CommitRefIter<'a> {
     }
 
     /// Returns the committer signature if there is no decoding error.
-    /// Errors are coerced into options, hiding whether there was an error or not. The caller knows if there was an error or not.
     pub fn committer(mut self) -> Result<git_actor::SignatureRef<'a>, crate::decode::Error> {
         self.find_map(|t| match t {
             Ok(Token::Committer { signature }) => Some(Ok(signature)),
@@ -90,7 +89,6 @@ impl<'a> CommitRefIter<'a> {
     /// Returns the author signature if there is no decoding error.
     ///
     /// It may contain white space surrounding it, and is exactly as parsed.
-    /// Errors are coerced into options, hiding whether there was an error or not. The caller knows if there was an error or not.
     pub fn author(mut self) -> Result<git_actor::SignatureRef<'a>, crate::decode::Error> {
         self.find_map(|t| match t {
             Ok(Token::Author { signature }) => Some(Ok(signature)),
@@ -104,7 +102,6 @@ impl<'a> CommitRefIter<'a> {
     ///
     /// It may contain white space surrounding it, and is exactly as
     //  parsed.
-    /// Errors are coerced into options, hiding whether there was an error or not. The caller knows if there was an error or not.
     pub fn message(mut self) -> Result<&'a BStr, crate::decode::Error> {
         self.find_map(|t| match t {
             Ok(Token::Message(msg)) => Some(Ok(msg)),

--- a/git-object/src/lib.rs
+++ b/git-object/src/lib.rs
@@ -148,6 +148,7 @@ pub struct TagRef<'a> {
 
 /// Like [`TagRef`], but as `Iterator` to support entirely allocation free parsing.
 /// It's particularly useful to dereference only the target chain.
+#[derive(Copy, Clone)]
 pub struct TagRefIter<'a> {
     data: &'a [u8],
     state: tag::ref_iter::State,

--- a/git-object/tests/immutable/tag.rs
+++ b/git-object/tests/immutable/tag.rs
@@ -26,17 +26,21 @@ mod iter {
 
     #[test]
     fn empty() -> crate::Result {
+        let tag = fixture_bytes("tag", "empty.txt");
+        let tag_iter = TagRefIter::from_bytes(&tag);
+        let target_id = hex_to_id("01dd4e2a978a9f5bd773dae6da7aa4a5ac1cdbbc");
+        let tagger = Some(signature(1592381636));
         assert_eq!(
-            TagRefIter::from_bytes(&fixture_bytes("tag", "empty.txt")).collect::<Result<Vec<_>, _>>()?,
+            tag_iter.collect::<Result<Vec<_>, _>>()?,
             vec![
-                Token::Target {
-                    id: hex_to_id("01dd4e2a978a9f5bd773dae6da7aa4a5ac1cdbbc")
-                },
+                Token::Target { id: target_id },
                 Token::TargetKind(Kind::Commit),
                 Token::Name(b"empty".as_bstr()),
-                Token::Tagger(Some(signature(1592381636))),
+                Token::Tagger(tagger),
             ]
         );
+        assert_eq!(tag_iter.target_id()?, target_id);
+        assert_eq!(tag_iter.tagger()?, tagger);
         Ok(())
     }
 

--- a/git-repository/src/commit.rs
+++ b/git-repository/src/commit.rs
@@ -55,6 +55,7 @@ pub mod describe {
     }
 
     /// A selector to choose what kind of references should contribute to names.
+    #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, Hash)]
     pub enum SelectRef {
         /// Only use annotated tags for names.
         AnnotatedTags,
@@ -160,7 +161,7 @@ pub mod describe {
         /// if one was found.
         ///
         /// Note that there will always be `Some(format)`
-        pub fn try_format(self) -> Result<Option<git_revision::describe::Format<'static>>, Error> {
+        pub fn try_format(&self) -> Result<Option<git_revision::describe::Format<'static>>, Error> {
             self.try_resolve()?.map(|r| r.format()).transpose()
         }
 
@@ -168,7 +169,7 @@ pub mod describe {
         /// if one was found.
         ///
         /// The outcome provides additional information, but leaves the caller with the burden
-        pub fn try_resolve(self) -> Result<Option<crate::commit::describe::Resolution<'repo>>, Error> {
+        pub fn try_resolve(&self) -> Result<Option<crate::commit::describe::Resolution<'repo>>, Error> {
             // TODO: dirty suffix with respective dirty-detection
             let outcome = git_revision::describe(
                 &self.id,
@@ -194,7 +195,7 @@ pub mod describe {
         }
 
         /// Like [`try_format()`][Platform::try_format()], but turns `id_as_fallback()` on to always produce a format.
-        pub fn format(mut self) -> Result<git_revision::describe::Format<'static>, Error> {
+        pub fn format(&mut self) -> Result<git_revision::describe::Format<'static>, Error> {
             self.id_as_fallback = true;
             Ok(self.try_format()?.expect("BUG: fallback must always produce a format"))
         }

--- a/git-repository/src/object/tag.rs
+++ b/git-repository/src/object/tag.rs
@@ -1,10 +1,15 @@
 use crate::{ext::ObjectIdExt, Tag};
 
 impl<'repo> Tag<'repo> {
-    /// Decode this tag and return the id of its target.
+    /// Decode this tag partially and return the id of its target.
     pub fn target_id(&self) -> Result<crate::Id<'repo>, git_object::decode::Error> {
         git_object::TagRefIter::from_bytes(&self.data)
             .target_id()
             .map(|id| id.attach(self.repo))
+    }
+
+    /// Decode this tag partially and return the tagger, if the field exists.
+    pub fn tagger(&self) -> Result<Option<git_actor::SignatureRef<'_>>, git_object::decode::Error> {
+        git_object::TagRefIter::from_bytes(&self.data).tagger()
     }
 }

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -1,14 +1,15 @@
 mod describe {
     use crate::named_repo;
+    use git_repository::commit::describe::SelectRef::AnnotatedTags;
 
     #[test]
-    #[ignore]
     fn tags_are_sorted_by_date_and_lexigraphically() {
         let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
         assert_eq!(
             repo.head_commit()
                 .unwrap()
                 .describe()
+                .names(AnnotatedTags)
                 .format()
                 .unwrap()
                 .name

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -3,15 +3,12 @@ mod describe {
     use git_repository::commit::describe::SelectRef::{AllRefs, AllTags, AnnotatedTags};
 
     #[test]
-    #[ignore]
     fn tags_are_sorted_by_date_and_lexigraphically() {
         let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
         let mut describe = repo.head_commit().unwrap().describe();
         for filter in &[AnnotatedTags, AllTags, AllRefs] {
             describe = describe.names(*filter);
-            assert_eq!(describe.format().unwrap().to_string(), "v1", "{:?}", filter);
+            assert_eq!(describe.format().unwrap().to_string(), "v2", "{:?}", filter);
         }
-        let mut describe = describe.names(AllRefs);
-        assert_eq!(describe.format().unwrap().to_string(), "v1");
     }
 }

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -1,21 +1,17 @@
 mod describe {
     use crate::named_repo;
-    use git_repository::commit::describe::SelectRef::AnnotatedTags;
+    use git_repository::commit::describe::SelectRef::{AllRefs, AllTags, AnnotatedTags};
 
     #[test]
+    #[ignore]
     fn tags_are_sorted_by_date_and_lexigraphically() {
         let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
-        assert_eq!(
-            repo.head_commit()
-                .unwrap()
-                .describe()
-                .names(AnnotatedTags)
-                .format()
-                .unwrap()
-                .name
-                .expect("name set")
-                .as_ref(),
-            "v1"
-        );
+        let mut describe = repo.head_commit().unwrap().describe();
+        for filter in &[AnnotatedTags, AllTags, AllRefs] {
+            describe = describe.names(*filter);
+            assert_eq!(describe.format().unwrap().to_string(), "v1", "{:?}", filter);
+        }
+        let mut describe = describe.names(AllRefs);
+        assert_eq!(describe.format().unwrap().to_string(), "v1");
     }
 }

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -1,0 +1,20 @@
+mod describe {
+    use crate::named_repo;
+
+    #[test]
+    #[ignore]
+    fn tags_are_sorted_by_date_and_lexigraphically() {
+        let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
+        assert_eq!(
+            repo.head_commit()
+                .unwrap()
+                .describe()
+                .format()
+                .unwrap()
+                .name
+                .expect("name set")
+                .as_ref(),
+            "v1"
+        );
+    }
+}

--- a/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
+++ b/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28fb09e31eca8d5c43d5b93918691ef3cc9007d97edb73ef803e505353f3ed46
-size 10396
+oid sha256:22fd60100187fc3f4180b31d3ae1d8c5506a65c3ee059b4bbc3a40009fb23f60
+size 10408

--- a/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
+++ b/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28fb09e31eca8d5c43d5b93918691ef3cc9007d97edb73ef803e505353f3ed46
+size 10396

--- a/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
+++ b/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
@@ -7,4 +7,5 @@ git commit --allow-empty -q -m c2
 
 git tag v0 -m "tag object 0" "HEAD~1"
 git tag v1 -m "tag object 1"
+git tag v1.5
 GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v2 -m "tag object 2"

--- a/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
+++ b/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu -o pipefail
+
+git init -q
+git commit --allow-empty -q -m c1
+git commit --allow-empty -q -m c2
+
+git tag v0 -m "tag object 0" "HEAD~1"
+git tag v1 -m "tag object 1"
+GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v2 -m "tag object 2"

--- a/git-repository/tests/git.rs
+++ b/git-repository/tests/git.rs
@@ -28,6 +28,7 @@ fn basic_rw_repo() -> crate::Result<(Repository, tempfile::TempDir)> {
     repo_rw("make_basic_repo.sh")
 }
 
+mod commit;
 mod discover;
 mod id;
 mod init;


### PR DESCRIPTION
If a commit has multiple tags, `describe` should return the most recent one.

Commands to reproduce:
```
❯ git tag v2 -m "Testing tags v2"
❯ git tag v0 -m "Testing tags v0" "HEAD~1"
❯ git tag v1 -m "Testing tags v1"
❯ git describe
v1
❯ gix repository commit describe
v2
```