### PR TITLE
feat: Implement `TryFrom<&str>` for `Prefix`

### DIFF
--- a/git-hash/src/owned.rs
+++ b/git-hash/src/owned.rs
@@ -4,7 +4,7 @@ use crate::{borrowed::oid, Kind, SIZE_OF_SHA1_DIGEST};
 
 /// An partial owned hash possibly identifying an object uniquely,
 /// whose non-prefix bytes are zeroed.
-#[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Prefix {
     bytes: ObjectId,

--- a/git-hash/tests/oid/mod.rs
+++ b/git-hash/tests/oid/mod.rs
@@ -70,6 +70,57 @@ mod prefix {
             ));
         }
     }
+
+    mod try_from {
+        use std::{cmp::Ordering, convert::TryFrom};
+
+        use git_hash::prefix::HexError;
+        use git_hash::Prefix;
+        use git_testtools::hex_to_id;
+
+        #[test]
+        fn id_8_chars() {
+            let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+            let input = "abcdef";
+
+            let expected = hex_to_id(oid_hex);
+            let actual = Prefix::try_from(input).expect("No errors");
+            assert_eq!(actual.cmp_oid(&expected), Ordering::Equal);
+        }
+
+        #[test]
+        fn id_9_chars() {
+            let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+            let input = "abcdefa";
+
+            let expected = hex_to_id(oid_hex);
+            let actual = Prefix::try_from(input).expect("No errors");
+            assert_eq!(actual.cmp_oid(&expected), Ordering::Equal);
+        }
+        #[test]
+        fn id_to_short() {
+            let input = "ab";
+            let expected = HexError::TooShort { hex_len: 2 };
+            let actual = Prefix::try_from(input).unwrap_err();
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn id_to_long() {
+            let input = "abcdefabcdefabcdefabcdefabcdefabcdefabcd123123123123123123";
+            let expected = HexError::TooLong { hex_len: 58 };
+            let actual = Prefix::try_from(input).unwrap_err();
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn invalid_chars() {
+            let input = "abcdfOsd";
+            let expected = HexError::Invalid { c: 'O', index: 5 };
+            let actual = Prefix::try_from(input).unwrap_err();
+            assert_eq!(actual, expected);
+        }
+    }
 }
 
 mod short_hex {


### PR DESCRIPTION
Currently there is no easy way to create a `struct Prefix` from a hex string. The method `Parser::from_hex()` is NIY.

`Parser::from_hex()` has the wrong API. It currently is defined to return `Self`, while the proper way would be to return `Result<Self, Error>`. I think the cleaner way would be to implement `std:;convert::TryFrom` for `Prefix`.
