### PR TITLE
git-repository: allow reading information about remote branch

### DIFF
--- a/cargo-smart-release/src/git/mod.rs
+++ b/cargo-smart-release/src/git/mod.rs
@@ -117,10 +117,10 @@ pub fn author() -> anyhow::Result<git_repository::actor::Signature> {
     .to_owned())
 }
 
-pub fn strip_tag_path(name: FullNameRef<'_>) -> &BStr {
+pub fn strip_tag_path(name: &FullNameRef) -> &BStr {
     try_strip_tag_path(name).expect("prefix iteration works")
 }
 
-pub fn try_strip_tag_path(name: FullNameRef<'_>) -> Option<&BStr> {
+pub fn try_strip_tag_path(name: &FullNameRef) -> Option<&BStr> {
     name.as_bstr().strip_prefix(b"refs/tags/").map(|b| b.as_bstr())
 }

--- a/git-ref/src/fullname.rs
+++ b/git-ref/src/fullname.rs
@@ -3,7 +3,7 @@ use std::{convert::TryFrom, path::Path};
 
 use git_object::bstr::{BStr, BString, ByteSlice};
 
-use crate::{bstr::ByteVec, FullName, FullNameRef, FullNameRef2, Namespace};
+use crate::{bstr::ByteVec, FullName, FullNameRef, Namespace};
 
 impl TryFrom<&str> for FullName {
     type Error = git_validate::refname::Error;
@@ -45,14 +45,14 @@ impl From<FullName> for BString {
     }
 }
 
-impl<'a> From<FullNameRef<'a>> for &'a BStr {
-    fn from(name: FullNameRef<'a>) -> Self {
-        name.0
+impl<'a> From<&'a FullNameRef> for &'a BStr {
+    fn from(name: &'a FullNameRef) -> Self {
+        &name.0
     }
 }
 
-impl<'a> From<crate::FullNameRef<'a>> for FullName {
-    fn from(value: crate::FullNameRef<'a>) -> Self {
+impl<'a> From<&'a FullNameRef> for FullName {
+    fn from(value: &'a FullNameRef) -> Self {
         FullName(value.as_bstr().into())
     }
 }
@@ -70,8 +70,8 @@ impl FullName {
     }
 
     /// Interpret this fully qualified reference as shared full name
-    pub fn to_ref(&self) -> crate::FullNameRef<'_> {
-        crate::FullNameRef(self.0.as_bstr())
+    pub fn to_ref(&self) -> &FullNameRef {
+        self.borrow()
     }
 
     /// Convert this name into the relative path, lossily, identifying the reference location relative to a repository
@@ -126,7 +126,7 @@ impl FullName {
     }
 }
 
-impl<'a> FullNameRef<'a> {
+impl FullNameRef {
     /// Create an owned copy of ourself
     pub fn to_owned(&self) -> FullName {
         FullName(self.0.to_owned())
@@ -139,18 +139,20 @@ impl<'a> FullNameRef<'a> {
     }
 }
 
-impl Borrow<FullNameRef2> for FullName {
+impl Borrow<FullNameRef> for FullName {
     #[inline]
-    fn borrow(&self) -> &FullNameRef2 {
-        // SAFETY: FullNameRef2 is transparent and equivalent to a &BStr if provided as reference
-        #[allow(unsafe_code)]
-        unsafe {
-            std::mem::transmute(self.0.as_bstr())
-        }
+    fn borrow(&self) -> &FullNameRef {
+        FullNameRef::new_unchecked(self.0.as_bstr())
     }
 }
 
-impl ToOwned for FullNameRef2 {
+impl AsRef<FullNameRef> for FullName {
+    fn as_ref(&self) -> &FullNameRef {
+        self.borrow()
+    }
+}
+
+impl ToOwned for FullNameRef {
     type Owned = FullName;
 
     fn to_owned(&self) -> Self::Owned {
@@ -165,6 +167,6 @@ mod fullname_tests {
 
     #[test]
     fn cow_works() {
-        let _x: Cow<'_, FullNameRef2> = Cow::Owned(FullName::try_from("HEAD").unwrap());
+        let _x: Cow<'_, FullNameRef> = Cow::Owned(FullName::try_from("HEAD").unwrap());
     }
 }

--- a/git-ref/src/lib.rs
+++ b/git-ref/src/lib.rs
@@ -96,13 +96,9 @@ pub struct Store {
 pub struct FullName(pub(crate) BString);
 
 /// A validated and potentially partial reference name - it can safely be used for common operations.
-#[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-pub struct FullNameRef<'a>(&'a BStr);
-
-/// A validated and potentially partial reference name - it can safely be used for common operations.
-#[derive(Hash)]
+#[derive(Hash, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[repr(transparent)]
-pub struct FullNameRef2(BStr);
+pub struct FullNameRef(BStr);
 
 /// A validated complete and fully qualified reference name, safe to use for all operations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
@@ -157,5 +153,5 @@ pub enum TargetRef<'a> {
     /// A ref that points to an object id
     Peeled(&'a oid),
     /// A ref that points to another reference by its validated name, adding a level of indirection.
-    Symbolic(FullNameRef<'a>),
+    Symbolic(&'a FullNameRef),
 }

--- a/git-ref/src/lib.rs
+++ b/git-ref/src/lib.rs
@@ -98,6 +98,12 @@ pub struct FullName(pub(crate) BString);
 /// A validated and potentially partial reference name - it can safely be used for common operations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 pub struct FullNameRef<'a>(&'a BStr);
+
+/// A validated and potentially partial reference name - it can safely be used for common operations.
+#[derive(Hash)]
+#[repr(transparent)]
+pub struct FullNameRef2(BStr);
+
 /// A validated complete and fully qualified reference name, safe to use for all operations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 pub struct PartialNameRef<'a>(Cow<'a, BStr>);

--- a/git-ref/src/raw.rs
+++ b/git-ref/src/raw.rs
@@ -68,12 +68,12 @@ mod access {
         /// Return the full validated name of the reference, with the given namespace stripped if possible.
         ///
         /// If the reference name wasn't prefixed with `namespace`, `None` is returned instead.
-        pub fn name_without_namespace(&self, namespace: &Namespace) -> Option<FullNameRef<'_>> {
+        pub fn name_without_namespace(&self, namespace: &Namespace) -> Option<&FullNameRef> {
             self.name
                 .0
                 .as_bstr()
                 .strip_prefix(namespace.0.as_bstr().as_ref())
-                .map(|stripped| FullNameRef(stripped.as_bstr()))
+                .map(|stripped| FullNameRef::new_unchecked(stripped.as_bstr()))
         }
 
         /// Strip the given namespace from our name as well as the name, but not the reference we point to.

--- a/git-ref/src/store/file/log/iter.rs
+++ b/git-ref/src/store/file/log/iter.rs
@@ -83,7 +83,7 @@ pub struct Platform<'a, 's> {
     /// The store containing the reflogs
     pub store: &'s file::Store,
     /// The full name of the reference whose reflog to retrieve.
-    pub name: FullNameRef<'a>,
+    pub name: &'a FullNameRef,
     /// A reusable buffer for storing log lines read from disk.
     pub buf: Vec<u8>,
 }

--- a/git-ref/src/store/file/loose/reflog.rs
+++ b/git-ref/src/store/file/loose/reflog.rs
@@ -13,7 +13,7 @@ impl file::Store {
     /// If the caller needs to know if it's readable, try to read the log instead with a reverse or forward iterator.
     pub fn reflog_exists<'a, Name, E>(&self, name: Name) -> Result<bool, E>
     where
-        Name: TryInto<FullNameRef<'a>, Error = E>,
+        Name: TryInto<&'a FullNameRef, Error = E>,
         crate::name::Error: From<E>,
     {
         Ok(self.reflog_path(name.try_into()?).is_file())
@@ -29,10 +29,10 @@ impl file::Store {
         buf: &'b mut [u8],
     ) -> Result<Option<log::iter::Reverse<'b, std::fs::File>>, Error>
     where
-        Name: TryInto<FullNameRef<'a>, Error = E>,
+        Name: TryInto<&'a FullNameRef, Error = E>,
         crate::name::Error: From<E>,
     {
-        let name: FullNameRef<'_> = name.try_into().map_err(|err| Error::RefnameValidation(err.into()))?;
+        let name: &FullNameRef = name.try_into().map_err(|err| Error::RefnameValidation(err.into()))?;
         let path = self.reflog_path(name);
         if path.is_dir() {
             return Ok(None);
@@ -54,10 +54,10 @@ impl file::Store {
         buf: &'b mut Vec<u8>,
     ) -> Result<Option<log::iter::Forward<'b>>, Error>
     where
-        Name: TryInto<FullNameRef<'a>, Error = E>,
+        Name: TryInto<&'a FullNameRef, Error = E>,
         crate::name::Error: From<E>,
     {
-        let name: FullNameRef<'_> = name.try_into().map_err(|err| Error::RefnameValidation(err.into()))?;
+        let name: &FullNameRef = name.try_into().map_err(|err| Error::RefnameValidation(err.into()))?;
         let path = self.reflog_path(name);
         match std::fs::File::open(&path) {
             Ok(mut file) => {
@@ -77,7 +77,7 @@ impl file::Store {
 
 impl file::Store {
     /// Implements the logic required to transform a fully qualified refname into its log name
-    pub(crate) fn reflog_path(&self, name: FullNameRef<'_>) -> PathBuf {
+    pub(crate) fn reflog_path(&self, name: &FullNameRef) -> PathBuf {
         self.reflog_path_inner(name.to_path())
     }
 }

--- a/git-ref/src/store/file/loose/reflog/create_or_update/tests.rs
+++ b/git-ref/src/store/file/loose/reflog/create_or_update/tests.rs
@@ -18,7 +18,7 @@ fn empty_store(writemode: WriteReflog) -> Result<(TempDir, file::Store)> {
 }
 
 fn reflock(store: &file::Store, full_name: &str) -> Result<git_lock::Marker> {
-    let full_name: FullNameRef<'_> = full_name.try_into()?;
+    let full_name: &FullNameRef = full_name.try_into()?;
     git_lock::Marker::acquire_to_hold_resource(
         store.reference_path(full_name.to_path()),
         Fail::Immediately,

--- a/git-ref/src/store/packed/decode.rs
+++ b/git-ref/src/store/packed/decode.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::convert::TryInto;
 
 use git_object::bstr::{BStr, ByteSlice};
 use nom::{
@@ -73,7 +73,7 @@ pub fn reference<'a, E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], crate
 ) -> IResult<&'a [u8], packed::Reference<'a>, E> {
     let (input, (target, name)) = tuple((
         terminated(hex_hash, tag(b" ")),
-        map_res(until_newline, crate::FullNameRef::try_from),
+        map_res(until_newline, TryInto::try_into),
     ))(input)?;
     let (rest, object) = opt(delimited(tag(b"^"), hex_hash, newline))(input)?;
     Ok((rest, packed::Reference { name, target, object }))

--- a/git-ref/src/store/packed/decode/tests.rs
+++ b/git-ref/src/store/packed/decode/tests.rs
@@ -28,7 +28,7 @@ mod reference {
         assert_eq!(
             parsed,
             packed::Reference {
-                name: FullNameRef("refs/heads/alternates-after-packs-and-loose".into()),
+                name: FullNameRef::new_unchecked("refs/heads/alternates-after-packs-and-loose".into()),
                 target: "d53c4b0f91f1b29769c9430f2d1c0bcab1170c75".into(),
                 object: Some("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37".into())
             }
@@ -38,7 +38,10 @@ mod reference {
 
         let (input, parsed) = decode::reference::<VerboseError<_>>(input)?;
         assert!(input.is_empty(), "exhausted");
-        assert_eq!(parsed.name, FullNameRef("refs/heads/avoid-double-lookup".into()));
+        assert_eq!(
+            parsed.name,
+            FullNameRef::new_unchecked("refs/heads/avoid-double-lookup".into())
+        );
         assert_eq!(parsed.target, "eaae9c1bc723209d793eb93f5587fa2604d5cd92");
         assert!(parsed.object.is_none());
         Ok(())

--- a/git-ref/src/store/packed/mod.rs
+++ b/git-ref/src/store/packed/mod.rs
@@ -45,7 +45,7 @@ pub(crate) struct Transaction {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Reference<'a> {
     /// The validated full name of the reference.
-    pub name: FullNameRef<'a>,
+    pub name: &'a FullNameRef,
     /// The target object id of the reference, hex encoded.
     pub target: &'a BStr,
     /// The fully peeled object id, hex encoded, that the ref is ultimately pointing to

--- a/git-ref/tests/transaction/mod.rs
+++ b/git-ref/tests/transaction/mod.rs
@@ -107,7 +107,7 @@ mod refedit_ext {
         use crate::transaction::refedit_ext::MockStore;
 
         fn find<'a>(edits: &'a [RefEdit], name: &str) -> &'a RefEdit {
-            let name: FullNameRef = name.try_into().unwrap();
+            let name: &FullNameRef = name.try_into().unwrap();
             edits
                 .iter()
                 .find(|e| e.name.as_bstr() == name.as_bstr())

--- a/git-repository/src/config.rs
+++ b/git-repository/src/config.rs
@@ -19,8 +19,6 @@ pub enum Error {
 /// Utility type to keep pre-obtained configuration values.
 #[derive(Debug, Clone)]
 pub(crate) struct Cache {
-    // TODO: remove this once resolved is used without a feature dependency
-    #[cfg_attr(not(any(feature = "git-mailmap", feature = "git-index")), allow(dead_code))]
     pub resolved: crate::Config,
     /// The hex-length to assume when shortening object ids. If `None`, it should be computed based on the approximate object count.
     pub hex_len: Option<usize>,

--- a/git-repository/src/head.rs
+++ b/git-repository/src/head.rs
@@ -1,6 +1,7 @@
 //!
 use git_hash::ObjectId;
 use git_ref::FullNameRef;
+use std::convert::TryInto;
 
 use crate::{
     ext::{ObjectIdExt, ReferenceExt},
@@ -37,14 +38,13 @@ impl Kind {
 
 impl<'repo> Head<'repo> {
     /// Returns the name of this references, always `HEAD`.
-    pub fn name(&self) -> FullNameRef<'static> {
+    pub fn name(&self) -> &'static FullNameRef {
         // TODO: use a statically checked version of this when available.
-        use std::convert::TryFrom;
-        FullNameRef::try_from("HEAD").expect("HEAD is valid")
+        "HEAD".try_into().expect("HEAD is valid")
     }
 
     /// Returns the full reference name of this head if it is not detached, or `None` otherwise.
-    pub fn referent_name(&self) -> Option<FullNameRef<'_>> {
+    pub fn referent_name(&self) -> Option<&FullNameRef> {
         Some(match &self.kind {
             Kind::Symbolic(r) => r.name.to_ref(),
             Kind::Unborn(name) => name.to_ref(),
@@ -82,9 +82,7 @@ impl<'repo> Head<'repo> {
 }
 ///
 pub mod log {
-    use std::convert::TryFrom;
-
-    use git_ref::FullNameRef;
+    use std::convert::TryInto;
 
     use crate::Head;
 
@@ -93,7 +91,7 @@ pub mod log {
         pub fn log_iter(&self) -> git_ref::file::log::iter::Platform<'static, '_> {
             git_ref::file::log::iter::Platform {
                 store: &self.repo.refs,
-                name: FullNameRef::try_from("HEAD").expect("HEAD is always valid"),
+                name: "HEAD".try_into().expect("HEAD is always valid"),
                 buf: Vec::new(),
             }
         }

--- a/git-repository/src/reference/mod.rs
+++ b/git-repository/src/reference/mod.rs
@@ -24,7 +24,7 @@ impl<'repo> Reference<'repo> {
     }
 
     /// Return the reference's full name.
-    pub fn name(&self) -> git_ref::FullNameRef<'_> {
+    pub fn name(&self) -> &git_ref::FullNameRef {
         self.inner.name.to_ref()
     }
 

--- a/git-repository/src/repository/mod.rs
+++ b/git-repository/src/repository/mod.rs
@@ -61,3 +61,5 @@ mod reference;
 mod object;
 
 mod thread_safe;
+
+mod remote;

--- a/git-repository/src/repository/remote.rs
+++ b/git-repository/src/repository/remote.rs
@@ -1,0 +1,26 @@
+use std::borrow::Cow;
+use std::convert::TryInto;
+
+use crate::bstr::BStr;
+use git_ref::FullName;
+use git_validate::reference::name::Error as ValidateNameError;
+
+impl crate::Repository {
+    /// Returns a reference to the remote associated with the given branch name.
+    /// Returns `None` if the remote refernce was not found.
+    /// May return an error if the reference is invalid.
+    // TODO: Use `Cow<FullNameRef>` instead of `FullName`
+    pub fn remote_ref(&self, branch: &str) -> Option<Result<FullName, ValidateNameError>> {
+        self.config
+            .resolved
+            .string("branch", Some(branch), "merge")
+            .map(|v| v.into_owned().try_into())
+    }
+
+    /// Returns the name of the remote associated with the given branch name.
+    /// In some cases, the returned name will be an URL.
+    /// Returns `None` if the remote was not found.
+    pub fn branch_remote_name<'a>(&'a self, branch: &str) -> Option<Cow<'a, BStr>> {
+        self.config.resolved.string("branch", Some(branch), "remote")
+    }
+}

--- a/git-repository/tests/fixtures/generated-archives/make_remote_repo.tar.xz
+++ b/git-repository/tests/fixtures/generated-archives/make_remote_repo.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ab9d6d5371329ca17613dabc48fdd1a7642cc2f535c961513e4dd616b23a6cd
+size 10080

--- a/git-repository/tests/fixtures/make_remote_repo.sh
+++ b/git-repository/tests/fixtures/make_remote_repo.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu -o pipefail
+
+git init -q
+
+git checkout -b main
+
+touch f1
+git add f1
+git commit -q -m c1
+
+git remote add --fetch remote_repo .
+git branch --set-upstream-to remote_repo/main
+
+git config branch.broken.merge not_a_valid_merge_ref

--- a/git-repository/tests/reference/mod.rs
+++ b/git-repository/tests/reference/mod.rs
@@ -22,6 +22,7 @@ mod find {
     use std::convert::TryInto;
 
     use git_ref as refs;
+    use git_ref::FullNameRef;
     use git_testtools::hex_to_id;
 
     fn repo() -> crate::Result<git_repository::Repository> {
@@ -32,7 +33,8 @@ mod find {
     fn and_peel() -> crate::Result {
         let repo = repo()?;
         let mut packed_tag_ref = repo.try_find_reference("dt1")?.expect("tag to exist");
-        assert_eq!(packed_tag_ref.name(), "refs/tags/dt1".try_into()?);
+        let expected: &FullNameRef = "refs/tags/dt1".try_into()?;
+        assert_eq!(packed_tag_ref.name(), expected);
 
         assert_eq!(
             packed_tag_ref.inner.target,
@@ -50,13 +52,13 @@ mod find {
         );
 
         let mut symbolic_ref = repo.find_reference("multi-link-target1")?;
-        assert_eq!(symbolic_ref.name(), "refs/heads/multi-link-target1".try_into()?);
+
+        let expected: &FullNameRef = "refs/heads/multi-link-target1".try_into()?;
+        assert_eq!(symbolic_ref.name(), expected);
         assert_eq!(symbolic_ref.peel_to_id_in_place()?, the_commit);
-        assert_eq!(
-            symbolic_ref.name(),
-            "refs/remotes/origin/multi-link-target3".try_into()?,
-            "it follows symbolic refs, too"
-        );
+
+        let expected: &FullNameRef = "refs/remotes/origin/multi-link-target3".try_into()?;
+        assert_eq!(symbolic_ref.name(), expected, "it follows symbolic refs, too");
         assert_eq!(symbolic_ref.into_fully_peeled_id()?, the_commit, "idempotency");
         Ok(())
     }

--- a/git-repository/tests/repository/mod.rs
+++ b/git-repository/tests/repository/mod.rs
@@ -2,3 +2,5 @@ mod object;
 mod reference;
 mod state;
 mod worktree;
+
+mod remote;

--- a/git-repository/tests/repository/remote.rs
+++ b/git-repository/tests/repository/remote.rs
@@ -1,0 +1,24 @@
+use crate::{named_repo, Result};
+
+#[test]
+fn simple() -> Result {
+    let repo = named_repo("make_remote_repo.sh")?;
+
+    assert_eq!(
+        repo.remote_ref("main")
+            .expect("Remote Merge ref exists")
+            .expect("Remote Merge ref is valid")
+            .shorten(),
+        "main"
+    );
+    assert_eq!(
+        repo.branch_remote_name("main").expect("Remote name exists").as_ref(),
+        "remote_repo"
+    );
+
+    assert!(repo.remote_ref("broken").expect("Remote Merge ref exists").is_err());
+    assert!(repo.remote_ref("missing").is_none());
+    assert!(repo.branch_remote_name("broken").is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
I added two helper functions. For a given branch name, they return the remote target reference (this allows getting to the remote branch name) and the name of the associated remote.

`remote_ref` isn't zero-copy, because I couldn't make it return a `Cow<FullnameRef>`.