### PR TITLE
git-discover: add ceiling_dirs option to upwards discovery

### DIFF
--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -405,7 +405,7 @@ pub mod discover {
         /// for instantiations.
         pub fn discover_opts(
             directory: impl AsRef<Path>,
-            options: upwards::Options,
+            options: upwards::Options<'_>,
             trust_map: git_sec::trust::Mapping<crate::open::Options>,
         ) -> Result<Self, Error> {
             let (path, trust) = upwards_opts(directory, options)?;


### PR DESCRIPTION
This is useful for instance to avoid going into expensive network paths. I made the type `Cow` to make it easier to add something like `Options::from_env` in the future. I also intend to implement something to keep discovery on the same device in another PR, though if desired I could also add this here.