### PR TITLE
git-discover: add cross_fs option to upwards discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "defer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647605a6345d5e89c3950a36a638c56478af9b414c55c6f2477c73b115f9acde"
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1206,7 @@ name = "git-discover"
 version = "0.1.0"
 dependencies = [
  "bstr",
+ "defer",
  "git-hash",
  "git-path",
  "git-ref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
  "git-sec",
  "git-testtools",
  "is_ci",
+ "tempfile",
  "thiserror",
 ]
 

--- a/git-discover/Cargo.toml
+++ b/git-discover/Cargo.toml
@@ -25,3 +25,6 @@ thiserror = "1.0.26"
 [dev-dependencies]
 git-testtools = { path = "../tests/tools" }
 is_ci = "1.1.1"
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+tempfile = "3.2.0"

--- a/git-discover/Cargo.toml
+++ b/git-discover/Cargo.toml
@@ -27,4 +27,5 @@ git-testtools = { path = "../tests/tools" }
 is_ci = "1.1.1"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
+defer = "0.1.0"
 tempfile = "3.2.0"

--- a/git-discover/src/upwards.rs
+++ b/git-discover/src/upwards.rs
@@ -133,7 +133,13 @@ pub(crate) mod function {
 
             #[cfg(unix)]
             if current_height != 0 && !cross_fs {
-                let metadata = cursor.metadata().map_err(|_| Error::InaccessibleDirectory {
+                let metadata = if cursor.as_os_str().is_empty() {
+                    Path::new(".")
+                } else {
+                    cursor.as_ref()
+                }
+                .metadata()
+                .map_err(|_| Error::InaccessibleDirectory {
                     path: cursor.to_path_buf(),
                 })?;
 

--- a/git-discover/src/upwards.rs
+++ b/git-discover/src/upwards.rs
@@ -139,14 +139,12 @@ pub(crate) mod function {
                     cursor.as_ref()
                 }
                 .metadata()
-                .map_err(|_| Error::InaccessibleDirectory {
-                    path: cursor.to_path_buf(),
-                })?;
+                .map_err(|_| Error::InaccessibleDirectory { path: cursor.clone() })?;
 
                 if device_id(&metadata) != initial_device {
                     return Err(Error::NoGitRepositoryWithinFs {
                         path: dir.into_owned(),
-                        limit: cursor.to_path_buf(),
+                        limit: cursor.clone(),
                     });
                 }
             }


### PR DESCRIPTION
Related #421

Like `ceiling_dirs` this is helpful for avoiding expensive paths on networks etc. This features only supports Unix-like systems, but as far as I can tell, libgit2 doesn't support this on Windows either.
I've enabled this by default as IIRC libgit2 does this too, but this might count as a breaking change.

This change is somewhat difficult to test, but I've written a small test for macOS.