### PR TITLE
git-sec: adopt git-for-windows exception rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ name = "git-sec"
 version = "0.1.1"
 dependencies = [
  "bitflags",
+ "dirs",
  "libc",
  "serde",
  "tempfile",

--- a/git-discover/tests/upwards/mod.rs
+++ b/git-discover/tests/upwards/mod.rs
@@ -3,18 +3,7 @@ use std::path::PathBuf;
 use git_discover::repository::Kind;
 
 fn expected_trust() -> git_sec::Trust {
-    #[cfg(not(windows))]
-    {
-        git_sec::Trust::Full
-    }
-    #[cfg(windows)]
-    {
-        if is_ci::cached() {
-            git_sec::Trust::Reduced
-        } else {
-            git_sec::Trust::Full
-        }
-    }
+    git_sec::Trust::Full
 }
 
 mod ceiling_dirs;

--- a/git-sec/Cargo.toml
+++ b/git-sec/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { version = "1.0.26", optional = true }
 libc = "0.2.123"
 
 [target.'cfg(windows)'.dependencies]
+dirs = "4"
 windows = { version = "0.36.0", features = [ "alloc",
     "Win32_Foundation",
     "Win32_Security_Authorization",

--- a/git-sec/tests/identity/mod.rs
+++ b/git-sec/tests/identity/mod.rs
@@ -7,3 +7,11 @@ fn is_path_owned_by_current_user() -> crate::Result {
     assert!(git_sec::identity::is_path_owned_by_current_user(dir.path())?);
     Ok(())
 }
+
+#[test]
+#[cfg(windows)]
+fn windows_home() -> crate::Result {
+    let home = dirs::home_dir().expect("home dir is available");
+    assert!(git_sec::identity::is_path_owned_by_current_user(home)?);
+    Ok(())
+}


### PR DESCRIPTION
This PR implements the changes proposed in #424:

> Git-for-Windows has some exceptions for the ownership checks. The home directory is accepted unconditionally (which is owned by admin instead of the user), and admin-group-owned folders are accepted if the user is an admin (helpful in environments like Github-Actions).
>
> Git-for-Windows references:
> https://github.com/git-for-windows/git/blob/0cd1496fc3dd78dadbdf3644ec4d384188573e6f/compat/mingw.c#L3503-L3515
> 
> https://github.com/git-for-windows/git/blob/0cd1496fc3dd78dadbdf3644ec4d384188573e6f/compat/mingw.c#L3535-L3543


I couldn't make `CheckTokenMembership` work with the token/handle already being opened, so I instead I made it forward a null value to have the Windows API handle the details. As part of that attempt, I also made the code prefer using a thread token instead of a process token, which seems to be preferred, and added a `CloseHandle` call for the old handle.