### PR TITLE
Add discovery opt env-overrides & env discovery helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ version = "0.1.3"
 dependencies = [
  "bstr",
  "defer",
+ "git-config",
  "git-hash",
  "git-path",
  "git-ref",

--- a/git-discover/Cargo.toml
+++ b/git-discover/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+git-config = { version = "^0.4.0", path = "../git-config" }
 git-sec = { version = "^0.1.2", path = "../git-sec", features = ["thiserror"] }
 git-path = { version = "^0.1.3", path = "../git-path" }
 git-ref = { version = "^0.13.0", path = "../git-ref" }
@@ -28,4 +29,6 @@ is_ci = "1.1.1"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 defer = "0.1.0"
+
+[target.'cfg(unix)'.dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
This PR adds a `upwards::Options::load_env_overrides`-function in git-discover to load environment overrides for the `ceiling_dirs` and `cross_fs` options. This required changing the `ceiling_dirs`-type to `Vec<_>`.

Furthermore, in `git-repository` add simple `discover_with_environment_overrides` and `discover_with_environment_overrides_opt`-helpers that both handle `GIT_DIR` and fallbacks to upwards discovery with `load_env_overrides`.

Only `parse_ceiling_dirs` in `load_env_overrides` are tested, because anything more would require either environment mocking or integrations tests, but I've tested the functionality.