### PR TITLE
git-discover: avoid shortening absolute paths

### DIFF
--- a/git-discover/src/upwards.rs
+++ b/git-discover/src/upwards.rs
@@ -157,7 +157,7 @@ pub(crate) mod function {
                     match filter_by_trust(&cursor)? {
                         Some(trust) => {
                             // TODO: test this more, it definitely doesn't find the shortest path to a directory
-                            let path = if dir_made_absolute {
+                            let path = if dir_made_absolute && !directory.as_ref().is_absolute() {
                                 shorten_path_with_cwd(cursor, cwd)
                             } else {
                                 cursor

--- a/git-discover/tests/upwards/mod.rs
+++ b/git-discover/tests/upwards/mod.rs
@@ -259,6 +259,21 @@ fn cross_fs() -> crate::Result {
     Ok(())
 }
 
+#[test]
+fn do_not_shorten_absolute_paths() -> crate::Result {
+    let top_level_repo = repo_path()?.canonicalize().expect("repo path exists");
+    let (repo_path, _trust) = git_discover::upwards(top_level_repo).expect("we can discover the repo");
+
+    match repo_path {
+        git_discover::repository::Path::WorkTree(work_dir) => {
+            assert!(work_dir.is_absolute());
+        }
+        _ => panic!("expected worktree path"),
+    };
+
+    Ok(())
+}
+
 fn repo_path() -> crate::Result<PathBuf> {
     git_testtools::scripted_fixture_repo_read_only("make_basic_repo.sh")
 }


### PR DESCRIPTION
Avoid calling `shorten_path_with_cwd` if original path was absolute. I think it's reasonable to expect that absolute paths are left untouched.