### PR TITLE
git-attributes: Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,10 +523,13 @@ checksum = "f3f6d59c71e7dc3af60f0af9db32364d96a16e9310f3f5db2b55ed642162dd35"
 
 [[package]]
 name = "compact_str"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e60dedcb8b23cedf6f23ee35ecf5c7889961e99f26f79ab196aaf4a8b48608"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
+ "castaway",
+ "itoa 1.0.2",
+ "ryu",
  "serde",
 ]
 

--- a/git-attributes/Cargo.toml
+++ b/git-attributes/Cargo.toml
@@ -27,7 +27,7 @@ bstr = { version = "0.2.13", default-features = false, features = ["std"]}
 unicode-bom = "1.1.4"
 quick-error = "2.0.0"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
-compact_str = "0.3.2"
+compact_str = "0.4"
 
 [dev-dependencies]
 git-testtools = { path = "../tests/tools"}

--- a/git-attributes/src/lib.rs
+++ b/git-attributes/src/lib.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use bstr::{BStr, BString};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 pub use git_glob as glob;
 
 /// The state an attribute can be in, referencing the value.
@@ -37,7 +37,7 @@ pub enum State {
     Unset,
     /// The attribute is set to the given value, which followed the `=` sign.
     /// Note that values can be empty.
-    Value(compact_str::CompactStr),
+    Value(CompactString),
     /// The attribute isn't mentioned with a given path or is explicitly set to `Unspecified` using the `!` sign.
     Unspecified,
 }
@@ -47,7 +47,7 @@ pub enum State {
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Assignment {
     /// The name of the attribute.
-    pub name: CompactStr,
+    pub name: CompactString,
     /// The state of the attribute.
     pub state: State,
 }


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning