### PR TITLE
Support native zlib-ng via flate2's zlib-ng feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,13 +979,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
+ "libz-ng-sys",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1995,10 +1994,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.6"
+name = "libz-ng-sys"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
+checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = ["max"]
 ## Makes the crate execute as fast as possible by supporting parallel computation of otherwise long-running functions
 ## as well as fast, hardware accelerated hashing, along with a faster zlib backend.
 ## If disabled, the binary will be visibly smaller.
-fast = ["git-features/parallel", "git-features/fast-sha1", "git-features/zlib-ng-compat", "git-repository/max-performance"]
+fast = ["git-features/parallel", "git-features/fast-sha1", "git-features/zlib-ng", "git-repository/max-performance"]
 
 ## Use `clap` 3.0 to build the prettiest, best documented and most user-friendly CLI at the expense of binary size.
 ## Provides a terminal user interface for detailed and exhaustive progress.

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ check: ## Build all code in suitable configurations
 			   && cargo check --features io-pipe \
 			   && cargo check --features crc32 \
 			   && cargo check --features zlib \
+			   && cargo check --features zlib,zlib-ng \
 			   && cargo check --features zlib,zlib-ng-compat \
 			   && cargo check --features cache-efficiency-debug
 	cd git-commitgraph && cargo check --all-features \

--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -32,14 +32,19 @@ crc32 = ["crc32fast"]
 #! ### Mutually Exclusive ZLIB
 
 ## Enable the usage of zlib related utilities to compress or decompress data.
-## By default it uses a pure rust implementation which is slower than the **zlib-ng-compat** version, but might be relevant if you prefer a pure-rust build
-## and reduced performance is acceptable. Note that a competitive Zlib implementation is critical to `gitoxide's` object database performance.
-## Additional backends are supported, each of which overriding the default Rust backend.
+## The base `zlib` feature uses the `flate2` Rust crate; the other mutually exclusive features select the `flate2 backend.
+## Note that a competitive Zlib implementation is critical to `gitoxide's` object database performance.
+## Enabling this without enabling one of the other features below will use a low-performance pure-Rust backend.
 zlib = ["flate2", "flate2/rust_backend", "quick-error"]
-## Use a C-based backend which can compress and decompress significantly faster.
-zlib-ng-compat = ["flate2/zlib-ng-compat"]
-## available for completeness even though it's the default - it may be chosen for more specific feature flag names, instead of a bare `zlib`.
-zlib-rust-backend = ["flate2/rust_backend"]
+## Use the C-based zlib-ng backend, which can compress and decompress significantly faster.
+zlib-ng = ["zlib", "flate2/zlib-ng"]
+## Use zlib-ng via its zlib-compat API. Useful if you already need zlib for C
+## code elsewhere in your dependencies. Otherwise, use zlib-ng.
+zlib-ng-compat = ["zlib", "flate2/zlib-ng-compat"]
+## Pure Rust backend, available for completeness even though it's the default
+## if neither of the above options are set. Low performance, but pure Rust, so it
+## may build in environments where other backends don't.
+zlib-rust-backend = ["zlib", "flate2/rust_backend"]
 
 #! ### Mutually Exclusive SHA1
 ## A fast SHA1 implementation is critical to `gitoxide's` object database performance
@@ -111,7 +116,7 @@ prodash = { version = "19.0.0", optional = true, default-features = false, featu
 bytes = { version = "1.0.0", optional = true }
 
 # zlib module
-flate2 = { version = "1.0.17", optional = true, default-features = false }
+flate2 = { version = "1.0.24", optional = true, default-features = false }
 quick-error = { version = "2.0.0", optional = true }
 
 ## make the `time` module available with access to the local time as configured by the system.

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -18,7 +18,7 @@ test = true
 default = ["max-performance", "one-stop-shop"]
 
 # enable when https://github.com/RustCrypto/asm-hashes/issues/17 is fixed
-# max-performance = ["git-features/parallel", "git-features/zlib-ng-compat", "git-features/fast-sha1", "git-pack/pack-cache-lru-static", "git-pack/pack-cache-lru-dynamic"]
+# max-performance = ["git-features/parallel", "git-features/zlib-ng", "git-features/fast-sha1", "git-pack/pack-cache-lru-static", "git-pack/pack-cache-lru-dynamic"]
 
 #! ### Mutually Exclusive Client
 #! Either `async-*` or `blocking-*` versions of these toggles may be enabled at a time.
@@ -43,8 +43,7 @@ one-stop-shop = [ "local", "local-time-support" ]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["git-pack/serde1", "git-object/serde1", "git-protocol/serde1", "git-transport/serde1", "git-ref/serde1", "git-odb/serde1", "git-index/serde1", "git-mailmap/serde1", "git-attributes/serde1"]
 ## Activate other features that maximize performance, like usage of threads, `zlib-ng` and access to caching in object databases.
-## **Note** that
-max-performance = ["git-features/parallel", "git-features/zlib-ng-compat", "git-pack/pack-cache-lru-static", "git-pack/pack-cache-lru-dynamic"]
+max-performance = ["git-features/parallel", "git-features/zlib-ng", "git-pack/pack-cache-lru-static", "git-pack/pack-cache-lru-dynamic"]
 ## Functions dealing with time may include the local timezone offset, not just UTC with the offset being zero.
 local-time-support = ["git-actor/local-time-support"]
 ## Re-export stability tier 2 crates for convenience and make `Repository` struct fields with types from these crates publicly accessible.


### PR DESCRIPTION
In addition to the zlib-ng-compat feature, flate2 now supports zlib-ng
via its native API and the libz-ng-sys crate. This avoids potential
symbol conflicts with dependencies on system C libraries that link to
system zlib. Using zlib-ng increases compatibility, avoids those
conflicts, and allows using zlib-ng in more circumstances.

(zlib-ng-compat is still useful when you have dependencies that need the
zlib C ABI and don't support zlib-ng, such as curl; git-transport still
uses zlib-ng-compat.)

----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [x] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

If you ticked any of the above boxes, I will always share a link to the video in the PR.
