### PR TITLE
Drop non-existent gitconfig paths before parsing

### DIFF
--- a/git-config/src/file/from_env.rs
+++ b/git-config/src/file/from_env.rs
@@ -62,6 +62,12 @@ impl<'a> File<'a> {
             paths.push(PathBuf::from(git_dir).join("config"));
         }
 
+        // To support more platforms/configurations:
+        // Drop any possible config locations which aren't present to avoid
+        // `parser::parse_from_path` failing too early with "not found" before
+        // it reaches a path which _does_ exist.
+        let paths = paths.into_iter().filter(|p| p.exists());
+
         File::from_paths(paths, options)
     }
 


### PR DESCRIPTION
`git_config::File::from_env_paths` is currently fails too fast iterating git configuration locations, probably in part to its current UNIX-like biases assuming places like `/etc` usually exist (Git for Windows probably tweaks these in their fork). 

This poses a problem on Windows as in a "stock" setup (no manually set env variables in the shell) leads to `/etc/gitconfig` _always_ being added to the list. With that, this function can never work since it tries reading the hardcoded path and instantly fails and bails out without attempting the later items. The same problem exists for `.config/git/config` (I think?) but maybe is less noticeable day to day.

To fix both my active problem and make this code less problematic onwards, a quick filter was added that skips any paths that can't be `stat`ed. With it, it actually finds my user's `.gitconfig` now. 

----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [x] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

If you ticked any of the above boxes, I will always share a link to the video in the PR.
