### PR TITLE
git-features' walkdir: 2.3.1 -> 2.3.2

### DIFF
--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -97,7 +97,7 @@ parking_lot = { version = "0.12.0", default-features = false, optional = true }
 jwalk = { version = "0.6.0", optional = true }
 ## Makes facilities of the `walkdir` crate partially available.
 ## In conjunction with the **parallel** feature, directory walking will be parallel instead behind a compatible interface.
-walkdir = { version = "2.3.1", optional = true } # used when parallel is off
+walkdir = { version = "2.3.2", optional = true } # used when parallel is off
 
 # hashing and 'fast-sha1' feature
 sha1_smol = { version = "1.0.0", optional = true }


### PR DESCRIPTION
[`sort_by_file_name`](https://docs.rs/walkdir/latest/walkdir/struct.WalkDir.html#method.sort_by_file_name) is not present in 2.3.1 version of walkdir. "caret" requirement (https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility) which is implicit here, sort of makes it work when the setup of crates is not so complicated, but when 2.3.1 is choosen the build fails.


----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [ ] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

If you ticked any of the above boxes, I will always share a link to the video in the PR.
