### PR TITLE
Write V2 Index Files (with TREE and EOIE extensions)

### DIFF
--- a/git-index/src/extension/mod.rs
+++ b/git-index/src/extension/mod.rs
@@ -14,7 +14,7 @@ pub struct Iter<'a> {
 ///
 /// It allows to more quickly build trees by avoiding as it can quickly re-use portions of the index and its associated tree ids
 /// if there was no change to them. Portions of this tree are invalidated as the index is changed.
-#[derive(Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Tree {
     pub name: SmallVec<[u8; 23]>,
     /// The id of the directory tree of the associated tree object.

--- a/git-index/src/file/mod.rs
+++ b/git-index/src/file/mod.rs
@@ -32,3 +32,4 @@ mod impl_ {
 }
 pub mod init;
 pub mod verify;
+pub mod write;

--- a/git-index/src/file/write.rs
+++ b/git-index/src/file/write.rs
@@ -7,8 +7,6 @@ impl File {
         self.state.write_to(&mut hasher, options)?;
 
         let hash = hasher.hash.digest();
-        out.write_all(&hash)?;
-
-        Ok(())
+        out.write_all(&hash)
     }
 }

--- a/git-index/src/file/write.rs
+++ b/git-index/src/file/write.rs
@@ -1,0 +1,14 @@
+use crate::{write, File};
+use git_features::hash;
+
+impl File {
+    pub fn write_to(&self, mut out: &mut impl std::io::Write, options: write::Options) -> std::io::Result<()> {
+        let mut hasher = hash::Write::new(&mut out, options.hash_kind);
+        self.state.write_to(&mut hasher, options)?;
+
+        let hash = hasher.hash.digest();
+        out.write_all(&hash)?;
+
+        Ok(())
+    }
+}

--- a/git-index/src/write.rs
+++ b/git-index/src/write.rs
@@ -1,6 +1,7 @@
 use crate::{extension, State, Version};
 use std::io::Write;
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Options {
     /// The hash kind to use when writing the index file.
     ///

--- a/git-index/src/write.rs
+++ b/git-index/src/write.rs
@@ -106,8 +106,8 @@ fn tree<T: std::io::Write>(
     if let Some(tree) = tree {
         let signature = b"TREE";
 
-        // TODO: Can this work without allocating?
-        let mut entries: Vec<u8> = Vec::new();
+        let estimated_size = tree.num_entries * (300 + 3 + 1 + 3 + 1 + 20);
+        let mut entries: Vec<u8> = Vec::with_capacity(estimated_size as usize);
         tree_entry(&mut entries, tree)?;
 
         out.write_all(signature)?;

--- a/git-index/src/write.rs
+++ b/git-index/src/write.rs
@@ -147,7 +147,7 @@ fn end_of_index_entry(
     let extension_size = 4 + hash_kind.len_in_bytes() as u32;
 
     let mut hasher = git_features::hash::hasher(hash_kind);
-    let tree_size = tree_offset - 8 - entries_offset;
+    let tree_size = (tree_offset - entries_offset).saturating_sub(8);
     if tree_size > 0 {
         hasher.update(b"TREE");
         hasher.update(&tree_size.to_be_bytes());

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -1,5 +1,6 @@
 use filetime::FileTime;
-use git_index::{decode, write, Version};
+use git_features::hash;
+use git_index::{decode, write, State, Version};
 use std::{
     cmp::{max, min},
     io::Write,
@@ -19,49 +20,131 @@ fn roundtrips() {
         ),
     ];
 
-    for (fixture_name, options) in input {
-        let path = crate::fixture_index_path(fixture_name);
-        let actual_index = git_index::File::at(&path, decode::Options::default()).unwrap();
-        let actual_bytes = std::fs::read(&path).unwrap();
+    for (fixture, options) in input {
+        let path = crate::fixture_index_path(fixture);
+        let expected_index = git_index::File::at(&path, decode::Options::default()).unwrap();
+        let expected_bytes = std::fs::read(&path).unwrap();
+        let mut generated_bytes = Vec::<u8>::new();
+        let mut hasher = hash::Write::new(&mut generated_bytes, options.hash_kind);
+        expected_index.state.write_to(&mut hasher, options).unwrap();
+        let hash = hasher.hash.digest();
+        generated_bytes.write_all(&hash).unwrap();
+        let (generated_index, _) =
+            State::from_bytes(&generated_bytes, FileTime::now(), decode::Options::default()).unwrap();
 
-        let mut output = Vec::<u8>::new();
-        let mut write_hasher = git_features::hash::Write::new(&mut output, options.hash_kind);
-        actual_index.state.write_to(&mut write_hasher, options).unwrap();
-        let hash = write_hasher.hash.digest();
-        output.write_all(&hash).unwrap();
-
-        let (output_index, _) =
-            git_index::State::from_bytes(&output, FileTime::now(), decode::Options::default()).unwrap();
-
-        assert_eq!(output_index.version(), Version::V2);
-        assert_eq!(output_index.entries().len(), actual_index.entries().len());
-
-        if let Some((index, input, expected)) = find_first_nonmatching_byte(&output, &actual_bytes, fixture_name) {
-            panic! {"\n\nRoundtrip failed for index in fixture {:?} at position {:?}\n\
-            \t   Input: ...{:?}...\n\
-            \tExpected: ...{:?}...\n\n\
-            ", &fixture_name, index, &input, &expected}
-        }
+        compare_states(&generated_index, &expected_index, options, fixture);
+        compare_raw_bytes(&generated_bytes, &expected_bytes, fixture);
     }
 }
 
-fn find_first_nonmatching_byte<'a, 'b>(
-    output: &'a [u8],
-    actual: &'b [u8],
-    fixture_name: &str,
-) -> Option<(usize, &'a [u8], &'b [u8])> {
-    assert_eq!(output.len(), actual.len(), "lengths not equal in {:?}", fixture_name);
+#[test]
+fn v2_index_no_extensions() {
+    let input = [
+        "V2_empty",
+        "v2",
+        "v2_more_files",
+        "v2_split_index",
+        "v4_more_files_IEOT",
+    ];
 
-    let return_range_on_error = 10;
-    for (i, (a, b)) in output.iter().zip(actual.iter()).enumerate() {
+    for fixture in input {
+        let path = crate::fixture_index_path(fixture);
+        let expected = git_index::File::at(&path, decode::Options::default()).unwrap();
+
+        let mut out = Vec::<u8>::new();
+        let options = write::Options {
+            hash_kind: git_hash::Kind::Sha1,
+            version: Version::V2,
+            tree_cache: false,
+            end_of_index_entry: false,
+        };
+        let mut hasher = hash::Write::new(&mut out, options.hash_kind);
+        expected.write_to(&mut hasher, options).unwrap();
+        let hash = hasher.hash.digest();
+        out.write_all(&hash).unwrap();
+
+        let (generated, _) = State::from_bytes(&out, FileTime::now(), decode::Options::default()).unwrap();
+        compare_states(&generated, &expected, options, fixture);
+    }
+}
+
+#[test]
+fn v2_index_tree_extensions() {
+    let input = [
+        "V2_empty",
+        "v2",
+        "v2_more_files",
+        "v2_split_index",
+        "v4_more_files_IEOT",
+    ];
+
+    for fixture in input {
+        let path = crate::fixture_index_path(fixture);
+        let expected = git_index::File::at(&path, decode::Options::default()).unwrap();
+
+        let mut out = Vec::<u8>::new();
+        let options = write::Options {
+            hash_kind: git_hash::Kind::Sha1,
+            version: Version::V2,
+            tree_cache: true,
+            end_of_index_entry: false,
+        };
+        let mut hasher = hash::Write::new(&mut out, options.hash_kind);
+        expected.write_to(&mut hasher, options).unwrap();
+        let hash = hasher.hash.digest();
+        out.write_all(&hash).unwrap();
+
+        let (generated, _) = State::from_bytes(&out, FileTime::now(), decode::Options::default()).unwrap();
+        compare_states(&generated, &expected, options, fixture);
+    }
+}
+
+fn compare_states(generated: &State, expected: &State, options: write::Options, fixture: &str) {
+    assert_eq!(generated.version(), options.version, "version mismatch in {}", fixture);
+    assert_eq!(
+        generated.tree(),
+        match options.tree_cache {
+            true => expected.tree(),
+            false => None,
+        },
+        "tree extension mismatch in {}",
+        fixture
+    );
+    assert_eq!(
+        generated.entries().len(),
+        expected.entries().len(),
+        "entry count mismatch in {}",
+        fixture
+    );
+    assert_eq!(
+        generated.entries(),
+        expected.entries(),
+        "entries mismatch in {}",
+        fixture
+    );
+    assert_eq!(
+        generated.path_backing(),
+        expected.path_backing(),
+        "path_backing mismatch in {}",
+        fixture
+    );
+}
+
+fn compare_raw_bytes<'a, 'b>(generated: &'a [u8], expected: &'b [u8], fixture: &str) {
+    assert_eq!(generated.len(), expected.len(), "file length mismatch in {}", fixture);
+
+    let print_range = 10;
+    for (index, (a, b)) in generated.iter().zip(expected.iter()).enumerate() {
         if a != b {
-            return Some((
-                i,
-                &output[max(i - return_range_on_error, 0)..min(i + return_range_on_error, output.len())],
-                &actual[max(i - return_range_on_error, 0)..min(i + return_range_on_error, actual.len())],
-            ));
+            let range_left = max(index - print_range, 0);
+            let range_right = min(index + print_range, generated.len());
+            let generated = &generated[range_left..range_right];
+            let expected = &expected[range_left..range_right];
+
+            panic! {"\n\nRoundtrip failed for index in fixture {:?} at position {:?}\n\
+            \t   Input: ... {:?} ...\n\
+            \tExpected: ... {:?} ...\n\n\
+            ", &fixture, index, generated, expected}
         }
     }
-
-    None
 }

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -10,7 +10,7 @@ fn roundtrips() {
         (
             "v2_more_files",
             write::Options {
-                end_of_index_entry: false,
+                end_of_index_entry_extension: false,
                 ..write::Options::default()
             },
         ),
@@ -48,8 +48,8 @@ fn v2_index_no_extensions() {
         let options = write::Options {
             hash_kind: git_hash::Kind::Sha1,
             version: Version::V2,
-            tree_cache: false,
-            end_of_index_entry: false,
+            tree_cache_extension: false,
+            end_of_index_entry_extension: false,
         };
 
         expected.write_to(&mut out, options).unwrap();
@@ -77,8 +77,8 @@ fn v2_index_tree_extensions() {
         let options = write::Options {
             hash_kind: git_hash::Kind::Sha1,
             version: Version::V2,
-            tree_cache: true,
-            end_of_index_entry: false,
+            tree_cache_extension: true,
+            end_of_index_entry_extension: false,
         };
 
         expected.write_to(&mut out, options).unwrap();
@@ -106,8 +106,8 @@ fn v2_index_eoie_extensions() {
         let options = write::Options {
             hash_kind: git_hash::Kind::Sha1,
             version: Version::V2,
-            tree_cache: false,
-            end_of_index_entry: true,
+            tree_cache_extension: false,
+            end_of_index_entry_extension: true,
         };
 
         expected.write_to(&mut out, options).unwrap();
@@ -121,7 +121,7 @@ fn compare_states(generated: &State, expected: &State, options: write::Options, 
     assert_eq!(generated.version(), options.version, "version mismatch in {}", fixture);
     assert_eq!(
         generated.tree(),
-        match options.tree_cache {
+        match options.tree_cache_extension {
             true => expected.tree(),
             false => None,
         },
@@ -148,7 +148,7 @@ fn compare_states(generated: &State, expected: &State, options: write::Options, 
     );
 }
 
-fn compare_raw_bytes<'a, 'b>(generated: &'a [u8], expected: &'b [u8], fixture: &str) {
+fn compare_raw_bytes(generated: &[u8], expected: &[u8], fixture: &str) {
     assert_eq!(generated.len(), expected.len(), "file length mismatch in {}", fixture);
 
     let print_range = 10;


### PR DESCRIPTION
# Write V2 Index Files

- Link to git [Documentation](https://git-scm.com/docs/index-format)
- [git implementation](https://github.com/git/git/blob/master/read-cache.c#L2873)

## Features

**Version Support**
- [x] V2

**Extensions**
- [x] tree cache
- [x] end of index entry

## Out of Scope
- V3
- V4
- resolve undo
- split index / link
- untracked cache
- fs monitor
- index entry offset table