### PR TITLE
open::Options::strict_config()

### DIFF
--- a/git-repository/src/config/cache.rs
+++ b/git-repository/src/config/cache.rs
@@ -20,7 +20,12 @@ pub(crate) struct StageOne {
 
 /// Initialization
 impl StageOne {
-    pub fn new(git_dir: &std::path::Path, git_dir_trust: git_sec::Trust, lossy: Option<bool>) -> Result<Self, Error> {
+    pub fn new(
+        git_dir: &std::path::Path,
+        git_dir_trust: git_sec::Trust,
+        lossy: Option<bool>,
+        lenient: bool,
+    ) -> Result<Self, Error> {
         let mut buf = Vec::with_capacity(512);
         let config = {
             let config_path = git_dir.join("config");
@@ -38,7 +43,7 @@ impl StageOne {
             )?
         };
 
-        let is_bare = config_bool(&config, "core.bare", false)?;
+        let is_bare = config_bool(&config, "core.bare", false, lenient)?;
         let repo_format_version = config
             .value::<Integer>("core", None, "repositoryFormatVersion")
             .map_or(0, |v| v.to_decimal().unwrap_or_default());
@@ -99,6 +104,7 @@ impl Cache {
             env: use_env,
             includes: use_includes,
         }: repository::permissions::Config,
+        lenient_config: bool,
     ) -> Result<Self, Error> {
         let options = git_config::file::init::Options {
             includes: if use_includes {
@@ -174,45 +180,25 @@ impl Cache {
             globals
         };
 
-        let excludes_file = config
+        let excludes_file = match config
             .path_filter("core", None, "excludesFile", &mut filter_config_section)
             .map(|p| p.interpolate(options.includes.interpolate).map(|p| p.into_owned()))
-            .transpose()?;
+            .transpose()
+        {
+            Ok(f) => f,
+            Err(_err) if lenient_config => None,
+            Err(err) => return Err(err.into()),
+        };
 
-        let mut hex_len = None;
-        if let Some(hex_len_str) = config.string("core", None, "abbrev") {
-            if hex_len_str.trim().is_empty() {
-                return Err(Error::EmptyValue { key: "core.abbrev" });
-            }
-            if !hex_len_str.eq_ignore_ascii_case(b"auto") {
-                let value_bytes = hex_len_str.as_ref();
-                if let Ok(false) = Boolean::try_from(value_bytes).map(Into::into) {
-                    hex_len = object_hash.len_in_hex().into();
-                } else {
-                    let value = Integer::try_from(value_bytes)
-                        .map_err(|_| Error::CoreAbbrev {
-                            value: hex_len_str.clone().into_owned(),
-                            max: object_hash.len_in_hex() as u8,
-                        })?
-                        .to_decimal()
-                        .ok_or_else(|| Error::CoreAbbrev {
-                            value: hex_len_str.clone().into_owned(),
-                            max: object_hash.len_in_hex() as u8,
-                        })?;
-                    if value < 4 || value as usize > object_hash.len_in_hex() {
-                        return Err(Error::CoreAbbrev {
-                            value: hex_len_str.clone().into_owned(),
-                            max: object_hash.len_in_hex() as u8,
-                        });
-                    }
-                    hex_len = Some(value as usize);
-                }
-            }
-        }
+        let hex_len = match parse_core_abbrev(&config, object_hash) {
+            Ok(v) => v,
+            Err(_err) if lenient_config => None,
+            Err(err) => return Err(err),
+        };
 
         let reflog = query_refupdates(&config);
-        let ignore_case = config_bool(&config, "core.ignoreCase", false)?;
-        let use_multi_pack_index = config_bool(&config, "core.multiPackIndex", true)?;
+        let ignore_case = config_bool(&config, "core.ignoreCase", false, lenient_config)?;
+        let use_multi_pack_index = config_bool(&config, "core.multiPackIndex", true, lenient_config)?;
         let object_kind_hint = config.string("core", None, "disambiguate").and_then(|value| {
             Some(match value.as_ref().as_ref() {
                 b"commit" => ObjectKindHint::Commit,
@@ -292,15 +278,19 @@ fn base_options(lossy: Option<bool>) -> git_config::file::init::Options<'static>
     }
 }
 
-fn config_bool(config: &git_config::File<'_>, key: &str, default: bool) -> Result<bool, Error> {
+fn config_bool(config: &git_config::File<'_>, key: &str, default: bool, lenient: bool) -> Result<bool, Error> {
     let (section, key) = key.split_once('.').expect("valid section.key format");
-    config
+    match config
         .boolean(section, None, key)
         .unwrap_or(Ok(default))
         .map_err(|err| Error::DecodeBoolean {
             value: err.input,
             key: key.into(),
-        })
+        }) {
+        Ok(v) => Ok(v),
+        Err(_err) if lenient => Ok(default),
+        Err(err) => Err(err),
+    }
 }
 
 fn query_refupdates(config: &git_config::File<'static>) -> Option<git_ref::store::WriteReflog> {
@@ -314,4 +304,41 @@ fn query_refupdates(config: &git_config::File<'static>) -> Option<git_ref::store
             })
             .unwrap_or(git_ref::store::WriteReflog::Disable)
     })
+}
+
+fn parse_core_abbrev(config: &git_config::File<'static>, object_hash: git_hash::Kind) -> Result<Option<usize>, Error> {
+    match config.string("core", None, "abbrev") {
+        Some(hex_len_str) => {
+            if hex_len_str.trim().is_empty() {
+                return Err(Error::EmptyValue { key: "core.abbrev" });
+            }
+            if hex_len_str.trim().eq_ignore_ascii_case(b"auto") {
+                Ok(None)
+            } else {
+                let value_bytes = hex_len_str.as_ref();
+                if let Ok(false) = Boolean::try_from(value_bytes).map(Into::into) {
+                    Ok(object_hash.len_in_hex().into())
+                } else {
+                    let value = Integer::try_from(value_bytes)
+                        .map_err(|_| Error::CoreAbbrev {
+                            value: hex_len_str.clone().into_owned(),
+                            max: object_hash.len_in_hex() as u8,
+                        })?
+                        .to_decimal()
+                        .ok_or_else(|| Error::CoreAbbrev {
+                            value: hex_len_str.clone().into_owned(),
+                            max: object_hash.len_in_hex() as u8,
+                        })?;
+                    if value < 4 || value as usize > object_hash.len_in_hex() {
+                        return Err(Error::CoreAbbrev {
+                            value: hex_len_str.clone().into_owned(),
+                            max: object_hash.len_in_hex() as u8,
+                        });
+                    }
+                    Ok(Some(value as usize))
+                }
+            }
+        }
+        None => Ok(None),
+    }
 }

--- a/git-repository/src/repository/permissions.rs
+++ b/git-repository/src/repository/permissions.rs
@@ -26,8 +26,8 @@ pub struct Config {
     /// Whether to use the user configuration.
     /// This is usually `~/.gitconfig` on unix.
     pub user: bool,
-    /// Whether to use worktree configuration from `config.worktree`.
     // TODO: figure out how this really applies and provide more information here.
+    // Whether to use worktree configuration from `config.worktree`.
     // pub worktree: bool,
     /// Whether to use the configuration from environment variables.
     pub env: bool,
@@ -98,6 +98,27 @@ impl Permissions {
         Permissions {
             env: Environment::all(),
             config: Config::all(),
+        }
+    }
+
+    /// Don't read any but the local git configuration and deny reading any environment variables.
+    pub fn isolated() -> Self {
+        Permissions {
+            config: Config {
+                system: false,
+                git: false,
+                user: false,
+                env: false,
+                includes: false,
+            },
+            env: {
+                let deny = permission::env_var::Resource::resource(git_sec::Permission::Deny);
+                Environment {
+                    xdg_config_home: deny.clone(),
+                    home: deny.clone(),
+                    git_prefix: deny,
+                }
+            },
         }
     }
 }

--- a/git-repository/tests/id/mod.rs
+++ b/git-repository/tests/id/mod.rs
@@ -31,14 +31,15 @@ fn prefix() -> crate::Result {
 
     assert!(
         matches!(
-            git_repository::open(worktree_dir.path()).unwrap_err(),
+            git_repository::open_opts(worktree_dir.path(), git::open::Options::isolated().strict_config(true))
+                .unwrap_err(),
             git::open::Error::Config(git::config::Error::EmptyValue { .. })
         ),
         "an empty core.abbrev fails the open operation in strict config mode, emulating git behaviour"
     );
     assert!(
-        git_repository::open_opts(worktree_dir.path(), git::open::Options::isolated().lenient_config(true)).is_ok(),
-        "but it can be made to work when we are lenient (good for APIs)"
+        git_repository::open(worktree_dir.path()).is_ok(),
+        "By default gitoxide acts like `libgit2` here and we prefer to be lenient when possible"
     );
     Ok(())
 }

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -53,10 +53,15 @@ pub fn main() -> Result<()> {
     let object_hash = args.object_hash;
     use git_repository as git;
     let repository = args.repository;
-    let repository = move || {
+    enum Mode {
+        Strict,
+        Lenient,
+    }
+    let repository = move |mode: Mode| {
         let mut mapping: git::sec::trust::Mapping<git::open::Options> = Default::default();
-        mapping.full = mapping.full.strict_config(true);
-        mapping.reduced = mapping.reduced.strict_config(true);
+        let toggle = matches!(mode, Mode::Strict);
+        mapping.full = mapping.full.strict_config(toggle);
+        mapping.reduced = mapping.reduced.strict_config(toggle);
         git::ThreadSafeRepository::discover_opts(repository, Default::default(), mapping)
             .map(git::Repository::from)
             .map(|r| r.apply_environment())
@@ -88,7 +93,7 @@ pub fn main() -> Result<()> {
             progress,
             progress_keep_open,
             None,
-            move |_progress, out, _err| core::repository::config::list(repository()?, filter, format, out),
+            move |_progress, out, _err| core::repository::config::list(repository(Mode::Lenient)?, filter, format, out),
         )
         .map(|_| ()),
         Subcommands::Free(subcommands) => match subcommands {
@@ -505,7 +510,7 @@ pub fn main() -> Result<()> {
             core::repository::verify::PROGRESS_RANGE,
             move |progress, out, _err| {
                 core::repository::verify::integrity(
-                    repository()?,
+                    repository(Mode::Strict)?,
                     out,
                     progress,
                     &should_interrupt,
@@ -525,7 +530,9 @@ pub fn main() -> Result<()> {
                 progress,
                 progress_keep_open,
                 None,
-                move |_progress, out, _err| core::repository::revision::previous_branches(repository()?, out, format),
+                move |_progress, out, _err| {
+                    core::repository::revision::previous_branches(repository(Mode::Lenient)?, out, format)
+                },
             ),
             revision::Subcommands::Explain { spec } => prepare_and_run(
                 "revision-explain",
@@ -547,7 +554,7 @@ pub fn main() -> Result<()> {
                 None,
                 move |_progress, out, _err| {
                     core::repository::revision::resolve(
-                        repository()?,
+                        repository(Mode::Strict)?,
                         specs,
                         out,
                         core::repository::revision::resolve::Options {
@@ -577,7 +584,7 @@ pub fn main() -> Result<()> {
                 None,
                 move |_progress, out, err| {
                     core::repository::commit::describe(
-                        repository()?,
+                        repository(Mode::Strict)?,
                         rev_spec.as_deref(),
                         out,
                         err,
@@ -606,7 +613,14 @@ pub fn main() -> Result<()> {
                 progress_keep_open,
                 None,
                 move |_progress, out, _err| {
-                    core::repository::tree::entries(repository()?, treeish.as_deref(), recursive, extended, format, out)
+                    core::repository::tree::entries(
+                        repository(Mode::Strict)?,
+                        treeish.as_deref(),
+                        recursive,
+                        extended,
+                        format,
+                        out,
+                    )
                 },
             ),
             tree::Subcommands::Info { treeish, extended } => prepare_and_run(
@@ -616,7 +630,14 @@ pub fn main() -> Result<()> {
                 progress_keep_open,
                 None,
                 move |_progress, out, err| {
-                    core::repository::tree::info(repository()?, treeish.as_deref(), extended, format, out, err)
+                    core::repository::tree::info(
+                        repository(Mode::Strict)?,
+                        treeish.as_deref(),
+                        extended,
+                        format,
+                        out,
+                        err,
+                    )
                 },
             ),
         },
@@ -627,7 +648,7 @@ pub fn main() -> Result<()> {
                 progress,
                 progress_keep_open,
                 None,
-                move |_progress, out, _err| core::repository::odb::entries(repository()?, format, out),
+                move |_progress, out, _err| core::repository::odb::entries(repository(Mode::Strict)?, format, out),
             ),
             odb::Subcommands::Info => prepare_and_run(
                 "odb-info",
@@ -635,7 +656,7 @@ pub fn main() -> Result<()> {
                 progress,
                 progress_keep_open,
                 None,
-                move |_progress, out, err| core::repository::odb::info(repository()?, format, out, err),
+                move |_progress, out, err| core::repository::odb::info(repository(Mode::Strict)?, format, out, err),
             ),
         },
         Subcommands::Mailmap(cmd) => match cmd {
@@ -645,7 +666,9 @@ pub fn main() -> Result<()> {
                 progress,
                 progress_keep_open,
                 None,
-                move |_progress, out, err| core::repository::mailmap::entries(repository()?, format, out, err),
+                move |_progress, out, err| {
+                    core::repository::mailmap::entries(repository(Mode::Lenient)?, format, out, err)
+                },
             ),
         },
         Subcommands::Exclude(cmd) => match cmd {
@@ -662,7 +685,7 @@ pub fn main() -> Result<()> {
                 move |_progress, out, _err| {
                     use git::bstr::ByteSlice;
                     core::repository::exclude::query(
-                        repository()?,
+                        repository(Mode::Strict)?,
                         if pathspecs.is_empty() {
                             Box::new(
                                 stdin_or_bail()?

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -54,7 +54,10 @@ pub fn main() -> Result<()> {
     use git_repository as git;
     let repository = args.repository;
     let repository = move || {
-        git::ThreadSafeRepository::discover(repository)
+        let mut mapping: git::sec::trust::Mapping<git::open::Options> = Default::default();
+        mapping.full = mapping.full.strict_config(true);
+        mapping.reduced = mapping.reduced.strict_config(true);
+        git::ThreadSafeRepository::discover_opts(repository, Default::default(), mapping)
             .map(git::Repository::from)
             .map(|r| r.apply_environment())
     };


### PR DESCRIPTION
interpret git configuration leniently by default, but support a strict mode
to get exactly the behaviour that `git` exhibits, preferring correctness
which forces issues to be fixed.

Related to https://github.com/starship/starship/issues/4272
