### PR TITLE
Show required features for items when compiling on docs.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ name = "git-mailmap"
 version = "0.3.1"
 dependencies = [
  "bstr",
+ "document-features",
  "git-actor",
  "git-testtools",
  "quick-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,11 @@ default-run = "gix"
 include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 resolver = "2"
 
-
 [[bin]]
 name = "ein"
 path = "src/ein.rs"
 test = false
 doctest = false
-
 
 [[bin]]
 name = "gix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ pretty-cli = [ "gitoxide-core/serde1", "prodash/progress-tree", "prodash/progres
 ## that appears after a short duration.
 prodash-render-line-crossterm = ["prodash-render-line", "prodash/render-line-crossterm", "atty", "crosstermion"]
 
-
 #! ### Convenience Features
 #! These combine common choices of the above features to represent typical builds
 
@@ -181,3 +180,4 @@ exclude = ["cargo-smart-release/tests/fixtures/tri-depth-workspace/a",
 
 [package.metadata.docs.rs]
 features = ["document-features", "max"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cargo-smart-release/Cargo.toml
+++ b/cargo-smart-release/Cargo.toml
@@ -10,8 +10,6 @@ categories = ["development-tools::cargo-plugins"]
 keywords = ["cargo"]
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [[bin]]
 name = "cargo-smart-release"
 path = "src/cli/main-smart-release.rs"

--- a/git-actor/Cargo.toml
+++ b/git-actor/Cargo.toml
@@ -33,5 +33,6 @@ pretty_assertions = "1.0.0"
 git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-actor/src/lib.rs
+++ b/git-actor/src/lib.rs
@@ -5,8 +5,10 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
+
 use bstr::{BStr, BString};
 pub use git_date::{time::Sign, Time};
 

--- a/git-actor/src/lib.rs
+++ b/git-actor/src/lib.rs
@@ -5,8 +5,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
 use bstr::{BStr, BString};
 pub use git_date::{time::Sign, Time};
 

--- a/git-attributes/Cargo.toml
+++ b/git-attributes/Cargo.toml
@@ -34,4 +34,5 @@ git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 features = ["document-features"]

--- a/git-attributes/Cargo.toml
+++ b/git-attributes/Cargo.toml
@@ -15,8 +15,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "bstr/serde1", "git-glob/serde1", "compact_str/serde"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-features = { version = "^0.22.1", path = "../git-features" }
 git-path = { version = "^0.4.0", path = "../git-path" }

--- a/git-attributes/src/lib.rs
+++ b/git-attributes/src/lib.rs
@@ -5,8 +5,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
 
 use std::path::PathBuf;
 

--- a/git-attributes/src/lib.rs
+++ b/git-attributes/src/lib.rs
@@ -5,6 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-bitmap/Cargo.toml
+++ b/git-bitmap/Cargo.toml
@@ -11,8 +11,6 @@ edition = "2018"
 doctest = false
 test = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 quick-error = "2.0.0"
 

--- a/git-bitmap/src/lib.rs
+++ b/git-bitmap/src/lib.rs
@@ -1,8 +1,8 @@
-#![deny(unsafe_code, missing_docs, rust_2018_idioms)]
-#![allow(missing_docs)]
 //! An implementation of the shared parts of git bitmaps used in `git-pack`, `git-index` and `git-worktree`.
 //!
 //! Note that many tests are performed indirectly by tests in the aforementioned consumer crates.
+#![deny(rust_2018_idioms, unsafe_code)]
+#![allow(missing_docs)]
 
 /// Bitmap utilities for the advanced word-aligned hybrid bitmap
 pub mod ewah;

--- a/git-chunk/src/lib.rs
+++ b/git-chunk/src/lib.rs
@@ -1,8 +1,7 @@
 //! Low-level access to reading and writing chunk file based formats.
 //!
 //! See the [git documentation](https://github.com/git/git/blob/seen/Documentation/technical/chunk-format.txt) for details.
-#![deny(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// An identifier to describe the kind of chunk, unique within a chunk file, typically in ASCII
 pub type Id = [u8; 4];

--- a/git-commitgraph/Cargo.toml
+++ b/git-commitgraph/Cargo.toml
@@ -32,5 +32,6 @@ document-features = { version = "0.2.0", optional = true }
 git-testtools = { path = "../tests/tools" }
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-commitgraph/src/lib.rs
+++ b/git-commitgraph/src/lib.rs
@@ -12,7 +12,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code, rust_2018_idioms, missing_docs)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub mod file;
 pub mod graph;

--- a/git-commitgraph/src/lib.rs
+++ b/git-commitgraph/src/lib.rs
@@ -12,6 +12,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub mod file;

--- a/git-config/Cargo.toml
+++ b/git-config/Cargo.toml
@@ -49,5 +49,6 @@ harness = false
 path = "./benches/large_config_file.rs"
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-config/src/lib.rs
+++ b/git-config/src/lib.rs
@@ -34,6 +34,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub mod file;

--- a/git-config/src/lib.rs
+++ b/git-config/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs, unsafe_code, rust_2018_idioms)]
-
 //! # `git_config`
 //!
 //! This crate is a high performance `git-config` file reader and writer. It
@@ -36,6 +34,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub mod file;
 

--- a/git-credentials/Cargo.toml
+++ b/git-credentials/Cargo.toml
@@ -25,3 +25,4 @@ document-features = { version = "0.2.1", optional = true }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-credentials/Cargo.toml
+++ b/git-credentials/Cargo.toml
@@ -14,8 +14,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "bstr/serde1", "git-sec/serde1"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-sec = { version = "^0.3.0", path = "../git-sec" }
 quick-error = "2.0.0"

--- a/git-credentials/src/lib.rs
+++ b/git-credentials/src/lib.rs
@@ -5,8 +5,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![forbid(unsafe_code)]
 #![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 ///
 pub mod helper;

--- a/git-credentials/src/lib.rs
+++ b/git-credentials/src/lib.rs
@@ -5,6 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-date/Cargo.toml
+++ b/git-date/Cargo.toml
@@ -26,5 +26,6 @@ document-features = { version = "0.2.0", optional = true }
 git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-date/Cargo.toml
+++ b/git-date/Cargo.toml
@@ -10,8 +10,6 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "bstr/serde1"]

--- a/git-date/src/lib.rs
+++ b/git-date/src/lib.rs
@@ -6,8 +6,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![forbid(unsafe_code)]
 #![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 ///
 pub mod time;

--- a/git-date/src/lib.rs
+++ b/git-date/src/lib.rs
@@ -6,6 +6,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-diff/Cargo.toml
+++ b/git-diff/Cargo.toml
@@ -11,8 +11,6 @@ include = ["src/**/*"]
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-hash = { version = "^0.9.7", path = "../git-hash" }
 git-object = { version = "^0.20.1", path = "../git-object" }

--- a/git-diff/src/lib.rs
+++ b/git-diff/src/lib.rs
@@ -1,6 +1,6 @@
 //! Algorithms for diffing various git object types and for generating patches, highly optimized for performance.
-#![forbid(unsafe_code, rust_2018_idioms)]
-#[deny(missing_docs)]
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 ///
 pub mod tree;

--- a/git-discover/Cargo.toml
+++ b/git-discover/Cargo.toml
@@ -11,8 +11,6 @@ include = ["src/**/*", "CHANGELOG.md"]
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-sec = { version = "^0.3.0", path = "../git-sec", features = ["thiserror"] }
 git-path = { version = "^0.4.0", path = "../git-path" }

--- a/git-discover/src/lib.rs
+++ b/git-discover/src/lib.rs
@@ -1,8 +1,8 @@
 //! Find git repositories or search them upwards from a starting point, or determine if a directory looks like a git repository.
 //!
 //! Note that detection methods are educated guesses using the presence of files, without looking too much into the details.
-#![forbid(unsafe_code, rust_2018_idioms)]
-#![deny(missing_docs)]
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 /// The name of the `.git` directory.
 pub const DOT_GIT_DIR: &str = ".git";

--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 progress = ["prodash"]
 
 ## If set, and with the `parallel` feature set, walkdir iterators will be single-threaded.
-## This feature exists to avoid [certain side-effects](https://github.com/starship/starship/issues/4251) of rayong threadpool configuration with `jwalk`.
+## This feature exists to avoid [certain side-effects](https://github.com/starship/starship/issues/4251) of rayon threadpool configuration with `jwalk`.
 fs-walkdir-single-threaded = []
 
 ## Use scoped threads and channels to parallelize common workloads on multiple objects. If enabled, it is used everywhere
@@ -131,12 +131,14 @@ libc = { version = "0.2.119" }
 [dev-dependencies]
 bstr = { version = "0.2.15", default-features = false }
 
-[package.metadata.docs.rs]
-features = ["document-features"]
-all-features = true
 
 # Assembly doesn't yet compile on MSVC on windows, but does on GNU, see https://github.com/RustCrypto/asm-hashes/issues/17
 # TODO: potentially include it only for certain architectures
 # [target.'cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(target_env = "msvc")))'.dependencies]
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 sha-1 = { version = "0.10.0", optional = true, features = ["asm"] }
+
+[package.metadata.docs.rs]
+all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-features/src/lib.rs
+++ b/git-features/src/lib.rs
@@ -11,6 +11,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///

--- a/git-features/src/lib.rs
+++ b/git-features/src/lib.rs
@@ -1,5 +1,3 @@
-#![forbid(rust_2018_idioms)]
-#![deny(unsafe_code, missing_docs)]
 //! A crate providing foundational capabilities to other `git-*` crates with trade-offs between compile time, binary size or speed
 //! selectable using cargo feature toggles.
 //!
@@ -13,6 +11,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///
 pub mod cache;

--- a/git-filter/Cargo.toml
+++ b/git-filter/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-filter/src/lib.rs
+++ b/git-filter/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-glob/Cargo.toml
+++ b/git-glob/Cargo.toml
@@ -14,8 +14,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "bstr/serde1"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bstr = { version = "0.2.13", default-features = false, features = ["std"]}
 bitflags = "1.3.2"

--- a/git-glob/Cargo.toml
+++ b/git-glob/Cargo.toml
@@ -25,5 +25,6 @@ document-features = { version = "0.2.0", optional = true }
 git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-glob/src/lib.rs
+++ b/git-glob/src/lib.rs
@@ -4,8 +4,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
 
 use bstr::BString;
 

--- a/git-glob/src/lib.rs
+++ b/git-glob/src/lib.rs
@@ -4,6 +4,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-hash/Cargo.toml
+++ b/git-hash/Cargo.toml
@@ -27,5 +27,6 @@ document-features = { version = "0.2.0", optional = true }
 git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-hash/src/lib.rs
+++ b/git-hash/src/lib.rs
@@ -6,6 +6,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 mod borrowed;

--- a/git-hash/src/lib.rs
+++ b/git-hash/src/lib.rs
@@ -3,11 +3,10 @@
 //! These are provided in borrowed versions as well as owned ones.
 //! ## Feature Flags
 #![cfg_attr(
-feature = "document-features",
-cfg_attr(doc, doc = ::document_features::document_features!())
+    feature = "document-features",
+    cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 mod borrowed;
 

--- a/git-index/Cargo.toml
+++ b/git-index/Cargo.toml
@@ -29,8 +29,6 @@ serde1 = ["serde", "smallvec/serde", "git-hash/serde1"]
 internal-testing-git-features-parallel = ["git-features/parallel"]
 internal-testing-to-avoid-being-run-by-cargo-test-all = []
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-features = { version = "^0.22.1", path = "../git-features", features = ["rustsha1", "progress"] }
 git-hash = { version = "^0.9.7", path = "../git-hash" }

--- a/git-index/Cargo.toml
+++ b/git-index/Cargo.toml
@@ -53,4 +53,4 @@ git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde1"]
-
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-index/src/lib.rs
+++ b/git-index/src/lib.rs
@@ -3,6 +3,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(unsafe_code, missing_docs, rust_2018_idioms)]
 
 use std::{ops::Range, path::PathBuf};

--- a/git-lfs/Cargo.toml
+++ b/git-lfs/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-lfs/src/lib.rs
+++ b/git-lfs/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-lock/Cargo.toml
+++ b/git-lock/Cargo.toml
@@ -12,8 +12,6 @@ include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 doctest = false
 test = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 fastrand = "1.5.0"
 git-tempfile = { version = "^2.0.0", path = "../git-tempfile" }

--- a/git-lock/src/lib.rs
+++ b/git-lock/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! * As the lock file is separate from the actual resource, locking is merely a convention rather than being enforced.
 //! * The limitations of `git-tempfile` apply.
-#![deny(missing_docs, unsafe_code, rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::path::PathBuf;
 

--- a/git-mailmap/Cargo.toml
+++ b/git-mailmap/Cargo.toml
@@ -14,8 +14,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "bstr/serde1", "git-actor/serde1"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-actor = { version = "^0.11.1", path = "../git-actor" }
 bstr = { version = "0.2.13", default-features = false, features = ["std", "unicode"]}

--- a/git-mailmap/Cargo.toml
+++ b/git-mailmap/Cargo.toml
@@ -20,5 +20,12 @@ bstr = { version = "0.2.13", default-features = false, features = ["std", "unico
 quick-error = "2.0.0"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
+document-features = { version = "0.2.0", optional = true }
+
 [dev-dependencies]
 git-testtools = { path = "../tests/tools"}
+
+[package.metadata.docs.rs]
+all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-mailmap/src/lib.rs
+++ b/git-mailmap/src/lib.rs
@@ -5,6 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-mailmap/src/lib.rs
+++ b/git-mailmap/src/lib.rs
@@ -1,7 +1,12 @@
-#![forbid(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
 //! [Parse][parse()] .mailmap files as used in git repositories and remap names and emails
 //! using an [accelerated data-structure][Snapshot].
+//! ## Feature Flags
+#![cfg_attr(
+    feature = "document-features",
+    cfg_attr(doc, doc = ::document_features::document_features!())
+)]
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 use bstr::BStr;
 

--- a/git-note/Cargo.toml
+++ b/git-note/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-note/src/lib.rs
+++ b/git-note/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-object/Cargo.toml
+++ b/git-object/Cargo.toml
@@ -42,6 +42,7 @@ pretty_assertions = "1.0.0"
 git-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]
 

--- a/git-object/src/lib.rs
+++ b/git-object/src/lib.rs
@@ -5,6 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-object/src/lib.rs
+++ b/git-object/src/lib.rs
@@ -5,8 +5,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
 
 use std::borrow::Cow;
 

--- a/git-odb/Cargo.toml
+++ b/git-odb/Cargo.toml
@@ -50,5 +50,5 @@ filetime = "0.2.15"
 maplit = "1.0.2"
 
 [package.metadata.docs.rs]
-all-features = true
-features = ["document-features"]
+features = ["document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-odb/src/lib.rs
+++ b/git-odb/src/lib.rs
@@ -12,6 +12,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::{

--- a/git-odb/src/lib.rs
+++ b/git-odb/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs, unsafe_code, rust_2018_idioms)]
-
 //! Git stores all of its data as _Objects_, which are data along with a hash over all data. Thus it's an
 //! object store indexed by the signature of data itself with inherent deduplication: the same data will have the same hash,
 //! and thus occupy the same space within the store.
@@ -14,6 +12,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::{
     cell::RefCell,

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -67,6 +67,6 @@ bstr = { version = "0.2.13", default-features = false, features = ["std"] }
 maplit = "1.0.2"
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
-
+features = ["document-features", "pack-cache-lru-dynamic", "object-cache-dynamic", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-pack/src/lib.rs
+++ b/git-pack/src/lib.rs
@@ -15,6 +15,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///

--- a/git-pack/src/lib.rs
+++ b/git-pack/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs, unsafe_code, rust_2018_idioms)]
-
 //! Git stores all of its data as _Objects_, which are data along with a hash over all data. Storing objects efficiently
 //! is what git packs are concerned about.
 //!
@@ -17,6 +15,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///
 pub mod bundle;

--- a/git-packetline/Cargo.toml
+++ b/git-packetline/Cargo.toml
@@ -56,4 +56,5 @@ async-std = { version = "1.9.0", features = ["attributes"] }
 maybe-async = "0.2.6"
 
 [package.metadata.docs.rs]
-features = ["document-features", "blocking-io"]
+features = ["document-features", "blocking-io", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-packetline/Cargo.toml
+++ b/git-packetline/Cargo.toml
@@ -37,9 +37,6 @@ name = "blocking-packetline"
 path = "tests/blocking-packetline.rs"
 required-features = ["blocking-io", "maybe-async/is_sync"]
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"]}
 quick-error = "2.0.0"

--- a/git-packetline/src/lib.rs
+++ b/git-packetline/src/lib.rs
@@ -6,6 +6,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 const U16_HEX_BYTES: usize = 4;

--- a/git-packetline/src/lib.rs
+++ b/git-packetline/src/lib.rs
@@ -6,7 +6,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code, rust_2018_idioms, missing_docs)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 const U16_HEX_BYTES: usize = 4;
 const MAX_DATA_LEN: usize = 65516;

--- a/git-path/Cargo.toml
+++ b/git-path/Cargo.toml
@@ -11,8 +11,6 @@ include = ["src/**/*", "CHANGELOG.md"]
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bstr = { version = "0.2.17", default-features = false, features = ["std"] }
 thiserror = "1.0.26"

--- a/git-path/src/lib.rs
+++ b/git-path/src/lib.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
-#![deny(missing_docs)]
 //! This crate contains an assortment of utilities to deal with paths and their conversions.
 //!
 //! Generally `git` treats paths as bytes, but inherently assumes non-illformed UTF-8 as encoding on windows. Internally, it expects
@@ -48,6 +46,8 @@
 //! Callers may `.expect()` on the result to indicate they don't wish to handle this special and rare case. Note that servers should not
 //! ever get into a code-path which does panic though.
 //! </details>
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 /// A dummy type to represent path specs and help finding all spots that take path specs once it is implemented.
 

--- a/git-pathspec/Cargo.toml
+++ b/git-pathspec/Cargo.toml
@@ -10,8 +10,6 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-glob = { version = "^0.3.0", path = "../git-glob" }
 git-attributes = { version = "^0.3.1", path = "../git-attributes" }

--- a/git-pathspec/src/lib.rs
+++ b/git-pathspec/src/lib.rs
@@ -1,7 +1,7 @@
 //! Parse [path specifications](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec) and
 //! see if a path matches.
-#![forbid(unsafe_code, rust_2018_idioms)]
-#![deny(missing_docs)]
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 use bitflags::bitflags;
 use bstr::BString;

--- a/git-protocol/Cargo.toml
+++ b/git-protocol/Cargo.toml
@@ -64,4 +64,5 @@ git-packetline = { path = "../git-packetline" ,version = "^0.12.6" }
 git-testtools = { path = "../tests/tools" }
 
 [package.metadata.docs.rs]
-features = ["blocking-client", "document-features"]
+features = ["blocking-client", "document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-protocol/src/lib.rs
+++ b/git-protocol/src/lib.rs
@@ -7,6 +7,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub use git_credentials as credentials;

--- a/git-protocol/src/lib.rs
+++ b/git-protocol/src/lib.rs
@@ -7,8 +7,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub use git_credentials as credentials;
 /// A convenience export allowing users of git-protocol to use the transport layer without their own cargo dependency.

--- a/git-quote/Cargo.toml
+++ b/git-quote/Cargo.toml
@@ -10,8 +10,6 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bstr = { version = "0.2.13", default-features = false, features = ["std"]}
 quick-error = "2.0.0"

--- a/git-quote/src/lib.rs
+++ b/git-quote/src/lib.rs
@@ -1,4 +1,5 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 ///
 pub mod ansi_c;

--- a/git-rebase/Cargo.toml
+++ b/git-rebase/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-rebase/src/lib.rs
+++ b/git-rebase/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-ref/Cargo.toml
+++ b/git-ref/Cargo.toml
@@ -22,8 +22,6 @@ name = "refs-parallel-fs-traversal"
 path = "tests/refs-parallel.rs"
 required-features = ["internal-testing-git-features-parallel"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-features = { version = "^0.22.1", path = "../git-features", features = ["walkdir"]}
 git-path = { version = "^0.4.0", path = "../git-path" }

--- a/git-ref/Cargo.toml
+++ b/git-ref/Cargo.toml
@@ -49,5 +49,5 @@ tempfile = "3.2.0"
 
 
 [package.metadata.docs.rs]
-features = ["document-features"]
-all-features = true
+features = ["document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-ref/src/lib.rs
+++ b/git-ref/src/lib.rs
@@ -20,7 +20,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code, missing_docs, rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::borrow::Cow;
 

--- a/git-ref/src/lib.rs
+++ b/git-ref/src/lib.rs
@@ -20,6 +20,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::borrow::Cow;

--- a/git-refspec/Cargo.toml
+++ b/git-refspec/Cargo.toml
@@ -11,8 +11,6 @@ include = ["src/**/*", "CHANGELOG.md", "README.md"]
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-revision = { version = "^0.4.1", path = "../git-revision" }
 git-validate = { version = "^0.5.4", path = "../git-validate" }

--- a/git-refspec/src/lib.rs
+++ b/git-refspec/src/lib.rs
@@ -1,6 +1,6 @@
 //! Parse git ref-specs and represent them.
-#![forbid(unsafe_code, rust_2018_idioms)]
-#![deny(missing_docs)]
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 ///
 pub mod parse;

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -136,5 +136,5 @@ walkdir = "2.3.2"
 serial_test = "0.8.0"
 
 [package.metadata.docs.rs]
-features = ["document-features", "max-performance", "one-stop-shop", "unstable", "blocking-network-client"]
-
+features = ["document-features", "max-performance", "one-stop-shop", "unstable", "blocking-network-client", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -120,7 +120,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(missing_docs, unsafe_code, rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 // Re-exports to make this a potential one-stop shop crate avoiding people from having to reference various crates themselves.
 // This also means that their major version changes affect our major version, but that's alright as we directly expose their

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -120,6 +120,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 // Re-exports to make this a potential one-stop shop crate avoiding people from having to reference various crates themselves.

--- a/git-revision/Cargo.toml
+++ b/git-revision/Cargo.toml
@@ -33,3 +33,4 @@ git-repository = { path = "../git-repository", default-features = false, feature
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-revision/Cargo.toml
+++ b/git-revision/Cargo.toml
@@ -15,7 +15,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = [ "serde", "git-hash/serde1", "git-object/serde1" ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 git-hash = { version = "^0.9.7", path = "../git-hash" }
 git-object = { version = "^0.20.1", path = "../git-object" }

--- a/git-revision/src/lib.rs
+++ b/git-revision/src/lib.rs
@@ -5,7 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code, missing_docs, rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// Access to collections optimized for keys that are already a hash.
 pub use hash_hasher;

--- a/git-revision/src/lib.rs
+++ b/git-revision/src/lib.rs
@@ -5,6 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// Access to collections optimized for keys that are already a hash.

--- a/git-sec/Cargo.toml
+++ b/git-sec/Cargo.toml
@@ -40,5 +40,6 @@ windows = { version = "0.37.0", features = [ "alloc",
 tempfile = "3.3.0"
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-sec/Cargo.toml
+++ b/git-sec/Cargo.toml
@@ -15,8 +15,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = [ "serde" ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 bitflags = "1.3.2"

--- a/git-sec/src/lib.rs
+++ b/git-sec/src/lib.rs
@@ -5,6 +5,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 // `unsafe_code` not forbidden because we need to interact with the libc
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 

--- a/git-sec/src/lib.rs
+++ b/git-sec/src/lib.rs
@@ -5,7 +5,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code, rust_2018_idioms, missing_docs)]
+// `unsafe_code` not forbidden because we need to interact with the libc
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::{
     fmt::{Debug, Display, Formatter},

--- a/git-sequencer/Cargo.toml
+++ b/git-sequencer/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-sequencer/src/lib.rs
+++ b/git-sequencer/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-submodule/Cargo.toml
+++ b/git-submodule/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-submodule/src/lib.rs
+++ b/git-submodule/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-tempfile/Cargo.toml
+++ b/git-tempfile/Cargo.toml
@@ -12,13 +12,12 @@ include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 doctest = false
 test = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 dashmap = "5.1.0"
 once_cell = { version = "1.8.0", default-features = false, features = ["race", "std"] }
 signal-hook = { version = "0.3.9", default-features = false }
 signal-hook-registry = "1.4.0"
 tempfile = "3.2.0"
+
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.98", default-features = false }

--- a/git-tempfile/src/lib.rs
+++ b/git-tempfile/src/lib.rs
@@ -24,7 +24,7 @@
 //!   but not others. Any other operation dealing with the tempfile suffers from the same issue.
 //!
 //! [signal-hook]: https://docs.rs/signal-hook
-#![deny(missing_docs, unsafe_code, rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::{
     io,

--- a/git-tix/Cargo.toml
+++ b/git-tix/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-tix/src/lib.rs
+++ b/git-tix/src/lib.rs
@@ -1,1 +1,2 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]

--- a/git-transport/Cargo.toml
+++ b/git-transport/Cargo.toml
@@ -47,8 +47,6 @@ name = "async-transport"
 path = "tests/async-transport.rs"
 required-features = ["async-client"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-features = { version = "^0.22.1", path = "../git-features" }
 git-url = { version = "^0.7.1", path = "../git-url" }

--- a/git-transport/Cargo.toml
+++ b/git-transport/Cargo.toml
@@ -79,4 +79,5 @@ maybe-async = "0.2.6"
 blocking = "1.0.2"
 
 [package.metadata.docs.rs]
-features = ["http-client-curl", "document-features"]
+features = ["http-client-curl", "document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-transport/src/lib.rs
+++ b/git-transport/src/lib.rs
@@ -7,6 +7,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-transport/src/lib.rs
+++ b/git-transport/src/lib.rs
@@ -7,8 +7,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
 
 pub use git_packetline as packetline;
 

--- a/git-traverse/Cargo.toml
+++ b/git-traverse/Cargo.toml
@@ -11,8 +11,6 @@ include = ["src/**/*"]
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-hash = { version = "^0.9.7", path = "../git-hash" }
 git-object = { version = "^0.20.1", path = "../git-object" }

--- a/git-traverse/src/lib.rs
+++ b/git-traverse/src/lib.rs
@@ -1,6 +1,6 @@
-#![forbid(unsafe_code, rust_2018_idioms)]
-#![deny(missing_docs)]
 //! Various ways to traverse commit graphs and trees with implementations as iterator
+#![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 /// Commit traversal
 pub mod commit;

--- a/git-tui/Cargo.toml
+++ b/git-tui/Cargo.toml
@@ -13,6 +13,4 @@ path = "src/main.rs"
 doctest = false
 test = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/git-tui/src/main.rs
+++ b/git-tui/src/main.rs
@@ -1,5 +1,5 @@
-#![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 fn main() {
     unimplemented!();

--- a/git-url/Cargo.toml
+++ b/git-url/Cargo.toml
@@ -15,8 +15,6 @@ doctest = false
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "bstr/serde1"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"]}
 git-features = { version = "^0.22.1", path = "../git-features" }

--- a/git-url/Cargo.toml
+++ b/git-url/Cargo.toml
@@ -27,5 +27,6 @@ home = "0.5.3"
 document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
-features = ["document-features"]
 all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-url/src/lib.rs
+++ b/git-url/src/lib.rs
@@ -4,6 +4,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/git-url/src/lib.rs
+++ b/git-url/src/lib.rs
@@ -1,11 +1,11 @@
 //! A library implementing a URL for use in git with access to its special capabilities.
 //! ## Feature Flags
 #![cfg_attr(
-feature = "document-features",
-cfg_attr(doc, doc = ::document_features::document_features!())
+    feature = "document-features",
+    cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 use std::{
     convert::TryFrom,

--- a/git-validate/Cargo.toml
+++ b/git-validate/Cargo.toml
@@ -12,8 +12,6 @@ include = ["src/**/*"]
 doctest = false
 test = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 quick-error = "2.0.0"
 bstr = { version = "0.2.13", default-features = false, features = ["std"] }

--- a/git-validate/src/lib.rs
+++ b/git-validate/src/lib.rs
@@ -1,6 +1,6 @@
 //! Validation for various kinds of git related items.
-#![forbid(unsafe_code)]
 #![deny(missing_docs, rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 ///
 pub mod reference;

--- a/git-worktree/Cargo.toml
+++ b/git-worktree/Cargo.toml
@@ -55,3 +55,4 @@ tempfile = "3.2.0"
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-worktree/Cargo.toml
+++ b/git-worktree/Cargo.toml
@@ -21,7 +21,6 @@ name = "single-threaded"
 path = "tests/worktree-single-threaded.rs"
 required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
 
-
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = [ "serde", "bstr/serde1", "git-index/serde1", "git-hash/serde1", "git-object/serde1" ]

--- a/git-worktree/src/lib.rs
+++ b/git-worktree/src/lib.rs
@@ -3,8 +3,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![deny(unsafe_code)]
-#![deny(rust_2018_idioms, missing_docs)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// file system related utilities
 pub mod fs;

--- a/git-worktree/src/lib.rs
+++ b/git-worktree/src/lib.rs
@@ -3,6 +3,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// file system related utilities

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -68,3 +68,4 @@ document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["document-features", "blocking-client", "organize", "estimate-hours", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -3,6 +3,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(feature = "async-client", allow(unused))]
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]

--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -3,9 +3,9 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![forbid(unsafe_code)]
-#![deny(rust_2018_idioms)]
 #![cfg_attr(feature = "async-client", allow(unused))]
+#![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 use std::str::FromStr;
 

--- a/src/ein.rs
+++ b/src/ein.rs
@@ -3,6 +3,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/src/ein.rs
+++ b/src/ein.rs
@@ -3,8 +3,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 mod porcelain;
 mod shared;

--- a/src/gix.rs
+++ b/src/gix.rs
@@ -3,6 +3,7 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/src/gix.rs
+++ b/src/gix.rs
@@ -3,8 +3,8 @@
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
-#![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+#![forbid(unsafe_code)]
 
 mod plumbing;
 mod shared;

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -10,8 +10,6 @@ license = "MIT OR Apache-2.0"
 name = "jtt"
 path = "src/main.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 git-hash = { version = "^0.9.7", path = "../../git-hash" }
 git-lock = { version = "^2.0.0", path = "../../git-lock" }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -1,5 +1,6 @@
 //! Utilities for testing `gitoxide` crates, many of which might be useful for testing programs that use `git` in general.
 #![deny(missing_docs)]
+
 use std::{
     collections::BTreeMap,
     convert::Infallible,


### PR DESCRIPTION
- chore: remove default link to cargo doc everywhere
- feat: pass --cfg docsrs when compiling for https://docs.rs
- chore: uniformize deny attributes
- feat: use docsrs feature in code to show what is feature-gated automatically

This is my first PR, I'm interested by gitoxide and the work you have done is fantastic. As I
explored the code base through the docs I wondered what was available with which feature so I added
this to make it easier. To generate the docs with this locally one can do:

`RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features=max --open`

----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [x] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

If you ticked any of the above boxes, I will always share a link to the video in the PR.
