### PR TITLE
fix typo in git-repository doc

### DIFF
--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -26,7 +26,7 @@
 //! to understand which cache levels exist and how to leverage them.
 //!
 //! When accessing an object, the first cache that's queried is a  memory-capped LRU object cache, mapping their id to data and kind.
-//! On miss, the object is looked up and if ia pack is hit, there is a small fixed-size cache for delta-base objects.
+//! On miss, the object is looked up and if a pack is hit, there is a small fixed-size cache for delta-base objects.
 //!
 //! In scenarios where the same objects are accessed multiple times, an object cache can be useful and is to be configured specifically
 //! using the [`object_cache_size(…)`][crate::Repository::object_cache_size()] method.


### PR DESCRIPTION
This is a very tiny PR -- typo in docs

I noticed a typo when looking at docs.  Would not expect it will be useful to record and publish a video, but feel free :)

----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [X] Feel free to record review and upload on YouTube publicly, if you think it will be useful to anyone
- [ ] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

