### PR TITLE
Update CI workflows to use recent/maintained actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - name: Setup dependencies
       run:
         sudo apt-get install tree
@@ -60,7 +60,7 @@ jobs:
           profile: default
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies (macos)
         if: startsWith(matrix.os, 'macos')
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,7 @@ jobs:
           brew install tree openssl gnu-sed
       - name: "cargo check default features"
         if: startsWith(matrix.os, 'windows')
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all --bins --examples
+        run: cargo check --all --bins --examples
       - run: git lfs fetch && git lfs checkout
       - uses: taiki-e/install-action@v1
         with:
@@ -76,10 +73,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
       - name: "Installation from crates.io"
         if: startsWith(matrix.os, 'windows')
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: "--force gitoxide cargo-smart-release"
+        run: cargo install --force gitoxide cargo-smart-release
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: rustup set auto-self-update disable
-        if: contains(runner.os, 'windows')
-        shell: bash
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies (macos)
         if: startsWith(matrix.os, 'macos')
@@ -92,11 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: default
           toolchain: stable
-          override: true
+          components: clippy,rustfmt
       - name: Run cargo clippy
         run: cargo clippy --all --tests
       - name: Run cargo fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
     - name: Setup dependencies
       run:
@@ -51,7 +51,7 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: rustup set auto-self-update disable
         if: contains(runner.os, 'windows')
         shell: bash
@@ -91,7 +91,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
@@ -122,7 +122,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches: [ main ]
-    tags-ignore: '*'
+    tags-ignore: [ '*' ]
     paths:
       - '.github/**'
       - 'ci/**'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,7 +9,7 @@ jobs:
   stress:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
     - name: stress
       run: make stress

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - name: stress
       run: make stress

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,15 +1,13 @@
+name: Minimum Supported Rust Version
+
 on:
   # Trigger the workflow on push to master or any pull request
   # Ignore all tags
   push:
-    branches:
-      - main
-    tags-ignore: '*'
+    branches: [ main ]
+    tags-ignore: [ '*' ]
   pull_request:
-    branches:
-      - 'main'
-
-name: Minimum Supported Rust Version
+    branches: [ main ]
 
 jobs:
   rustfmt:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -19,7 +19,7 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustup set auto-self-update disable
         if: contains(runner.os, 'windows')
         shell: bash

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,14 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: rustup set auto-self-update disable
-        if: contains(runner.os, 'windows')
-        shell: bash
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.59.0" # dictated by `windows` crates effectively, IMPORTANT: adjust etc/msrv-badge.svg as well
-          override: true
+      - uses: dtolnay/rust-toolchain@1.59.0 # dictated by `windows` crates effectively, IMPORTANT: adjust etc/msrv-badge.svg as well
       - run: make check-msrv-on-ci
         continue-on-error: true # TODO: turn this off once the toolchain gets updated. There is a strange error preventing cargo to select the correct libgit2 version
                                 #       like it doesn't exist.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "${{ env.ARTIFACT_VERSION }}" > artifacts/release-version
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: artifacts
@@ -141,7 +141,7 @@ jobs:
           echo "target dir is: ${{ env.TARGET_DIR }}"
 
       - name: Get release download URL
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,12 @@
 # The key here is that we create the release only once.
 
 name: release
+
 on:
   push:
     # Enable when testing release infrastructure on a branch.
-    # branches:
-    # - ag/release
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+    # branches: [ 'ag/release' ]
+    tags: [ "v[0-9]+.[0-9]+.[0-9]+" ]
 jobs:
   create-release:
     name: create-release
@@ -60,14 +59,14 @@ jobs:
 
   build-release:
     name: build-release
-    needs: ["create-release"]
+    needs: [ "create-release" ]
     runs-on: ${{ matrix.os }}
     env:
       # For some builds, we use cross to test on 32-bit and big-endian
       # systems.
       CARGO: cargo
       # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS:
+      TARGET_FLAGS: ""
       # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
       TARGET_DIR: ./target
       # Emit backtraces on panics.
@@ -76,9 +75,9 @@ jobs:
       EXE_NAME: ein
     strategy:
       matrix:
-#         build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]
-        build: [linux, macos, win-msvc, win-gnu, win32-msvc]
-        feature: ["small", "lean", "max"]
+#         build: [ linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc ]
+        build: [ linux, macos, win-msvc, win-gnu, win32-msvc ]
+        feature: [ "small", "lean", "max" ]
         include:
           - build: linux
             os: ubuntu-18.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,17 +120,11 @@ jobs:
         run: |
           ci/macos-install-packages
 
-      - run: rustup set auto-self-update disable
-        if: contains(runner.os, 'windows')
-        shell: bash
-
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Use Cross
         # if: matrix.os != 'windows-2019'


### PR DESCRIPTION
Currently the CI workflows use some outdated actions or unmaintained ones. This PR should fix that.
I don't know if there is a way to be warned when an action is outdated.

I'm marking as draft and doing separate pushes for the commit so I can see if I break CI on a 
specific one.

----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [x] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

If you ticked any of the above boxes, I will always share a link to the video in the PR.
