### PR TITLE
write blob

### DIFF
--- a/git-repository/examples/init-repo-and-commit.rs
+++ b/git-repository/examples/init-repo-and-commit.rs
@@ -3,7 +3,6 @@
 
 use anyhow::Context;
 use git::objs::tree;
-use git_odb::Write;
 use git_repository as git;
 
 fn main() -> anyhow::Result<()> {
@@ -37,8 +36,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("initial commit id with empty tree: {:?}", initial_commit_id);
 
-    let blob_id = repo.objects.write_buf(git_object::Kind::Blob, b"hello world")?;
-
+    let blob_id = repo.write_blob("hello world")?.into();
     let entry = tree::Entry {
         mode: tree::EntryMode::Blob,
         oid: blob_id,

--- a/git-repository/examples/init-repo-and-commit.rs
+++ b/git-repository/examples/init-repo-and-commit.rs
@@ -2,6 +2,8 @@
 // adds initial commit with empty tree
 
 use anyhow::Context;
+use git::objs::tree;
+use git_odb::Write;
 use git_repository as git;
 
 fn main() -> anyhow::Result<()> {
@@ -19,13 +21,16 @@ fn main() -> anyhow::Result<()> {
         repo.work_dir().expect("non-bare repositories have a work-dir")
     );
 
-    let empty_tree_id = repo.write_object(git::objs::Tree::empty())?;
+    let mut tree = git::objs::Tree::empty();
+    //let empty_tree_id = repo.write_object(git::objs::Tree::empty())?;
+    let empty_tree_id = repo.write_object(&tree)?;
+
     let author = git::actor::SignatureRef {
         name: "Maria Sanchez".into(),
         email: "maria@example.com".into(),
         time: git_date::Time::now_local_or_utc(),
     };
-    let id = repo.commit(
+    let initial_commit_id = repo.commit(
         "HEAD",
         author,
         author,
@@ -33,6 +38,32 @@ fn main() -> anyhow::Result<()> {
         empty_tree_id,
         git::commit::NO_PARENT_IDS,
     )?;
-    println!("new commit id with empty tree: {:?}", id);
+
+    println!("initial commit id with empty tree: {:?}", initial_commit_id);
+
+    let blob_id = repo
+        .objects
+        .write_buf(git_object::Kind::Blob, "hello world".as_bytes())?;
+
+    let entry = tree::Entry {
+        mode: tree::EntryMode::Blob,
+        oid: blob_id,
+        filename: "hello.txt".into(),
+    };
+
+    tree.entries.push(entry);
+    let hello_tree_id = repo.write_object(&tree)?;
+
+    let blob_commit_id = repo.commit(
+        "HEAD",
+        author,
+        author,
+        "hello commit",
+        hello_tree_id,
+        [initial_commit_id],
+    )?;
+
+    println!("commit id for 'hello world' blob: {:?}", blob_commit_id);
+
     Ok(())
 }

--- a/git-repository/examples/init-repo-and-commit.rs
+++ b/git-repository/examples/init-repo-and-commit.rs
@@ -11,18 +11,14 @@ fn main() -> anyhow::Result<()> {
     // paths may not be UTF-8 encoded and thus can't be forced into a String.
     // gitoxide does not assume encodings that aren't there
     // to match the way git does it as a bare minimum and be just as flexible.
-    let work_dir = std::env::args_os()
+    let git_dir = std::env::args_os()
         .nth(1)
         .context("First argument needs to be the directory to initialize the repository in")?;
-    let repo = git::init(work_dir)?;
+    let repo = git::init_bare(git_dir)?;
 
-    println!(
-        "Repo: {:?}",
-        repo.work_dir().expect("non-bare repositories have a work-dir")
-    );
+    println!("Repo (bare): {:?}", repo.git_dir());
 
     let mut tree = git::objs::Tree::empty();
-    //let empty_tree_id = repo.write_object(git::objs::Tree::empty())?;
     let empty_tree_id = repo.write_object(&tree)?;
 
     let author = git::actor::SignatureRef {
@@ -41,9 +37,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("initial commit id with empty tree: {:?}", initial_commit_id);
 
-    let blob_id = repo
-        .objects
-        .write_buf(git_object::Kind::Blob, "hello world".as_bytes())?;
+    let blob_id = repo.objects.write_buf(git_object::Kind::Blob, b"hello world")?;
 
     let entry = tree::Entry {
         mode: tree::EntryMode::Blob,

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -299,10 +299,20 @@ pub mod init {
         /// won't mind if the `directory` otherwise is non-empty.
         pub fn init(directory: impl AsRef<Path>, options: crate::create::Options) -> Result<Self, Error> {
             use git_sec::trust::DefaultForLevel;
-            let path = crate::create::into(directory.as_ref(), options)?;
+            let open_options = crate::open::Options::default_for_level(git_sec::Trust::Full);
+            Self::init_opts(directory, options, open_options)
+        }
+
+        /// Similar to [`init`][Self::init()], but allows to determine how exactly to open the newly created repository.
+        pub fn init_opts(
+            directory: impl AsRef<Path>,
+            create_options: crate::create::Options,
+            mut open_options: crate::open::Options,
+        ) -> Result<Self, Error> {
+            let path = crate::create::into(directory.as_ref(), create_options)?;
             let (git_dir, worktree_dir) = path.into_repository_and_work_tree_directories();
-            let options = crate::open::Options::default_for_level(git_sec::Trust::Full);
-            ThreadSafeRepository::open_from_paths(git_dir, worktree_dir, options).map_err(Into::into)
+            open_options.git_dir_trust = Some(git_sec::Trust::Full);
+            ThreadSafeRepository::open_from_paths(git_dir, worktree_dir, open_options).map_err(Into::into)
         }
     }
 }

--- a/git-repository/src/repository/object.rs
+++ b/git-repository/src/repository/object.rs
@@ -41,10 +41,9 @@ impl crate::Repository {
     /// `try_find_object()` operations from succeeding while alive.
     /// To bypass this limit, clone this `sync::Handle` instance.
     pub fn try_find_object(&self, id: impl Into<ObjectId>) -> Result<Option<Object<'_>>, object::find::OdbError> {
-        let state = self;
         let id = id.into();
 
-        let mut buf = state.free_buf();
+        let mut buf = self.free_buf();
         match self.objects.try_find(&id, &mut buf)? {
             Some(obj) => {
                 let kind = obj.kind;
@@ -58,9 +57,7 @@ impl crate::Repository {
     pub fn write_object(&self, object: impl git_object::WriteTo) -> Result<Id<'_>, object::write::Error> {
         use git_odb::Write;
 
-        let state = self;
-        state
-            .objects
+        self.objects
             .write(object)
             .map(|oid| oid.attach(self))
             .map_err(Into::into)


### PR DESCRIPTION
expand `init-repo-and-commit.rs` to write another commit a blob

It doesn't write a file to the local filesystem, just the commit.  I honestly didn't know how it was going to work before I wrote the code.  Then I thought this might be the way one might use git as data storage from an application where the user interacts with the app not the filesystem (and, if that's a valid use case, might change so it saves data that is less file-like).

interested in feedback!

----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [x] Record if you want to
