### PR TITLE
make video an option for both Byron and submitter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,7 @@
 ----
 
-Can [Byron](https://github.com/Byron) review the PR on video?
+Ok for [Byron](https://github.com/Byron) review the PR on video?
 
-Please choose one - no choice means no recordings are made.
+- [ ] I give my permission to record review and upload on YouTube publicly
 
-- [ ] Record review and upload on YouTube publicly
-- [ ] Record review and upload on YouTube, but keep video unlisted
-
-If you ticked any of the above boxes, I will always share a link to the video in the PR.
+If I think the review will be helpful for the community, then I might record and publish a video.


### PR DESCRIPTION
----

Can [Byron](https://github.com/Byron) review the PR on video?

Please choose one - no choice means no recordings are made.

- [ ] Record review and upload on YouTube publicly
- [ ] Record review and upload on YouTube, but keep video unlisted

If you ticked any of the above boxes, I will always share a link to the video in the PR.
