### PR TITLE
git-repository: more granular feature toggles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ check: ## Build all code in suitable configurations
 					  && cargo check --no-default-features --features blocking-network-client,blocking-http-transport \
 					  && cargo check --no-default-features --features one-stop-shop \
 					  && cargo check --no-default-features --features max-performance \
+					  && cargo check --no-default-features --features max-performance-safe \
 					  && cargo check --no-default-features
 	cd git-odb && cargo check --features serde1
 	cd cargo-smart-release && cargo check --all

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -61,14 +61,23 @@ serde1 = [  "serde",
             "git-mailmap/serde1",
             "git-attributes/serde1",
             "git-revision/serde1"]
-## Activate other features that maximize performance, like usage of threads, `zlib-ng` and access to caching in object databases.
-## **Note** that
 
-max-performance = [ "git-features/fast-sha1",
-                    "git-features/parallel",
-                    "git-features/zlib-ng-compat",
-                    "git-pack/pack-cache-lru-static",
-                    "git-pack/pack-cache-lru-dynamic"]
+## Activate other features that maximize performance, like usage of threads, `zlib-ng` and access to caching in object databases.
+## Note that some platforms might suffer from compile failures, which is when `max-performance-safe` should be used.
+max-performance = [ "fast-sha1", "max-performance-safe" ]
+
+## If enabled, use assembly versions of sha1 on supported platforms.
+## This might cause compile failures as well which is why it can be turned off separately.
+fast-sha1 = [ "git-features/fast-sha1" ]
+
+## Activate features that maximize performance, like usage of threads, `zlib-ng` and access to caching in object databases, skipping the ones known to cause compile failures
+## on some platforms.
+max-performance-safe = [
+    "git-features/parallel",
+    "git-features/zlib-ng-compat",
+    "git-pack/pack-cache-lru-static",
+    "git-pack/pack-cache-lru-dynamic"
+]
 ## Re-export stability tier 2 crates for convenience and make `Repository` struct fields with types from these crates publicly accessible.
 ## Doing so is less stable than the stability tier 1 that `git-repository` is a member of.
 unstable = ["git-mailmap", "git-credentials"]

--- a/git-repository/src/repository/cache.rs
+++ b/git-repository/src/repository/cache.rs
@@ -41,9 +41,9 @@ impl crate::Repository {
     /// Use the `GITOXIDE_OBJECT_CACHE_MEMORY=16mb` to set the given amount of memory to store full objects, on a per-thread basis.
     pub fn apply_environment(self) -> Self {
         // We have no cache types available without this flag currently. Maybe this should change at some point.
-        #[cfg(not(feature = "max-performance"))]
+        #[cfg(not(feature = "max-performance-safe"))]
         return self;
-        #[cfg(feature = "max-performance")]
+        #[cfg(feature = "max-performance-safe")]
         {
             let pack_cache_disabled = std::env::var_os("GITOXIDE_DISABLE_PACK_CACHE").is_some();
             let mut this = self;
@@ -69,7 +69,7 @@ impl crate::Repository {
     }
 }
 
-#[cfg(feature = "max-performance")]
+#[cfg(feature = "max-performance-safe")]
 fn parse_bytes_from_var(name: &str) -> Option<usize> {
     std::env::var(name)
         .ok()

--- a/git-repository/src/repository/init.rs
+++ b/git-repository/src/repository/init.rs
@@ -15,11 +15,11 @@ impl crate::Repository {
             work_tree,
             common_dir,
             objects: {
-                #[cfg(feature = "max-performance")]
+                #[cfg(feature = "max-performance-safe")]
                 {
                     objects.with_pack_cache(|| Box::new(git_pack::cache::lru::StaticLinkedList::<64>::default()))
                 }
-                #[cfg(not(feature = "max-performance"))]
+                #[cfg(not(feature = "max-performance-safe"))]
                 {
                     objects
                 }


### PR DESCRIPTION
That way one has an angle on compile failures in client libraries,
see https://github.com/o2sh/onefetch/pull/752 for motivation.

