### PR TITLE
restrict `sha1` `asm` to supported archs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prodash",
  "quick-error",
- "sha-1",
+ "sha1",
  "sha1_smol",
  "walkdir",
 ]
@@ -2713,10 +2713,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
+name = "sha1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "04cc229fb94bcb689ffc39bd4ded842f6ff76885efede7c6d1ffb62582878bea"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ git-hash = { opt-level = 3 }
 git-actor = { opt-level = 3 }
 git-config = { opt-level = 3 }
 miniz_oxide = { opt-level = 3 }
-sha-1 = { opt-level = 3 }
+sha1 = { opt-level = 3 }
 sha1_smol = { opt-level = 3 }
 
 [profile.release]

--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -50,7 +50,7 @@ zlib-rust-backend = ["flate2/rust_backend"]
 ## A multi-crate implementation that can use hardware acceleration, thus bearing the potential for up to 2Gb/s throughput on
 ## CPUs that support it, like AMD Ryzen or Intel Core i3, as well as Apple Silicon like M1.
 ## Takes precedence over `rustsha1` if both are specified.
-fast-sha1 = ["sha-1"]
+fast-sha1 = ["sha1"]
 ## A standard and well performing pure Rust implementation of Sha1. Will significantly slow down various git operations.
 rustsha1 = ["sha1_smol"]
 
@@ -106,7 +106,7 @@ walkdir = { version = "2.3.2", optional = true } # used when parallel is off
 # hashing and 'fast-sha1' feature
 sha1_smol = { version = "1.0.0", optional = true }
 crc32fast = { version = "1.2.1", optional = true }
-sha-1 = { version = "0.10.0", optional = true }
+sha1 = { version = "0.10.0", optional = true }
 
 # progress
 prodash = { version = "19.0.0", optional = true, default-features = false, features = ["unit-bytes", "unit-human"] }
@@ -133,10 +133,9 @@ bstr = { version = "0.2.15", default-features = false }
 
 
 # Assembly doesn't yet compile on MSVC on windows, but does on GNU, see https://github.com/RustCrypto/asm-hashes/issues/17
-# TODO: potentially include it only for certain architectures
-# [target.'cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(target_env = "msvc")))'.dependencies]
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-sha-1 = { version = "0.10.0", optional = true, features = ["asm"] }
+# At this time, only aarch64, x86 and x86_64 are supported.
+[target.'cfg(all(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"), not(target_env = "msvc")))'.dependencies]
+sha1 = { version = "0.10.0", optional = true, features = ["asm"] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
It only compiles on aarch64, x86 and x86_64 (I also made an upstream PR, but I'm not sure how receptive they will be to that considering they still haven't disabled MSVC). I also switched the cargo files to use the new crate name `sha1`.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
