### PR TITLE
git-discover: fix is_git check for macOS exFAT

### DIFF
--- a/git-discover/src/is.rs
+++ b/git-discover/src/is.rs
@@ -46,64 +46,52 @@ pub fn git(git_dir: impl AsRef<Path>) -> Result<crate::repository::Kind, crate::
         LinkedWorkTreeDir,
         WorkTreeGitDir { work_dir: std::path::PathBuf },
     }
-    #[cfg(not(windows))]
-    fn is_directory(err: &std::io::Error) -> bool {
-        err.raw_os_error() == Some(21)
-    }
-    // TODO: use ::IsDirectory as well when stabilized, but it's permission denied on windows
-    #[cfg(windows)]
-    fn is_directory(err: &std::io::Error) -> bool {
-        err.kind() == std::io::ErrorKind::PermissionDenied
-    }
+    let metadata = git_dir.as_ref().metadata().map_err(crate::is_git::Error::Metadata)?;
     let git_dir = git_dir.as_ref();
-    let (dot_git, common_dir, kind) = match crate::path::from_gitdir_file(git_dir) {
-        Ok(private_git_dir) => {
-            let common_dir = private_git_dir.join("commondir");
-            match crate::path::from_plain_file(&common_dir) {
-                Some(Err(err)) => {
-                    return Err(crate::is_git::Error::MissingCommonDir {
-                        missing: common_dir,
-                        source: err,
-                    })
-                }
-                Some(Ok(common_dir)) => {
-                    let common_dir = private_git_dir.join(common_dir);
-                    (
-                        Cow::Owned(private_git_dir),
-                        Cow::Owned(common_dir),
-                        Kind::LinkedWorkTreeDir,
-                    )
-                }
-                None => (
-                    Cow::Owned(private_git_dir.clone()),
+    let (dot_git, common_dir, kind) = if metadata.is_file() {
+        let private_git_dir = crate::path::from_gitdir_file(git_dir)?;
+        let common_dir = private_git_dir.join("commondir");
+        match crate::path::from_plain_file(&common_dir) {
+            Some(Err(err)) => {
+                return Err(crate::is_git::Error::MissingCommonDir {
+                    missing: common_dir,
+                    source: err,
+                })
+            }
+            Some(Ok(common_dir)) => {
+                let common_dir = private_git_dir.join(common_dir);
+                (
                     Cow::Owned(private_git_dir),
-                    Kind::Submodule,
-                ),
+                    Cow::Owned(common_dir),
+                    Kind::LinkedWorkTreeDir,
+                )
             }
+            None => (
+                Cow::Owned(private_git_dir.clone()),
+                Cow::Owned(private_git_dir),
+                Kind::Submodule,
+            ),
         }
-        Err(crate::path::from_gitdir_file::Error::Io(err)) if is_directory(&err) => {
-            let common_dir = git_dir.join("commondir");
-            let worktree_and_common_dir =
-                crate::path::from_plain_file(common_dir)
+    } else {
+        let common_dir = git_dir.join("commondir");
+        let worktree_and_common_dir = crate::path::from_plain_file(common_dir)
+            .and_then(Result::ok)
+            .and_then(|cd| {
+                crate::path::from_plain_file(git_dir.join("gitdir"))
                     .and_then(Result::ok)
-                    .and_then(|cd| {
-                        crate::path::from_plain_file(git_dir.join("gitdir"))
-                            .and_then(Result::ok)
-                            .map(|worktree_gitfile| (crate::path::without_dot_git_dir(worktree_gitfile), cd))
-                    });
-            match worktree_and_common_dir {
-                Some((work_dir, common_dir)) => {
-                    let common_dir = git_dir.join(common_dir);
-                    (
-                        Cow::Borrowed(git_dir),
-                        Cow::Owned(common_dir),
-                        Kind::WorkTreeGitDir { work_dir },
-                    )
-                }
-                None => (Cow::Borrowed(git_dir), Cow::Borrowed(git_dir), Kind::MaybeRepo),
+                    .map(|worktree_gitfile| (crate::path::without_dot_git_dir(worktree_gitfile), cd))
+            });
+        match worktree_and_common_dir {
+            Some((work_dir, common_dir)) => {
+                let common_dir = git_dir.join(common_dir);
+                (
+                    Cow::Borrowed(git_dir),
+                    Cow::Owned(common_dir),
+                    Kind::WorkTreeGitDir { work_dir },
+                )
             }
+            None => (Cow::Borrowed(git_dir), Cow::Borrowed(git_dir), Kind::MaybeRepo),
         }
-        Err(err) => return Err(err.into()),
     };
 
     {

--- a/git-discover/src/lib.rs
+++ b/git-discover/src/lib.rs
@@ -33,6 +33,8 @@ pub mod is_git {
         MissingRefsDirectory { missing: PathBuf },
         #[error(transparent)]
         GitFile(#[from] crate::path::from_gitdir_file::Error),
+        #[error("Could not retrieve metadata")]
+        Metadata(#[from] std::io::Error),
     }
 }
 

--- a/git-discover/tests/discover.rs
+++ b/git-discover/tests/discover.rs
@@ -1,5 +1,6 @@
 pub use git_testtools::Result;
 
+mod is_git;
 mod parse;
 mod path;
 mod upwards;

--- a/git-discover/tests/fixtures/generated-archives/make_exfat_repo_darwin.tar.xz
+++ b/git-discover/tests/fixtures/generated-archives/make_exfat_repo_darwin.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ebda918a3263c7d2da6b5f1de2dca926498f5736a7f0ad5be9feaf028e2b272
+size 17168

--- a/git-discover/tests/fixtures/make_exfat_repo_darwin.sh
+++ b/git-discover/tests/fixtures/make_exfat_repo_darwin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu -o pipefail
+
+[[ $(uname) == Darwin ]] || exit 1
+
+hdiutil create -size 10m -fs exfat -volname "test" exfat_repo.dmg
+mkdir exfat_mount
+hdiutil attach exfat_repo.dmg -nobrowse -mountpoint exfat_mount
+
+(
+  cd exfat_mount
+  git init -q
+  git checkout -b main
+  touch this
+  git add this
+  git commit -q -m c1
+)
+
+hdiutil detach exfat_mount
+rm -R exfat_mount

--- a/git-discover/tests/is_git/mod.rs
+++ b/git-discover/tests/is_git/mod.rs
@@ -1,0 +1,39 @@
+#[cfg(target_os = "macos")]
+#[test]
+fn verify_on_exfat() -> crate::Result<()> {
+    use git_discover::repository::Kind;
+    use std::process::Command;
+
+    let fixtures = git_testtools::scripted_fixture_repo_read_only("make_exfat_repo_darwin.sh")?;
+    let mount_point = tempfile::tempdir()?;
+
+    let _cleanup = {
+        // Mount dmg file
+        Command::new("hdiutil")
+            .args(&["attach", "-nobrowse", "-mountpoint"])
+            .arg(mount_point.path())
+            .arg(fixtures.as_path().join("exfat_repo.dmg"))
+            .status()?;
+
+        // Ensure that the mount point is always cleaned up
+        let cleanup = defer::defer({
+            let mount_point = mount_point.path().to_owned();
+            move || {
+                Command::new("hdiutil")
+                    .arg("detach")
+                    .arg(&mount_point)
+                    .status()
+                    .expect("detach temporary test dmg filesystem successfully");
+            }
+        });
+        cleanup
+    };
+
+    let is_git = git_discover::is_git(mount_point.path().join(".git"));
+
+    assert!(
+        matches!(is_git, Ok(Kind::WorkTree { linked_git_dir: None })),
+        "repo on exFAT is recognized as a valid worktree repo"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Closes #514

> Repositories can't be opened on macOS exFAT Volumes. ([starship/starship#4316](https://github.com/starship/starship/issues/4316))
> 
> Despite encountering a `.git` (directory) `File::open` succeeds, leading to the code path for opening `.git` files instead of directories. It contains file system data which cannot pass gitfile validation or could be rejected for size reasons.

Regarding the test, I am aware of the other `hdiutil` test (which I originally wrote). But for this I tried to handle the repository creation in a bash script, because as far as I can tell `git_testtools` performs some environment sanitization and should be a bit faster on subsequent runs.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
