### PR TITLE
gix rev parse uses ISO8601 time format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,7 @@ dependencies = [
  "futures-lite",
  "git-commitgraph",
  "git-config",
+ "git-date",
  "git-features",
  "git-pack",
  "git-repository",

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -42,6 +42,7 @@ git-transport-configuration-only = { package = "git-transport", version = "^0.20
 git-commitgraph = { version = "^0.8.2", path = "../git-commitgraph" }
 git-config = { version = "^0.7.1", path = "../git-config" }
 git-features = { version = "^0.22.4", path = "../git-features" }
+git-date = { version = "^0.1.0", path = "../git-date" }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 anyhow = "1.0.42"
 thiserror = "1.0.34"

--- a/gitoxide-core/src/repository/revision/explain.rs
+++ b/gitoxide-core/src/repository/revision/explain.rs
@@ -94,17 +94,13 @@ impl<'a> delegate::Revision for Explain<'a> {
             ReflogLookup::Entry(no) => {
                 writeln!(self.out, "Find entry {} in reflog of '{}' reference", no, ref_name).ok()
             }
-            ReflogLookup::Date(time) => {
-                let mut buf = Vec::new();
-                time.write_to(&mut buf).ok()?;
-                writeln!(
-                    self.out,
-                    "Find entry closest to time {} in reflog of '{}' reference",
-                    buf.as_bstr(),
-                    ref_name
-                )
-                .ok()
-            }
+            ReflogLookup::Date(time) => writeln!(
+                self.out,
+                "Find entry closest to time {} in reflog of '{}' reference",
+                time.format(git_date::time::format::ISO8601),
+                ref_name
+            )
+            .ok(),
         }
     }
 


### PR DESCRIPTION
----
Tasks:
* [x]  `gix rev parse '@{1979-02-26 18:30:00}' -e` - should use a nicer format when displaying the _parsed_ time



Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
