### PR TITLE
feat: add zlib-ng feature to allow linking against system libz-ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -2077,6 +2078,16 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]

--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -41,6 +41,8 @@ crc32 = ["crc32fast"]
 ## Note that a competitive Zlib implementation is critical to `gitoxide's` object database performance.
 ## Additional backends are supported, each of which overriding the default Rust backend.
 zlib = ["flate2", "flate2/rust_backend", "quick-error"]
+## Use zlib-ng (libz-ng-sys) with native API (no compat mode) that can co-exist with system libz.
+zlib-ng= ["flate2/zlib-ng"]
 ## Use a C-based backend which can compress and decompress significantly faster than the other options.
 zlib-ng-compat = ["flate2/zlib-ng-compat"]
 ## Use a slower C-based backend which can compress and decompress significantly faster than the rust version.


### PR DESCRIPTION
Allow to use zlib-ng (zlib-ng-sys) with native API (no compat mode) that can co-exist with system libz (loaded by e.g. libcurl). This is used in gitoxide package on Alpine Linux.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
