### PR TITLE
`ein t hours -fl` based ODB panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ name = "git-odb"
 version = "0.33.0"
 dependencies = [
  "arc-swap",
+ "crossbeam-channel",
  "document-features",
  "filetime",
  "git-actor",
@@ -1427,6 +1428,7 @@ dependencies = [
  "git-quote",
  "git-testtools",
  "maplit",
+ "num_cpus",
  "parking_lot 0.12.1",
  "pretty_assertions",
  "serde",

--- a/crate-status.md
+++ b/crate-status.md
@@ -473,6 +473,8 @@ See its [README.md](https://github.com/Byron/gitoxide/blob/main/git-lock/README.
       * [x] tree entries
     * **diffs/changes**
         * [x] tree with other tree
+           * [ ] respect case-sensitivity of host filesystem.
+           * [ ] a way to access various diff related settings or use them
         * [ ] tree with working tree
         * [x] diffs between modified blobs with various algorithms
         * [ ] tree with index

--- a/git-odb/Cargo.toml
+++ b/git-odb/Cargo.toml
@@ -48,6 +48,8 @@ git-actor = { path = "../git-actor" }
 pretty_assertions = "1.0.0"
 filetime = "0.2.15"
 maplit = "1.0.2"
+num_cpus = "1.13.1"
+crossbeam-channel = "0.5.6"
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde1"]

--- a/git-odb/tests/fixtures/generated-archives/make_repo_multi_index.tar.xz
+++ b/git-odb/tests/fixtures/generated-archives/make_repo_multi_index.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b7c838e9bc586515b7bcbb2acdd3fbad294a080041a3e99fbe472159eb97478
-size 78172
+oid sha256:1ce58ace572ae5ef51d4d13d62cb81196991b6d2fba08de429a9ab78dae0fa98
+size 200564

--- a/git-odb/tests/fixtures/make_repo_multi_index.sh
+++ b/git-odb/tests/fixtures/make_repo_multi_index.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
+omit_multi_index=${1:-no}
+
 git init -q
 git config commit.gpgsign false
 
@@ -26,6 +28,7 @@ for round in $(seq $rounds); do
   write_files "${dirs[$dir_index]}" $num_files "$round"
   git add .
   git commit -qm "$round $num_files"
+  git repack
 done
 
 echo hello world > referee
@@ -34,6 +37,6 @@ git commit -qm "to be forgotten"
 git tag -m "a tag object" referrer
 git reset --hard HEAD~1
 
-# speed up all access by creating a pack
-git gc --aggressive
-git multi-pack-index write
+if [ "$omit_multi_index" == "no" ]; then
+  git multi-pack-index write
+fi

--- a/git-odb/tests/odb-multi-threaded.rs
+++ b/git-odb/tests/odb-multi-threaded.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "internal-testing-git-features-parallel")]
 mod odb;
+#[cfg(feature = "internal-testing-git-features-parallel")]
 use odb::*;

--- a/git-odb/tests/odb-single-threaded.rs
+++ b/git-odb/tests/odb-single-threaded.rs
@@ -1,2 +1,4 @@
+#[cfg(not(feature = "internal-testing-git-features-parallel"))]
 mod odb;
+#[cfg(not(feature = "internal-testing-git-features-parallel"))]
 use odb::*;

--- a/git-odb/tests/odb/regression/mod.rs
+++ b/git-odb/tests/odb/regression/mod.rs
@@ -4,15 +4,58 @@ mod repo_with_small_packs {
     use crate::odb::{fixture_path, hex_to_id};
 
     #[test]
-    fn all_packed_objects_can_be_found() {
-        let store = git_odb::at(fixture_path("repos/small-packs.git/objects")).unwrap();
+    fn all_packed_objects_can_be_found() -> crate::Result {
+        let store = git_odb::at(fixture_path("repos/small-packs.git/objects"))?;
         let mut buf = Vec::new();
         assert!(
             store
-                .try_find(hex_to_id("ecc68100297fff843a7eef8df0d0fb80c1c8bac5"), &mut buf)
-                .unwrap()
+                .try_find(hex_to_id("ecc68100297fff843a7eef8df0d0fb80c1c8bac5"), &mut buf)?
                 .is_some(),
             "object is present and available"
         );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "internal-testing-git-features-parallel")]
+    fn multi_threaded_access_will_not_panic() {
+        for arg in ["no", "without-multi-index"] {
+            let base = git_testtools::scripted_fixture_repo_read_only_with_args("make_repo_multi_index.sh", Some(arg))
+                .unwrap()
+                .join(".git")
+                .join("objects");
+            let store = git_odb::at(base).unwrap();
+            let (tx, barrier) = crossbeam_channel::unbounded::<()>();
+            let handles = (0..num_cpus::get()).map(|tid| {
+                std::thread::spawn({
+                    let store = store.clone();
+                    let barrier = barrier.clone();
+                    move || {
+                        barrier.recv().ok();
+                        let mut buf = Vec::new();
+                        let mut count = 0;
+                        for id in store.iter().unwrap() {
+                            let id = id.unwrap();
+                            assert!(
+                                store.try_find(id, &mut buf).is_ok(),
+                                "Thread {} could not find {}",
+                                tid,
+                                id
+                            );
+                            count += 1;
+                        }
+                        count
+                    }
+                })
+            });
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            drop(tx);
+            let expected = store.iter().unwrap().count();
+            for handle in handles {
+                let actual = handle.join().expect("no panic");
+                assert_eq!(actual, expected);
+            }
+        }
     }
 }

--- a/git-odb/tests/odb/store/dynamic.rs
+++ b/git-odb/tests/odb/store/dynamic.rs
@@ -62,7 +62,7 @@ fn multi_index_access() -> crate::Result {
         assert!(handle.find(oid, &mut buf).is_ok());
         count += 1;
     }
-    assert_eq!(count, 868);
+    assert_eq!(count, 1732);
 
     assert_eq!(
         handle.store_ref().metrics(),
@@ -71,8 +71,8 @@ fn multi_index_access() -> crate::Result {
             num_refreshes: 1,
             open_reachable_indices: 1,
             known_reachable_indices: 1,
-            open_reachable_packs: 1,
-            known_packs: 1,
+            open_reachable_packs: 15,
+            known_packs: 15,
             unused_slots: 31,
             loose_dbs: 1,
             unreachable_indices: 0,
@@ -91,8 +91,8 @@ fn multi_index_access() -> crate::Result {
             num_refreshes: 2,
             open_reachable_indices: 1,
             known_reachable_indices: 1,
-            open_reachable_packs: 1,
-            known_packs: 1,
+            open_reachable_packs: 15,
+            known_packs: 15,
             unused_slots: 31,
             loose_dbs: 1,
             unreachable_indices: 0,
@@ -115,7 +115,7 @@ fn multi_index_access() -> crate::Result {
             open_reachable_indices: 1,
             known_reachable_indices: 1,
             open_reachable_packs: 0,
-            known_packs: 1,
+            known_packs: 15,
             unused_slots: 31,
             loose_dbs: 1,
             unreachable_indices: 0,
@@ -147,7 +147,7 @@ fn multi_index_keep_open() -> crate::Result {
             open_reachable_indices: 1,
             known_reachable_indices: 1,
             open_reachable_packs: 0,
-            known_packs: 1,
+            known_packs: 15,
             unused_slots: 31,
             loose_dbs: 1,
             unreachable_indices: 0,
@@ -176,7 +176,7 @@ fn multi_index_keep_open() -> crate::Result {
             open_reachable_indices: 1,
             known_reachable_indices: 1,
             open_reachable_packs: 0, /*no pack is open anymore at least as seen from the index*/
-            known_packs: 1,
+            known_packs: 15,
             unused_slots: 30,
             loose_dbs: 1,
             unreachable_indices: 1,

--- a/src/porcelain/main.rs
+++ b/src/porcelain/main.rs
@@ -40,6 +40,7 @@ pub fn main() -> Result<()> {
                 working_dir,
                 rev_spec,
                 no_bots,
+                threads,
                 file_stats,
                 line_stats,
                 show_pii,
@@ -60,6 +61,7 @@ pub fn main() -> Result<()> {
                             hours::Context {
                                 show_pii,
                                 ignore_bots: no_bots,
+                                threads,
                                 file_stats,
                                 line_stats,
                                 omit_unify_identities,

--- a/src/porcelain/options.rs
+++ b/src/porcelain/options.rs
@@ -109,6 +109,9 @@ pub struct EstimateHours {
     /// Note that this implies the work to be done for file-stats, so it should be set as well.
     #[clap(short = 'l', long)]
     pub line_stats: bool,
+    /// The amount of threads to use. If unset, use all cores, if 0 use al physical cores.
+    #[clap(short = 't', long)]
+    pub threads: Option<usize>,
     /// Show personally identifiable information before the summary. Includes names and email addresses.
     #[clap(short = 'p', long)]
     pub show_pii: bool,


### PR DESCRIPTION
The above invocation stresses the ODB in never before seen ways, apparently, as it extracts every single object ever seen. On repos that have multiple packs the parallel pack loading logic fails in ways that cause objects not to be found (reproducibly) or to trigger a panic.

### Observations

* single pack repos work with no issues
* single-threaded access is fine
* one or more packs and multi-threaded operation cause panics to hit, crashing all threads at different times even though by then all packs must have been loaded already.
* It happens only with multi-indices (so removing the multi-index makes the issue disappear), and is related to recursion code that happens if an object refers to a base which is outside of its pack. Maybe not even related to multi-threading. Probably not related to multi-threading.