### PR TITLE
Make Content-Type header check case-insensitive

### DIFF
--- a/git-transport/src/client/blocking_io/http/mod.rs
+++ b/git-transport/src/client/blocking_io/http/mod.rs
@@ -54,12 +54,12 @@ impl Transport<Impl> {
 
 impl<H: Http> Transport<H> {
     fn check_content_type(service: Service, kind: &str, headers: <H as Http>::Headers) -> Result<(), client::Error> {
-        let wanted_content_type = format!("Content-Type: application/x-{}-{}", service.as_str(), kind);
+        let wanted_content_type = format!("content-type: application/x-{}-{}", service.as_str(), kind);
         if !headers
             .lines()
             .collect::<Result<Vec<_>, _>>()?
             .iter()
-            .any(|l| l == &wanted_content_type)
+            .any(|l| l.to_lowercase() == wanted_content_type)
         {
             return Err(client::Error::Http(Error::Detail {
                 description: format!(

--- a/git-transport/tests/client/blocking_io/http/mod.rs
+++ b/git-transport/tests/client/blocking_io/http/mod.rs
@@ -455,3 +455,15 @@ Git-Protocol: version=2
     );
     Ok(())
 }
+
+#[test]
+fn check_content_type_is_case_insensitive() -> crate::Result {
+    let (_server, mut client) = mock::serve_and_connect(
+        "v2/http-handshake-lowercase-headers.response",
+        "path/not/important/due/to/mock",
+        Protocol::V2,
+    )?;
+    let result = client.handshake(Service::UploadPack, &[]);
+    assert!(result.is_ok());
+    Ok(())
+}

--- a/git-transport/tests/fixtures/v2/http-handshake-lowercase-headers.response
+++ b/git-transport/tests/fixtures/v2/http-handshake-lowercase-headers.response
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+server: GitHub Babel 2.0
+content-type: application/x-git-upload-pack-advertisement
+content-length: 1000
+expires: Fri, 01 Jan 1980 00:00:00 GMT
+pragma: no-cache
+cache-control: no-cache, max-age=0, must-revalidate
+vary: Accept-Encoding
+x-frame-options: DENY
+x-github-request-id: 737D:544E:C932CB:113F404:5F3F3EE5
+
+001e# service=git-upload-pack
+0000000eversion 2
+0023agent=git/github-gdf51a71f0236
+000cls-refs
+0019fetch=shallow filter
+0012server-option
+0000


### PR DESCRIPTION
Git allows lowercase (for example) header field names but prior to this change, `check_content_type` would return an error saying that the header couldn't be found unless the casing matched.

***

RFC 7230 (HTTP/1.1) says:

> Each header field consists of a case-insensitive field name followed by a colon (":"), optional leading whitespace, the field value, and optional trailing whitespace.

https://www.rfc-editor.org/rfc/rfc7230#section-3.2

***

RFC 7540 (HTTP/2) says:

> Just as in HTTP/1.x, header field names are strings of ASCII
characters that are compared in a case-insensitive fashion.

https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
