### PR TITLE
Introduce http-client feature to decouple from curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ check: ## Build all code in suitable configurations
 					 && cargo check --features blocking-client \
 					 && cargo check --features async-client \
 					 && cargo check --features async-client,async-std \
+					 && cargo check --features http-client \
 					 && cargo check --features http-client-curl
 	cd git-transport && if cargo check --all-features 2>/dev/null; then false; else true; fi
 	cd git-protocol && cargo check \

--- a/git-transport/Cargo.toml
+++ b/git-transport/Cargo.toml
@@ -20,8 +20,10 @@ default = []
 
 ## If set, blocking implementations of the typical git transports become available in `crate::client`
 blocking-client = ["git-packetline/blocking-io"]
-## Implies `blocking-client`, and adds support for the http and https transports using the Rust bindings for `libcurl`.
-http-client-curl = ["curl", "base64", "git-features/io-pipe", "blocking-client"]
+## Implies `blocking-client`, and adds support for the http and https transports.
+http-client = ["base64", "git-features/io-pipe", "blocking-client"]
+## Implies `http-client`, and adds support for the http and https transports using the Rust bindings for `libcurl`.
+http-client-curl = ["curl", "http-client"]
 ## If set, an async implementations of the git transports becomes available in `crate::client`.
 ## Suitable for implementing your own transports while using git's way of communication, typically in conjunction with a custom server.
 ## **Note** that the _blocking_ client has a wide range of available transports, with the _async_ version of it supporting only the TCP based `git` transport leaving you
@@ -62,11 +64,13 @@ futures-io = { version = "0.3.16", optional = true }
 futures-lite = { version  = "1.12.0", optional = true }
 pin-project-lite = { version = "0.2.6", optional = true }
 
+# for http-client
+base64 = { version = "0.13.0", optional = true }
+
 # for http-client-curl
 # zlib-ng-compat doesn't force zlib-ng
 curl = { version = "0.4", optional = true, features = ["static-curl", "static-ssl", "zlib-ng-compat"] }
 thiserror = "1.0.26"
-base64 = { version = "0.13.0", optional = true }
 
 ## If used in conjunction with `async-client`, the `connect()` method will be come available along with supporting the git protocol over TCP,
 ## where the TCP stream is created using this crate.

--- a/git-transport/src/client/blocking_io/mod.rs
+++ b/git-transport/src/client/blocking_io/mod.rs
@@ -4,7 +4,7 @@ pub mod connect;
 ///
 pub mod file;
 ///
-#[cfg(feature = "http-client-curl")]
+#[cfg(feature = "http-client")]
 pub mod http;
 
 mod bufread_ext;

--- a/git-transport/src/client/mod.rs
+++ b/git-transport/src/client/mod.rs
@@ -10,7 +10,7 @@ pub use traits::TransportWithoutIO;
 
 #[cfg(feature = "blocking-client")]
 mod blocking_io;
-#[cfg(all(feature = "blocking-client", feature = "http-client-curl"))]
+#[cfg(feature = "http-client")]
 pub use blocking_io::http;
 #[cfg(feature = "blocking-client")]
 pub use blocking_io::{

--- a/git-transport/src/client/non_io_types.rs
+++ b/git-transport/src/client/non_io_types.rs
@@ -58,12 +58,12 @@ mod error {
     use bstr::BString;
 
     use crate::client::capabilities;
-    #[cfg(feature = "http-client-curl")]
+    #[cfg(feature = "http-client")]
     use crate::client::http;
 
-    #[cfg(feature = "http-client-curl")]
+    #[cfg(feature = "http-client")]
     type HttpError = http::Error;
-    #[cfg(not(feature = "http-client-curl"))]
+    #[cfg(not(feature = "http-client"))]
     type HttpError = std::convert::Infallible;
 
     /// The error used in most methods of the [`client`][crate::client] module


### PR DESCRIPTION
This is a backwards-compatible change that allows for using implementations of the `Http` trait other than `Curl`.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
