### PR TITLE
Don't panic on parsing too short loose object

### DIFF
--- a/git-object/src/object/mod.rs
+++ b/git-object/src/object/mod.rs
@@ -180,7 +180,14 @@ impl<'a> ObjectRef<'a> {
     /// Deserialize an object from a loose serialisation
     pub fn from_loose(data: &'a [u8]) -> Result<ObjectRef<'a>, LooseDecodeError> {
         let (kind, size, offset) = loose_header(data)?;
-        Ok(Self::from_bytes(kind, &data[offset..][..size])?)
+
+        let body = &data[offset..]
+            .get(..size)
+            .ok_or(LooseHeaderDecodeError::InvalidHeader {
+                message: "invalid size",
+            })?;
+
+        Ok(Self::from_bytes(kind, body)?)
     }
 
     /// Deserialize an object of `kind` from the given `data`.

--- a/git-object/tests/loose.rs
+++ b/git-object/tests/loose.rs
@@ -1,5 +1,5 @@
 use bstr::ByteSlice;
-use git_object::{decode, encode, Kind};
+use git_object::{decode, encode, Kind, ObjectRef};
 
 #[test]
 fn all() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,4 +17,12 @@ fn all() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(actual_read, buf.len());
     }
     Ok(())
+}
+
+#[test]
+fn invalid_loose() {
+    assert_eq!(
+        ObjectRef::from_loose(b"tree 1000\x00").unwrap_err().to_string(),
+        "invalid size"
+    );
 }


### PR DESCRIPTION
Not sure about the error we return here. This was the easiest to return, but it's not technically true? Open to feedback here.

At least it doesn't panic anymore :)

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
