### PR TITLE
fixes to make `crates-index-diff` fetching possible

### DIFF
--- a/git-repository/src/remote/connection/fetch/mod.rs
+++ b/git-repository/src/remote/connection/fetch/mod.rs
@@ -41,7 +41,7 @@ pub use error::Error;
 /// The status of the repository after the fetch operation
 #[derive(Debug, Clone)]
 pub enum Status {
-    /// Nothing changed as the remote didn't have anything new.
+    /// Nothing changed as the remote didn't have anything new compared to our tracking branches.
     NoChange,
     /// There was at least one tip with a new object which we received.
     Change {
@@ -70,8 +70,11 @@ pub struct Outcome<'spec> {
 ///
 pub mod negotiate;
 
+///
 pub mod prepare {
+    /// The error returned by [`prepare_fetch()`][super::Connection::prepare_fetch()].
     #[derive(Debug, thiserror::Error)]
+    #[allow(missing_docs)]
     pub enum Error {
         #[error("Cannot perform a meaningful fetch operation without any configured ref-specs")]
         MissingRefSpecs,

--- a/git-repository/src/remote/fetch.rs
+++ b/git-repository/src/remote/fetch.rs
@@ -56,4 +56,4 @@ pub struct Mapping {
 }
 
 #[cfg(feature = "blocking-network-client")]
-pub use super::connection::fetch::{negotiate, refs, Error, Outcome, Prepare, Status};
+pub use super::connection::fetch::{negotiate, prepare, refs, Error, Outcome, Prepare, Status};


### PR DESCRIPTION
This PR contains changes to improve the API based on findings
when making fetch available via `gitoxide` in `crates-index-diff`.
