### PR TITLE
reduce pack memory footprint

### DIFF
--- a/git-pack/src/cache/delta/iter.rs
+++ b/git-pack/src/cache/delta/iter.rs
@@ -68,7 +68,7 @@ impl<'a, T> Node<'a, T> {
             // SAFETY: The resulting mutable pointer cannot be yielded by any other node.
             #[allow(unsafe_code)]
             Node {
-                item: unsafe { &mut *(children as *mut Item<T>).add(index) },
+                item: unsafe { &mut *(children as *mut Item<T>).add(index as usize) },
                 children,
             }
         })

--- a/git-pack/src/cache/delta/mod.rs
+++ b/git-pack/src/cache/delta/mod.rs
@@ -119,7 +119,7 @@ impl<T> Tree<T> {
             offset,
             next_offset: 0,
             data,
-            children: Vec::new(),
+            children: Default::default(),
         });
         Ok(())
     }
@@ -147,7 +147,7 @@ impl<T> Tree<T> {
             offset,
             next_offset: 0,
             data,
-            children: Vec::new(),
+            children: Default::default(),
         });
         Ok(())
     }
@@ -193,6 +193,12 @@ mod tests {
                 Ok(())
             }
         }
+    }
+
+    #[test]
+    fn size_of_pack_tree_item() {
+        use super::Item;
+        assert_eq!(std::mem::size_of::<[Item<()>; 7_500_000]>(), 300_000_000);
     }
 
     #[test]

--- a/git-pack/src/cache/delta/mod.rs
+++ b/git-pack/src/cache/delta/mod.rs
@@ -195,38 +195,9 @@ mod tests {
         }
     }
 
-    struct TreeItem<D> {
-        _offset: crate::data::Offset,
-        _data: D,
-        _children: Vec<usize>,
-    }
-
-    #[test]
-    fn using_option_as_data_does_not_increase_size_in_memory() {
-        struct Entry {
-            pub _id: Option<git_hash::ObjectId>,
-            pub _crc32: u32,
-        }
-
-        struct TreeItemOption<D> {
-            _offset: crate::data::Offset,
-            _data: Option<D>,
-            _children: Vec<usize>,
-        }
-        assert_eq!(
-            std::mem::size_of::<TreeItem<Entry>>(),
-            std::mem::size_of::<TreeItemOption<Entry>>(),
-            "we hope niche filling optimizations kick in for our data structures to not pay for the Option at all"
-        );
-        assert_eq!(
-            std::mem::size_of::<[TreeItemOption<Entry>; 7_500_000]>(),
-            480_000_000,
-            "it should be as small as possible"
-        );
-    }
-
     #[test]
     fn size_of_pack_verify_data_structure() {
+        use super::Item;
         use git_odb::pack;
         pub struct EntryWithDefault {
             _index_entry: pack::index::Entry,
@@ -238,9 +209,6 @@ mod tests {
             _level: u16,
         }
 
-        assert_eq!(
-            std::mem::size_of::<[TreeItem<EntryWithDefault>; 7_500_000]>(),
-            780_000_000
-        );
+        assert_eq!(std::mem::size_of::<[Item<EntryWithDefault>; 7_500_000]>(), 840_000_000);
     }
 }


### PR DESCRIPTION
All numbers on the linux kernel.

- start at 1380MB
- use u32 instead of usize for 55MB reduction to 1345
