### PR TITLE
reduce delta-cache memory usage

### DIFF
--- a/git-pack/src/cache/delta/iter.rs
+++ b/git-pack/src/cache/delta/iter.rs
@@ -57,6 +57,11 @@ impl<'a, T> Node<'a, T> {
         &mut self.item.data
     }
 
+    /// Returns true if this node has children, e.g. is not a leaf in the tree.
+    pub fn has_children(&self) -> bool {
+        !self.item.children.is_empty()
+    }
+
     /// Transform this `Node` into an iterator over its children.
     ///
     /// Children are `Node`s referring to pack entries whose base object is this pack entry.


### PR DESCRIPTION
This change makes the biggest difference by not keeping the decompressed
memory of leaf nodes alive for longer than needed, at the cost of
some code duplication which could be extracted into a function if one
was inclined to deal with the boilerplate and lots of generics.

