### PR TITLE
Make jwalk and rayon optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ check: ## Build all code in suitable configurations
 			   && cargo check
 	cd git-features && cargo check --all-features \
 			   && cargo check --features parallel \
-			   && cargo check --features parallel,fs-walkdir-single-threaded \
+			   && cargo check --features parallel,fs-walkdir-parallel \
 			   && cargo check --features rustsha1 \
 			   && cargo check --features fast-sha1 \
 			   && cargo check --features progress \

--- a/git-features/Cargo.toml
+++ b/git-features/Cargo.toml
@@ -18,16 +18,19 @@ default = []
 ## using facilities of the `prodash` crate.
 progress = ["prodash"]
 
-## If set, and with the `parallel` feature set, walkdir iterators will be single-threaded.
-## This feature exists to avoid [certain side-effects](https://github.com/starship/starship/issues/4251) of rayon threadpool configuration with `jwalk`.
-fs-walkdir-single-threaded = []
+## If set, walkdir iterators will be multi-threaded.
+## This feature has [certain side-effects](https://github.com/starship/starship/issues/4251) of rayon threadpool configuration with `jwalk`.
+fs-walkdir-parallel = ["parallel", "jwalk" ]
 
 ## Use scoped threads and channels to parallelize common workloads on multiple objects. If enabled, it is used everywhere
 ## where it makes sense.
 ## As caches are likely to be used and instantiated per thread, more memory will be used on top of the costs for threads.
 ## The `threading` module will contain thread-safe primitives for shared ownership and mutation, otherwise these will be their single threaded counterparts.
 ## This way, single-threaded applications don't have to pay for threaded primitives.
-parallel = ["crossbeam-utils", "crossbeam-channel", "num_cpus", "jwalk", "parking_lot"]
+parallel = ["crossbeam-utils",
+ "crossbeam-channel",
+ "num_cpus",
+ "parking_lot"]
 #* an in-memory unidirectional pipe using `bytes` as efficient transfer mechanism.
 io-pipe = ["bytes"]
 ## provide a proven and fast `crc32` implementation.

--- a/git-features/src/fs.rs
+++ b/git-features/src/fs.rs
@@ -6,7 +6,7 @@
 //! For information on how to use the [`WalkDir`] type, have a look at
 //! * [`jwalk::WalkDir`](https://docs.rs/jwalk/0.5.1/jwalk/type.WalkDir.html) if `parallel` feature is enabled
 //! * [walkdir::WalkDir](https://docs.rs/walkdir/2.3.1/walkdir/struct.WalkDir.html) otherwise
-#[cfg(feature = "parallel")]
+#[cfg(feature = "fs-walkdir-parallel")]
 ///
 pub mod walkdir {
     use std::path::Path;
@@ -18,38 +18,24 @@ pub mod walkdir {
 
     /// Instantiate a new directory iterator which will not skip hidden files.
     pub fn walkdir_new(root: impl AsRef<Path>) -> WalkDir {
-        #[cfg(not(feature = "fs-walkdir-single-threaded"))]
-        {
-            WalkDir::new(root).skip_hidden(false)
-        }
-        #[cfg(feature = "fs-walkdir-single-threaded")]
-        {
-            WalkDir::new(root)
-                .skip_hidden(false)
-                .parallelism(jwalk::Parallelism::Serial)
-        }
+        WalkDir::new(root)
+            .skip_hidden(false)
+            .parallelism(jwalk::Parallelism::Serial)
     }
 
     /// Instantiate a new directory iterator which will not skip hidden files and is sorted
     pub fn walkdir_sorted_new(root: impl AsRef<Path>) -> WalkDir {
-        #[cfg(not(feature = "fs-walkdir-single-threaded"))]
-        {
-            WalkDir::new(root).skip_hidden(false).sort(true)
-        }
-        #[cfg(feature = "fs-walkdir-single-threaded")]
-        {
-            WalkDir::new(root)
-                .skip_hidden(false)
-                .sort(true)
-                .parallelism(jwalk::Parallelism::Serial)
-        }
+        WalkDir::new(root)
+            .skip_hidden(false)
+            .sort(true)
+            .parallelism(jwalk::Parallelism::Serial)
     }
 
     /// The Iterator yielding directory items
     pub type DirEntryIter = DirEntryIterGeneric<((), ())>;
 }
 
-#[cfg(all(feature = "walkdir", not(feature = "parallel")))]
+#[cfg(all(feature = "walkdir", not(feature = "fs-walkdir-parallel")))]
 ///
 pub mod walkdir {
     use std::path::Path;
@@ -70,7 +56,7 @@ pub mod walkdir {
     pub type DirEntryIter = walkdir::IntoIter;
 }
 
-#[cfg(any(feature = "walkdir", feature = "jwalk"))]
+#[cfg(any(feature = "walkdir", feature = "fs-walkdir-parallel"))]
 pub use self::walkdir::{walkdir_new, walkdir_sorted_new, WalkDir};
 
 /// Prepare open options which won't follow symlinks when the file is opened.

--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -58,7 +58,7 @@ serde1 = [  "serde",
 
 ## Activate other features that maximize performance, like usage of threads, `zlib-ng` and access to caching in object databases.
 ## Note that some platforms might suffer from compile failures, which is when `max-performance-safe` should be used.
-max-performance = [ "git-features/zlib-ng-compat", "fast-sha1", "max-performance-safe" ]
+max-performance = [ "git-features/zlib-ng-compat", "fast-sha1", "max-performance-safe", "git-features/fs-walkdir-parallel" ]
 
 ## If enabled, use assembly versions of sha1 on supported platforms.
 ## This might cause compile failures as well which is why it can be turned off separately.


### PR DESCRIPTION
Gitoxide uses `jwalk` (which depends on rayon) for a parallel `walkdir` implementation.
`jwalk` is included if the `parallel` feature of `git-features` is enabled.
#481 made using `jwalk` optional while using the `parallel` feature to address problems like starship/starship#4251 by introducing the `fs-walkdir-single-threaded` feature flag.
However, if with this flag `jwalk` is still compiled which causes quite a bit of compile-time overhead, because optional dependencies can only be enabled (but not disabled) by a feature.

This PR replaces the `fs-walkdir-single-threaded` feature flag with the `fs-walkdir-parallel` feature flag.
`jwalk` is only enabled if this feature flag is used and always disabled otherwise.
This allows downstream crates to fully remove the dependency on `jwalk`/`rayon`.

This PR is a breaking change.
To avoid churn for downstream crates I have added the `fs-walkdir-parallel` feature flag as a dependency to the `max-performance` feature flag of `git-repository`

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
