### PR TITLE
`git_index::File::write()` for easy index writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "git-bitmap",
  "git-features",
  "git-hash",
+ "git-lock",
  "git-object",
  "git-repository",
  "git-testtools",

--- a/git-index/Cargo.toml
+++ b/git-index/Cargo.toml
@@ -35,6 +35,7 @@ git-hash = { version = "^0.9.11", path = "../git-hash" }
 git-bitmap = { version = "^0.1.2", path = "../git-bitmap" }
 git-object = { version = "^0.22.0", path = "../git-object" }
 git-traverse = { version = "^0.18.0", path = "../git-traverse" }
+git-lock = { version = "2.1.1", path = "../git-lock" }
 
 thiserror = "1.0.32"
 memmap2 = "0.5.0"

--- a/git-index/src/access.rs
+++ b/git-index/src/access.rs
@@ -9,6 +9,11 @@ impl State {
         self.version
     }
 
+    /// Return the kind of hashes used in this instance.
+    pub fn object_hash(&self) -> git_hash::Kind {
+        self.object_hash
+    }
+
     /// Return our entries
     pub fn entries(&self) -> &[Entry] {
         &self.entries

--- a/git-index/src/decode/mod.rs
+++ b/git-index/src/decode/mod.rs
@@ -30,10 +30,8 @@ use git_features::parallel::InOrderIter;
 use crate::util::read_u32;
 
 /// Options to define how to decode an index state [from bytes][State::from_bytes()].
-#[derive(Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 pub struct Options {
-    /// The kind of object hash to assume when decoding object ids.
-    pub object_hash: git_hash::Kind,
     /// If Some(_), we are allowed to use more than one thread. If Some(N), use no more than N threads. If Some(0)|None, use as many threads
     /// as there are logical cores.
     ///
@@ -45,24 +43,14 @@ pub struct Options {
     pub min_extension_block_in_bytes_for_threading: usize,
 }
 
-impl Options {
-    /// Produce a reasonable default set of options knowing only the kind of object hash to expect.
-    pub fn default_from_object_hash(object_hash: git_hash::Kind) -> Self {
-        Options {
-            object_hash,
-            thread_limit: None,
-            min_extension_block_in_bytes_for_threading: 0,
-        }
-    }
-}
-
 impl State {
-    /// Decode an index state from `data` and store `timestamp` in the resulting instance for pass-through.
+    /// Decode an index state from `data` and store `timestamp` in the resulting instance for pass-through, assuming `object_hash`
+    /// to be used through the file.
     pub fn from_bytes(
         data: &[u8],
         timestamp: FileTime,
+        object_hash: git_hash::Kind,
         Options {
-            object_hash,
             thread_limit,
             min_extension_block_in_bytes_for_threading,
         }: Options,

--- a/git-index/src/decode/mod.rs
+++ b/git-index/src/decode/mod.rs
@@ -30,8 +30,7 @@ use git_features::parallel::InOrderIter;
 use crate::util::read_u32;
 
 /// Options to define how to decode an index state [from bytes][State::from_bytes()].
-// TODO: remove default, hash can't be defaulted actually
-#[derive(Default)]
+#[derive(Clone, Copy)]
 pub struct Options {
     /// The kind of object hash to assume when decoding object ids.
     pub object_hash: git_hash::Kind,

--- a/git-index/src/decode/mod.rs
+++ b/git-index/src/decode/mod.rs
@@ -30,6 +30,7 @@ use git_features::parallel::InOrderIter;
 use crate::util::read_u32;
 
 /// Options to define how to decode an index state [from bytes][State::from_bytes()].
+// TODO: remove default, hash can't be defaulted actually
 #[derive(Default)]
 pub struct Options {
     /// The kind of object hash to assume when decoding object ids.

--- a/git-index/src/decode/mod.rs
+++ b/git-index/src/decode/mod.rs
@@ -209,6 +209,7 @@ impl State {
 
         Ok((
             State {
+                object_hash,
                 timestamp,
                 version,
                 entries,

--- a/git-index/src/decode/mod.rs
+++ b/git-index/src/decode/mod.rs
@@ -45,6 +45,17 @@ pub struct Options {
     pub min_extension_block_in_bytes_for_threading: usize,
 }
 
+impl Options {
+    /// Produce a reasonable default set of options knowing only the kind of object hash to expect.
+    pub fn default_from_object_hash(object_hash: git_hash::Kind) -> Self {
+        Options {
+            object_hash,
+            thread_limit: None,
+            min_extension_block_in_bytes_for_threading: 0,
+        }
+    }
+}
+
 impl State {
     /// Decode an index state from `data` and store `timestamp` in the resulting instance for pass-through.
     pub fn from_bytes(

--- a/git-index/src/file/init.rs
+++ b/git-index/src/file/init.rs
@@ -35,7 +35,11 @@ impl File {
         };
 
         let (state, checksum) = State::from_bytes(&data, mtime, options)?;
-        Ok(File { state, path, checksum })
+        Ok(File {
+            state,
+            path,
+            checksum: Some(checksum),
+        })
     }
 
     /// Consume `state` and pretend it was read from `path`, setting our checksum to `null`.
@@ -45,7 +49,7 @@ impl File {
         File {
             state,
             path: path.into(),
-            checksum: git_hash::ObjectId::null(git_hash::Kind::default()),
+            checksum: None,
         }
     }
 }

--- a/git-index/src/file/init.rs
+++ b/git-index/src/file/init.rs
@@ -37,4 +37,15 @@ impl File {
         let (state, checksum) = State::from_bytes(&data, mtime, options)?;
         Ok(File { state, path, checksum })
     }
+
+    /// Consume `state` and pretend it was read from `path`, setting our checksum to `null`.
+    ///
+    /// `File` instances created like that should be written to disk to set the correct checksum via `[File::write()]`.
+    pub fn from_state(state: crate::State, path: impl Into<PathBuf>) -> Self {
+        File {
+            state,
+            path: path.into(),
+            checksum: git_hash::ObjectId::null(git_hash::Kind::default()),
+        }
+    }
 }

--- a/git-index/src/file/init.rs
+++ b/git-index/src/file/init.rs
@@ -23,8 +23,8 @@ pub use error::Error;
 
 /// Initialization
 impl File {
-    /// Open an index file at `path` with `options`.
-    pub fn at(path: impl Into<PathBuf>, options: decode::Options) -> Result<Self, Error> {
+    /// Open an index file at `path` with `options`, assuming `object_hash` is used throughout the file.
+    pub fn at(path: impl Into<PathBuf>, object_hash: git_hash::Kind, options: decode::Options) -> Result<Self, Error> {
         let path = path.into();
         let (data, mtime) = {
             // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
@@ -34,7 +34,7 @@ impl File {
             (data, filetime::FileTime::from_last_modification_time(&file.metadata()?))
         };
 
-        let (state, checksum) = State::from_bytes(&data, mtime, options)?;
+        let (state, checksum) = State::from_bytes(&data, mtime, object_hash, options)?;
         Ok(File {
             state,
             path,

--- a/git-index/src/file/mod.rs
+++ b/git-index/src/file/mod.rs
@@ -30,6 +30,39 @@ mod impl_ {
         }
     }
 }
+
+mod access {
+    use crate::File;
+
+    /// Consumption
+    impl File {
+        /// Take the state and discard the rest.
+        pub fn into_state(self) -> crate::State {
+            self.state
+        }
+
+        /// Take all non-copy parts of the index.
+        pub fn into_parts(self) -> (crate::State, std::path::PathBuf) {
+            (self.state, self.path)
+        }
+    }
+
+    /// Access
+    impl File {
+        /// The path from which the index was read or to which it is supposed to be written when used with [`File::from_state()`].
+        pub fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+
+        /// The checksum over the file that was read or written to disk, or `None` if the state in memory was never serialized.
+        ///
+        /// Note that even if `Some`, it will only represent the state in memory right after reading or [writing][File::write()].
+        pub fn checksum(&self) -> Option<git_hash::ObjectId> {
+            (!self.checksum.is_null()).then(|| self.checksum)
+        }
+    }
+}
+
 ///
 pub mod init;
 ///

--- a/git-index/src/file/mod.rs
+++ b/git-index/src/file/mod.rs
@@ -58,7 +58,7 @@ mod access {
         ///
         /// Note that even if `Some`, it will only represent the state in memory right after reading or [writing][File::write()].
         pub fn checksum(&self) -> Option<git_hash::ObjectId> {
-            (!self.checksum.is_null()).then(|| self.checksum)
+            self.checksum
         }
     }
 }

--- a/git-index/src/file/write.rs
+++ b/git-index/src/file/write.rs
@@ -8,24 +8,44 @@ use crate::{write, File, Version};
 pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("Could not acquire lock for index file")]
+    AcquireLock(#[from] git_lock::acquire::Error),
+    #[error("Could not commit lock for index file")]
+    CommitLock(#[from] git_lock::commit::Error<git_lock::File>),
 }
 
 impl File {
     /// Write the index to `out` with `options`, to be readable by [`File::at()`], returning the version that was actually written
     /// to retain all information of this index.
-    pub fn write_to(&self, mut out: impl std::io::Write, options: write::Options) -> std::io::Result<Version> {
+    pub fn write_to(
+        &self,
+        mut out: impl std::io::Write,
+        options: write::Options,
+    ) -> std::io::Result<(Version, git_hash::ObjectId)> {
         let mut hasher = hash::Write::new(&mut out, options.hash_kind);
         let version = self.state.write_to(&mut hasher, options)?;
 
         let hash = hasher.hash.digest();
         out.write_all(&hash)?;
-        Ok(version)
+        Ok((version, git_hash::ObjectId::from(hash)))
     }
 
     /// Write ourselves to the path we were read from after acquiring a lock, using `options`.
     ///
     /// Note that the hash produced will be stored which is why we need to be mutable.
-    pub fn write(&mut self, _options: write::Options) -> Result<(), Error> {
-        todo!()
+    pub fn write(&mut self, options: write::Options) -> Result<(), Error> {
+        let mut lock = std::io::BufWriter::new(git_lock::File::acquire_to_update_resource(
+            &self.path,
+            git_lock::acquire::Fail::Immediately,
+            None,
+        )?);
+        let (version, digest) = self.write_to(&mut lock, options)?;
+        match lock.into_inner() {
+            Ok(lock) => lock.commit()?,
+            Err(err) => return Err(err.into_error().into()),
+        };
+        self.state.version = version;
+        self.checksum = digest;
+        Ok(())
     }
 }

--- a/git-index/src/file/write.rs
+++ b/git-index/src/file/write.rs
@@ -2,6 +2,14 @@ use git_features::hash;
 
 use crate::{write, File, Version};
 
+/// The error produced by [`File::write()`].
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
 impl File {
     /// Write the index to `out` with `options`, to be readable by [`File::at()`], returning the version that was actually written
     /// to retain all information of this index.
@@ -12,5 +20,12 @@ impl File {
         let hash = hasher.hash.digest();
         out.write_all(&hash)?;
         Ok(version)
+    }
+
+    /// Write ourselves to the path we were read from after acquiring a lock, using `options`.
+    ///
+    /// Note that the hash produced will be stored which is why we need to be mutable.
+    pub fn write(&mut self, _options: write::Options) -> Result<(), Error> {
+        todo!()
     }
 }

--- a/git-index/src/file/write.rs
+++ b/git-index/src/file/write.rs
@@ -45,7 +45,7 @@ impl File {
             Err(err) => return Err(err.into_error().into()),
         };
         self.state.version = version;
-        self.checksum = digest;
+        self.checksum = Some(digest);
         Ok(())
     }
 }

--- a/git-index/src/file/write.rs
+++ b/git-index/src/file/write.rs
@@ -22,7 +22,7 @@ impl File {
         mut out: impl std::io::Write,
         options: write::Options,
     ) -> std::io::Result<(Version, git_hash::ObjectId)> {
-        let mut hasher = hash::Write::new(&mut out, options.hash_kind);
+        let mut hasher = hash::Write::new(&mut out, self.state.object_hash);
         let version = self.state.write_to(&mut hasher, options)?;
 
         let hash = hasher.hash.digest();

--- a/git-index/src/init.rs
+++ b/git-index/src/init.rs
@@ -37,6 +37,7 @@ mod from_tree {
             entries.sort_by(|a, b| Entry::cmp_filepaths(a.path_in(&path_backing), b.path_in(&path_backing)));
 
             Ok(State {
+                object_hash: tree.kind(),
                 timestamp: filetime::FileTime::now(),
                 version: Version::V2,
                 entries,

--- a/git-index/src/lib.rs
+++ b/git-index/src/lib.rs
@@ -81,6 +81,10 @@ pub type PathStorageRef = [u8];
 /// We treat index and its state synonymous.
 #[derive(Clone)]
 pub struct State {
+    /// The kind of object hash used when storing the underlying file.
+    ///
+    /// Empty states for example won't have a single object id, so deduction of the hash used isn't always possible.
+    object_hash: git_hash::Kind,
     /// The time at which the state was created, indicating its freshness compared to other files on disk.
     ///
     /// Note that on platforms that only have a precisions of a second for this time, we will treat all entries with the

--- a/git-index/src/lib.rs
+++ b/git-index/src/lib.rs
@@ -63,11 +63,11 @@ pub struct Entry {
 /// An index file whose state was read from a file on disk.
 pub struct File {
     /// The state containing the actual index data.
-    pub state: State,
+    pub(crate) state: State,
     /// The path from which the index was read or to which it is supposed to be written.
-    pub path: PathBuf,
+    pub(crate) path: PathBuf,
     /// The checksum of all bytes prior to the checksum itself.
-    pub checksum: git_hash::ObjectId,
+    pub(crate) checksum: git_hash::ObjectId,
 }
 
 /// The type to use and store paths to all entries.

--- a/git-index/src/lib.rs
+++ b/git-index/src/lib.rs
@@ -67,7 +67,7 @@ pub struct File {
     /// The path from which the index was read or to which it is supposed to be written.
     pub(crate) path: PathBuf,
     /// The checksum of all bytes prior to the checksum itself.
-    pub(crate) checksum: git_hash::ObjectId,
+    pub(crate) checksum: Option<git_hash::ObjectId>,
 }
 
 /// The type to use and store paths to all entries.

--- a/git-index/src/write.rs
+++ b/git-index/src/write.rs
@@ -46,8 +46,7 @@ impl Extensions {
 /// The options for use when [writing an index][State::write_to()].
 ///
 /// Note that default options write either index V2 or V3 depending on the content of the entries.
-// TODO: remove Default
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Options {
     /// The hash kind to use when writing the index file.
     ///

--- a/git-index/src/write.rs
+++ b/git-index/src/write.rs
@@ -46,24 +46,15 @@ impl Extensions {
 /// The options for use when [writing an index][State::write_to()].
 ///
 /// Note that default options write either index V2 or V3 depending on the content of the entries.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Options {
-    /// The hash kind to use when writing the index file.
-    ///
-    /// It is not always possible to infer the hash kind when reading an index, so this is required.
-    pub hash_kind: git_hash::Kind,
-
     /// Configures which extensions to write
     pub extensions: Extensions,
 }
 
 impl State {
     /// Serialize this instance to `out` with [`options`][Options].
-    pub fn write_to(
-        &self,
-        out: impl std::io::Write,
-        Options { hash_kind, extensions }: Options,
-    ) -> std::io::Result<Version> {
+    pub fn write_to(&self, out: impl std::io::Write, Options { extensions }: Options) -> std::io::Result<Version> {
         let version = self.detect_required_version();
 
         let mut write = CountBytes::new(out);
@@ -83,7 +74,7 @@ impl State {
                 .is_some()
             && !extension_toc.is_empty()
         {
-            extension::end_of_index_entry::write_to(out, hash_kind, offset_to_extensions, extension_toc)?
+            extension::end_of_index_entry::write_to(out, self.object_hash, offset_to_extensions, extension_toc)?
         }
 
         Ok(version)

--- a/git-index/src/write.rs
+++ b/git-index/src/write.rs
@@ -46,6 +46,7 @@ impl Extensions {
 /// The options for use when [writing an index][State::write_to()].
 ///
 /// Note that default options write either index V2 or V3 depending on the content of the entries.
+// TODO: remove Default
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Options {
     /// The hash kind to use when writing the index file.

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -6,11 +6,11 @@ mod from_state {
     fn writes_data_to_disk_and_is_a_valid_index() -> git_testtools::Result {
         let fixtures = [
             (Loose("extended-flags"), V3),
-            (Generated("v2.sh"), V2),
-            (Generated("v2_empty.sh"), V2),
-            (Generated("v2_more_files.sh"), V2),
-            (Generated("v2_all_file_kinds.sh"), V2),
-            (Generated("v4_more_files_IEOT.sh"), V2),
+            (Generated("v2"), V2),
+            (Generated("V2_empty"), V2),
+            (Generated("v2_more_files"), V2),
+            (Generated("v2_all_file_kinds"), V2),
+            (Generated("v4_more_files_IEOT"), V2),
         ];
 
         for (fixture, expected_version) in fixtures {

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -1,6 +1,5 @@
 mod from_state {
     #[test]
-    #[ignore]
     fn writes_data_to_disk_and_is_a_valid_index() -> git_testtools::Result {
         let fixtures = [
             "v2.sh",
@@ -11,13 +10,13 @@ mod from_state {
         ];
 
         for fixture in fixtures {
+            let tmp = git_testtools::tempfile::TempDir::new()?;
+            let index_path = tmp.path().join(fixture);
+
             let fixture = format!("make_index/{}", fixture);
             let repo_dir = git_testtools::scripted_fixture_repo_read_only(&fixture)?;
             let index = git_index::File::at(repo_dir.join(".git").join("index"), Default::default())?;
 
-            let tmp = git_testtools::tempfile::TempDir::new()?;
-
-            let index_path = tmp.path().join(fixture);
             assert!(!index_path.exists());
             let mut index = git_index::File::from_state(index.state, index_path.clone());
             assert!(index.checksum.is_null());
@@ -29,6 +28,12 @@ mod from_state {
             })?;
             assert!(!index.checksum.is_null(), "checksum is adjusted after writing");
             assert!(index.path.is_file());
+            // TODO: make it easier to test on loose indices.
+            assert_eq!(
+                index.state.version(),
+                git_index::Version::V2,
+                "V2 is enough as we don't have extended attributes"
+            );
 
             index.verify_integrity()?;
         }

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -1,5 +1,4 @@
 mod from_state {
-    use crate::decode_options;
     use crate::index::Fixture::*;
     use git_index::Version::{V2, V3};
 
@@ -19,7 +18,7 @@ mod from_state {
             let index_path = tmp.path().join(fixture.to_name());
             assert!(!index_path.exists());
 
-            let index = git_index::File::at(fixture.to_path(), decode_options())?;
+            let index = git_index::File::at(fixture.to_path(), git_hash::Kind::Sha1, Default::default())?;
             let mut index = git_index::File::from_state(index.into_state(), index_path.clone());
             assert!(index.checksum().is_none());
             assert_eq!(index.path(), index_path);

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -1,0 +1,37 @@
+mod from_state {
+    #[test]
+    #[ignore]
+    fn writes_data_to_disk_and_is_a_valid_index() -> git_testtools::Result {
+        let fixtures = [
+            "v2.sh",
+            "v2_empty.sh",
+            "v2_more_files.sh",
+            "v2_all_file_kinds.sh",
+            "v4_more_files_IEOT.sh",
+        ];
+
+        for fixture in fixtures {
+            let fixture = format!("make_index/{}", fixture);
+            let repo_dir = git_testtools::scripted_fixture_repo_read_only(&fixture)?;
+            let index = git_index::File::at(repo_dir.join(".git").join("index"), Default::default())?;
+
+            let tmp = git_testtools::tempfile::TempDir::new()?;
+
+            let index_path = tmp.path().join(fixture);
+            assert!(!index_path.exists());
+            let mut index = git_index::File::from_state(index.state, index_path.clone());
+            assert!(index.checksum.is_null());
+            assert_eq!(index.path, index_path);
+
+            index.write(git_index::write::Options {
+                hash_kind: git_hash::Kind::Sha1,
+                ..Default::default()
+            })?;
+            assert!(!index.checksum.is_null(), "checksum is adjusted after writing");
+            assert!(index.path.is_file());
+
+            index.verify_integrity()?;
+        }
+        Ok(())
+    }
+}

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -24,7 +24,7 @@ mod from_state {
 
             index.write(git_index::write::Options {
                 hash_kind: git_hash::Kind::Sha1,
-                ..Default::default()
+                extensions: Default::default(),
             })?;
             assert!(!index.checksum.is_null(), "checksum is adjusted after writing");
             assert!(index.path.is_file());

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -1,4 +1,5 @@
 mod from_state {
+    use crate::decode_options;
     use crate::index::Fixture::*;
     use git_index::Version::{V2, V3};
 
@@ -18,7 +19,7 @@ mod from_state {
             let index_path = tmp.path().join(fixture.to_name());
             assert!(!index_path.exists());
 
-            let index = git_index::File::at(fixture.to_path(), Default::default())?;
+            let index = git_index::File::at(fixture.to_path(), decode_options())?;
             let mut index = git_index::File::from_state(index.state, index_path.clone());
             assert!(index.checksum.is_null());
             assert_eq!(index.path, index_path);

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -20,17 +20,17 @@ mod from_state {
             assert!(!index_path.exists());
 
             let index = git_index::File::at(fixture.to_path(), decode_options())?;
-            let mut index = git_index::File::from_state(index.state, index_path.clone());
-            assert!(index.checksum.is_null());
-            assert_eq!(index.path, index_path);
+            let mut index = git_index::File::from_state(index.into_state(), index_path.clone());
+            assert!(index.checksum().is_none());
+            assert_eq!(index.path(), index_path);
 
             index.write(git_index::write::Options {
                 hash_kind: git_hash::Kind::Sha1,
                 extensions: Default::default(),
             })?;
-            assert!(!index.checksum.is_null(), "checksum is adjusted after writing");
-            assert!(index.path.is_file());
-            assert_eq!(index.state.version(), expected_version,);
+            assert!(index.checksum().is_some(), "checksum is adjusted after writing");
+            assert!(index.path().is_file());
+            assert_eq!(index.version(), expected_version,);
 
             index.verify_integrity()?;
         }

--- a/git-index/tests/index/file/init.rs
+++ b/git-index/tests/index/file/init.rs
@@ -23,10 +23,7 @@ mod from_state {
             assert!(index.checksum().is_none());
             assert_eq!(index.path(), index_path);
 
-            index.write(git_index::write::Options {
-                hash_kind: git_hash::Kind::Sha1,
-                extensions: Default::default(),
-            })?;
+            index.write(git_index::write::Options::default())?;
             assert!(index.checksum().is_some(), "checksum is adjusted after writing");
             assert!(index.path().is_file());
             assert_eq!(index.version(), expected_version,);

--- a/git-index/tests/index/file/mod.rs
+++ b/git-index/tests/index/file/mod.rs
@@ -1,3 +1,4 @@
 mod access;
+mod init;
 mod read;
 mod write;

--- a/git-index/tests/index/file/read.rs
+++ b/git-index/tests/index/file/read.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{decode_options, loose_file_path};
+use crate::loose_file_path;
 use bstr::ByteSlice;
 use git_index::{entry, Version};
 use git_testtools::hex_to_id;
@@ -16,15 +16,20 @@ fn verify(index: git_index::File) -> git_index::File {
 
 pub(crate) fn loose_file(name: &str) -> git_index::File {
     let path = loose_file_path(name);
-    let file = git_index::File::at(path, decode_options()).unwrap();
+    let file = git_index::File::at(path, git_hash::Kind::Sha1, Default::default()).unwrap();
     verify(file)
 }
 pub(crate) fn file(name: &str) -> git_index::File {
-    let file = git_index::File::at(crate::fixture_index_path(name), decode_options()).unwrap();
+    let file = git_index::File::at(
+        crate::fixture_index_path(name),
+        git_hash::Kind::Sha1,
+        Default::default(),
+    )
+    .unwrap();
     verify(file)
 }
 fn file_opt(name: &str, opts: git_index::decode::Options) -> git_index::File {
-    let file = git_index::File::at(crate::fixture_index_path(name), opts).unwrap();
+    let file = git_index::File::at(crate::fixture_index_path(name), git_hash::Kind::Sha1, opts).unwrap();
     verify(file)
 }
 
@@ -34,7 +39,7 @@ fn v2_with_single_entry_tree_and_eoie_ext() {
         "v2",
         git_index::decode::Options {
             min_extension_block_in_bytes_for_threading: 100000,
-            ..decode_options()
+            ..Default::default()
         },
     );
     for file in [file("v2"), file_disallow_threaded_loading] {
@@ -107,7 +112,8 @@ fn find_shared_index_for(index: impl AsRef<Path>) -> PathBuf {
 fn split_index_without_any_extension() {
     let file = git_index::File::at(
         find_shared_index_for(crate::fixture_index_path("v2_split_index")),
-        decode_options(),
+        git_hash::Kind::Sha1,
+        Default::default(),
     )
     .unwrap();
     assert_eq!(file.version(), Version::V2);

--- a/git-index/tests/index/file/read.rs
+++ b/git-index/tests/index/file/read.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::loose_file_path;
 use bstr::ByteSlice;
 use git_index::{entry, Version};
 use git_testtools::hex_to_id;
@@ -11,10 +12,6 @@ fn verify(index: git_index::File) -> git_index::File {
         .verify_extensions(false, git_index::verify::extensions::no_find)
         .unwrap();
     index
-}
-
-pub(crate) fn loose_file_path(name: &str) -> PathBuf {
-    git_testtools::fixture_path(Path::new("loose_index").join(name).with_extension("git-index"))
 }
 
 pub(crate) fn loose_file(name: &str) -> git_index::File {

--- a/git-index/tests/index/file/read.rs
+++ b/git-index/tests/index/file/read.rs
@@ -46,7 +46,7 @@ fn v2_with_single_entry_tree_and_eoie_ext() {
         assert_eq!(entry.id, hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"));
         assert!(entry.flags.is_empty());
         assert_eq!(entry.mode, entry::Mode::FILE);
-        assert_eq!(entry.path(&file.state), "a");
+        assert_eq!(entry.path(&file), "a");
 
         let tree = file.tree().unwrap();
         assert_eq!(tree.num_entries.unwrap_or_default(), 1);
@@ -132,9 +132,9 @@ fn v2_very_long_path() {
     let file = loose_file("very-long-path");
     assert_eq!(file.version(), Version::V2);
 
-    assert_eq!(file.state.entries().len(), 9);
+    assert_eq!(file.entries().len(), 9);
     assert_eq!(
-        file.state.entries()[0].path(&file.state),
+        file.entries()[0].path(&file),
         std::iter::repeat('a')
             .take(4096)
             .chain(std::iter::once('q'))

--- a/git-index/tests/index/file/read.rs
+++ b/git-index/tests/index/file/read.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::loose_file_path;
+use crate::{decode_options, loose_file_path};
 use bstr::ByteSlice;
 use git_index::{entry, Version};
 use git_testtools::hex_to_id;
@@ -16,11 +16,11 @@ fn verify(index: git_index::File) -> git_index::File {
 
 pub(crate) fn loose_file(name: &str) -> git_index::File {
     let path = loose_file_path(name);
-    let file = git_index::File::at(path, git_index::decode::Options::default()).unwrap();
+    let file = git_index::File::at(path, decode_options()).unwrap();
     verify(file)
 }
 pub(crate) fn file(name: &str) -> git_index::File {
-    let file = git_index::File::at(crate::fixture_index_path(name), git_index::decode::Options::default()).unwrap();
+    let file = git_index::File::at(crate::fixture_index_path(name), decode_options()).unwrap();
     verify(file)
 }
 fn file_opt(name: &str, opts: git_index::decode::Options) -> git_index::File {
@@ -34,7 +34,7 @@ fn v2_with_single_entry_tree_and_eoie_ext() {
         "v2",
         git_index::decode::Options {
             min_extension_block_in_bytes_for_threading: 100000,
-            ..Default::default()
+            ..decode_options()
         },
     );
     for file in [file("v2"), file_disallow_threaded_loading] {
@@ -107,7 +107,7 @@ fn find_shared_index_for(index: impl AsRef<Path>) -> PathBuf {
 fn split_index_without_any_extension() {
     let file = git_index::File::at(
         find_shared_index_for(crate::fixture_index_path("v2_split_index")),
-        git_index::decode::Options::default(),
+        decode_options(),
     )
     .unwrap();
     assert_eq!(file.version(), Version::V2);

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -15,8 +15,8 @@ fn roundtrips() -> crate::Result {
         (Loose("extended-flags"), all_ext_but_eoie()),
         (Loose("conflicting-file"), all_ext_but_eoie()),
         (Loose("very-long-path"), all_ext_but_eoie()),
-        (Generated("v2"), Options::default()),
-        (Generated("V2_empty"), Options::default()),
+        (Generated("v2"), sha1_options()),
+        (Generated("V2_empty"), sha1_options()),
         (Generated("v2_more_files"), all_ext_but_eoie()),
         (Generated("v2_all_file_kinds"), all_ext_but_eoie()),
     ];
@@ -109,7 +109,7 @@ fn extended_flags_automatically_upgrade_the_version_to_avoid_data_loss() -> crat
     expected.entries_mut()[0].flags.insert(entry::Flags::EXTENDED);
 
     let mut buf = Vec::new();
-    let (actual_version, _digest) = expected.write_to(&mut buf, Default::default())?;
+    let (actual_version, _digest) = expected.write_to(&mut buf, sha1_options())?;
     assert_eq!(actual_version, Version::V3, "extended flags need V3");
 
     Ok(())
@@ -169,6 +169,13 @@ fn all_ext_but_eoie() -> Options {
             end_of_index_entry: false,
             tree_cache: true,
         },
-        ..Options::default()
+        ..sha1_options()
+    }
+}
+
+fn sha1_options() -> git_index::write::Options {
+    git_index::write::Options {
+        hash_kind: git_hash::Kind::Sha1,
+        extensions: Default::default(),
     }
 }

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -30,7 +30,7 @@ fn roundtrips() -> crate::Result {
         let expected_bytes = std::fs::read(&path)?;
         let mut out_bytes = Vec::new();
 
-        let actual_version = expected.write_to(&mut out_bytes, options)?;
+        let (actual_version, _digest) = expected.write_to(&mut out_bytes, options)?;
         assert_eq!(
             actual_version,
             expected.version(),
@@ -94,7 +94,7 @@ fn state_comparisons_with_various_extension_configurations() {
             let expected = git_index::File::at(&path, Default::default()).unwrap();
 
             let mut out = Vec::<u8>::new();
-            let actual_version = expected.write_to(&mut out, options).unwrap();
+            let (actual_version, _digest) = expected.write_to(&mut out, options).unwrap();
 
             let (actual, _) = State::from_bytes(&out, FileTime::now(), decode::Options::default()).unwrap();
             compare_states(&actual, actual_version, &expected, options, fixture);
@@ -109,7 +109,7 @@ fn extended_flags_automatically_upgrade_the_version_to_avoid_data_loss() -> crat
     expected.entries_mut()[0].flags.insert(entry::Flags::EXTENDED);
 
     let mut buf = Vec::new();
-    let actual_version = expected.write_to(&mut buf, Default::default())?;
+    let (actual_version, _digest) = expected.write_to(&mut buf, Default::default())?;
     assert_eq!(actual_version, Version::V3, "extended flags need V3");
 
     Ok(())

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -1,16 +1,12 @@
+use crate::index::Fixture::*;
 use filetime::FileTime;
 use git_index::{decode, entry, extension, verify::extensions::no_find, write, write::Options, State, Version};
 
-use crate::{fixture_index_path, index::file::read::loose_file_path};
+use crate::{fixture_index_path, loose_file_path};
 
 /// Round-trips should eventually be possible for all files we have, as we write them back exactly as they were read.
 #[test]
 fn roundtrips() -> crate::Result {
-    enum Kind {
-        Generated(&'static str),
-        Loose(&'static str),
-    }
-    use Kind::*;
     let input = [
         (Loose("extended-flags"), all_ext_but_eoie()),
         (Loose("conflicting-file"), all_ext_but_eoie()),
@@ -54,12 +50,6 @@ fn state_comparisons_with_various_extension_configurations() {
         }
     }
 
-    enum Kind {
-        Generated(&'static str),
-        Loose(&'static str),
-    }
-    use Kind::*;
-
     for fixture in [
         Loose("extended-flags"),
         Loose("conflicting-file"),
@@ -87,10 +77,8 @@ fn state_comparisons_with_various_extension_configurations() {
                 end_of_index_entry: true,
             }),
         ] {
-            let (path, fixture) = match fixture {
-                Generated(name) => (fixture_index_path(name), name),
-                Loose(name) => (loose_file_path(name), name),
-            };
+            let path = fixture.to_path();
+            let fixture = fixture.to_name();
             let expected = git_index::File::at(&path, Default::default()).unwrap();
 
             let mut out = Vec::<u8>::new();

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -2,7 +2,7 @@ use crate::index::Fixture::*;
 use filetime::FileTime;
 use git_index::{entry, extension, verify::extensions::no_find, write, write::Options, State, Version};
 
-use crate::{decode_options, fixture_index_path, loose_file_path};
+use crate::{fixture_index_path, loose_file_path};
 
 /// Round-trips should eventually be possible for all files we have, as we write them back exactly as they were read.
 #[test]
@@ -22,7 +22,7 @@ fn roundtrips() -> crate::Result {
             Generated(name) => (fixture_index_path(name), name),
             Loose(name) => (loose_file_path(name), name),
         };
-        let expected = git_index::File::at(&path, decode_options())?;
+        let expected = git_index::File::at(&path, git_hash::Kind::Sha1, Default::default())?;
         let expected_bytes = std::fs::read(&path)?;
         let mut out_bytes = Vec::new();
 
@@ -33,7 +33,7 @@ fn roundtrips() -> crate::Result {
             "{} didn't write the expected version",
             fixture
         );
-        let (actual, _) = State::from_bytes(&out_bytes, FileTime::now(), decode_options())?;
+        let (actual, _) = State::from_bytes(&out_bytes, FileTime::now(), git_hash::Kind::Sha1, Default::default())?;
 
         compare_states(&actual, actual_version, &expected, options, fixture);
         compare_raw_bytes(&out_bytes, &expected_bytes, fixture);
@@ -79,12 +79,13 @@ fn state_comparisons_with_various_extension_configurations() {
         ] {
             let path = fixture.to_path();
             let fixture = fixture.to_name();
-            let expected = git_index::File::at(&path, decode_options()).unwrap();
+            let expected = git_index::File::at(&path, git_hash::Kind::Sha1, Default::default()).unwrap();
 
             let mut out = Vec::<u8>::new();
             let (actual_version, _digest) = expected.write_to(&mut out, options).unwrap();
 
-            let (actual, _) = State::from_bytes(&out, FileTime::now(), decode_options()).unwrap();
+            let (actual, _) =
+                State::from_bytes(&out, FileTime::now(), git_hash::Kind::Sha1, Default::default()).unwrap();
             compare_states(&actual, actual_version, &expected, options, fixture);
         }
     }
@@ -92,7 +93,7 @@ fn state_comparisons_with_various_extension_configurations() {
 
 #[test]
 fn extended_flags_automatically_upgrade_the_version_to_avoid_data_loss() -> crate::Result {
-    let mut expected = git_index::File::at(fixture_index_path("v2"), decode_options())?;
+    let mut expected = git_index::File::at(fixture_index_path("v2"), git_hash::Kind::Sha1, Default::default())?;
     assert_eq!(expected.version(), Version::V2);
     expected.entries_mut()[0].flags.insert(entry::Flags::EXTENDED);
 

--- a/git-index/tests/index/file/write.rs
+++ b/git-index/tests/index/file/write.rs
@@ -11,8 +11,8 @@ fn roundtrips() -> crate::Result {
         (Loose("extended-flags"), all_ext_but_eoie()),
         (Loose("conflicting-file"), all_ext_but_eoie()),
         (Loose("very-long-path"), all_ext_but_eoie()),
-        (Generated("v2"), sha1_options()),
-        (Generated("V2_empty"), sha1_options()),
+        (Generated("v2"), Default::default()),
+        (Generated("V2_empty"), Default::default()),
         (Generated("v2_more_files"), all_ext_but_eoie()),
         (Generated("v2_all_file_kinds"), all_ext_but_eoie()),
     ];
@@ -44,10 +44,7 @@ fn roundtrips() -> crate::Result {
 #[test]
 fn state_comparisons_with_various_extension_configurations() {
     fn options_with(extensions: write::Extensions) -> Options {
-        Options {
-            hash_kind: git_hash::Kind::Sha1,
-            extensions,
-        }
+        Options { extensions }
     }
 
     for fixture in [
@@ -98,7 +95,7 @@ fn extended_flags_automatically_upgrade_the_version_to_avoid_data_loss() -> crat
     expected.entries_mut()[0].flags.insert(entry::Flags::EXTENDED);
 
     let mut buf = Vec::new();
-    let (actual_version, _digest) = expected.write_to(&mut buf, sha1_options())?;
+    let (actual_version, _digest) = expected.write_to(&mut buf, Default::default())?;
     assert_eq!(actual_version, Version::V3, "extended flags need V3");
 
     Ok(())
@@ -158,13 +155,6 @@ fn all_ext_but_eoie() -> Options {
             end_of_index_entry: false,
             tree_cache: true,
         },
-        ..sha1_options()
-    }
-}
-
-fn sha1_options() -> git_index::write::Options {
-    git_index::write::Options {
-        hash_kind: git_hash::Kind::Sha1,
-        extensions: Default::default(),
+        ..Default::default()
     }
 }

--- a/git-index/tests/index/init.rs
+++ b/git-index/tests/index/init.rs
@@ -4,7 +4,7 @@ use git_repository::prelude::FindExt;
 use git_testtools::scripted_fixture_repo_read_only;
 
 #[test]
-fn tree_to_state() -> crate::Result {
+fn from_tree() -> crate::Result {
     let fixtures = [
         "make_index/v2.sh",
         "make_index/v2_more_files.sh",

--- a/git-index/tests/index/mod.rs
+++ b/git-index/tests/index/mod.rs
@@ -22,10 +22,6 @@ fn size_of_entry() {
     assert_eq!(std::mem::size_of::<filetime::FileTime>(), 16);
 }
 
-pub fn decode_options() -> git_index::decode::Options {
-    git_index::decode::Options::default_from_object_hash(git_hash::Kind::Sha1)
-}
-
 enum Fixture {
     Generated(&'static str),
     Loose(&'static str),

--- a/git-index/tests/index/mod.rs
+++ b/git-index/tests/index/mod.rs
@@ -9,6 +9,10 @@ pub fn fixture_index_path(name: &str) -> PathBuf {
     dir.join(".git").join("index")
 }
 
+pub fn loose_file_path(name: &str) -> PathBuf {
+    git_testtools::fixture_path(Path::new("loose_index").join(name).with_extension("git-index"))
+}
+
 #[test]
 fn size_of_entry() {
     assert_eq!(std::mem::size_of::<git_index::Entry>(), 80);
@@ -16,4 +20,23 @@ fn size_of_entry() {
     // the reason we have our own time is half the size.
     assert_eq!(std::mem::size_of::<git_index::entry::Time>(), 8);
     assert_eq!(std::mem::size_of::<filetime::FileTime>(), 16);
+}
+
+enum Fixture {
+    Generated(&'static str),
+    Loose(&'static str),
+}
+
+impl Fixture {
+    pub fn to_path(&self) -> PathBuf {
+        match self {
+            Fixture::Generated(name) => fixture_index_path(name),
+            Fixture::Loose(name) => loose_file_path(name),
+        }
+    }
+    pub fn to_name(&self) -> &'static str {
+        match self {
+            Fixture::Generated(name) | Fixture::Loose(name) => name,
+        }
+    }
 }

--- a/git-index/tests/index/mod.rs
+++ b/git-index/tests/index/mod.rs
@@ -22,6 +22,14 @@ fn size_of_entry() {
     assert_eq!(std::mem::size_of::<filetime::FileTime>(), 16);
 }
 
+pub fn decode_options() -> git_index::decode::Options {
+    git_index::decode::Options {
+        object_hash: git_hash::Kind::Sha1,
+        thread_limit: None,
+        min_extension_block_in_bytes_for_threading: 0,
+    }
+}
+
 enum Fixture {
     Generated(&'static str),
     Loose(&'static str),

--- a/git-index/tests/index/mod.rs
+++ b/git-index/tests/index/mod.rs
@@ -23,11 +23,7 @@ fn size_of_entry() {
 }
 
 pub fn decode_options() -> git_index::decode::Options {
-    git_index::decode::Options {
-        object_hash: git_hash::Kind::Sha1,
-        thread_limit: None,
-        min_extension_block_in_bytes_for_threading: 0,
-    }
+    git_index::decode::Options::default_from_object_hash(git_hash::Kind::Sha1)
 }
 
 enum Fixture {

--- a/git-repository/src/repository/worktree.rs
+++ b/git-repository/src/repository/worktree.rs
@@ -77,8 +77,8 @@ impl crate::Repository {
             .transpose()?;
         git_index::File::at(
             self.index_path(),
+            self.object_hash(),
             git_index::decode::Options {
-                object_hash: self.object_hash(),
                 thread_limit,
                 min_extension_block_in_bytes_for_threading: 0,
             },

--- a/git-worktree/tests/worktree/fs/cache/ignore_and_attributes.rs
+++ b/git-worktree/tests/worktree/fs/cache/ignore_and_attributes.rs
@@ -92,7 +92,7 @@ fn check_against_baseline() -> crate::Result {
     let user_exclude_path = dir.join("user.exclude");
     assert!(user_exclude_path.is_file());
 
-    let mut index = git_index::File::at(git_dir.join("index"), Default::default())?;
+    let mut index = git_index::File::at(git_dir.join("index"), git_hash::Kind::Sha1, Default::default())?;
     let odb = git_odb::at(git_dir.join("objects"))?;
     let case = git_glob::pattern::Case::Sensitive;
     let state = git_worktree::fs::cache::State::for_add(
@@ -105,7 +105,7 @@ fn check_against_baseline() -> crate::Result {
         ),
     );
     let paths_storage = index.take_path_backing();
-    let attribute_files_in_index = state.build_attribute_list(&index.state, &paths_storage, case);
+    let attribute_files_in_index = state.build_attribute_list(&index, &paths_storage, case);
     assert_eq!(
         attribute_files_in_index,
         vec![(

--- a/git-worktree/tests/worktree/index/checkout.rs
+++ b/git-worktree/tests/worktree/index/checkout.rs
@@ -391,7 +391,7 @@ fn checkout_index_in_tmp_dir_opts(
 )> {
     let source_tree = fixture_path(name);
     let git_dir = source_tree.join(".git");
-    let mut index = git_index::File::at(git_dir.join("index"), Default::default())?;
+    let mut index = git_index::File::at(git_dir.join("index"), git_hash::Kind::Sha1, Default::default())?;
     let odb = git_odb::at(git_dir.join("objects"))?.into_inner().into_arc()?;
     let destination = tempfile::tempdir_in(std::env::current_dir()?)?;
     prep_dest(destination.path())?;

--- a/gitoxide-core/src/index/entries.rs
+++ b/gitoxide-core/src/index/entries.rs
@@ -58,7 +58,7 @@ pub(crate) fn to_json(
             hex_id: entry.id.to_hex().to_string(),
             flags: entry.flags.bits(),
             mode: entry.mode.bits(),
-            path: entry.path(&file.state).to_str_lossy(),
+            path: entry.path(&file).to_str_lossy(),
         },
     )?;
 
@@ -91,6 +91,6 @@ pub(crate) fn to_human(
         },
         entry.mode,
         entry.id,
-        entry.path(&file.state)
+        entry.path(&file)
     )
 }

--- a/gitoxide-core/src/index/entries.rs
+++ b/gitoxide-core/src/index/entries.rs
@@ -58,7 +58,7 @@ pub(crate) fn to_json(
             hex_id: entry.id.to_hex().to_string(),
             flags: entry.flags.bits(),
             mode: entry.mode.bits(),
-            path: entry.path(&file).to_str_lossy(),
+            path: entry.path(file).to_str_lossy(),
         },
     )?;
 
@@ -91,6 +91,6 @@ pub(crate) fn to_human(
         },
         entry.mode,
         entry.id,
-        entry.path(&file)
+        entry.path(file)
     )
 }

--- a/gitoxide-core/src/index/information.rs
+++ b/gitoxide-core/src/index/information.rs
@@ -82,7 +82,7 @@ mod serde_only {
         pub fn try_from_file(f: git::index::File, extension_details: bool) -> anyhow::Result<Self> {
             Ok(Collection {
                 version: f.version() as u8,
-                checksum: f.checksum.to_hex().to_string(),
+                checksum: f.checksum().expect("just read from disk").to_hex().to_string(),
                 extensions: {
                     let mut names = Vec::new();
                     let tree = f.tree().and_then(|tree| {

--- a/gitoxide-core/src/index/mod.rs
+++ b/gitoxide-core/src/index/mod.rs
@@ -14,10 +14,7 @@ pub mod information;
 fn parse_file(index_path: impl AsRef<Path>, object_hash: git::hash::Kind) -> anyhow::Result<git::index::File> {
     git::index::File::at(
         index_path.as_ref(),
-        git::index::decode::Options {
-            object_hash,
-            ..Default::default()
-        },
+        git::index::decode::Options::default_from_object_hash(object_hash),
     )
     .map_err(Into::into)
 }

--- a/gitoxide-core/src/index/mod.rs
+++ b/gitoxide-core/src/index/mod.rs
@@ -12,11 +12,7 @@ pub use entries::entries;
 pub mod information;
 
 fn parse_file(index_path: impl AsRef<Path>, object_hash: git::hash::Kind) -> anyhow::Result<git::index::File> {
-    git::index::File::at(
-        index_path.as_ref(),
-        git::index::decode::Options::default_from_object_hash(object_hash),
-    )
-    .map_err(Into::into)
+    git::index::File::at(index_path.as_ref(), object_hash, Default::default()).map_err(Into::into)
 }
 
 pub mod checkout_exclusive {

--- a/gitoxide-core/src/repository/exclude.rs
+++ b/gitoxide-core/src/repository/exclude.rs
@@ -37,7 +37,7 @@ pub fn query(
         .with_context(|| "Cannot check excludes without a current worktree")?;
     let index = worktree.index()?;
     let mut cache = worktree.excludes(
-        &index.state,
+        &index,
         Some(git::attrs::MatchGroup::<git::attrs::Ignore>::from_overrides(overrides)),
     )?;
 

--- a/gitoxide-core/src/repository/index.rs
+++ b/gitoxide-core/src/repository/index.rs
@@ -16,7 +16,7 @@ pub fn from_tree(
     let state = git::index::State::from_tree(&tree, |oid, buf| repo.objects.find_tree_iter(oid, buf).ok())?;
     let options = git::index::write::Options {
         hash_kind: repo.object_hash(),
-        ..Default::default()
+        extensions: Default::default(),
     };
 
     match index_path {

--- a/gitoxide-core/src/repository/index.rs
+++ b/gitoxide-core/src/repository/index.rs
@@ -14,10 +14,7 @@ pub fn from_tree(
     let spec = git::path::os_str_into_bstr(&spec)?;
     let tree = repo.rev_parse_single(spec)?;
     let state = git::index::State::from_tree(&tree, |oid, buf| repo.objects.find_tree_iter(oid, buf).ok())?;
-    let options = git::index::write::Options {
-        hash_kind: repo.object_hash(),
-        extensions: Default::default(),
-    };
+    let options = git::index::write::Options::default();
 
     match index_path {
         Some(index_path) => {

--- a/gitoxide-core/src/repository/index.rs
+++ b/gitoxide-core/src/repository/index.rs
@@ -1,7 +1,7 @@
 use git::prelude::FindExt;
 use git_repository as git;
 use std::ffi::OsString;
-use std::{io::BufWriter, path::PathBuf};
+use std::path::PathBuf;
 
 pub fn from_tree(
     mut spec: OsString,
@@ -13,7 +13,7 @@ pub fn from_tree(
     spec.push("^{tree}");
     let spec = git::path::os_str_into_bstr(&spec)?;
     let tree = repo.rev_parse_single(spec)?;
-    let state = git::index::State::from_tree(&tree, |oid, buf| repo.objects.find_tree_iter(oid, buf).ok())?;
+    let index = git::index::State::from_tree(&tree, |oid, buf| repo.objects.find_tree_iter(oid, buf).ok())?;
     let options = git::index::write::Options::default();
 
     match index_path {
@@ -24,11 +24,12 @@ pub fn from_tree(
                     index_path.display()
                 );
             }
-            let writer = BufWriter::new(std::fs::File::create(&index_path)?);
-            state.write_to(writer, options)?;
+            let mut index = git::index::File::from_state(index, index_path);
+            index.write(options)?;
         }
         None => {
-            state.write_to(&mut out, options)?;
+            let index = git::index::File::from_state(index, std::path::PathBuf::new());
+            index.write_to(&mut out, options)?;
         }
     }
 

--- a/gitoxide-core/src/repository/verify.rs
+++ b/gitoxide-core/src/repository/verify.rs
@@ -51,7 +51,9 @@ pub fn integrity(
             let objects = repo.objects;
             move |oid, buf: &mut Vec<u8>| objects.find_tree_iter(oid, buf).ok()
         })?;
-        outcome.progress.info(format!("Index at '{}' OK", index.path.display()));
+        outcome
+            .progress
+            .info(format!("Index at '{}' OK", index.path().display()));
     }
     match output_statistics {
         Some(OutputFormat::Human) => writeln!(out, "Human output is currently unsupported, use JSON instead")?,


### PR DESCRIPTION
Indices need to be written using `git_index::File`, and `gix index from-tree` currently does not do
that. It turns out that the matter isn't entirely trivial so let's make it so.


### Tasks

* [x] test for index writing
* [x] implementation
* [x] use `File::write()` in `gix index from-tree` and validate it still performs well
