### PR TITLE
Fix "http not compiled in" w/ http-client-reqwest

### DIFF
--- a/git-transport/src/client/blocking_io/connect.rs
+++ b/git-transport/src/client/blocking_io/connect.rs
@@ -63,9 +63,9 @@ pub(crate) mod function {
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
                 })
             }
-            #[cfg(not(feature = "http-client-curl"))]
+            #[cfg(all(not(feature = "http-client-curl"), not(feature = "http-client-reqwest")))]
             git_url::Scheme::Https | git_url::Scheme::Http => return Err(Error::CompiledWithoutHttp(url.scheme)),
-            #[cfg(feature = "http-client-curl")]
+            #[cfg(any(feature = "http-client-curl", feature = "http-client-reqwest"))]
             git_url::Scheme::Https | git_url::Scheme::Http => Box::new(crate::client::http::connect(
                 &url.to_bstring().to_string(),
                 desired_version,

--- a/git-transport/src/client/non_io_types.rs
+++ b/git-transport/src/client/non_io_types.rs
@@ -48,8 +48,8 @@ pub(crate) mod connect {
         },
         #[error("The '{0}' protocol is currently unsupported")]
         UnsupportedScheme(git_url::Scheme),
-        #[cfg(not(feature = "http-client-curl"))]
-        #[error("'{0}' is not compiled in. Compile with the 'http-client-curl' cargo feature")]
+        #[cfg(all(not(feature = "http-client-curl"), not(feature = "http-client-reqwest")))]
+        #[error("'{0}' is not compiled in. Compile with the 'http-client-curl' or 'http-client-reqwest' cargo feature")]
         CompiledWithoutHttp(git_url::Scheme),
     }
 }


### PR DESCRIPTION
This fixes a runtime error; `Error: 'http' is not compiled in. Compile with the 'http-client-curl' cargo feature` when using `git-transport` with `features = ["http-client-reqwest"]`.

I wasn't sure how best to go about testing this.

I ran `make tests` locally and saw what appeared to be an unrelated failure.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
