### PR TITLE
fix: build error on Android

### DIFF
--- a/git-config-value/src/path.rs
+++ b/git-config-value/src/path.rs
@@ -170,7 +170,7 @@ impl<'a> Path<'a> {
         Err(interpolate::Error::UserInterpolationUnsupported)
     }
 
-    #[cfg(not(windows))]
+    #[cfg(not(any(target_os = "windows", target_os = "android")))]
     fn interpolate_user(
         self,
         home_for_user: fn(&str) -> Option<PathBuf>,


### PR DESCRIPTION
----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.

----

The library fails to build on Android due to a `cfg` misuse causing the `interpolate_user` function to be defined twice. This PR fixes it by using a correct `cfg` condition.

Discovered this issue when trying to use https://github.com/helix-editor/helix/pull/3890 on Android without success.