### PR TITLE
fix connections over the git:// protocol not specifying the host

### DIFF
--- a/git-transport/src/client/git/blocking_io.rs
+++ b/git-transport/src/client/git/blocking_io.rs
@@ -187,13 +187,14 @@ pub mod connect {
         let vhost = std::env::var("GIT_OVERRIDE_VIRTUAL_HOST")
             .ok()
             .map(parse_host)
-            .transpose()?;
+            .transpose()?
+            .unwrap_or_else(|| (host.to_owned(), port));
         Ok(git::Connection::new(
             read,
             write,
             desired_version,
             path,
-            vhost,
+            Some(vhost),
             git::ConnectMode::Daemon,
         ))
     }


### PR DESCRIPTION
Fixes `gix clone` reporting a permission error when connecting to servers
over the `git://` protocol that use virtual hosts like `git.kernel.org`.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
