### PR TITLE
read-worktree-config

### DIFF
--- a/git-config/src/file/init/comfort.rs
+++ b/git-config/src/file/init/comfort.rs
@@ -75,6 +75,7 @@ impl File<'static> {
     ///
     /// - globals
     /// - repository-local by loading `dir`/config
+    /// - worktree by loading `dir`/config.worktree
     /// - environment
     ///
     /// Note that `dir` is the `.git` dir to load the configuration from, not the configuration file.

--- a/git-config/src/file/init/comfort.rs
+++ b/git-config/src/file/init/comfort.rs
@@ -129,12 +129,12 @@ impl File<'static> {
         globals.resolve_includes(options)?;
         local.resolve_includes(options)?;
 
-        // TODO: Does the order matter here?
-        globals.append(local).append(Self::from_environment_overrides()?);
+        globals.append(local);
         if let Some(mut worktree) = worktree {
             worktree.resolve_includes(options)?;
             globals.append(worktree);
         }
+        globals.append(Self::from_environment_overrides()?);
 
         Ok(globals)
     }

--- a/git-config/src/file/init/comfort.rs
+++ b/git-config/src/file/init/comfort.rs
@@ -95,6 +95,20 @@ impl File<'static> {
             (local, path)
         };
 
+        let worktree = match local.boolean("extensions", None, "worktreeConfig") {
+            Some(Ok(worktree_config)) => worktree_config.then(|| {
+                let source = Source::Worktree;
+                let path = git_dir.join(
+                    source
+                        .storage_location(&mut |n| std::env::var_os(n))
+                        .expect("location available for worktree"),
+                );
+                Self::from_path_no_includes(path, source)
+            }),
+            _ => None,
+        }
+        .transpose()?;
+
         let home = std::env::var("HOME").ok().map(PathBuf::from);
         let options = init::Options {
             includes: init::includes::Options::follow(
@@ -114,7 +128,13 @@ impl File<'static> {
         globals.resolve_includes(options)?;
         local.resolve_includes(options)?;
 
+        // TODO: Does the order matter here?
         globals.append(local).append(Self::from_environment_overrides()?);
+        if let Some(mut worktree) = worktree {
+            worktree.resolve_includes(options)?;
+            globals.append(worktree);
+        }
+
         Ok(globals)
     }
 }

--- a/git-config/tests/file/init/comfort.rs
+++ b/git-config/tests/file/init/comfort.rs
@@ -79,3 +79,27 @@ fn from_git_dir() -> crate::Result {
     }
     Ok(())
 }
+
+#[test]
+#[serial]
+fn from_git_dir_with_worktree_extension() -> crate::Result {
+    let git_dir = git_testtools::scripted_fixture_repo_read_only("config_with_worktree_extension.sh")?.join(".git");
+    let config = git_config::File::from_git_dir(git_dir)?;
+
+    assert_eq!(
+        config
+            .string("extensions", None, "worktreeConfig")
+            .expect("present")
+            .as_ref(),
+        "true"
+    );
+    assert_eq!(
+        config
+            .string("someSection", None, "someSetting")
+            .expect("present")
+            .as_ref(),
+        "some value"
+    );
+
+    Ok(())
+}

--- a/git-config/tests/fixtures/config_with_worktree_extension.sh
+++ b/git-config/tests/fixtures/config_with_worktree_extension.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu -o pipefail
+
+git init -q
+
+git config extensions.worktreeConfig true
+git config --worktree someSection.someSetting "some value"

--- a/git-config/tests/fixtures/generated-archives/config_with_worktree_extension.tar.xz
+++ b/git-config/tests/fixtures/generated-archives/config_with_worktree_extension.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e69c00993aa38ea977f010eb3784cf8eacb3df3a8baaa7c483dd04ebfa96901c
+size 9148


### PR DESCRIPTION
**How are configs loaded from different worktrees**

If `extensions.worktreeConfig` is enabled, then worktrees will load the worktree-specific config from the `$GIT_DIR/config.worktree` file, and the shared config from `$GIT_COMMON_DIR/config` file, where `$GIT_DIR` points to `path/to/main/worktree/.git/worktrees/linked-worktree-id` and `$GIT_COMMON_DIR` points to the main worktrees' git dir at `path/to/main/worktree/.git`.
When working in the main worktree `$GIT_DIR` and `$GIT_COMMON_DIR` point to the same path, namely the main worktrees git dir at `path/to/main/worktree/.git`.

**Tasks**

- [x] Detect if `extensions.worktreeConfig` is set and load and merge in the `config.worktree` file
  - [ ] make sure we are doing this in all the required places
- [ ] Use the `$GIT_DIR` and `$GIT_COMMON_DIR` env vars to load the configs

**Notes**

- gitoxide does not yet support linked worktrees, so we don't consider loading config files for those as they are handled differently than the main worktree
- `.git/config` is read before `config.worktree` meaning `config.worktree` overrides the shared config

**References**
- [git-worktree | config files](https://git-scm.com/docs/git-worktree#_configuration_file)
- [git-config | worktree extension](https://git-scm.com/docs/git-config#Documentation/git-config.txt-extensionsworktreeConfig)
- [repository layout | worktreeConfig](https://git-scm.com/docs/gitrepository-layout#_worktreeconfig)