### PR TITLE
fix(describe): also sort entries lexigraphically

### DIFF
--- a/git-repository/src/commit.rs
+++ b/git-repository/src/commit.rs
@@ -100,12 +100,12 @@ pub mod describe {
                     })
                     .collect();
                     // By priority, then by time ascending, then lexicographically.
-                    // More recent entries overwrite older ones.
+                    // More recent entries overwrite older ones due to collection into hashmap.
                     refs.sort_by(
                         |(_a_peeled_id, a_prio, a_time, a_name), (_b_peeled_id, b_prio, b_time, b_name)| {
-                            a_time
-                                .cmp(b_time)
-                                .then_with(|| a_prio.cmp(b_prio))
+                            a_prio
+                                .cmp(b_prio)
+                                .then_with(|| a_time.cmp(b_time))
                                 .then_with(|| b_name.cmp(a_name))
                         },
                     );
@@ -128,13 +128,10 @@ pub mod describe {
                             Some((commit_id, tag_time, Cow::<BStr>::from(r.name().shorten().to_owned())))
                         })
                         .collect();
-                    // Sort by priority, then by time ascending, then lexicographically.
-                    // More recent entries overwrite older ones.
+                    // Sort by time ascending, then lexicographically.
+                    // More recent entries overwrite older ones due to collection into hashmap.
                     peeled_commits_and_tag_date.sort_by(|(_a_id, a_time, a_name), (_b_id, b_time, b_name)| {
-                        a_time
-                            .cmp(b_time)
-                            .then_with(|| _a_id.cmp(_b_id))
-                            .then_with(|| b_name.cmp(a_name))
+                        a_time.cmp(b_time).then_with(|| b_name.cmp(a_name))
                     });
                     peeled_commits_and_tag_date
                         .into_iter()

--- a/git-repository/src/commit.rs
+++ b/git-repository/src/commit.rs
@@ -99,14 +99,16 @@ pub mod describe {
                             .into()
                     })
                     .collect();
-                    // By priority, then by time ascending, then lexigraphically.
-                    // Older entries overwrite older ones.
-                    refs.sort_by(|(_, a_time, a_prio, a_name), (_, b_time, b_prio, b_name)| {
-                        a_prio
-                            .cmp(b_prio)
-                            .then_with(|| a_time.cmp(b_time))
-                            .then_with(|| b_name.cmp(a_name))
-                    });
+                    // By priority, then by time ascending, then lexicographically.
+                    // More recent entries overwrite older ones.
+                    refs.sort_by(
+                        |(_a_peeled_id, a_time, a_prio, a_name), (_b_peeled_id, b_time, b_prio, b_name)| {
+                            a_prio
+                                .cmp(b_prio)
+                                .then_with(|| a_time.cmp(b_time))
+                                .then_with(|| b_name.cmp(a_name))
+                        },
+                    );
                     refs.into_iter().map(|(a, _, _, b)| (a, b)).collect()
                 }
                 SelectRef::AnnotatedTags => {
@@ -126,8 +128,8 @@ pub mod describe {
                             Some((commit_id, tag_time, Cow::<BStr>::from(r.name().shorten().to_owned())))
                         })
                         .collect();
-                    // Sort by priority, then by time ascending, then lexigraphically.
-                    // Older entries overwrite older ones.
+                    // Sort by priority, then by time ascending, then lexicographically.
+                    // More recent entries overwrite older ones.
                     peeled_commits_and_tag_date.sort_by(|(a_time, a_prio, a_name), (b_time, b_prio, b_name)| {
                         a_prio
                             .cmp(b_prio)

--- a/git-repository/src/commit.rs
+++ b/git-repository/src/commit.rs
@@ -99,7 +99,14 @@ pub mod describe {
                             .into()
                     })
                     .collect();
-                    refs.sort_by(|a, b| a.2.cmp(&b.2).then_with(|| a.1.cmp(&b.1))); // by time ascending, then by priority. Older entries overwrite newer ones.
+                    // By priority, then by time ascending, then lexigraphically.
+                    // Older entries overwrite older ones.
+                    refs.sort_by(|(_, a_time, a_prio, a_name), (_, b_time, b_prio, b_name)| {
+                        a_prio
+                            .cmp(b_prio)
+                            .then_with(|| a_time.cmp(b_time))
+                            .then_with(|| b_name.cmp(a_name))
+                    });
                     refs.into_iter().map(|(a, _, _, b)| (a, b)).collect()
                 }
                 SelectRef::AnnotatedTags => {
@@ -116,10 +123,17 @@ pub mod describe {
                                 .and_then(|s| s.map(|s| s.time.seconds_since_unix_epoch))
                                 .unwrap_or(0);
                             let commit_id = tag.target_id().ok()?.object().ok()?.try_into_commit().ok()?.id;
-                            Some((commit_id, tag_time, r.name().shorten().to_owned().into()))
+                            Some((commit_id, tag_time, Cow::<BStr>::from(r.name().shorten().to_owned())))
                         })
                         .collect();
-                    peeled_commits_and_tag_date.sort_by(|a, b| a.1.cmp(&b.1)); // by time, ascending, causing older names to overwrite newer ones.
+                    // Sort by priority, then by time ascending, then lexigraphically.
+                    // Older entries overwrite older ones.
+                    peeled_commits_and_tag_date.sort_by(|(a_time, a_prio, a_name), (b_time, b_prio, b_name)| {
+                        a_prio
+                            .cmp(b_prio)
+                            .then_with(|| a_time.cmp(b_time))
+                            .then_with(|| b_name.cmp(a_name))
+                    });
                     peeled_commits_and_tag_date
                         .into_iter()
                         .map(|(a, _, c)| (a, c))

--- a/git-repository/src/commit.rs
+++ b/git-repository/src/commit.rs
@@ -102,10 +102,10 @@ pub mod describe {
                     // By priority, then by time ascending, then lexicographically.
                     // More recent entries overwrite older ones.
                     refs.sort_by(
-                        |(_a_peeled_id, a_time, a_prio, a_name), (_b_peeled_id, b_time, b_prio, b_name)| {
-                            a_prio
-                                .cmp(b_prio)
-                                .then_with(|| a_time.cmp(b_time))
+                        |(_a_peeled_id, a_prio, a_time, a_name), (_b_peeled_id, b_prio, b_time, b_name)| {
+                            a_time
+                                .cmp(b_time)
+                                .then_with(|| a_prio.cmp(b_prio))
                                 .then_with(|| b_name.cmp(a_name))
                         },
                     );
@@ -130,10 +130,10 @@ pub mod describe {
                         .collect();
                     // Sort by priority, then by time ascending, then lexicographically.
                     // More recent entries overwrite older ones.
-                    peeled_commits_and_tag_date.sort_by(|(a_time, a_prio, a_name), (b_time, b_prio, b_name)| {
-                        a_prio
-                            .cmp(b_prio)
-                            .then_with(|| a_time.cmp(b_time))
+                    peeled_commits_and_tag_date.sort_by(|(_a_id, a_time, a_name), (_b_id, b_time, b_name)| {
+                        a_time
+                            .cmp(b_time)
+                            .then_with(|| _a_id.cmp(_b_id))
                             .then_with(|| b_name.cmp(a_name))
                     });
                     peeled_commits_and_tag_date

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -4,12 +4,12 @@ mod describe {
     use crate::named_repo;
 
     #[test]
-    fn tags_are_sorted_by_date_and_lexigraphically() {
+    fn tags_are_sorted_by_date_prio_and_lexigraphically() {
         let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
         let mut describe = repo.head_commit().unwrap().describe();
         for filter in &[AnnotatedTags, AllTags, AllRefs] {
             describe = describe.names(*filter);
-            assert_eq!(describe.format().unwrap().to_string(), "v2", "{:?}", filter);
+            assert_eq!(describe.format().unwrap().to_string(), "v3", "{:?}", filter);
         }
     }
 }

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -4,7 +4,7 @@ mod describe {
     use crate::named_repo;
 
     #[test]
-    fn tags_are_sorted_by_date_prio_and_lexigraphically() {
+    fn tags_are_sorted_by_date_prio_and_lexicographically() {
         let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
         let mut describe = repo.head_commit().unwrap().describe();
         for filter in &[AnnotatedTags, AllTags, AllRefs] {

--- a/git-repository/tests/commit/mod.rs
+++ b/git-repository/tests/commit/mod.rs
@@ -4,12 +4,51 @@ mod describe {
     use crate::named_repo;
 
     #[test]
-    fn tags_are_sorted_by_date_prio_and_lexicographically() {
+    fn tags_are_sorted_by_date_and_lexicographically() {
         let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
         let mut describe = repo.head_commit().unwrap().describe();
         for filter in &[AnnotatedTags, AllTags, AllRefs] {
             describe = describe.names(*filter);
-            assert_eq!(describe.format().unwrap().to_string(), "v3", "{:?}", filter);
+            assert_eq!(describe.format().unwrap().to_string(), "v4", "{:?}", filter);
+        }
+    }
+
+    #[test]
+    fn tags_are_sorted_by_priority() {
+        let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
+        let commit = repo
+            .find_reference("refs/tags/v0")
+            .unwrap()
+            .id()
+            .object()
+            .unwrap()
+            .into_commit();
+        let mut describe = commit.describe();
+        for filter in &[AnnotatedTags, AllTags, AllRefs] {
+            describe = describe.names(*filter);
+            assert_eq!(describe.format().unwrap().to_string(), "v1", "{:?}", filter);
+        }
+    }
+
+    #[test]
+    fn lightweight_tags_are_sorted_lexicographically() {
+        let repo = named_repo("make_commit_describe_multiple_tags.sh").unwrap();
+        let commit = repo
+            .find_reference("refs/tags/l0")
+            .unwrap()
+            .id()
+            .object()
+            .unwrap()
+            .into_commit();
+        let mut describe = commit.describe();
+        for filter in &[AnnotatedTags, AllTags, AllRefs] {
+            describe = describe.names(*filter);
+            let expected = match filter {
+                AnnotatedTags => None,
+                _ => Some("l0"),
+            };
+            let actual = describe.try_format().unwrap().map(|f| f.to_string());
+            assert_eq!(actual.as_deref(), expected, "{:?}", filter);
         }
     }
 }

--- a/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
+++ b/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22fd60100187fc3f4180b31d3ae1d8c5506a65c3ee059b4bbc3a40009fb23f60
-size 10408
+oid sha256:31bdcf716054fd807309a23783ab0283e92a6bcdcb8a32a7c9cd6ae9ad99dd18
+size 10724

--- a/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
+++ b/git-repository/tests/fixtures/generated-archives/make_commit_describe_multiple_tags.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31bdcf716054fd807309a23783ab0283e92a6bcdcb8a32a7c9cd6ae9ad99dd18
-size 10724
+oid sha256:f19ab2492f20366a2ee60fc7bd346f07b7a36e06ee077c2db5b78f8d97ff14d6
+size 10984

--- a/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
+++ b/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
@@ -6,6 +6,8 @@ git commit --allow-empty -q -m c1
 git commit --allow-empty -q -m c2
 
 git tag v0 -m "tag object 0" "HEAD~1"
-git tag v1 -m "tag object 1"
-git tag v1.5
-GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v2 -m "tag object 2"
+git tag v2 -m "tag object 1"
+git tag v2.5
+GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v3 -m "tag object 2"
+GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v4 -m "tag object 4"
+GIT_COMMITTER_DATE="2022-01-03 00:00:00 +0000" git tag v1

--- a/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
+++ b/git-repository/tests/fixtures/make_commit_describe_multiple_tags.sh
@@ -4,10 +4,20 @@ set -eu -o pipefail
 git init -q
 git commit --allow-empty -q -m c1
 git commit --allow-empty -q -m c2
+git commit --allow-empty -q -m c3
 
-git tag v0 -m "tag object 0" "HEAD~1"
+# Tag the first commit (with lightweight tags only)
+git tag l0 "HEAD~2"
+GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag l1 "HEAD~2"
+
+# Tag the second commit (for tests involving tag priority)
+# The date is not checked for lightweight tags, so date the annotated tag to 0
+GIT_COMMITTER_DATE="1970-01-01 00:00:00 +0000" git tag v1 -m "tag object 0" "HEAD~1"
+git tag v0 "HEAD~1"
+
+# Tag the third (HEAD) commit (testing the combination of priority, date and lexicographical order)
 git tag v2 -m "tag object 1"
 git tag v2.5
-GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v3 -m "tag object 2"
 GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v4 -m "tag object 4"
-GIT_COMMITTER_DATE="2022-01-03 00:00:00 +0000" git tag v1
+GIT_COMMITTER_DATE="2022-01-02 00:00:00 +0000" git tag v5 -m "tag object 5"
+GIT_COMMITTER_DATE="2022-01-03 00:00:00 +0000" git tag v3


### PR DESCRIPTION
I noticed that lightweight git tags were sorted differently by `describe()`, compared to git. The difference seems to be that git will sort lightweight tags or tags created at the same time lexigraphically.

There was already a test that was supposed to check this, which I changed to actually verify this. The sorting code also first compared the time, followed by the priority, but as far as I can tell git will check the priority first, so I changed the order to match git.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
