### PR TITLE
[refactor] Deduplicate Tag and TagRef

### DIFF
--- a/git-object/src/lib.rs
+++ b/git-object/src/lib.rs
@@ -159,8 +159,9 @@ pub struct TagRefIter<'a> {
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tag {
-    /// The hash this tag is pointing to.
-    pub target: git_hash::ObjectId,
+    /// The hash this tag is pointing to stored as a 40 bytes hexadecimal representation from which an `ObjectId`
+    /// can be constructed. Use `.target()` to access that `ObjectId`
+    pub target: BString,
     /// The kind of object this tag is pointing to.
     pub target_kind: crate::Kind,
     /// The name of the tag, e.g. "v1.0".
@@ -171,6 +172,13 @@ pub struct Tag {
     pub message: BString,
     /// A pgp signature over all bytes of the encoded tag, excluding the pgp signature itself.
     pub pgp_signature: Option<BString>,
+}
+
+impl Tag {
+    /// The hash this tag is pointing to.
+    pub fn target(&self) -> git_hash::ObjectId {
+        git_hash::ObjectId::from_hex(&self.target).expect("40 bytes hex sha1")
+    }
 }
 
 /// Immutable objects are read-only structures referencing most data from [a byte slice][crate::ObjectRef::from_bytes()].

--- a/git-object/src/object/convert.rs
+++ b/git-object/src/object/convert.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use crate::{tree, Blob, BlobRef, Commit, CommitRef, Object, ObjectRef, Tag, TagRef, Tree, TreeRef};
+use crate::{bstr::BStr, tree, Blob, BlobRef, Commit, CommitRef, Object, ObjectRef, Tag, TagRef, Tree, TreeRef};
 
 impl From<TagRef<'_>> for Tag {
     fn from(other: TagRef<'_>) -> Tag {
@@ -13,12 +13,33 @@ impl From<TagRef<'_>> for Tag {
             pgp_signature,
         } = other;
         Tag {
-            target: git_hash::ObjectId::from_hex(target).expect("40 bytes hex sha1"),
+            target: target.to_owned(),
             name: name.to_owned(),
             target_kind,
             message: message.to_owned(),
             tagger: signature.map(Into::into),
             pgp_signature: pgp_signature.map(ToOwned::to_owned),
+        }
+    }
+}
+
+impl<'a> From<&'a Tag> for TagRef<'a> {
+    fn from(other: &'a Tag) -> TagRef<'a> {
+        let Tag {
+            target,
+            target_kind,
+            name,
+            tagger,
+            message,
+            pgp_signature,
+        } = other;
+        TagRef {
+            target: target.as_ref(),
+            target_kind: *target_kind,
+            name: name.as_ref(),
+            tagger: tagger.as_ref().map(|s| s.to_ref()),
+            message: message.as_ref(),
+            pgp_signature: pgp_signature.as_deref().map(BStr::new),
         }
     }
 }

--- a/git-object/src/tag/write.rs
+++ b/git-object/src/tag/write.rs
@@ -21,36 +21,12 @@ impl From<Error> for io::Error {
 }
 
 impl crate::WriteTo for Tag {
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
-        encode::trusted_header_id(b"object", &self.target, &mut out)?;
-        encode::trusted_header_field(b"type", self.target_kind.as_bytes(), &mut out)?;
-        encode::header_field(b"tag", validated_name(self.name.as_ref())?, &mut out)?;
-        if let Some(tagger) = &self.tagger {
-            encode::trusted_header_signature(b"tagger", &tagger.to_ref(), &mut out)?;
-        }
-
-        out.write_all(NL)?;
-        if !self.message.is_empty() {
-            out.write_all(&self.message)?;
-        }
-        if let Some(ref message) = self.pgp_signature {
-            out.write_all(NL)?;
-            out.write_all(message)?;
-        }
-        Ok(())
+    fn write_to(&self, out: impl io::Write) -> io::Result<()> {
+        TagRef::from(self).write_to(out)
     }
 
     fn size(&self) -> usize {
-        b"object".len() + 1 /* space */ + self.target.kind().len_in_hex() + 1 /* nl */
-            + b"type".len() + 1 /* space */ + self.target_kind.as_bytes().len() + 1 /* nl */
-            + b"tag".len() + 1 /* space */ + self.name.len() + 1 /* nl */
-            + self
-                .tagger
-                .as_ref()
-                .map(|t| b"tagger".len() + 1 /* space */ + t.size() + 1 /* nl */)
-                .unwrap_or(0)
-            + 1 /* nl */ + self.message.len()
-            + self.pgp_signature.as_ref().map(|m| 1 /* nl */ + m.len() ).unwrap_or(0)
+        TagRef::from(self).size()
     }
 
     fn kind(&self) -> Kind {

--- a/git-repository/src/repository/object.rs
+++ b/git-repository/src/repository/object.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+use crate::bstr::BString;
 use git_hash::{oid, ObjectId};
 use git_odb::{Find, FindExt, Write};
 use git_ref::{
@@ -112,9 +113,12 @@ impl crate::Repository {
         message: impl AsRef<str>,
         constraint: PreviousValue,
     ) -> Result<Reference<'_>, tag::Error> {
+        let mut buf = Vec::with_capacity(40);
+        oid::write_hex_to(target.as_ref(), &mut buf).expect("Failed to write target hash to buffer");
+        let target = BString::new(buf);
         // NOTE: This could be more efficient if we use a TagRef instead.
         let tag = git_object::Tag {
-            target: target.as_ref().into(),
+            target,
             target_kind,
             name: name.as_ref().into(),
             tagger: tagger.map(|t| t.to_owned()),


### PR DESCRIPTION
To do so, implement a conversion from a `&Tag` to a `TagRef`.

This wasn't possible with the existing reprensentation of `Tag` as the target was represented by an `ObjectId` which internally stored only 20 bytes, but the `TagRef` type used a `BStr` that represented the 40 bytes `oid` representation of that object.

To fix that issue, store the target as a 40 bytes `BString` in `Tag`.

Alternative: The existing conversion from `TagRef` to `Tag` could have been used instead, but that would have required allocating memory for the entire data-structure which felt heavy handed for a simple refactoring.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
