### PR TITLE
fix: Disable tag.gpgSign in test scripts

### DIFF
--- a/cargo-smart-release/tests/journey.sh
+++ b/cargo-smart-release/tests/journey.sh
@@ -28,6 +28,7 @@ function set-static-git-environment() {
 function init-git-repo() {
   git init . &&
   git config commit.gpgsign false &&
+  git config tag.gpgsign false &&
   git add . && git commit -q -m "initial"
 }
 

--- a/git-odb/tests/fixtures/make_replaced_history.sh
+++ b/git-odb/tests/fixtures/make_replaced_history.sh
@@ -3,6 +3,7 @@ set -eu -o pipefail
 
 git init -q
 git config commit.gpgsign false
+git config tag.gpgsign false
 
 echo "#include <stdio.h>" > file.c && git add file.c
 git commit -m "Initial commit"

--- a/git-odb/tests/fixtures/make_repo_multi_index.sh
+++ b/git-odb/tests/fixtures/make_repo_multi_index.sh
@@ -5,6 +5,7 @@ omit_multi_index=${1:-no}
 
 git init -q
 git config commit.gpgsign false
+git config tag.gpgsign false
 
 function write_files() {
   local base_dir=${1:?directory to write them into}

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -30,6 +30,7 @@ function repo-with-remotes() {
         shift 2
     done
     git config commit.gpgsign false
+    git config tag.gpgsign false
     touch a
     git add a
     git commit -m "non-bare"
@@ -42,6 +43,7 @@ function small-repo-in-sandbox() {
     git init
     git checkout -b main
     git config commit.gpgsign false
+    git config tag.gpgsign false
     touch a
     git add a
     git commit -m "first"

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -382,13 +382,15 @@ fn scripted_fixture_repo_read_only_with_args_inner(
                     .env("GIT_COMMITTER_DATE", "2000-01-02 00:00:00 +0000")
                     .env("GIT_COMMITTER_EMAIL", "committer@example.com")
                     .env("GIT_COMMITTER_NAME", "committer")
-                    .env("GIT_CONFIG_COUNT", "3")
+                    .env("GIT_CONFIG_COUNT", "4")
                     .env("GIT_CONFIG_KEY_0", "commit.gpgsign")
                     .env("GIT_CONFIG_VALUE_0", "false")
-                    .env("GIT_CONFIG_KEY_1", "init.defaultBranch")
-                    .env("GIT_CONFIG_VALUE_1", "main")
-                    .env("GIT_CONFIG_KEY_2", "protocol.file.allow")
-                    .env("GIT_CONFIG_VALUE_2", "always")
+                    .env("GIT_CONFIG_KEY_1", "tag.gpgsign")
+                    .env("GIT_CONFIG_VALUE_1", "false")
+                    .env("GIT_CONFIG_KEY_2", "init.defaultBranch")
+                    .env("GIT_CONFIG_VALUE_2", "main")
+                    .env("GIT_CONFIG_KEY_3", "protocol.file.allow")
+                    .env("GIT_CONFIG_VALUE_3", "always")
                     .output()?;
                 if !output.status.success() {
                     write_failure_marker(&failure_marker);


### PR DESCRIPTION
This is done for the same reason that commit.gpgsign is disabled for test scripts. It prevents test failures if the user has tag.gpgsign enabled in their global git config when invoking tests.

Signed-off-by: Peter Grayson <pete@jpgrayson.net>

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
