### PR TITLE
cwd consistency

### DIFF
--- a/git-discover/src/upwards/mod.rs
+++ b/git-discover/src/upwards/mod.rs
@@ -4,6 +4,7 @@ pub use types::{Error, Options};
 mod util;
 
 pub(crate) mod function {
+    use std::borrow::Cow;
     use std::path::Path;
 
     use git_sec::Trust;
@@ -30,14 +31,20 @@ pub(crate) mod function {
             ceiling_dirs,
             match_ceiling_dir_or_error,
             cross_fs,
-        }: Options,
+            current_dir,
+        }: Options<'_>,
     ) -> Result<(crate::repository::Path, Trust), Error> {
         // Absolutize the path so that `Path::parent()` _actually_ gives
         // us the parent directory. (`Path::parent` just strips off the last
         // path component, which means it will not do what you expect when
         // working with paths paths that contain '..'.)
-        let cwd = std::env::current_dir().ok();
-        let dir = git_path::absolutize(directory.as_ref(), cwd.as_deref());
+        let cwd = current_dir
+            .map(|cwd| Ok(Cow::Borrowed(cwd)))
+            .unwrap_or_else(|| std::env::current_dir().map(Cow::Owned))?;
+        let directory = directory.as_ref();
+        let dir = git_path::absolutize(directory, cwd.as_ref()).ok_or_else(|| Error::InvalidInput {
+            directory: directory.into(),
+        })?;
         let dir_metadata = dir.metadata().map_err(|_| Error::InaccessibleDirectory {
             path: dir.to_path_buf(),
         })?;
@@ -45,12 +52,12 @@ pub(crate) mod function {
         if !dir_metadata.is_dir() {
             return Err(Error::InaccessibleDirectory { path: dir.into_owned() });
         }
-        let mut dir_made_absolute = !directory.as_ref().is_absolute()
-            && cwd.as_deref().map_or(false, |cwd| {
-                cwd.strip_prefix(dir.as_ref())
-                    .or_else(|_| dir.as_ref().strip_prefix(cwd))
-                    .is_ok()
-            });
+        let mut dir_made_absolute = !directory.is_absolute()
+            && cwd
+                .as_ref()
+                .strip_prefix(dir.as_ref())
+                .or_else(|_| dir.as_ref().strip_prefix(cwd.as_ref()))
+                .is_ok();
 
         let filter_by_trust = |x: &Path| -> Result<Option<Trust>, Error> {
             let trust = Trust::from_path_ownership(x).map_err(|err| Error::CheckTrust { path: x.into(), err })?;
@@ -58,7 +65,7 @@ pub(crate) mod function {
         };
 
         let max_height = if !ceiling_dirs.is_empty() {
-            let max_height = find_ceiling_height(&dir, &ceiling_dirs, cwd.as_deref());
+            let max_height = find_ceiling_height(&dir, &ceiling_dirs, cwd.as_ref());
             if max_height.is_none() && match_ceiling_dir_or_error {
                 return Err(Error::NoMatchingCeilingDir);
             }
@@ -108,11 +115,18 @@ pub(crate) mod function {
                         Some(trust) => {
                             // TODO: test this more, it definitely doesn't always find the shortest path to a directory
                             let path = if dir_made_absolute {
-                                shorten_path_with_cwd(cursor, cwd.as_deref())
+                                shorten_path_with_cwd(cursor, cwd.as_ref())
                             } else {
                                 cursor
                             };
-                            break 'outer Ok((crate::repository::Path::from_dot_git_dir_inner(path, kind, cwd), trust));
+                            break 'outer Ok((
+                                crate::repository::Path::from_dot_git_dir(path, kind, cwd).ok_or_else(|| {
+                                    Error::InvalidInput {
+                                        directory: directory.into(),
+                                    }
+                                })?,
+                                trust,
+                            ));
                         }
                         None => {
                             break 'outer Err(Error::NoTrustedGitRepository {
@@ -138,12 +152,15 @@ pub(crate) mod function {
                 } else {
                     dir_made_absolute = true;
                     cursor = if cursor.as_os_str().is_empty() {
-                        cwd.clone()
+                        cwd.clone().into_owned()
                     } else {
                         // TODO: realpath or absolutize? No test runs into this.
-                        Some(git_path::absolutize(&cursor, cwd.as_deref()).into_owned())
+                        git_path::absolutize(&cursor, cwd.as_ref())
+                            .ok_or_else(|| Error::InvalidInput {
+                                directory: cursor.clone(),
+                            })?
+                            .into_owned()
                     }
-                    .ok_or(Error::InaccessibleDirectory { path: cursor })?;
                 }
             }
         }

--- a/git-discover/src/upwards/util.rs
+++ b/git-discover/src/upwards/util.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::DOT_GIT_DIR;
 
-pub(crate) fn shorten_path_with_cwd(cursor: PathBuf, cwd: Option<&Path>) -> PathBuf {
+pub(crate) fn shorten_path_with_cwd(cursor: PathBuf, cwd: &Path) -> PathBuf {
     fn comp_len(c: std::path::Component<'_>) -> usize {
         use std::path::Component::*;
         match c {
@@ -14,38 +14,34 @@ pub(crate) fn shorten_path_with_cwd(cursor: PathBuf, cwd: Option<&Path>) -> Path
         }
     }
 
-    if let Some(cwd) = cwd {
-        debug_assert_eq!(cursor.file_name().and_then(|f| f.to_str()), Some(DOT_GIT_DIR));
-        let parent = cursor.parent().expect(".git appended");
-        cwd.strip_prefix(parent)
-            .ok()
-            .and_then(|path_relative_to_cwd| {
-                let relative_path_components = path_relative_to_cwd.components().count();
-                let current_component_len = cursor.components().map(comp_len).sum::<usize>();
-                (relative_path_components * "..".len() < current_component_len).then(|| {
-                    std::iter::repeat("..")
-                        .take(relative_path_components)
-                        .chain(Some(DOT_GIT_DIR))
-                        .collect()
-                })
+    debug_assert_eq!(cursor.file_name().and_then(|f| f.to_str()), Some(DOT_GIT_DIR));
+    let parent = cursor.parent().expect(".git appended");
+    cwd.strip_prefix(parent)
+        .ok()
+        .and_then(|path_relative_to_cwd| {
+            let relative_path_components = path_relative_to_cwd.components().count();
+            let current_component_len = cursor.components().map(comp_len).sum::<usize>();
+            (relative_path_components * "..".len() < current_component_len).then(|| {
+                std::iter::repeat("..")
+                    .take(relative_path_components)
+                    .chain(Some(DOT_GIT_DIR))
+                    .collect()
             })
-            .unwrap_or(cursor)
-    } else {
-        cursor
-    }
+        })
+        .unwrap_or(cursor)
 }
 
 /// Find the number of components parenting the `search_dir` before the first directory in `ceiling_dirs`.
 /// `search_dir` needs to be absolutized, and we absolutize every ceiling as well.
-pub(crate) fn find_ceiling_height(search_dir: &Path, ceiling_dirs: &[PathBuf], cwd: Option<&Path>) -> Option<usize> {
+pub(crate) fn find_ceiling_height(search_dir: &Path, ceiling_dirs: &[PathBuf], cwd: &Path) -> Option<usize> {
     ceiling_dirs
         .iter()
         .filter_map(|ceiling_dir| {
-            let mut ceiling_dir = git_path::absolutize(ceiling_dir, cwd);
+            let mut ceiling_dir = git_path::absolutize(ceiling_dir, cwd)?;
             match (search_dir.is_absolute(), ceiling_dir.is_absolute()) {
-                (true, false) => ceiling_dir = cwd?.join(ceiling_dir.as_ref()).into(),
+                (true, false) => ceiling_dir = cwd.join(ceiling_dir.as_ref()).into(),
                 (false, true) => {
-                    let stripped = ceiling_dir.as_ref().strip_prefix(cwd?).ok()?.to_owned();
+                    let stripped = ceiling_dir.as_ref().strip_prefix(cwd).ok()?.to_owned();
                     ceiling_dir = stripped.into();
                 }
                 (false, false) | (true, true) => {}

--- a/git-odb/src/lib.rs
+++ b/git-odb/src/lib.rs
@@ -103,6 +103,11 @@ pub struct Store {
     /// The source directory from which all content is loaded, and the central write lock for use when a directory refresh is needed.
     pub(crate) path: PathBuf,
 
+    /// The current working directory at the time this store was instantiated. It becomes relevant when resolving alternate paths
+    /// when re-reading the store configuration on updates when an object was missed.
+    /// Keeping it here helps to assure consistency even while a process changes its CWD.
+    pub(crate) current_dir: PathBuf,
+
     /// A set of replacements that given a source OID return a destination OID. The vector is sorted.
     pub(crate) replacements: Vec<(git_hash::ObjectId, git_hash::ObjectId)>,
 

--- a/git-odb/src/store_impls/dynamic/handle.rs
+++ b/git-odb/src/store_impls/dynamic/handle.rs
@@ -354,6 +354,7 @@ impl TryFrom<&super::Store> for super::Store {
                 slots: crate::store::init::Slots::Given(s.files.len().try_into().expect("BUG: too many slots")),
                 object_hash: Default::default(),
                 use_multi_pack_index: false,
+                current_dir: s.current_dir.clone().into(),
             },
         )
     }

--- a/git-odb/src/store_impls/dynamic/load_index.rs
+++ b/git-odb/src/store_impls/dynamic/load_index.rs
@@ -198,7 +198,7 @@ impl super::Store {
         self.num_disk_state_consolidation.fetch_add(1, Ordering::Relaxed);
 
         let db_paths: Vec<_> = std::iter::once(objects_directory.to_owned())
-            .chain(crate::alternate::resolve(objects_directory)?)
+            .chain(crate::alternate::resolve(objects_directory, &self.current_dir)?)
             .collect();
 
         // turn db paths into loose object databases. Reuse what's there, but only if it is in the right order.

--- a/git-odb/tests/fixtures/generated-archives/make_repo_multi_index.tar.xz
+++ b/git-odb/tests/fixtures/generated-archives/make_repo_multi_index.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2540d318e8e6bd3bfe81c6519df2afcb9cb8f86956d3f3a4cde37122e1e5d7d9
-size 205172
+oid sha256:e3112c623d569241c5d1115523fff51ca3d71da3a800b87eb3a084a52958c0f5
+size 200916

--- a/git-odb/tests/odb/alternate/mod.rs
+++ b/git-odb/tests/odb/alternate/mod.rs
@@ -67,7 +67,7 @@ fn circular_alternates_are_detected_with_relative_paths() -> crate::Result {
         None,
     )?;
 
-    match alternate::resolve(&from) {
+    match alternate::resolve(&from, std::env::current_dir()?) {
         Err(alternate::Error::Cycle(chain)) => {
             assert_eq!(
                 chain
@@ -88,7 +88,7 @@ fn single_link_with_comment_before_path_and_ansi_c_escape() -> crate::Result {
     let non_alternate = tmp.path().join("actual");
 
     let (from, to) = alternate_with(tmp.path().join("a"), non_alternate, Some("# comment\n"))?;
-    let alternates = alternate::resolve(from)?;
+    let alternates = alternate::resolve(from, std::env::current_dir()?)?;
     assert_eq!(alternates.len(), 1);
     assert_eq!(alternates[0], to);
     Ok(())
@@ -97,6 +97,6 @@ fn single_link_with_comment_before_path_and_ansi_c_escape() -> crate::Result {
 #[test]
 fn no_alternate_in_first_objects_dir() -> crate::Result {
     let tmp = git_testtools::tempfile::TempDir::new()?;
-    assert!(alternate::resolve(tmp.path())?.is_empty());
+    assert!(alternate::resolve(tmp.path(), std::env::current_dir()?)?.is_empty());
     Ok(())
 }

--- a/git-path/src/convert.rs
+++ b/git-path/src/convert.rs
@@ -244,10 +244,8 @@ pub fn absolutize<'a>(path: impl Into<Cow<'a, Path>>, current_dir: impl AsRef<Pa
             if path.as_os_str().is_empty() {
                 path.clear();
                 path.push(current_dir_opt.take()?);
-                if path_was_dot {
-                    if !path.pop() {
-                        return None;
-                    }
+                if path_was_dot && !path.pop() {
+                    return None;
                 }
             }
         } else {

--- a/git-path/src/convert.rs
+++ b/git-path/src/convert.rs
@@ -220,32 +220,43 @@ pub fn to_windows_separators<'a>(path: impl Into<Cow<'a, BStr>>) -> Cow<'a, BStr
 
 /// Resolve relative components virtually without accessing the file system, e.g. turn `a/./b/c/.././..` into `a`,
 /// without keeping intermediate `..` and `/a/../b/..` becomes `/`.
-/// Note that we might access the `current_dir` if we run out of path components to pop off. If unset, we continue
-/// which might lead to an invalid/uninteded path.
-pub fn absolutize<'a>(path: impl Into<Cow<'a, Path>>, mut current_dir: Option<impl Into<PathBuf>>) -> Cow<'a, Path> {
+/// Note that we might access the `current_dir` if we run out of path components to pop off, which is expected to be absolute
+/// as typical return value of `std::env::current_dir()`.
+/// As a `current_dir` like `/c` can be exhausted by paths like `../../r`, `None` will be returned to indicate the inability
+/// to produce a logically consistent path.
+pub fn absolutize<'a>(path: impl Into<Cow<'a, Path>>, current_dir: impl AsRef<Path>) -> Option<Cow<'a, Path>> {
     use std::path::Component::ParentDir;
 
     let path = path.into();
     if !path.components().any(|c| matches!(c, ParentDir)) {
-        return path;
+        return Some(path);
     }
+    let current_dir = current_dir.as_ref();
+    let mut current_dir_opt = Some(current_dir);
     let mut components = path.components();
     let mut path = PathBuf::from_iter(components.next());
     for component in components {
         if let ParentDir = component {
-            if path.as_os_str() == "." || (!path.pop() && path.as_os_str().is_empty()) {
-                if let Some(cwd) = current_dir.take() {
-                    path = cwd.into();
-                    path.pop();
+            let path_was_dot = path == Path::new(".");
+            if !path.pop() {
+                return None;
+            }
+            if path.as_os_str().is_empty() {
+                path.clear();
+                path.push(current_dir_opt.take()?);
+                if path_was_dot {
+                    if !path.pop() {
+                        return None;
+                    }
                 }
             }
         } else {
             path.push(component)
         }
     }
-    if path.as_os_str().is_empty() {
+    Some(if path.as_os_str().is_empty() || path == current_dir {
         PathBuf::from(".").into()
     } else {
         path.into()
-    }
+    })
 }

--- a/git-path/tests/convert/absolutize.rs
+++ b/git-path/tests/convert/absolutize.rs
@@ -10,7 +10,7 @@ fn p(input: &str) -> &Path {
 fn no_change_if_there_are_no_trailing_relative_components() {
     for input in ["./a/b/c/d", "/absolute/path", "C:\\hello\\world"] {
         let path = p(input);
-        assert_eq!(absolutize(path, None::<&Path>), path);
+        assert_eq!(absolutize(path, std::env::current_dir().unwrap()).unwrap(), path);
     }
 }
 
@@ -18,37 +18,69 @@ fn no_change_if_there_are_no_trailing_relative_components() {
 fn special_cases_around_cwd() -> crate::Result {
     let cwd = std::env::current_dir()?;
     assert_eq!(
-        absolutize(p("./../../.git/modules/src/llvm-project"), Some(&cwd)),
+        absolutize(p("./../../.git/modules/src/llvm-project"), &cwd).unwrap(),
         cwd.parent()
             .unwrap()
             .parent()
             .unwrap()
             .join(".git/modules/src/llvm-project"),
-        ". is handled specifically to not fail to swap in the CWD"
+        "'.' is handled specifically to not fail to swap in the CWD"
     );
     assert_eq!(
-        absolutize(p("a/.."), None::<&Path>),
-        p("."),
-        "empty paths are never returned as they are invalid"
+        absolutize(&cwd, &cwd).unwrap(),
+        cwd,
+        "absolute inputs yield absolute outputs"
     );
     assert_eq!(
-        absolutize(p("a/../.."), Some(&cwd)),
+        absolutize(p("a/../.."), &cwd).unwrap(),
         cwd.parent().expect("parent"),
-        "it automatically extends the poppable items by using the current working dir"
+        "it automatically extends the pop-able items by using the current working dir"
     );
+    assert_eq!(
+        absolutize(p("a/.."), &cwd).unwrap(),
+        p("."),
+        "absolute CWDs are always shortened…"
+    );
+    assert_eq!(absolutize(p("./a/.."), &cwd).unwrap(), p("."), "…like this as well…");
     Ok(())
 }
 
 #[test]
+fn parent_dirs_cause_the_cwd_to_be_used() {
+    assert_eq!(
+        absolutize(p("./a/b/../../.."), "/users/name").unwrap().as_ref(),
+        p("/users")
+    );
+}
+
+#[test]
+fn walking_up_too_much_yield_none() {
+    let cwd = "/users/name";
+    assert_eq!(absolutize(p("./a/b/../../../../../."), cwd), None);
+    assert_eq!(absolutize(p("./a/../../../.."), cwd), None);
+}
+
+#[test]
+fn trailing_directories_after_too_numereous_parent_dirs_yield_none() {
+    assert_eq!(
+        absolutize(p("./a/b/../../../../../actually-invalid"), "/users").as_ref(),
+        None,
+    );
+    assert_eq!(absolutize(p("/a/b/../../.."), "/does-not/matter").as_ref(), None,);
+}
+
+#[test]
 fn trailing_relative_components_are_resolved() {
+    let cwd = std::env::current_dir().unwrap();
     for (input, expected) in [
         ("./a/b/./c/../d/..", "./a/b"),
         ("/a/b/c/.././../.", "/a"),
         ("./a/..", "."),
         ("a/..", "."),
-        ("./a/b/../../..", "."),
-        ("/a/b/../../..", "/"),
+        ("./a", "./a"),
+        ("./a/./b/..", "./a/."),
         ("/a/./b/c/.././../.", "/a"),
+        ("/a/./b", "/a/./b"),
         ("/a/././c/.././../.", "/"),
         ("/a/b/../c/../..", "/"),
         ("C:/hello/../a", "C:/a"),
@@ -57,7 +89,7 @@ fn trailing_relative_components_are_resolved() {
     ] {
         let path = p(input);
         assert_eq!(
-            absolutize(path, None::<&Path>),
+            absolutize(path, &cwd).unwrap_or_else(|| panic!("{path:?}")),
             Cow::Borrowed(p(expected)),
             "'{}' got an unexpected result",
             input

--- a/git-repository/src/create.rs
+++ b/git-repository/src/create.rs
@@ -12,6 +12,8 @@ use git_discover::DOT_GIT_DIR;
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("Could not obtain the current directory")]
+    CurrentDir(#[from] std::io::Error),
     #[error("Could not open data at '{}'", .path.display())]
     IoOpen { source: std::io::Error, path: PathBuf },
     #[error("Could not write data at '{}'", .path.display())]
@@ -229,7 +231,9 @@ pub fn into(
         dot_git,
         bare.then(|| git_discover::repository::Kind::Bare)
             .unwrap_or(git_discover::repository::Kind::WorkTree { linked_git_dir: None }),
-    ))
+        std::env::current_dir()?,
+    )
+    .expect("by now the `dot_git` dir is valid as we have accessed it"))
 }
 
 fn key(name: &'static str) -> section::Key<'static> {

--- a/git-repository/src/discover.rs
+++ b/git-repository/src/discover.rs
@@ -32,13 +32,14 @@ impl ThreadSafeRepository {
     /// seems acceptable).
     pub fn discover_opts(
         directory: impl AsRef<Path>,
-        options: upwards::Options,
+        options: upwards::Options<'_>,
         trust_map: git_sec::trust::Mapping<crate::open::Options>,
     ) -> Result<Self, Error> {
         let (path, trust) = upwards_opts(directory, options)?;
         let (git_dir, worktree_dir) = path.into_repository_and_work_tree_directories();
         let mut options = trust_map.into_value_by_level(trust);
         options.git_dir_trust = trust.into();
+        options.current_dir = Some(std::env::current_dir().map_err(upwards::Error::CurrentDir)?);
         Self::open_from_paths(git_dir, worktree_dir, options).map_err(Into::into)
     }
 
@@ -60,10 +61,10 @@ impl ThreadSafeRepository {
     /// based on the trust level of the effective repository directory.
     pub fn discover_with_environment_overrides_opts(
         directory: impl AsRef<Path>,
-        mut options: upwards::Options,
+        mut options: upwards::Options<'_>,
         trust_map: git_sec::trust::Mapping<crate::open::Options>,
     ) -> Result<Self, Error> {
-        fn apply_additional_environment(mut opts: upwards::Options) -> upwards::Options {
+        fn apply_additional_environment(mut opts: upwards::Options<'_>) -> upwards::Options<'_> {
             use crate::bstr::ByteVec;
 
             if let Some(cross_fs) = std::env::var_os("GIT_DISCOVERY_ACROSS_FILESYSTEM")

--- a/git-repository/src/init.rs
+++ b/git-repository/src/init.rs
@@ -19,6 +19,8 @@ pub const DEFAULT_BRANCH_NAME: &str = "main";
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("Could not obtain the current directory")]
+    CurrentDir(#[from] std::io::Error),
     #[error(transparent)]
     Init(#[from] crate::create::Error),
     #[error(transparent)]
@@ -62,6 +64,7 @@ impl ThreadSafeRepository {
         let path = crate::create::into(directory.as_ref(), kind, create_options)?;
         let (git_dir, worktree_dir) = path.into_repository_and_work_tree_directories();
         open_options.git_dir_trust = Some(git_sec::Trust::Full);
+        open_options.current_dir = std::env::current_dir()?.into();
         let repo = ThreadSafeRepository::open_from_paths(git_dir, worktree_dir, open_options)?;
 
         let branch_name = repo

--- a/git-repository/tests/repository/mod.rs
+++ b/git-repository/tests/repository/mod.rs
@@ -11,7 +11,7 @@ mod worktree;
 #[test]
 fn size_in_memory() {
     let actual_size = std::mem::size_of::<Repository>();
-    let limit = 900;
+    let limit = 940;
     assert!(
         actual_size <= limit,
         "size of Repository shouldn't change without us noticing, it's meant to be cloned: should have been below {:?}, was {} (bigger on windows)",


### PR DESCRIPTION
Make sure our usage of the current_dir is somewhat consistent (#607)

With this patch set it's used implicitly only where absolutely required, namely `git-odb` in the
`Store` and in the higher-level `git-repository`.
