### PR TITLE
tests: Set GIT_EDITOR in make_rebase_i_repo.sh

### DIFF
--- a/git-repository/tests/fixtures/make_rebase_i_repo.sh
+++ b/git-repository/tests/fixtures/make_rebase_i_repo.sh
@@ -13,4 +13,4 @@ git commit -m 3 3
 
 # NOTE: Starting around git 2.35.0 --preserve-merges was renamed to --rebase-merges
 # however --preserve-merges first appeared in git 2.18.  That should cover most use cases.
-EDITOR="sed -i.bak 's/pick/edit/g'" git rebase --rebase-merges --interactive HEAD~2
+GIT_EDITOR="sed -i.bak 's/pick/edit/g'" git rebase --rebase-merges --interactive HEAD~2


### PR DESCRIPTION
If the user has core.editor set in their global git config, then that value takes precidence over the EDITOR environment variable. The GIT_EDITOR environment variable, however, has higher precidence than core.editor. For this test, using GIT_EDITOR ensures that the desired sed command line is used.

Signed-off-by: Peter Grayson <pete@jpgrayson.net>

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
