### PR TITLE
fix: Discover repo with relative path and ceiling

### DIFF
--- a/git-discover/tests/fixtures/make_basic_repo.sh
+++ b/git-discover/tests/fixtures/make_basic_repo.sh
@@ -10,6 +10,7 @@ git commit -q -m c1
 echo hello >> this
 git commit -q -am c2
 
+mkdir subdir
 mkdir -p some/very/deeply/nested/subdir
 
 git clone --bare --shared . bare.git

--- a/git-discover/tests/isolated-01.rs
+++ b/git-discover/tests/isolated-01.rs
@@ -1,0 +1,46 @@
+use git_discover::upwards::Options;
+use std::path::Path;
+
+#[test]
+fn upwards_with_relative_directories_and_optional_ceiling() -> git_testtools::Result {
+    let repo = git_testtools::scripted_fixture_repo_read_only("make_basic_repo.sh")?;
+
+    std::env::set_current_dir(repo.join("subdir"))?;
+    let cwd = std::env::current_dir()?;
+
+    for (search_dir, ceiling_dir_component) in [
+        (".", ".."),
+        (".", "./.."),
+        ("./.", "./.."),
+        (".", "./does-not-exist/../.."),
+    ] {
+        let ceiling_dir = cwd.join(ceiling_dir_component);
+        let (repo_path, _trust) = git_discover::upwards_opts(
+            search_dir,
+            Options {
+                ceiling_dirs: vec![ceiling_dir],
+                ..Default::default()
+            },
+        )
+        .expect("ceiling dir should allow us to discover the repo");
+        assert_eq!(
+            repo_path
+                .into_repository_and_work_tree_directories()
+                .1
+                .expect("work dir"),
+            Path::new(".."),
+        );
+
+        let (repo_path, _trust) =
+            git_discover::upwards_opts(search_dir, Default::default()).expect("without ceiling dir we see the same");
+        assert_eq!(
+            repo_path
+                .into_repository_and_work_tree_directories()
+                .1
+                .expect("work dir"),
+            Path::new(".."),
+        );
+    }
+
+    Ok(())
+}

--- a/git-path/src/convert.rs
+++ b/git-path/src/convert.rs
@@ -220,6 +220,11 @@ pub fn to_windows_separators<'a>(path: impl Into<Cow<'a, BStr>>) -> Cow<'a, BStr
 
 /// Resolve relative components virtually without accessing the file system, e.g. turn `a/./b/c/.././..` into `a`,
 /// without keeping intermediate `..` and `/a/../b/..` becomes `/`.
+///
+/// This is particularly useful when manipulating paths that are based on user input, and not resolving intermediate
+/// symlinks keeps the path similar to what the user provided. If that's not desirable, use `[realpath()][crate::realpath()`
+/// instead.
+///
 /// Note that we might access the `current_dir` if we run out of path components to pop off, which is expected to be absolute
 /// as typical return value of `std::env::current_dir()`.
 /// As a `current_dir` like `/c` can be exhausted by paths like `../../r`, `None` will be returned to indicate the inability


### PR DESCRIPTION
A couple of problems are repaired to allow discovering a repository from "." with a ceiling directory.

One problem was that find_ceiling_height() did the wrong thing when confronted with any relative search_dir. This is resolved by converting search_dir to be absolute if it is relative.

The other problem was that discover_opts() also mishandled relative paths. When the cursor started out as ".", cursor.pop() would be blindly called such that cursor would be "" for the second iteration. When a ceiling directory was in use such that there was a max_height, the current height would be burned going from ".", to "", and then to "<cwd>", before finally actually getting to a real parent directory. This problem is ameliorated by testing whether the cursor has a non-empty parent before popping.

N.B. the new test case relies on the test running from the git-discover directory such that the gitoxide repository will be found. This is a bit fragile and will fail if, for example, the test is run from an unpacked gitoxide source tarball.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
