### PR TITLE
fix: ssh connection error Bad port

### DIFF
--- a/git-transport/src/client/blocking_io/ssh.rs
+++ b/git-transport/src/client/blocking_io/ssh.rs
@@ -41,7 +41,7 @@ pub fn connect(
             if desired_version != Protocol::V1 {
                 let mut args = vec![Cow::from("-o"), "SendEnv=GIT_PROTOCOL".into()];
                 if let Some(port) = port {
-                    args.push(format!("-p={}", port).into());
+                    args.push(format!("-p{}", port).into());
                 }
                 Some((
                     args,


### PR DESCRIPTION
This fixes #642 

Removing '=' in the port argument passed to the ssh command when connecting

Tested with:
```bash
cargo run --bin gix -- -c "remote.origin.url=ssh://git@someting.io:777/something/api.git" remote refs
```

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.

