### PR TITLE
Allow parsing arbitrary URL schemes

### DIFF
--- a/git-repository/tests/fixtures/make_remote_repos.sh
+++ b/git-repository/tests/fixtures/make_remote_repos.sh
@@ -165,7 +165,7 @@ git init --bare bad-url-rewriting
 [remote "origin"]
   pushUrl = "file://dev/null"
 
-[url "foo://"]
+[url "invalid:://"]
   pushInsteadOf = "file://"
 
 [url "https://github.com/byron/"]

--- a/git-repository/tests/repository/remote.rs
+++ b/git-repository/tests/repository/remote.rs
@@ -215,7 +215,7 @@ mod find_remote {
             "…but is able to replace the fetch url successfully"
         );
 
-        let expected_err_msg = "The rewritten push url \"foo://dev/null\" failed to parse";
+        let expected_err_msg = "The rewritten push url \"invalid:://dev/null\" failed to parse";
         assert_eq!(
             repo.find_remote("origin").unwrap_err().to_string(),
             expected_err_msg,
@@ -237,7 +237,6 @@ mod find_remote {
                     "it can rewrite a single url like git can"
                 );
             }
-            assert_eq!(remote.url(Direction::Push).unwrap().to_bstring(), "file://dev/null",);
             assert_eq!(
                 remote.rewrite_urls().unwrap_err().to_string(),
                 expected_err_msg,

--- a/git-url/src/parse.rs
+++ b/git-url/src/parse.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    convert::{Infallible, TryFrom},
-};
+use std::{borrow::Cow, convert::Infallible};
 
 pub use bstr;
 use bstr::{BStr, ByteSlice};
@@ -16,8 +13,6 @@ pub enum Error {
     Utf8(#[from] std::str::Utf8Error),
     #[error(transparent)]
     Url(#[from] url::ParseError),
-    #[error("Protocol {protocol:?} is not supported")]
-    UnsupportedProtocol { protocol: String },
     #[error("Paths cannot be empty")]
     EmptyPath,
     #[error("Relative URLs are not permitted: {url:?}")]
@@ -30,10 +25,8 @@ impl From<Infallible> for Error {
     }
 }
 
-fn str_to_protocol(s: &str) -> Result<Scheme, Error> {
-    Scheme::try_from(s).map_err(|invalid| Error::UnsupportedProtocol {
-        protocol: invalid.into(),
-    })
+fn str_to_protocol(s: &str) -> Scheme {
+    Scheme::from(s)
 }
 
 fn guess_protocol(url: &[u8]) -> &str {
@@ -67,7 +60,7 @@ fn try_strip_file_protocol(url: &[u8]) -> Option<&[u8]> {
 fn to_owned_url(url: url::Url) -> Result<crate::Url, Error> {
     Ok(crate::Url {
         serialize_alternative_form: false,
-        scheme: str_to_protocol(url.scheme())?,
+        scheme: str_to_protocol(url.scheme()),
         user: if url.username().is_empty() {
             None
         } else {

--- a/git-url/src/scheme.rs
+++ b/git-url/src/scheme.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 /// A scheme for use in a [`Url`][crate::Url].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
@@ -13,19 +11,16 @@ pub enum Scheme {
     Ext(String),
 }
 
-impl<'a> TryFrom<&'a str> for Scheme {
-    type Error = &'a str;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        Ok(match value {
+impl<'a> From<&'a str> for Scheme {
+    fn from(value: &'a str) -> Self {
+        match value {
             "ssh" => Scheme::Ssh,
             "file" => Scheme::File,
             "git" => Scheme::Git,
             "http" => Scheme::Http,
             "https" => Scheme::Https,
-            "rad" => Scheme::Ext("rad".into()),
-            unknown => return Err(unknown),
-        })
+            unknown => Scheme::Ext(unknown.into()),
+        }
     }
 }
 

--- a/git-url/src/scheme.rs
+++ b/git-url/src/scheme.rs
@@ -1,13 +1,23 @@
-/// A scheme for use in a [`Url`][crate::Url].
+/// A scheme or protocol for use in a [`Url`][crate::Url].
+///
+/// It defines how to talk to a given repository.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Scheme {
+    /// A local resource that is accessible on the current host.
     File,
+    /// A git daemon, like `File` over TCP/IP.
     Git,
+    /// Launch `git-upload-pack` through an `ssh` tunnel.
     Ssh,
+    /// Use the HTTP protocol to talk to git servers.
     Http,
+    /// Use the HTTPS protocol to talk to git servers.
     Https,
+    /// Any other protocol or transport that isn't known at compile time.
+    ///
+    /// It's used to support plug-in transports.
     Ext(String),
 }
 

--- a/git-url/tests/parse/invalid.rs
+++ b/git-url/tests/parse/invalid.rs
@@ -1,8 +1,11 @@
 use crate::parse::assert_failure;
 
 #[test]
-fn unknown_protocol() {
-    assert_failure("foo://host.xz/path/to/repo.git/", "Protocol \"foo\" is not supported")
+fn relative_path_due_to_double_colon() {
+    assert_failure(
+        "invalid:://host.xz/path/to/repo.git/",
+        "Relative URLs are not permitted: \"invalid:://host.xz/path/to/repo.git/\"",
+    )
 }
 
 #[test]

--- a/git-url/tests/parse/mod.rs
+++ b/git-url/tests/parse/mod.rs
@@ -117,7 +117,7 @@ mod unknown {
     use crate::parse::{assert_url_roundtrip, url};
 
     #[test]
-    fn basic() -> crate::Result {
+    fn any_protocol_is_supported_via_the_ext_scheme() -> crate::Result {
         assert_url_roundtrip(
             "abc://example.com/~byron/hello",
             url(Scheme::Ext("abc".into()), None, "example.com", None, b"/~byron/hello"),

--- a/git-url/tests/parse/mod.rs
+++ b/git-url/tests/parse/mod.rs
@@ -110,3 +110,23 @@ mod git {
         )
     }
 }
+
+mod unknown {
+    use git_url::Scheme;
+
+    use crate::parse::{assert_url_roundtrip, url};
+
+    #[test]
+    fn basic() -> crate::Result {
+        assert_url_roundtrip(
+            "abc://example.com/~byron/hello",
+            url(
+                Scheme::Ext("abc".into()),
+                None,
+                "example.com",
+                None,
+                b"/~byron/hello",
+            ),
+        )
+    }
+}

--- a/git-url/tests/parse/mod.rs
+++ b/git-url/tests/parse/mod.rs
@@ -120,13 +120,7 @@ mod unknown {
     fn basic() -> crate::Result {
         assert_url_roundtrip(
             "abc://example.com/~byron/hello",
-            url(
-                Scheme::Ext("abc".into()),
-                None,
-                "example.com",
-                None,
-                b"/~byron/hello",
-            ),
+            url(Scheme::Ext("abc".into()), None, "example.com", None, b"/~byron/hello"),
         )
     }
 }


### PR DESCRIPTION
Prior to this change, a URL with an unknown scheme would fail to parse. I think it makes sense to parse unknown schemes to `git_url::Scheme::Ext(String)` instead.

The [`bad_url_rewriting_can_be_handled_much_like_git` test](https://github.com/paulyoung/gitoxide/blob/4753e641eada72f4e944811ea85390481444b210/git-repository/tests/repository/remote.rs#L202) now fails because it [expects an error](https://github.com/paulyoung/gitoxide/blob/4753e641eada72f4e944811ea85390481444b210/git-repository/tests/repository/remote.rs#L218) when parsing `foo://dev/null`.

I wasn't sure what to do about that and hoped we could discuss it here.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
