### PR TITLE
fix: always consider timestamps as UTC when loading from commits

### DIFF
--- a/git-date/src/time/format.rs
+++ b/git-date/src/time/format.rs
@@ -63,6 +63,6 @@ impl Time {
     fn to_time(self) -> time::OffsetDateTime {
         time::OffsetDateTime::from_unix_timestamp(self.seconds_since_unix_epoch as i64)
             .expect("always valid unix time")
-            .replace_offset(time::UtcOffset::from_whole_seconds(self.offset_in_seconds).expect("valid offset"))
+            .to_offset(time::UtcOffset::from_whole_seconds(self.offset_in_seconds).expect("valid offset"))
     }
 }

--- a/git-date/tests/time/format.rs
+++ b/git-date/tests/time/format.rs
@@ -6,7 +6,7 @@ use time::macros::format_description;
 
 #[test]
 fn short() {
-    assert_eq!(time().format(format::SHORT), "1973-11-29");
+    assert_eq!(time().format(format::SHORT), "1973-11-30");
 }
 
 #[test]
@@ -25,24 +25,24 @@ fn raw() {
 
 #[test]
 fn iso8601() {
-    assert_eq!(time().format(format::ISO8601), "1973-11-29 21:33:09 +0230");
+    assert_eq!(time().format(format::ISO8601), "1973-11-30 00:03:09 +0230");
 }
 
 #[test]
 fn iso8601_strict() {
-    assert_eq!(time().format(format::ISO8601_STRICT), "1973-11-29T21:33:09+02:30");
+    assert_eq!(time().format(format::ISO8601_STRICT), "1973-11-30T00:03:09+02:30");
 }
 
 #[test]
 fn rfc2822() {
-    assert_eq!(time().format(format::RFC2822), "Thu, 29 Nov 1973 21:33:09 +0230");
+    assert_eq!(time().format(format::RFC2822), "Fri, 30 Nov 1973 00:03:09 +0230");
 }
 
 #[test]
 fn default() {
     assert_eq!(
         time().format(git_date::time::format::DEFAULT),
-        "Thu Nov 29 1973 21:33:09 +0230"
+        "Fri Nov 30 1973 00:03:09 +0230"
     );
 }
 
@@ -50,7 +50,7 @@ fn default() {
 fn custom_compile_time() {
     assert_eq!(
         time().format(format_description!("[year]-[month]-[day] [hour]:[minute]:[second]")),
-        "1973-11-29 21:33:09",
+        "1973-11-30 00:03:09",
     );
 }
 


### PR DESCRIPTION
Hello, whilst working on #471 (very slowly every now and then) I realised gitoxide is incorrectly using [`replace_offset`](https://docs.rs/time/0.3.17/time/struct.OffsetDateTime.html#method.replace_offset) when we should be using [`to_offset`](https://docs.rs/time/0.3.17/time/struct.OffsetDateTime.html#method.to_offset).

> Replace the offset. The date and time components remain unchanged.

Which sounds great, cause what git stores is a timestamp in UTC and an offset explaining in which timezone the commit was made. So we want to apply the offset without changing the time.. however the time crate doesn't store time as unix seconds! So replacing the offset without adjusting the stored day and time is not what we want.

```
let t = time::OffsetDateTime::from_unix_timestamp(123456789).unwrap();
let to = t.replace_offset(time::UtcOffset::from_whole_seconds(3000).unwrap());
assert_eq(t.unix_timestamp(), to.unix_timestamp()); // THIS FAILS
```

And just to verify for myself I wrote a small script which uses `git` to convert from the hardcoded timestamp in the tests of this repo, to various formats. https://gist.github.com/willstott101/ecbd08d359e7bbf8dbfa0ac26f25b367

This script outputs the following (which this patch makes the tests for formatting in this repo match)
```
human= Nov 30 1973        human-local= Nov 29 1973        iso= 1973-11-30 00:03:09 +0230    raw= 123456789
```

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
