### PR TITLE
fix: A negative system timezone offset results in correct Time struct

### DIFF
--- a/git-date/src/time/init.rs
+++ b/git-date/src/time/init.rs
@@ -37,11 +37,11 @@ impl Time {
             .expect("this is not year 2038");
         // TODO: make this work without cfg(unsound_local_offset), see
         //       https://github.com/time-rs/time/issues/293#issuecomment-909158529
-        let offset = time::UtcOffset::local_offset_at(now).ok()?;
+        let offset_in_seconds = time::UtcOffset::local_offset_at(now).ok()?.whole_seconds();
         Self {
             seconds_since_unix_epoch,
-            offset_in_seconds: offset.whole_seconds(),
-            sign: Sign::Plus,
+            offset_in_seconds,
+            sign: offset_in_seconds.into(),
         }
         .into()
     }
@@ -62,7 +62,7 @@ impl Time {
         Self {
             seconds_since_unix_epoch,
             offset_in_seconds,
-            sign: Sign::Plus,
+            sign: offset_in_seconds.into(),
         }
     }
 }


### PR DESCRIPTION
Another really tiny PR fixing random parts of git-date

I don't know how to write tests for this, as the local timezone offset in tests appears to always be `+0000`, regardless of system time. This implies that tests have been considered by `time`... so presumably the local time is mockable somehow, but I couldn't find anything searching for `mock` in the time crate's github.

Sorry for the very small PRs, I'd just rather get easy things out of the way when I notice them, since I'm just tinkering when I have a few minutes rather than dedicating real time at the moment.

The actual affects of this are git commits being serialized incorrectly:
```
use git_date::time::{format, Format};

fn main() {
    println!("{:?}", git_date::Time::now_local_or_utc().format(Format::Custom(format::ISO8601_STRICT)));
    println!("{:?}", git_date::Time::now_local_or_utc().to_bstring());
}
```
results in (before the patch,  note the disagreeing timezones)
```
"2022-12-12T15:58:24-05:00"
"1670878704 +0500"
```
after this patch
```
"2022-12-12T16:00:04-05:00"
"1670878804 -0500"
```
----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
