### PR TITLE
adjustments for cargo

### DIFF
--- a/git-protocol/tests/fetch/v1.rs
+++ b/git-protocol/tests/fetch/v1.rs
@@ -80,7 +80,7 @@ async fn ls_remote_handshake_failure_due_to_downgrade() -> crate::Result {
     let out = Vec::new();
     let delegate = LsRemoteDelegate::default();
 
-    let err = match git_protocol::fetch(
+    git_protocol::fetch(
         transport(
             out,
             "v1/clone.response",
@@ -94,13 +94,6 @@ async fn ls_remote_handshake_failure_due_to_downgrade() -> crate::Result {
         "agent",
     )
     .await
-    {
-        Ok(_) => panic!("the V1 is not allowed in this transport"),
-        Err(err) => err,
-    };
-    assert_eq!(
-        err.to_string(),
-        "The transport didn't accept the advertised server version V1 and closed the connection client side"
-    );
+    .expect("V1 is OK for this transport");
     Ok(())
 }

--- a/git-repository/src/repository/config/transport.rs
+++ b/git-repository/src/repository/config/transport.rs
@@ -279,7 +279,7 @@ impl crate::Repository {
                             Ok((
                                 action_with_normalized_url,
                                 Arc::new(Mutex::new(move |action| cascade.invoke(action, prompt_opts.clone())))
-                                    as Arc<Mutex<git_transport::client::http::AuthenticateFn>>,
+                                    as Arc<Mutex<git_transport::client::http::options::AuthenticateFn>>,
                             ))
                         })
                         .transpose()?;

--- a/git-transport/src/client/async_io/traits.rs
+++ b/git-transport/src/client/async_io/traits.rs
@@ -34,7 +34,7 @@ pub trait Transport: TransportWithoutIO {
     /// Returns the service capabilities according according to the actual [Protocol] it supports,
     /// and possibly a list of refs to be obtained.
     /// This means that asking for an unsupported protocol might result in a protocol downgrade to the given one
-    /// if [TransportWithoutIO::supported_protocol_versions()] includes it.
+    /// if [TransportWithoutIO::supported_protocol_versions()] includes it or is empty.
     /// Exhaust the returned [BufReader][SetServiceResponse::refs] for a list of references in case of protocol V1
     /// before making another request.
     async fn handshake<'a>(

--- a/git-transport/src/client/blocking_io/http/mod.rs
+++ b/git-transport/src/client/blocking_io/http/mod.rs
@@ -144,7 +144,6 @@ pub struct Transport<H: Http> {
     url: String,
     user_agent_header: &'static str,
     desired_version: Protocol,
-    supported_versions: [Protocol; 1],
     actual_version: Protocol,
     http: H,
     service: Option<Service>,
@@ -153,14 +152,14 @@ pub struct Transport<H: Http> {
 }
 
 impl<H: Http> Transport<H> {
-    /// Create a new instance with `http` as implementation to communicate to `url` using the given `desired_version` of the `git` protocol.
+    /// Create a new instance with `http` as implementation to communicate to `url` using the given `desired_version`.
+    /// Note that we will always fallback to other versions as supported by the server.
     pub fn new_http(http: H, url: &str, desired_version: Protocol) -> Self {
         Transport {
             url: url.to_owned(),
             user_agent_header: concat!("User-Agent: git/oxide-", env!("CARGO_PKG_VERSION")),
             desired_version,
-            actual_version: desired_version,
-            supported_versions: [desired_version],
+            actual_version: Default::default(),
             service: None,
             http,
             line_provider: None,
@@ -278,10 +277,6 @@ impl<H: Http> client::TransportWithoutIO for Transport<H> {
 
     fn to_url(&self) -> Cow<'_, BStr> {
         Cow::Borrowed(self.url.as_str().into())
-    }
-
-    fn supported_protocol_versions(&self) -> &[Protocol] {
-        &self.supported_versions
     }
 
     fn connection_persists_across_multiple_requests(&self) -> bool {

--- a/git-transport/src/client/blocking_io/http/mod.rs
+++ b/git-transport/src/client/blocking_io/http/mod.rs
@@ -28,11 +28,14 @@ mod curl;
 #[cfg(feature = "http-client-reqwest")]
 pub mod reqwest;
 
-///
 mod traits;
 
 ///
 pub mod options {
+    /// A function to authenticate a URL.
+    pub type AuthenticateFn =
+        dyn FnMut(git_credentials::helper::Action) -> git_credentials::protocol::Result + Send + Sync;
+
     /// Possible settings for the `http.followRedirects` configuration option.
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub enum FollowRedirects {
@@ -72,10 +75,7 @@ pub mod options {
     }
 }
 
-/// A function to authenticate a URL.
-pub type AuthenticateFn = dyn FnMut(git_credentials::helper::Action) -> git_credentials::protocol::Result + Send + Sync;
-
-/// Options to configure curl requests.
+/// Options to configure http requests.
 // TODO: testing most of these fields requires a lot of effort, unless special flags to introspect ongoing requests are added.
 #[derive(Default, Clone)]
 pub struct Options {
@@ -110,7 +110,10 @@ pub struct Options {
     pub proxy_auth_method: options::ProxyAuthMethod,
     /// If authentication is needed for the proxy as its URL contains a username, this method must be set to provide a password
     /// for it before making the request, and to store it if the connection succeeds.
-    pub proxy_authenticate: Option<(git_credentials::helper::Action, Arc<std::sync::Mutex<AuthenticateFn>>)>,
+    pub proxy_authenticate: Option<(
+        git_credentials::helper::Action,
+        Arc<std::sync::Mutex<options::AuthenticateFn>>,
+    )>,
     /// The `HTTP` `USER_AGENT` string presented to an `HTTP` server, notably not the user agent present to the `git` server.
     ///
     /// If not overridden, it defaults to the user agent provided by `curl`, which is a deviation from how `git` handles this.
@@ -255,9 +258,12 @@ impl<H: Http> client::TransportWithoutIO for Transport<H> {
             headers,
             body,
             post_body,
-        } = self
-            .http
-            .post(&url, &self.url, static_headers.iter().chain(&dynamic_headers))?;
+        } = self.http.post(
+            &url,
+            &self.url,
+            static_headers.iter().chain(&dynamic_headers),
+            write_mode.into(),
+        )?;
         let line_provider = self
             .line_provider
             .as_mut()
@@ -444,71 +450,4 @@ pub fn connect(url: &str, desired_version: Protocol) -> Transport<Impl> {
 
 ///
 #[cfg(feature = "http-client-curl")]
-pub mod redirect {
-    /// The error provided when redirection went beyond what we deem acceptable.
-    #[derive(Debug, thiserror::Error)]
-    #[error("Redirect url {redirect_url:?} could not be reconciled with original url {expected_url} as they don't share the same suffix")]
-    pub struct Error {
-        redirect_url: String,
-        expected_url: String,
-    }
-
-    pub(crate) fn base_url(redirect_url: &str, base_url: &str, url: String) -> Result<String, Error> {
-        let tail = url
-            .strip_prefix(base_url)
-            .expect("BUG: caller assures `base_url` is subset of `url`");
-        redirect_url
-            .strip_suffix(tail)
-            .ok_or_else(|| Error {
-                redirect_url: redirect_url.into(),
-                expected_url: url,
-            })
-            .map(ToOwned::to_owned)
-    }
-
-    pub(crate) fn swap_tails(effective_base_url: Option<&str>, base_url: &str, mut url: String) -> String {
-        match effective_base_url {
-            Some(effective_base) => {
-                url.replace_range(..base_url.len(), effective_base);
-                url
-            }
-            None => url,
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn base_url_complete() {
-            assert_eq!(
-                base_url(
-                    "https://redirected.org/b/info/refs?hi",
-                    "https://original/a",
-                    "https://original/a/info/refs?hi".into()
-                )
-                .unwrap(),
-                "https://redirected.org/b"
-            );
-        }
-
-        #[test]
-        fn swap_tails_complete() {
-            assert_eq!(
-                swap_tails(None, "not interesting", "used".into()),
-                "used",
-                "without effective base url, it passes url, no redirect happened yet"
-            );
-            assert_eq!(
-                swap_tails(
-                    Some("https://redirected.org/b"),
-                    "https://original/a",
-                    "https://original/a/info/refs?something".into()
-                ),
-                "https://redirected.org/b/info/refs?something",
-                "the tail stays the same if redirection happened"
-            )
-        }
-    }
-}
+pub mod redirect;

--- a/git-transport/src/client/blocking_io/http/redirect.rs
+++ b/git-transport/src/client/blocking_io/http/redirect.rs
@@ -1,0 +1,66 @@
+/// The error provided when redirection went beyond what we deem acceptable.
+#[derive(Debug, thiserror::Error)]
+#[error("Redirect url {redirect_url:?} could not be reconciled with original url {expected_url} as they don't share the same suffix")]
+pub struct Error {
+    redirect_url: String,
+    expected_url: String,
+}
+
+pub(crate) fn base_url(redirect_url: &str, base_url: &str, url: String) -> Result<String, Error> {
+    let tail = url
+        .strip_prefix(base_url)
+        .expect("BUG: caller assures `base_url` is subset of `url`");
+    redirect_url
+        .strip_suffix(tail)
+        .ok_or_else(|| Error {
+            redirect_url: redirect_url.into(),
+            expected_url: url,
+        })
+        .map(ToOwned::to_owned)
+}
+
+pub(crate) fn swap_tails(effective_base_url: Option<&str>, base_url: &str, mut url: String) -> String {
+    match effective_base_url {
+        Some(effective_base) => {
+            url.replace_range(..base_url.len(), effective_base);
+            url
+        }
+        None => url,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_url_complete() {
+        assert_eq!(
+            base_url(
+                "https://redirected.org/b/info/refs?hi",
+                "https://original/a",
+                "https://original/a/info/refs?hi".into()
+            )
+            .unwrap(),
+            "https://redirected.org/b"
+        );
+    }
+
+    #[test]
+    fn swap_tails_complete() {
+        assert_eq!(
+            swap_tails(None, "not interesting", "used".into()),
+            "used",
+            "without effective base url, it passes url, no redirect happened yet"
+        );
+        assert_eq!(
+            swap_tails(
+                Some("https://redirected.org/b"),
+                "https://original/a",
+                "https://original/a/info/refs?something".into()
+            ),
+            "https://redirected.org/b/info/refs?something",
+            "the tail stays the same if redirection happened"
+        )
+    }
+}

--- a/git-transport/src/client/git/async_io.rs
+++ b/git-transport/src/client/git/async_io.rs
@@ -39,16 +39,6 @@ where
         )
     }
 
-    /// We implement this in a paranoid and safe way, not allowing downgrade to V1 which
-    /// could send large amounts of refs in case we didn't want to support V1.
-    fn supported_protocol_versions(&self) -> &[Protocol] {
-        if self.desired_version == Protocol::V1 {
-            &[]
-        } else {
-            &self.supported_versions
-        }
-    }
-
     fn connection_persists_across_multiple_requests(&self) -> bool {
         true
     }
@@ -120,7 +110,6 @@ where
             virtual_host: virtual_host.map(|(h, p)| (h.into(), p)),
             desired_version,
             custom_url: None,
-            supported_versions: [desired_version],
             mode,
         }
     }

--- a/git-transport/src/client/git/blocking_io.rs
+++ b/git-transport/src/client/git/blocking_io.rs
@@ -37,18 +37,6 @@ where
         )
     }
 
-    /// We implement this in a paranoid and safe way, not allowing downgrade to V1 which
-    /// could send large amounts of refs in case we didn't want to support V1.
-    fn supported_protocol_versions(&self) -> &[Protocol] {
-        if self.desired_version == Protocol::V1 {
-            // allow any version
-            &[]
-        } else {
-            // only allow the specified one
-            &self.supported_versions
-        }
-    }
-
     fn connection_persists_across_multiple_requests(&self) -> bool {
         true
     }
@@ -117,7 +105,6 @@ where
             virtual_host: virtual_host.map(|(h, p)| (h.into(), p)),
             desired_version,
             custom_url: None,
-            supported_versions: [desired_version],
             mode,
         }
     }

--- a/git-transport/src/client/git/mod.rs
+++ b/git-transport/src/client/git/mod.rs
@@ -21,7 +21,6 @@ pub struct Connection<R, W> {
     pub(in crate::client) path: BString,
     pub(in crate::client) virtual_host: Option<(String, Option<u16>)>,
     pub(in crate::client) desired_version: Protocol,
-    supported_versions: [Protocol; 1],
     custom_url: Option<BString>,
     pub(in crate::client) mode: ConnectMode,
 }
@@ -50,7 +49,7 @@ mod message {
 
     pub fn connect(
         service: Service,
-        version: Protocol,
+        desired_version: Protocol,
         path: &[u8],
         virtual_host: Option<&(String, Option<u16>)>,
         extra_parameters: &[(&str, Option<&str>)],
@@ -73,9 +72,9 @@ mod message {
         // as extra lines in the reply, which we don't want to handle. Especially since an old server will not respond with that
         // line (is what I assume, at least), so it's an optional part in the response to understand and handle. There is no value
         // in that, so let's help V2 servers to respond in a way that assumes V1.
-        let extra_params_need_null_prefix = if version != Protocol::V1 {
+        let extra_params_need_null_prefix = if desired_version != Protocol::V1 {
             out.push(0);
-            out.push_str(format!("version={}", version as usize));
+            out.push_str(format!("version={}", desired_version as usize));
             out.push(0);
             false
         } else {

--- a/git-transport/src/client/non_io_types.rs
+++ b/git-transport/src/client/non_io_types.rs
@@ -3,8 +3,14 @@
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum WriteMode {
     /// Each [write()][std::io::Write::write()] call writes the bytes verbatim as one or more packet lines.
+    ///
+    /// This mode also indicates to the transport that it should try to stream data as it is unbounded. This mode is typically used
+    /// for sending packs whose exact size is not necessarily known in advance.
     Binary,
     /// Each [write()][std::io::Write::write()] call assumes text in the input, assures a trailing newline and writes it as single packet line.
+    ///
+    /// This mode also indicates that the lines written fit into memory, hence the transport may chose to not stream it but to buffer it
+    /// instead. This is relevant for some transports, like the one for HTTP.
     OneLfTerminatedLinePerWriteCall,
 }
 

--- a/git-transport/src/client/traits.rs
+++ b/git-transport/src/client/traits.rs
@@ -32,7 +32,7 @@ pub trait TransportWithoutIO {
     /// Returns the canonical URL pointing to the destination of this transport.
     fn to_url(&self) -> Cow<'_, BStr>;
 
-    /// If the actually advertised server version is contained in the returned slice or empty, continue as normal,
+    /// If the actually advertised server version is contained in the returned slice or it is empty, continue as normal,
     /// assume the server's protocol version is desired or acceptable.
     ///
     /// Otherwise, abort the fetch operation with an error to avoid continuing any interaction with the transport.
@@ -41,6 +41,8 @@ pub trait TransportWithoutIO {
     /// leaving the server with a client who potentially unexpectedly terminated the connection.
     ///
     /// Note that `transport.close()` is not called explicitly.
+    ///
+    /// Custom transports can override this to prevent any use of older protocol versions.
     fn supported_protocol_versions(&self) -> &[Protocol] {
         &[]
     }

--- a/git-transport/tests/client/blocking_io/http/mod.rs
+++ b/git-transport/tests/client/blocking_io/http/mod.rs
@@ -396,18 +396,13 @@ fn clone_v1() -> crate::Result {
             "POST /path/not/important/due/to/mock/git-upload-pack HTTP/1.1
 Host: 127.0.0.1:{}
 User-Agent: git/oxide-{}
-Transfer-Encoding: Chunked
 Content-Type: application/x-git-upload-pack-request
+Content-Length: 29
 Accept: application/x-git-upload-pack-result
 
-1d
 000ahello
 000aworld
-0009done
-
-0
-
-",
+0009done",
             server.addr.port(),
             env!("CARGO_PKG_VERSION")
         )
@@ -574,21 +569,17 @@ Git-Protocol: version=2:value-only:key=value
         format!(
             "POST /path/not/important/due/to/mock/git-upload-pack HTTP/1.1
 Host: 127.0.0.1:{}
-Transfer-Encoding: chunked
 User-Agent: git/oxide-{}
 Content-Type: application/x-git-upload-pack-request
+Content-Length: 76
 Accept: application/x-git-upload-pack-result
 Git-Protocol: version=2
 
-4c
 0014command=ls-refs
 0012without-value
 0015with-value=value
 00010009arg1
-0000
-0
-
-",
+0000",
             server.addr.port(),
             env!("CARGO_PKG_VERSION")
         )
@@ -630,18 +621,14 @@ Git-Protocol: version=2
     let expected = format!(
         "POST /path/not/important/due/to/mock/git-upload-pack HTTP/1.1
 Host: 127.0.0.1:{}
-Transfer-Encoding: chunked
 User-Agent: git/oxide-{}
 Content-Type: application/x-git-upload-pack-request
 Accept: application/x-git-upload-pack-result
 Git-Protocol: version=2
+Content-Length: 22
 
-16
 0012command=fetch
-0000
-0
-
-",
+0000",
         server.addr.port(),
         env!("CARGO_PKG_VERSION")
     );

--- a/git-transport/tests/client/git.rs
+++ b/git-transport/tests/client/git.rs
@@ -251,7 +251,11 @@ async fn handshake_v2_downgrade_to_v1() -> crate::Result {
     );
     drop(res);
 
-    assert_eq!(c.supported_protocol_versions(), [Protocol::V2]);
+    assert_eq!(
+        c.supported_protocol_versions(),
+        [],
+        "it doesn't care and can handle all of them"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Adjustments for cargo

### Tasks 

* [x] allow to downgrade connections like git does, should be no problem. Maybe find a way to let the user enforce protocol versions, let's see how git does it.
* [x] make it possible to _not_ send streaming posts - that is only needed for posting packs and some git servers can't handle 'chunked' encoding that results from it. Lastly, `git` itself uses `content-length` as the buffer is pre-created in memory.

### Next PR

* [ ] additional HTTP configuration as [per cargo configuration](https://github.com/rust-lang/cargo/blob/381f9c8c8010d99b4fd71ade3f0ce5e535082356/src/doc/src/reference/config.md#L630)