### PR TITLE
Use specific `Iter` constructors in stats example

### DIFF
--- a/git-repository/examples/stats.rs
+++ b/git-repository/examples/stats.rs
@@ -49,9 +49,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // let num_branches = repo.branches()?;
     // let num_branches = repo.branches.remote("origin")?;
-    let num_branches = repo.references()?.prefixed("refs/heads/")?.count();
-    let num_remote_branches = repo.references()?.prefixed("refs/remotes/")?.count();
-    let num_tags = repo.references()?.prefixed("refs/tags/")?.count();
+    let num_branches = repo.references()?.local_branches()?.count();
+    let num_remote_branches = repo.references()?.remote_branches()?.count();
+    let num_tags = repo.references()?.tags()?.count();
     let broken_refs = repo
         .references()?
         .all()?


### PR DESCRIPTION
When looking through this example, I thought it might make sense to use the `Iter` constructors that are specifically for this use case, rather than manually do it using `Platform::prefixed`.

**NOTE**: Untested since I just did this quickly through GH editor. If I get a chance I'll run the example properly but I looked at the API docs and source and it looks like this should be a trivial change (touch wood)

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
