### PR TITLE
ODB header information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,9 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"

--- a/git-odb/src/cache.rs
+++ b/git-odb/src/cache.rs
@@ -139,6 +139,7 @@ mod impls {
     use git_object::{Data, Kind};
     use git_pack::cache::Object;
 
+    use crate::find::Header;
     use crate::{pack::data::entry::Location, Cache};
 
     impl<S> crate::Write for Cache<S>
@@ -164,6 +165,17 @@ mod impls {
 
         fn try_find<'a>(&self, id: impl AsRef<oid>, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, Self::Error> {
             git_pack::Find::try_find(self, id, buffer).map(|t| t.map(|t| t.0))
+        }
+    }
+
+    impl<S> crate::Header for Cache<S>
+    where
+        S: crate::Header,
+    {
+        type Error = S::Error;
+
+        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+            self.inner.try_header(id)
         }
     }
 

--- a/git-odb/src/lib.rs
+++ b/git-odb/src/lib.rs
@@ -74,7 +74,7 @@ pub mod find;
 /// An object database equivalent to `/dev/null`, dropping all objects stored into it.
 mod traits;
 
-pub use traits::{Find, FindExt, Write};
+pub use traits::{Find, FindExt, Header, HeaderExt, Write};
 
 /// A thread-local handle to access any object.
 pub type Handle = Cache<store::Handle<OwnShared<Store>>>;

--- a/git-odb/src/store_impls/dynamic/find.rs
+++ b/git-odb/src/store_impls/dynamic/find.rs
@@ -1,11 +1,10 @@
-use std::{collections::HashSet, convert::TryInto, ops::Deref};
+use std::{convert::TryInto, ops::Deref};
 
-use git_hash::{oid, ObjectId};
-use git_pack::{cache::DecodeEntry, data::entry::Location};
+use git_pack::cache::DecodeEntry;
 
 use crate::store::{handle, load_index};
 
-mod error {
+pub(crate) mod error {
     use crate::{loose, pack};
 
     /// Returned by [`Handle::try_find()`][git_pack::Find::try_find()]
@@ -14,21 +13,12 @@ mod error {
     pub enum Error {
         #[error("An error occurred while obtaining an object from the loose object store")]
         Loose(#[from] loose::find::Error),
-        #[error("An error occurred looking up a prefix which requires iteration")]
-        LooseWalkDir(#[from] loose::iter::Error),
         #[error("An error occurred while obtaining an object from the packed object store")]
         Pack(#[from] pack::data::decode::Error),
         #[error(transparent)]
         LoadIndex(#[from] crate::store::load_index::Error),
         #[error(transparent)]
         LoadPack(#[from] std::io::Error),
-        #[error("Object {} referred to its base object {} by its id but it's not within a multi-index", .id, .base_id)]
-        ThinPackAtRest {
-            /// the id of the base object which lived outside of the multi-index
-            base_id: git_hash::ObjectId,
-            /// The original object to lookup
-            id: git_hash::ObjectId,
-        },
         #[error("Reached recursion limit of {} while resolving ref delta bases for {}", .max_depth, .id)]
         DeltaBaseRecursionLimit {
             /// the maximum recursion depth we encountered.
@@ -86,136 +76,20 @@ mod error {
 }
 pub use error::Error;
 
-use crate::{
-    find::{PotentialPrefix, PrefixLookupResult},
-    store::types::PackId,
-    Find,
-};
+use crate::{store::types::PackId, Find};
 
 impl<S> super::Handle<S>
 where
     S: Deref<Target = super::Store> + Clone,
 {
-    /// Return the exact number of packed objects after loading all currently available indices
-    /// as last seen on disk.
-    pub fn packed_object_count(&self) -> Result<u64, Error> {
-        let mut count = self.packed_object_count.borrow_mut();
-        match *count {
-            Some(count) => Ok(count),
-            None => {
-                let mut snapshot = self.snapshot.borrow_mut();
-                *snapshot = self.store.load_all_indices()?;
-                let mut obj_count = 0;
-                for index in &snapshot.indices {
-                    obj_count += index.num_objects() as u64;
-                }
-                *count = Some(obj_count);
-                Ok(obj_count)
-            }
-        }
-    }
-
-    /// Given a prefix `candidate` with an object id and an initial `hex_len`, check if it only matches a single
-    /// object within the entire object database and increment its `hex_len` by one until it is unambiguous.
-    /// Return `Ok(None)` if no object with that prefix exists.
-    pub fn disambiguate_prefix(&self, mut candidate: PotentialPrefix) -> Result<Option<git_hash::Prefix>, Error> {
-        let max_hex_len = candidate.id().kind().len_in_hex();
-        if candidate.hex_len() == max_hex_len {
-            return Ok(self.contains(candidate.id()).then(|| candidate.to_prefix()));
-        }
-
-        while candidate.hex_len() != max_hex_len {
-            let res = self.lookup_prefix(candidate.to_prefix(), None)?;
-            match res {
-                Some(Ok(_id)) => return Ok(Some(candidate.to_prefix())),
-                Some(Err(())) => {
-                    candidate.inc_hex_len();
-                    continue;
-                }
-                None => return Ok(None),
-            }
-        }
-        Ok(Some(candidate.to_prefix()))
-    }
-    /// Find the only object matching `prefix` and return it as `Ok(Some(Ok(<ObjectId>)))`, or return `Ok(Some(Err(()))`
-    /// if multiple different objects with the same prefix were found.
-    ///
-    /// Return `Ok(None)` if no object matched the `prefix`.
-    ///
-    /// Pass `candidates` to obtain the set of all object ids matching `prefix`, with the same return value as
-    /// one would have received if it remained `None`.
-    ///
-    /// ### Performance Note
-    ///
-    /// - Unless the handles refresh mode is set to `Never`, each lookup will trigger a refresh of the object databases files
-    ///   on disk if the prefix doesn't lead to ambiguous results.
-    /// - Since all objects need to be examined to assure non-amiguous return values, after calling this method all indices will
-    ///   be loaded.
-    /// - If `candidates` is `Some(…)`, the traversal will continue to obtain all candidates, which takes more time
-    ///   as there is no early abort.
-    pub fn lookup_prefix(
-        &self,
-        prefix: git_hash::Prefix,
-        mut candidates: Option<&mut HashSet<git_hash::ObjectId>>,
-    ) -> Result<Option<PrefixLookupResult>, Error> {
-        let mut candidate: Option<ObjectId> = None;
-        loop {
-            let snapshot = self.snapshot.borrow();
-            for index in snapshot.indices.iter() {
-                #[allow(clippy::needless_option_as_deref)] // needed as it's the equivalent of a reborrow.
-                let lookup_result = index.lookup_prefix(prefix, candidates.as_deref_mut());
-                if candidates.is_none() && !check_candidate(lookup_result, &mut candidate) {
-                    return Ok(Some(Err(())));
-                }
-            }
-
-            for lodb in snapshot.loose_dbs.iter() {
-                #[allow(clippy::needless_option_as_deref)] // needed as it's the equivalent of a reborrow.
-                let lookup_result = lodb.lookup_prefix(prefix, candidates.as_deref_mut())?;
-                if candidates.is_none() && !check_candidate(lookup_result, &mut candidate) {
-                    return Ok(Some(Err(())));
-                }
-            }
-
-            match self.store.load_one_index(self.refresh, snapshot.marker)? {
-                Some(new_snapshot) => {
-                    drop(snapshot);
-                    *self.snapshot.borrow_mut() = new_snapshot;
-                }
-                None => {
-                    return match &candidates {
-                        Some(candidates) => match candidates.len() {
-                            0 => Ok(None),
-                            1 => Ok(candidates.iter().cloned().next().map(Ok)),
-                            _ => Ok(Some(Err(()))),
-                        },
-                        None => Ok(candidate.map(Ok)),
-                    };
-                }
-            }
-        }
-
-        fn check_candidate(lookup_result: Option<PrefixLookupResult>, candidate: &mut Option<ObjectId>) -> bool {
-            match (lookup_result, &*candidate) {
-                (Some(Ok(oid)), Some(candidate)) if *candidate != oid => false,
-                (Some(Ok(_)), Some(_)) | (None, None) | (None, Some(_)) => true,
-                (Some(Err(())), _) => false,
-                (Some(Ok(oid)), None) => {
-                    *candidate = Some(oid);
-                    true
-                }
-            }
-        }
-    }
-
     fn try_find_cached_inner<'a, 'b>(
         &'b self,
-        mut id: &'b oid,
+        mut id: &'b git_hash::oid,
         buffer: &'a mut Vec<u8>,
         pack_cache: &mut impl DecodeEntry,
         snapshot: &mut load_index::Snapshot,
         recursion: Option<error::DeltaBaseRecursion<'_>>,
-    ) -> Result<Option<(git_object::Data<'a>, Option<Location>)>, Error> {
+    ) -> Result<Option<(git_object::Data<'a>, Option<git_pack::data::entry::Location>)>, Error> {
         if let Some(r) = recursion {
             if r.depth >= self.max_recursion_depth {
                 return Err(Error::DeltaBaseRecursionLimit {
@@ -423,7 +297,7 @@ where
         }
     }
 
-    fn clear_cache(&self) {
+    pub(crate) fn clear_cache(&self) {
         self.packed_object_count.borrow_mut().take();
     }
 }
@@ -435,7 +309,7 @@ where
     type Error = Error;
 
     // TODO: probably make this method fallible, but that would mean its own error type.
-    fn contains(&self, id: impl AsRef<oid>) -> bool {
+    fn contains(&self, id: impl AsRef<git_hash::oid>) -> bool {
         let id = id.as_ref();
         let mut snapshot = self.snapshot.borrow_mut();
         loop {
@@ -467,16 +341,20 @@ where
 
     fn try_find_cached<'a>(
         &self,
-        id: impl AsRef<oid>,
+        id: impl AsRef<git_hash::oid>,
         buffer: &'a mut Vec<u8>,
         pack_cache: &mut impl DecodeEntry,
-    ) -> Result<Option<(git_object::Data<'a>, Option<Location>)>, Self::Error> {
+    ) -> Result<Option<(git_object::Data<'a>, Option<git_pack::data::entry::Location>)>, Self::Error> {
         let id = id.as_ref();
         let mut snapshot = self.snapshot.borrow_mut();
         self.try_find_cached_inner(id, buffer, pack_cache, &mut snapshot, None)
     }
 
-    fn location_by_oid(&self, id: impl AsRef<oid>, buf: &mut Vec<u8>) -> Option<Location> {
+    fn location_by_oid(
+        &self,
+        id: impl AsRef<git_hash::oid>,
+        buf: &mut Vec<u8>,
+    ) -> Option<git_pack::data::entry::Location> {
         assert!(
             matches!(self.token.as_ref(), Some(handle::Mode::KeepDeletedPacksAvailable)),
             "BUG: handle must be configured to `prevent_pack_unload()` before using this method"
@@ -578,7 +456,7 @@ where
         }
     }
 
-    fn entry_by_location(&self, location: &Location) -> Option<git_pack::find::Entry> {
+    fn entry_by_location(&self, location: &git_pack::data::entry::Location) -> Option<git_pack::find::Entry> {
         assert!(
             matches!(self.token.as_ref(), Some(handle::Mode::KeepDeletedPacksAvailable)),
             "BUG: handle must be configured to `prevent_pack_unload()` before using this method"
@@ -620,20 +498,20 @@ where
     }
 }
 
-impl<S> crate::Find for super::Handle<S>
+impl<S> Find for super::Handle<S>
 where
     S: Deref<Target = super::Store> + Clone,
     Self: git_pack::Find,
 {
     type Error = <Self as git_pack::Find>::Error;
 
-    fn contains(&self, id: impl AsRef<oid>) -> bool {
+    fn contains(&self, id: impl AsRef<git_hash::oid>) -> bool {
         git_pack::Find::contains(self, id)
     }
 
     fn try_find<'a>(
         &self,
-        id: impl AsRef<oid>,
+        id: impl AsRef<git_hash::oid>,
         buffer: &'a mut Vec<u8>,
     ) -> Result<Option<git_object::Data<'a>>, Self::Error> {
         git_pack::Find::try_find(self, id, buffer).map(|t| t.map(|t| t.0))

--- a/git-odb/src/store_impls/dynamic/handle.rs
+++ b/git-odb/src/store_impls/dynamic/handle.rs
@@ -11,24 +11,19 @@ use git_hash::oid;
 
 use crate::store::{handle, types, RefreshMode};
 
-pub(crate) mod multi_index {
-    // TODO: remove this declaration and replace it with the actual type where it's used
-    pub type File = git_pack::multi_index::File;
-}
-
-pub enum SingleOrMultiIndex {
+pub(crate) enum SingleOrMultiIndex {
     Single {
         index: Arc<git_pack::index::File>,
         data: Option<Arc<git_pack::data::File>>,
     },
     Multi {
-        index: Arc<multi_index::File>,
+        index: Arc<git_pack::multi_index::File>,
         data: Vec<Option<Arc<git_pack::data::File>>>,
     },
 }
 
 /// A utility to allow looking up pack offsets for a particular pack
-pub enum IntraPackLookup<'a> {
+pub(crate) enum IntraPackLookup<'a> {
     Single(&'a git_pack::index::File),
     /// the internal pack-id inside of a multi-index for which the lookup is supposed to be.
     /// Used to prevent ref-delta OIDs to, for some reason, point to a different pack.
@@ -145,7 +140,7 @@ pub(crate) mod index_lookup {
             &self,
             prefix: git_hash::Prefix,
             candidates: Option<&mut HashSet<git_hash::ObjectId>>,
-        ) -> Option<crate::find::PrefixLookupResult> {
+        ) -> Option<crate::store::prefix::lookup::Outcome> {
             let mut candidate_entries = candidates.as_ref().map(|_| 0..0);
             let res = match &self.file {
                 handle::SingleOrMultiIndex::Single { index, .. } => {

--- a/git-odb/src/store_impls/dynamic/header.rs
+++ b/git-odb/src/store_impls/dynamic/header.rs
@@ -12,7 +12,7 @@ impl<S> super::Handle<S>
 where
     S: Deref<Target = super::Store> + Clone,
 {
-    fn try_header_inner<'a, 'b>(
+    fn try_header_inner<'b>(
         &'b self,
         mut id: &'b git_hash::oid,
         snapshot: &mut load_index::Snapshot,

--- a/git-odb/src/store_impls/dynamic/header.rs
+++ b/git-odb/src/store_impls/dynamic/header.rs
@@ -1,0 +1,189 @@
+use std::ops::Deref;
+
+use crate::store::{handle, load_index};
+
+use super::find::Error;
+use git_hash::oid;
+
+use crate::find::Header;
+use crate::store::find::error::DeltaBaseRecursion;
+
+impl<S> super::Handle<S>
+where
+    S: Deref<Target = super::Store> + Clone,
+{
+    fn try_header_inner<'a, 'b>(
+        &'b self,
+        mut id: &'b git_hash::oid,
+        snapshot: &mut load_index::Snapshot,
+        recursion: Option<DeltaBaseRecursion<'_>>,
+    ) -> Result<Option<Header>, Error> {
+        if let Some(r) = recursion {
+            if r.depth >= self.max_recursion_depth {
+                return Err(Error::DeltaBaseRecursionLimit {
+                    max_depth: self.max_recursion_depth,
+                    id: r.original_id.to_owned(),
+                });
+            }
+        } else if !self.ignore_replacements {
+            if let Ok(pos) = self
+                .store
+                .replacements
+                .binary_search_by(|(map_this, _)| map_this.as_ref().cmp(id))
+            {
+                id = self.store.replacements[pos].1.as_ref();
+            }
+        }
+
+        'outer: loop {
+            {
+                let marker = snapshot.marker;
+                for (idx, index) in snapshot.indices.iter_mut().enumerate() {
+                    if let Some(handle::index_lookup::Outcome {
+                        object_index: handle::IndexForObjectInPack { pack_id, pack_offset },
+                        index_file,
+                        pack: possibly_pack,
+                    }) = index.lookup(id)
+                    {
+                        let pack = match possibly_pack {
+                            Some(pack) => pack,
+                            None => match self.store.load_pack(pack_id, marker)? {
+                                Some(pack) => {
+                                    *possibly_pack = Some(pack);
+                                    possibly_pack.as_deref().expect("just put it in")
+                                }
+                                None => {
+                                    // The pack wasn't available anymore so we are supposed to try another round with a fresh index
+                                    match self.store.load_one_index(self.refresh, snapshot.marker)? {
+                                        Some(new_snapshot) => {
+                                            *snapshot = new_snapshot;
+                                            self.clear_cache();
+                                            continue 'outer;
+                                        }
+                                        None => {
+                                            // nothing new in the index, kind of unexpected to not have a pack but to also
+                                            // to have no new index yet. We set the new index before removing any slots, so
+                                            // this should be observable.
+                                            return Ok(None);
+                                        }
+                                    }
+                                }
+                            },
+                        };
+                        let entry = pack.entry(pack_offset);
+                        let res = match pack.decode_header(entry, |id| {
+                            index_file.pack_offset_by_id(id).map(|pack_offset| {
+                                git_pack::data::decode::header::ResolvedBase::InPack(pack.entry(pack_offset))
+                            })
+                        }) {
+                            Ok(header) => Ok(header.into()),
+                            Err(git_pack::data::decode::Error::DeltaBaseUnresolved(base_id)) => {
+                                // Only with multi-pack indices it's allowed to jump to refer to other packs within this
+                                // multi-pack. Otherwise this would constitute a thin pack which is only allowed in transit.
+                                // However, if we somehow end up with that, we will resolve it safely, even though we could
+                                // avoid handling this case and error instead.
+                                let obj_kind = self
+                                    .try_header_inner(
+                                        &base_id,
+                                        snapshot,
+                                        recursion
+                                            .map(|r| r.inc_depth())
+                                            .or_else(|| DeltaBaseRecursion::new(id).into()),
+                                    )
+                                    .map_err(|err| Error::DeltaBaseLookup {
+                                        err: Box::new(err),
+                                        base_id,
+                                        id: id.to_owned(),
+                                    })?
+                                    .ok_or_else(|| Error::DeltaBaseMissing {
+                                        base_id,
+                                        id: id.to_owned(),
+                                    })?
+                                    .kind();
+                                let handle::index_lookup::Outcome {
+                                    object_index:
+                                        handle::IndexForObjectInPack {
+                                            pack_id: _,
+                                            pack_offset,
+                                        },
+                                    index_file,
+                                    pack: possibly_pack,
+                                } = match snapshot.indices[idx].lookup(id) {
+                                    Some(res) => res,
+                                    None => {
+                                        let mut out = None;
+                                        for index in snapshot.indices.iter_mut() {
+                                            out = index.lookup(id);
+                                            if out.is_some() {
+                                                break;
+                                            }
+                                        }
+
+                                        out.unwrap_or_else(|| {
+                                            panic!("could not find object {} in any index after looking up one of its base objects {}", id, base_id)
+                                        })
+                                    }
+                                };
+                                let pack = possibly_pack
+                                    .as_ref()
+                                    .expect("pack to still be available like just now");
+                                let entry = pack.entry(pack_offset);
+                                pack.decode_header(entry, |id| {
+                                    index_file
+                                        .pack_offset_by_id(id)
+                                        .map(|pack_offset| {
+                                            git_pack::data::decode::header::ResolvedBase::InPack(
+                                                pack.entry(pack_offset),
+                                            )
+                                        })
+                                        .or_else(|| {
+                                            (id == base_id).then(|| {
+                                                git_pack::data::decode::header::ResolvedBase::OutOfPack {
+                                                    kind: obj_kind,
+                                                }
+                                            })
+                                        })
+                                })
+                                .map(Into::into)
+                            }
+                            Err(err) => Err(err),
+                        }?;
+
+                        if idx != 0 {
+                            snapshot.indices.swap(0, idx);
+                        }
+                        return Ok(Some(res));
+                    }
+                }
+            }
+
+            for lodb in snapshot.loose_dbs.iter() {
+                // TODO: remove this double-lookup once the borrow checker allows it.
+                if lodb.contains(id) {
+                    return lodb.try_header(id).map(|opt| opt.map(Into::into)).map_err(Into::into);
+                }
+            }
+
+            match self.store.load_one_index(self.refresh, snapshot.marker)? {
+                Some(new_snapshot) => {
+                    *snapshot = new_snapshot;
+                    self.clear_cache();
+                }
+                None => return Ok(None),
+            }
+        }
+    }
+}
+
+impl<S> crate::Header for super::Handle<S>
+where
+    S: Deref<Target = super::Store> + Clone,
+{
+    type Error = Error;
+
+    fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+        let id = id.as_ref();
+        let mut snapshot = self.snapshot.borrow_mut();
+        self.try_header_inner(id, &mut snapshot, None)
+    }
+}

--- a/git-odb/src/store_impls/dynamic/iter.rs
+++ b/git-odb/src/store_impls/dynamic/iter.rs
@@ -124,7 +124,7 @@ impl<S> super::Handle<S>
 where
     S: Deref<Target = super::Store> + Clone,
 {
-    /// Return an iterator over all objects, first the ones in all packs of all linked databases (via alternates),
+    /// Return an iterator over all, _possibly duplicate_, objects, first the ones in all packs of all linked databases (via alternates),
     /// followed by all loose objects.
     pub fn iter(&self) -> Result<AllObjects, dynamic::load_index::Error> {
         AllObjects::new(self.store_ref())

--- a/git-odb/src/store_impls/dynamic/mod.rs
+++ b/git-odb/src/store_impls/dynamic/mod.rs
@@ -56,6 +56,11 @@ impl RefreshMode {
 pub mod find;
 
 ///
+pub mod prefix;
+
+mod header;
+
+///
 pub mod iter;
 
 ///

--- a/git-odb/src/store_impls/dynamic/prefix.rs
+++ b/git-odb/src/store_impls/dynamic/prefix.rs
@@ -1,0 +1,194 @@
+use crate::store::{load_index, Handle};
+use crate::Find;
+use std::collections::HashSet;
+use std::ops::Deref;
+
+///
+pub mod lookup {
+    use crate::loose;
+
+    /// Returned by [`Handle::lookup_prefix()`][crate::store::Handle::lookup_prefix()]
+    #[derive(thiserror::Error, Debug)]
+    #[allow(missing_docs)]
+    pub enum Error {
+        #[error("An error occurred looking up a prefix which requires iteration")]
+        LooseWalkDir(#[from] loose::iter::Error),
+        #[error(transparent)]
+        LoadIndex(#[from] crate::store::load_index::Error),
+    }
+
+    /// A way to indicate if a lookup, despite successful, was ambiguous or yielded exactly
+    /// one result in the particular index.
+    pub type Outcome = Result<git_hash::ObjectId, ()>;
+}
+
+///
+pub mod disambiguate {
+    /// A potentially ambiguous prefix for use with `Handle::disambiguate_prefix()`.
+    #[derive(Debug, Copy, Clone)]
+    pub struct Candidate {
+        id: git_hash::ObjectId,
+        hex_len: usize,
+    }
+
+    impl Candidate {
+        /// Create a new potentially ambiguous prefix from an `id` and the desired minimal `hex_len`.
+        ///
+        /// It is considered ambiguous until it's disambiguated by validating that there is only a single object
+        /// matching this prefix.
+        pub fn new(id: impl Into<git_hash::ObjectId>, hex_len: usize) -> Result<Self, git_hash::prefix::Error> {
+            let id = id.into();
+            git_hash::Prefix::new(id, hex_len)?;
+            Ok(Candidate { id, hex_len })
+        }
+
+        /// Transform ourselves into a `Prefix` with our current hex lengths.
+        pub fn to_prefix(&self) -> git_hash::Prefix {
+            git_hash::Prefix::new(self.id, self.hex_len).expect("our hex-len to always be in bounds")
+        }
+
+        pub(crate) fn inc_hex_len(&mut self) {
+            self.hex_len += 1;
+            assert!(self.hex_len <= self.id.kind().len_in_hex());
+        }
+
+        pub(crate) fn id(&self) -> &git_hash::oid {
+            &self.id
+        }
+
+        pub(crate) fn hex_len(&self) -> usize {
+            self.hex_len
+        }
+    }
+
+    /// Returned by [`Handle::disambiguate_prefix()`][crate::store::Handle::disambiguate_prefix()]
+    #[derive(thiserror::Error, Debug)]
+    #[allow(missing_docs)]
+    pub enum Error {
+        #[error("An error occurred while trying to determine if a full hash contained in the object database")]
+        Contains(#[from] crate::store::find::Error),
+        #[error(transparent)]
+        Lookup(#[from] super::lookup::Error),
+    }
+}
+
+impl<S> Handle<S>
+where
+    S: Deref<Target = super::Store> + Clone,
+{
+    /// Return the exact number of packed objects after loading all currently available indices
+    /// as last seen on disk.
+    pub fn packed_object_count(&self) -> Result<u64, load_index::Error> {
+        let mut count = self.packed_object_count.borrow_mut();
+        match *count {
+            Some(count) => Ok(count),
+            None => {
+                let mut snapshot = self.snapshot.borrow_mut();
+                *snapshot = self.store.load_all_indices()?;
+                let mut obj_count = 0;
+                for index in &snapshot.indices {
+                    obj_count += index.num_objects() as u64;
+                }
+                *count = Some(obj_count);
+                Ok(obj_count)
+            }
+        }
+    }
+
+    /// Given a prefix `candidate` with an object id and an initial `hex_len`, check if it only matches a single
+    /// object within the entire object database and increment its `hex_len` by one until it is unambiguous.
+    /// Return `Ok(None)` if no object with that prefix exists.
+    pub fn disambiguate_prefix(
+        &self,
+        mut candidate: disambiguate::Candidate,
+    ) -> Result<Option<git_hash::Prefix>, disambiguate::Error> {
+        let max_hex_len = candidate.id().kind().len_in_hex();
+        if candidate.hex_len() == max_hex_len {
+            return Ok(self.contains(candidate.id()).then(|| candidate.to_prefix()));
+        }
+
+        while candidate.hex_len() != max_hex_len {
+            let res = self.lookup_prefix(candidate.to_prefix(), None)?;
+            match res {
+                Some(Ok(_id)) => return Ok(Some(candidate.to_prefix())),
+                Some(Err(())) => {
+                    candidate.inc_hex_len();
+                    continue;
+                }
+                None => return Ok(None),
+            }
+        }
+        Ok(Some(candidate.to_prefix()))
+    }
+
+    /// Find the only object matching `prefix` and return it as `Ok(Some(Ok(<ObjectId>)))`, or return `Ok(Some(Err(()))`
+    /// if multiple different objects with the same prefix were found.
+    ///
+    /// Return `Ok(None)` if no object matched the `prefix`.
+    ///
+    /// Pass `candidates` to obtain the set of all object ids matching `prefix`, with the same return value as
+    /// one would have received if it remained `None`.
+    ///
+    /// ### Performance Note
+    ///
+    /// - Unless the handles refresh mode is set to `Never`, each lookup will trigger a refresh of the object databases files
+    ///   on disk if the prefix doesn't lead to ambiguous results.
+    /// - Since all objects need to be examined to assure non-ambiguous return values, after calling this method all indices will
+    ///   be loaded.
+    /// - If `candidates` is `Some(…)`, the traversal will continue to obtain all candidates, which takes more time
+    ///   as there is no early abort.
+    pub fn lookup_prefix(
+        &self,
+        prefix: git_hash::Prefix,
+        mut candidates: Option<&mut HashSet<git_hash::ObjectId>>,
+    ) -> Result<Option<lookup::Outcome>, lookup::Error> {
+        let mut candidate: Option<git_hash::ObjectId> = None;
+        loop {
+            let snapshot = self.snapshot.borrow();
+            for index in snapshot.indices.iter() {
+                #[allow(clippy::needless_option_as_deref)] // needed as it's the equivalent of a reborrow.
+                let lookup_result = index.lookup_prefix(prefix, candidates.as_deref_mut());
+                if candidates.is_none() && !check_candidate(lookup_result, &mut candidate) {
+                    return Ok(Some(Err(())));
+                }
+            }
+
+            for lodb in snapshot.loose_dbs.iter() {
+                #[allow(clippy::needless_option_as_deref)] // needed as it's the equivalent of a reborrow.
+                let lookup_result = lodb.lookup_prefix(prefix, candidates.as_deref_mut())?;
+                if candidates.is_none() && !check_candidate(lookup_result, &mut candidate) {
+                    return Ok(Some(Err(())));
+                }
+            }
+
+            match self.store.load_one_index(self.refresh, snapshot.marker)? {
+                Some(new_snapshot) => {
+                    drop(snapshot);
+                    *self.snapshot.borrow_mut() = new_snapshot;
+                }
+                None => {
+                    return match &candidates {
+                        Some(candidates) => match candidates.len() {
+                            0 => Ok(None),
+                            1 => Ok(candidates.iter().cloned().next().map(Ok)),
+                            _ => Ok(Some(Err(()))),
+                        },
+                        None => Ok(candidate.map(Ok)),
+                    };
+                }
+            }
+        }
+
+        fn check_candidate(lookup_result: Option<lookup::Outcome>, candidate: &mut Option<git_hash::ObjectId>) -> bool {
+            match (lookup_result, &*candidate) {
+                (Some(Ok(oid)), Some(candidate)) if *candidate != oid => false,
+                (Some(Ok(_)), Some(_)) | (None, None) | (None, Some(_)) => true,
+                (Some(Err(())), _) => false,
+                (Some(Ok(oid)), None) => {
+                    *candidate = Some(oid);
+                    true
+                }
+            }
+        }
+    }
+}

--- a/git-odb/src/store_impls/dynamic/types.rs
+++ b/git-odb/src/store_impls/dynamic/types.rs
@@ -233,7 +233,7 @@ pub(crate) struct IndexFileBundle {
 
 #[derive(Clone)]
 pub(crate) struct MultiIndexFileBundle {
-    pub multi_index: OnDiskFile<Arc<super::handle::multi_index::File>>,
+    pub multi_index: OnDiskFile<Arc<git_pack::multi_index::File>>,
     pub data: Vec<OnDiskFile<Arc<git_pack::data::File>>>,
 }
 

--- a/git-odb/src/store_impls/loose/find.rs
+++ b/git-odb/src/store_impls/loose/find.rs
@@ -47,7 +47,7 @@ impl Store {
         &self,
         prefix: git_hash::Prefix,
         mut candidates: Option<&mut HashSet<git_hash::ObjectId>>,
-    ) -> Result<Option<crate::find::PrefixLookupResult>, crate::loose::iter::Error> {
+    ) -> Result<Option<crate::store::prefix::lookup::Outcome>, crate::loose::iter::Error> {
         let single_directory_iter = crate::loose::Iter {
             inner: git_features::fs::walkdir_new(
                 self.path.join(prefix.as_oid().to_hex_with_len(2).to_string()),

--- a/git-odb/src/store_impls/loose/find.rs
+++ b/git-odb/src/store_impls/loose/find.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::HashSet, fs, io::Read, path::PathBuf};
 
 use git_features::zlib;
 
-use crate::store_impls::loose::{hash_path, Store, HEADER_READ_UNCOMPRESSED_BYTES};
+use crate::store_impls::loose::{hash_path, Store, HEADER_MAX_SIZE};
 
 /// Returned by [`Store::try_find()`]
 #[derive(thiserror::Error, Debug)]
@@ -127,6 +127,50 @@ impl Store {
         }
     }
 
+    /// Return only the decompressed size of the object and its kind without fully reading it into memory as tuple of `(size, kind)`.
+    /// Returns `None` if `id` does not exist in the database.
+    pub fn try_header(&self, id: impl AsRef<git_hash::oid>) -> Result<Option<(usize, git_object::Kind)>, Error> {
+        const BUF_SIZE: usize = 256;
+        let mut buf = [0_u8; BUF_SIZE];
+        let path = hash_path(id.as_ref(), self.path.clone());
+
+        let mut inflate = zlib::Inflate::default();
+        let mut istream = match fs::File::open(&path) {
+            Ok(f) => f,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => {
+                return Err(Error::Io {
+                    source: err,
+                    action: Self::OPEN_ACTION,
+                    path,
+                })
+            }
+        };
+
+        let (compressed_buf, _) = buf.split_at_mut(BUF_SIZE - HEADER_MAX_SIZE);
+        let bytes_read = istream.read(compressed_buf).map_err(|e| Error::Io {
+            source: e,
+            action: "read",
+            path: path.to_owned(),
+        })?;
+        let (compressed_buf, header_buf) = buf.split_at_mut(bytes_read);
+        let (status, _consumed_in, consumed_out) =
+            inflate
+                .once(compressed_buf, header_buf)
+                .map_err(|e| Error::DecompressFile {
+                    source: e,
+                    path: path.to_owned(),
+                })?;
+
+        assert_ne!(
+            status,
+            zlib::Status::BufError,
+            "Buffer errors might mean we encountered huge headers"
+        );
+        let (kind, size, _header_size) = git_object::decode::loose_header(&header_buf[..consumed_out])?;
+        Ok(Some((size, kind)))
+    }
+
     fn find_inner<'a>(&self, id: &git_hash::oid, buf: &'a mut Vec<u8>) -> Result<git_object::Data<'a>, Error> {
         let path = hash_path(id, self.path.clone());
 
@@ -144,7 +188,7 @@ impl Store {
                 action: "read",
                 path: path.to_owned(),
             })?;
-            buf.resize(bytes_read + HEADER_READ_UNCOMPRESSED_BYTES, 0);
+            buf.resize(bytes_read + HEADER_MAX_SIZE, 0);
             let (input, output) = buf.split_at_mut(bytes_read);
             (
                 inflate

--- a/git-odb/src/store_impls/loose/mod.rs
+++ b/git-odb/src/store_impls/loose/mod.rs
@@ -1,5 +1,6 @@
 //! An object database storing each object in a zlib compressed file with its hash in the path
-const HEADER_READ_UNCOMPRESSED_BYTES: usize = 512;
+/// The maximum size that an object header can have. `git2` says 64, and `git` says 32 but also mentions it can be larger.
+const HEADER_MAX_SIZE: usize = 64;
 use std::path::{Path, PathBuf};
 
 use git_features::fs;

--- a/git-odb/src/traits.rs
+++ b/git-odb/src/traits.rs
@@ -58,7 +58,7 @@ pub trait Find {
 
 /// A way to obtain object properties without fully decoding it.
 pub trait Header {
-    /// The error returned by [`try_header()`][Find::try_header()].
+    /// The error returned by [`try_header()`][Header::try_header()].
     type Error: std::error::Error + 'static;
     /// Try to read the header of the object associated with `id` or return `None` if it could not be found.
     fn try_header(&self, id: impl AsRef<git_hash::oid>) -> Result<Option<find::Header>, Self::Error>;

--- a/git-odb/src/traits.rs
+++ b/git-odb/src/traits.rs
@@ -56,9 +56,18 @@ pub trait Find {
     ) -> Result<Option<git_object::Data<'a>>, Self::Error>;
 }
 
+/// A way to obtain object properties without fully decoding it.
+pub trait Header {
+    /// The error returned by [`try_header()`][Find::try_header()].
+    type Error: std::error::Error + 'static;
+    /// Try to read the header of the object associated with `id` or return `None` if it could not be found.
+    fn try_header(&self, id: impl AsRef<git_hash::oid>) -> Result<Option<find::Header>, Self::Error>;
+}
+
 mod _impls {
     use std::{io::Read, ops::Deref, rc::Rc, sync::Arc};
 
+    use crate::find::Header;
     use git_hash::{oid, ObjectId};
     use git_object::{Data, Kind, WriteTo};
 
@@ -134,6 +143,17 @@ mod _impls {
         }
     }
 
+    impl<T> crate::Header for &T
+    where
+        T: crate::Header,
+    {
+        type Error = T::Error;
+
+        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+            (*self).try_header(id)
+        }
+    }
+
     impl<T> crate::Find for Rc<T>
     where
         T: crate::Find,
@@ -149,6 +169,17 @@ mod _impls {
         }
     }
 
+    impl<T> crate::Header for Rc<T>
+    where
+        T: crate::Header,
+    {
+        type Error = T::Error;
+
+        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+            self.deref().try_header(id)
+        }
+    }
+
     impl<T> crate::Find for Arc<T>
     where
         T: crate::Find,
@@ -161,6 +192,17 @@ mod _impls {
 
         fn try_find<'a>(&self, id: impl AsRef<oid>, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, Self::Error> {
             self.deref().try_find(id, buffer)
+        }
+    }
+
+    impl<T> crate::Header for Arc<T>
+    where
+        T: crate::Header,
+    {
+        type Error = T::Error;
+
+        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+            self.deref().try_header(id)
         }
     }
 }
@@ -222,6 +264,22 @@ mod ext {
     }
 
     /// An extension trait with convenience functions.
+    pub trait HeaderExt: super::Header {
+        /// Like [`try_header(…)`][super::Header::try_header()], but flattens the `Result<Option<_>>` into a single `Result` making a non-existing object an error.
+        fn header(
+            &self,
+            id: impl AsRef<git_hash::oid>,
+        ) -> Result<crate::find::Header, find::existing::Error<Self::Error>> {
+            let id = id.as_ref();
+            self.try_header(id)
+                .map_err(find::existing::Error::Find)?
+                .ok_or_else(|| find::existing::Error::NotFound { oid: id.to_owned() })
+        }
+    }
+
+    impl<T: super::Header> HeaderExt for T {}
+
+    /// An extension trait with convenience functions.
     pub trait FindExt: super::Find {
         /// Like [`try_find(…)`][super::Find::try_find()], but flattens the `Result<Option<_>>` into a single `Result` making a non-existing object an error.
         fn find<'a>(
@@ -232,9 +290,7 @@ mod ext {
             let id = id.as_ref();
             self.try_find(id, buffer)
                 .map_err(find::existing::Error::Find)?
-                .ok_or_else(|| find::existing::Error::NotFound {
-                    oid: id.as_ref().to_owned(),
-                })
+                .ok_or_else(|| find::existing::Error::NotFound { oid: id.to_owned() })
         }
 
         make_obj_lookup!(find_commit, ObjectRef::Commit, Kind::Commit, CommitRef<'a>);
@@ -248,4 +304,5 @@ mod ext {
 
     impl<T: super::Find> FindExt for T {}
 }
-pub use ext::FindExt;
+use crate::find;
+pub use ext::{FindExt, HeaderExt};

--- a/git-odb/tests/odb/find/mod.rs
+++ b/git-odb/tests/odb/find/mod.rs
@@ -1,12 +1,12 @@
 use crate::fixture_path;
 
-fn linked_db() -> git_odb::Handle {
+fn new_store() -> git_odb::Handle {
     git_odb::at(fixture_path("objects")).expect("valid object path")
 }
 
 use crate::hex_to_id;
 
-fn can_locate(db: impl git_odb::Find, hex_id: &str) {
+fn can_find(db: impl git_odb::Find, hex_id: &str) {
     let mut buf = vec![];
     assert!(db
         .try_find(hex_to_id(hex_id), &mut buf)
@@ -16,13 +16,13 @@ fn can_locate(db: impl git_odb::Find, hex_id: &str) {
 
 #[test]
 fn loose_object() {
-    can_locate(&linked_db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
+    can_find(&new_store(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
 }
 
 #[test]
 fn pack_object() {
-    let db = linked_db();
-    can_locate(&db, "501b297447a8255d3533c6858bb692575cdefaa0"); // pack 11fd
-    can_locate(&db, "4dac9989f96bc5b5b1263b582c08f0c5f0b58542"); // pack a2bf
-    can_locate(&db, "dd25c539efbb0ab018caa4cda2d133285634e9b5"); // pack c043
+    let db = new_store();
+    can_find(&db, "501b297447a8255d3533c6858bb692575cdefaa0"); // pack 11fd
+    can_find(&db, "4dac9989f96bc5b5b1263b582c08f0c5f0b58542"); // pack a2bf
+    can_find(&db, "dd25c539efbb0ab018caa4cda2d133285634e9b5"); // pack c043
 }

--- a/git-odb/tests/odb/header/mod.rs
+++ b/git-odb/tests/odb/header/mod.rs
@@ -1,0 +1,47 @@
+use crate::fixture_path;
+
+fn new_store() -> git_odb::Handle {
+    git_odb::at(fixture_path("objects")).expect("valid object path")
+}
+
+use crate::hex_to_id;
+
+fn find_header(db: impl git_odb::Header, hex_id: &str) -> git_odb::find::Header {
+    db.try_header(hex_to_id(hex_id))
+        .expect("no read error")
+        .expect("object exists")
+}
+
+#[test]
+fn loose_object() {
+    find_header(&new_store(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
+}
+
+#[test]
+fn pack_object() {
+    let db = new_store();
+    assert_eq!(
+        find_header(&db, "501b297447a8255d3533c6858bb692575cdefaa0"), // pack 11fd
+        git_odb::find::Header::Packed(git_pack::data::decode::header::Outcome {
+            kind: git_object::Kind::Commit,
+            object_size: 225,
+            num_deltas: 0,
+        })
+    );
+    assert_eq!(
+        find_header(&db, "4dac9989f96bc5b5b1263b582c08f0c5f0b58542"), // pack a2bf
+        git_odb::find::Header::Packed(git_pack::data::decode::header::Outcome {
+            kind: git_object::Kind::Tree,
+            object_size: 34,
+            num_deltas: 0,
+        })
+    );
+    assert_eq!(
+        find_header(&db, "dd25c539efbb0ab018caa4cda2d133285634e9b5"), // pack c043
+        git_odb::find::Header::Packed(git_pack::data::decode::header::Outcome {
+            kind: git_object::Kind::Blob,
+            object_size: 860,
+            num_deltas: 0,
+        })
+    );
+}

--- a/git-odb/tests/odb/mod.rs
+++ b/git-odb/tests/odb/mod.rs
@@ -4,6 +4,7 @@ pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub mod alternate;
 pub mod find;
+pub mod header;
 pub mod regression;
 pub mod sink;
 pub mod store;

--- a/git-odb/tests/odb/store/linked.rs
+++ b/git-odb/tests/odb/store/linked.rs
@@ -8,6 +8,7 @@ fn db() -> git_odb::Handle {
 }
 
 mod iter {
+    use git_odb::Header;
     use git_pack::Find;
 
     use crate::odb::store::linked::db;
@@ -23,7 +24,9 @@ mod iter {
         );
         assert_eq!(iter.count(), 146, "it sees the correct amount of objects");
         for id in db.iter()? {
-            assert!(db.contains(id?), "each object exists");
+            let id = id?;
+            assert!(db.contains(id), "each object exists");
+            assert!(db.try_header(id)?.is_some(), "header is readable");
         }
         Ok(())
     }

--- a/git-pack/src/bundle/find.rs
+++ b/git-pack/src/bundle/find.rs
@@ -10,7 +10,7 @@ impl crate::Bundle {
         id: impl AsRef<git_hash::oid>,
         out: &'a mut Vec<u8>,
         cache: &mut impl crate::cache::DecodeEntry,
-    ) -> Result<Option<(git_object::Data<'a>, crate::data::entry::Location)>, crate::data::decode_entry::Error> {
+    ) -> Result<Option<(git_object::Data<'a>, crate::data::entry::Location)>, crate::data::decode::Error> {
         let idx = match self.index.lookup(id) {
             Some(idx) => idx,
             None => return Ok(None),
@@ -29,7 +29,7 @@ impl crate::Bundle {
         idx: u32,
         out: &'a mut Vec<u8>,
         cache: &mut impl crate::cache::DecodeEntry,
-    ) -> Result<(git_object::Data<'a>, crate::data::entry::Location), crate::data::decode_entry::Error> {
+    ) -> Result<(git_object::Data<'a>, crate::data::entry::Location), crate::data::decode::Error> {
         let ofs = self.index.pack_offset_at_index(idx);
         let pack_entry = self.pack.entry(ofs);
         let header_size = pack_entry.header_size();
@@ -39,7 +39,9 @@ impl crate::Bundle {
                 out,
                 |id, _out| {
                     self.index.lookup(id).map(|idx| {
-                        crate::data::ResolvedBase::InPack(self.pack.entry(self.index.pack_offset_at_index(idx)))
+                        crate::data::decode::entry::ResolvedBase::InPack(
+                            self.pack.entry(self.index.pack_offset_at_index(idx)),
+                        )
                     })
                 },
                 cache,

--- a/git-pack/src/data/file/decode/entry.rs
+++ b/git-pack/src/data/file/decode/entry.rs
@@ -131,6 +131,20 @@ impl File {
             .map(|(_status, consumed_in, _consumed_out)| consumed_in)
     }
 
+    /// Like `decompress_entry_from_data_offset`, but returns consumed input and output.
+    pub(crate) fn decompress_entry_from_data_offset_2(
+        &self,
+        data_offset: data::Offset,
+        out: &mut [u8],
+    ) -> Result<(usize, usize), zlib::inflate::Error> {
+        let offset: usize = data_offset.try_into().expect("offset representable by machine");
+        assert!(offset < self.data.len(), "entry offset out of bounds");
+
+        zlib::Inflate::default()
+            .once(&self.data[offset..], out)
+            .map(|(_status, consumed_in, consumed_out)| (consumed_in, consumed_out))
+    }
+
     /// Decode an entry, resolving delta's as needed, while growing the `out` vector if there is not enough
     /// space to hold the result object.
     ///

--- a/git-pack/src/data/file/decode/header.rs
+++ b/git-pack/src/data/file/decode/header.rs
@@ -15,7 +15,7 @@ pub enum ResolvedBase {
 /// Additional information and statistics about a successfully decoded object produced by [`File::decode_header()`].
 ///
 /// Useful to understand the effectiveness of the pack compression or the cost of decompression.
-#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The kind of resolved object.
@@ -80,11 +80,10 @@ impl File {
 
     #[inline]
     fn decode_delta_object_size(&self, entry: &data::Entry) -> Result<u64, Error> {
-        // TODO: figure out the best size for this.
-        let mut buf = [0_u8; 64];
-        let used = self.decompress_entry_from_data_offset(entry.data_offset, &mut buf)?;
+        let mut buf = [0_u8; 32];
+        let used = self.decompress_entry_from_data_offset_2(entry.data_offset, &mut buf)?.1;
         let buf = &buf[..used];
-        let (_base_size, offset) = delta::decode_header_size(&buf);
+        let (_base_size, offset) = delta::decode_header_size(buf);
         let (result_size, _offset) = delta::decode_header_size(&buf[offset..]);
         Ok(result_size)
     }

--- a/git-pack/src/data/file/decode/mod.rs
+++ b/git-pack/src/data/file/decode/mod.rs
@@ -1,0 +1,16 @@
+///
+pub mod entry;
+///
+pub mod header;
+
+/// Returned by [`File::decode_header()`][crate::data::File::decode_header()],
+/// [`File::decode_entry()`][crate::data::File::decode_entry()] and .
+/// [`File::decompress_entry()`][crate::data::File::decompress_entry()]
+#[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error("Failed to decompress pack entry")]
+    ZlibInflate(#[from] git_features::zlib::inflate::Error),
+    #[error("A delta chain could not be followed as the ref base with id {0} could not be found")]
+    DeltaBaseUnresolved(git_hash::ObjectId),
+}

--- a/git-pack/src/data/file/decode_entry.rs
+++ b/git-pack/src/data/file/decode_entry.rs
@@ -35,7 +35,7 @@ struct Delta {
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
-    /// The kind of resolved object
+    /// The kind of resolved object.
     pub kind: git_object::Kind,
     /// The amount of deltas in the chain of objects that had to be resolved beforehand.
     ///
@@ -46,7 +46,7 @@ pub struct Outcome {
     pub decompressed_size: u64,
     /// The total compressed size of all pack entries in the delta chain
     pub compressed_size: usize,
-    /// The total size of all objects decoded as part of the delta chain
+    /// The total size of the decoded object.
     pub object_size: u64,
 }
 
@@ -60,7 +60,7 @@ impl Outcome {
             object_size: 0,
         }
     }
-    fn from_object_entry(kind: git_object::Kind, entry: &crate::data::Entry, compressed_size: usize) -> Self {
+    fn from_object_entry(kind: git_object::Kind, entry: &data::Entry, compressed_size: usize) -> Self {
         Self {
             kind,
             num_deltas: 0,
@@ -81,7 +81,7 @@ impl File {
     /// # Panics
     ///
     /// If `out` isn't large enough to hold the decompressed `entry`
-    pub fn decompress_entry(&self, entry: &crate::data::Entry, out: &mut [u8]) -> Result<usize, Error> {
+    pub fn decompress_entry(&self, entry: &data::Entry, out: &mut [u8]) -> Result<usize, Error> {
         assert!(
             out.len() as u64 >= entry.decompressed_size,
             "output buffer isn't large enough to hold decompressed result, want {}, have {}",
@@ -90,6 +90,7 @@ impl File {
         );
 
         self.decompress_entry_from_data_offset(entry.data_offset, out)
+            .map_err(Into::into)
     }
 
     fn assure_v2(&self) {
@@ -102,13 +103,13 @@ impl File {
     /// Obtain the [`Entry`][crate::data::Entry] at the given `offset` into the pack.
     ///
     /// The `offset` is typically obtained from the pack index file.
-    pub fn entry(&self, offset: data::Offset) -> crate::data::Entry {
+    pub fn entry(&self, offset: data::Offset) -> data::Entry {
         self.assure_v2();
         let pack_offset: usize = offset.try_into().expect("offset representable by machine");
         assert!(pack_offset <= self.data.len(), "offset out of bounds");
 
         let object_data = &self.data[pack_offset..];
-        crate::data::Entry::from_bytes(object_data, offset, self.hash_len)
+        data::Entry::from_bytes(object_data, offset, self.hash_len)
     }
 
     /// Decompress the object expected at the given data offset, sans pack header. This information is only
@@ -116,13 +117,16 @@ impl File {
     /// Note that this method does not resolve deltified objects, but merely decompresses their content
     /// `out` is expected to be large enough to hold `entry.size` bytes.
     /// Returns the amount of packed bytes there read from the pack data file.
-    fn decompress_entry_from_data_offset(&self, data_offset: data::Offset, out: &mut [u8]) -> Result<usize, Error> {
+    pub(crate) fn decompress_entry_from_data_offset(
+        &self,
+        data_offset: data::Offset,
+        out: &mut [u8],
+    ) -> Result<usize, zlib::inflate::Error> {
         let offset: usize = data_offset.try_into().expect("offset representable by machine");
         assert!(offset < self.data.len(), "entry offset out of bounds");
 
         zlib::Inflate::default()
             .once(&self.data[offset..], out)
-            .map_err(Into::into)
             .map(|(_status, consumed_in, _consumed_out)| consumed_in)
     }
 
@@ -138,7 +142,7 @@ impl File {
     /// Use a [Noop-Cache][cache::Never] to disable caching all together at the cost of repeating work.
     pub fn decode_entry(
         &self,
-        entry: crate::data::Entry,
+        entry: data::Entry,
         out: &mut Vec<u8>,
         resolve: impl Fn(&git_hash::oid, &mut Vec<u8>) -> Option<ResolvedBase>,
         delta_cache: &mut impl cache::DecodeEntry,
@@ -170,7 +174,7 @@ impl File {
     /// it's very, very large as 20bytes are smaller than the corresponding MSB encoded number
     fn resolve_deltas(
         &self,
-        last: crate::data::Entry,
+        last: data::Entry,
         resolve: impl Fn(&git_hash::oid, &mut Vec<u8>) -> Option<ResolvedBase>,
         out: &mut Vec<u8>,
         cache: &mut impl cache::DecodeEntry,
@@ -325,8 +329,8 @@ impl File {
 
         // From oldest to most recent, apply all deltas, swapping the buffer back and forth
         // TODO: once we have more tests, we could optimize this memory-intensive work to
-        // analyse the delta-chains to only copy data once - after all, with 'copy-from-base' deltas,
-        // all data originates from one base at some point.
+        //       analyse the delta-chains to only copy data once - after all, with 'copy-from-base' deltas,
+        //       all data originates from one base at some point.
         // `out` is: [source-buffer][target-buffer][max-delta-instructions-buffer]
         let (buffers, instructions) = out.split_at_mut(second_buffer_end);
         let (mut source_buf, mut target_buf) = buffers.split_at_mut(first_buffer_end);

--- a/git-pack/src/data/file/mod.rs
+++ b/git-pack/src/data/file/mod.rs
@@ -1,22 +1,9 @@
-///
-pub mod decode_entry;
 mod init;
-///
-pub mod resolve_header;
 ///
 pub mod verify;
 
+///
+pub mod decode;
+
 /// The bytes used as header in a pack data file.
 pub type Header = [u8; 12];
-
-/// A return value of a resolve function, which given an [`ObjectId`][git_hash::ObjectId] determines where an object can be found.
-#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
-pub enum ResolvedBase {
-    /// Indicate an object is within this pack, at the given entry, and thus can be looked up locally.
-    InPack(crate::data::Entry),
-    /// Indicates the object of `kind` was found outside of the pack, and its data was written into an output
-    /// vector which now has a length of `end`.
-    #[allow(missing_docs)]
-    OutOfPack { kind: git_object::Kind, end: usize },
-}

--- a/git-pack/src/data/file/mod.rs
+++ b/git-pack/src/data/file/mod.rs
@@ -2,6 +2,8 @@
 pub mod decode_entry;
 mod init;
 ///
+pub mod resolve_header;
+///
 pub mod verify;
 
 /// The bytes used as header in a pack data file.

--- a/git-pack/src/data/file/resolve_header.rs
+++ b/git-pack/src/data/file/resolve_header.rs
@@ -1,0 +1,115 @@
+use git_features::zlib;
+
+use crate::data::delta;
+use crate::{data, data::File};
+
+/// A return value of a resolve function, which given an [`ObjectId`][git_hash::ObjectId] determines where an object can be found.
+#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub enum ResolvedBase {
+    /// Indicate an object is within this pack, at the given entry, and thus can be looked up locally.
+    InPack(data::Entry),
+    /// Indicates the object of `kind` was found outside of the pack.
+    #[allow(missing_docs)]
+    OutOfPack { kind: git_object::Kind },
+}
+
+/// Returned by [`File::resolve_header()`].
+#[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error("Failed to decompress pack entry")]
+    ZlibInflate(#[from] zlib::inflate::Error),
+    #[error("A delta chain could not be followed as the ref base with id {0} could not be found")]
+    DeltaBaseUnresolved(git_hash::ObjectId),
+}
+
+/// Additional information and statistics about a successfully decoded object produced by [`File::resolve_header()`].
+///
+/// Useful to understand the effectiveness of the pack compression or the cost of decompression.
+#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct Outcome {
+    /// The kind of resolved object.
+    pub kind: git_object::Kind,
+    /// The decompressed size of the object.
+    pub object_size: u64,
+    /// The amount of deltas in the chain of objects that had to be resolved beforehand.
+    pub num_deltas: u32,
+}
+
+/// Obtain object information quickly.
+impl File {
+    /// Resolve the object header information starting at `entry`, following the chain of entries as needed.
+    ///
+    /// The `entry` determines which object to decode, and is commonly obtained with the help of a pack index file or through pack iteration.
+    ///
+    /// `resolve` is a function to lookup objects with the given [`ObjectId`][git_hash::ObjectId], in case the full object id
+    /// is used to refer to a base object, instead of an in-pack offset.
+    pub fn resolve_header(
+        &self,
+        mut entry: data::Entry,
+        resolve: impl Fn(&git_hash::oid) -> Option<ResolvedBase>,
+    ) -> Result<Outcome, Error> {
+        use crate::data::entry::Header::*;
+        let mut num_deltas = 0;
+        let mut first_delta_decompressed_size = None::<u64>;
+        loop {
+            match entry.header {
+                Tree | Blob | Commit | Tag => {
+                    return Ok(Outcome {
+                        kind: entry.header.as_kind().expect("always valid for non-refs"),
+                        object_size: first_delta_decompressed_size.unwrap_or(entry.decompressed_size),
+                        num_deltas,
+                    });
+                }
+                OfsDelta { base_distance } => {
+                    if first_delta_decompressed_size.is_none() {
+                        first_delta_decompressed_size = Some(self.decode_delta_object_size(&entry)?);
+                    }
+                    entry = self.entry(entry.base_pack_offset(base_distance))
+                }
+                RefDelta { base_id } => {
+                    if first_delta_decompressed_size.is_none() {
+                        first_delta_decompressed_size = Some(self.decode_delta_object_size(&entry)?);
+                    }
+                    entry = match resolve(base_id.as_ref()) {
+                        Some(ResolvedBase::InPack(entry)) => entry,
+                        Some(ResolvedBase::OutOfPack { kind }) => {
+                            return Ok(Outcome {
+                                kind,
+                                object_size: first_delta_decompressed_size.unwrap_or(entry.decompressed_size),
+                                num_deltas,
+                            })
+                        }
+                        None => return Err(Error::DeltaBaseUnresolved(base_id)),
+                    }
+                }
+            };
+            num_deltas += 1;
+        }
+    }
+
+    #[inline]
+    fn decode_delta_object_size(&self, entry: &data::Entry) -> Result<u64, Error> {
+        let mut buf = [0_u8; 64];
+        self.decompress_entry_from_data_offset(entry.data_offset, &mut buf)?;
+        let (_base_size, offset) = delta::decode_header_size(&buf);
+        let (result_size, _offset) = delta::decode_header_size(&buf[offset..]);
+        Ok(result_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_of_decode_entry_outcome() {
+        assert_eq!(
+            std::mem::size_of::<Outcome>(),
+            16,
+            "this shouldn't change without use noticing as it's returned a lot"
+        );
+    }
+}

--- a/git-pack/src/data/mod.rs
+++ b/git-pack/src/data/mod.rs
@@ -24,7 +24,7 @@ pub struct Entry {
 }
 
 mod file;
-pub use file::{decode_entry, resolve_header, verify, Header, ResolvedBase};
+pub use file::{decode, verify, Header};
 ///
 pub mod header;
 

--- a/git-pack/src/data/mod.rs
+++ b/git-pack/src/data/mod.rs
@@ -15,14 +15,16 @@ use memmap2::Mmap;
 pub struct Entry {
     /// The entry's header
     pub header: entry::Header,
-    /// The decompressed size of the object in bytes
+    /// The decompressed size of the entry in bytes.
+    ///
+    /// Note that for non-delta entries this will be the size of the object itself.
     pub decompressed_size: u64,
     /// absolute offset to compressed object data in the pack, just behind the entry's header
     pub data_offset: Offset,
 }
 
 mod file;
-pub use file::{decode_entry, verify, Header, ResolvedBase};
+pub use file::{decode_entry, resolve_header, verify, Header, ResolvedBase};
 ///
 pub mod header;
 

--- a/git-pack/src/index/traverse/error.rs
+++ b/git-pack/src/index/traverse/error.rs
@@ -16,7 +16,7 @@ pub enum Error<E: std::error::Error + Send + Sync + 'static> {
     PackDecode {
         id: git_hash::ObjectId,
         offset: u64,
-        source: crate::data::decode_entry::Error,
+        source: crate::data::decode::Error,
     },
     #[error("The packfiles checksum didn't match the index file checksum: expected {expected}, got {actual}")]
     PackMismatch {

--- a/git-pack/src/index/traverse/mod.rs
+++ b/git-pack/src/index/traverse/mod.rs
@@ -160,7 +160,7 @@ impl index::File {
         progress: &mut P,
         index_entry: &crate::index::Entry,
         processor: &mut impl FnMut(git_object::Kind, &[u8], &index::Entry, &mut P) -> Result<(), E>,
-    ) -> Result<crate::data::decode_entry::Outcome, Error<E>>
+    ) -> Result<crate::data::decode::entry::Outcome, Error<E>>
     where
         C: crate::cache::DecodeEntry,
         P: Progress,
@@ -173,8 +173,9 @@ impl index::File {
                 pack_entry,
                 buf,
                 |id, _| {
-                    self.lookup(id)
-                        .map(|index| crate::data::ResolvedBase::InPack(pack.entry(self.pack_offset_at_index(index))))
+                    self.lookup(id).map(|index| {
+                        crate::data::decode::entry::ResolvedBase::InPack(pack.entry(self.pack_offset_at_index(index)))
+                    })
                 },
                 cache,
             )

--- a/git-pack/src/index/traverse/reduce.rs
+++ b/git-pack/src/index/traverse/reduce.rs
@@ -11,14 +11,14 @@ use git_features::{
 
 use crate::{data, index::traverse};
 
-fn add_decode_result(lhs: &mut data::decode_entry::Outcome, rhs: data::decode_entry::Outcome) {
+fn add_decode_result(lhs: &mut data::decode::entry::Outcome, rhs: data::decode::entry::Outcome) {
     lhs.num_deltas += rhs.num_deltas;
     lhs.decompressed_size += rhs.decompressed_size;
     lhs.compressed_size += rhs.compressed_size;
     lhs.object_size += rhs.object_size;
 }
 
-fn div_decode_result(lhs: &mut data::decode_entry::Outcome, div: usize) {
+fn div_decode_result(lhs: &mut data::decode::entry::Outcome, div: usize) {
     if div != 0 {
         lhs.num_deltas = (lhs.num_deltas as f32 / div as f32) as u32;
         lhs.decompressed_size /= div as u64;
@@ -68,7 +68,7 @@ where
     P: Progress,
     E: std::error::Error + Send + Sync + 'static,
 {
-    type Input = Result<Vec<data::decode_entry::Outcome>, traverse::Error<E>>;
+    type Input = Result<Vec<data::decode::entry::Outcome>, traverse::Error<E>>;
     type FeedProduce = ();
     type Output = traverse::Statistics;
     type Error = traverse::Error<E>;
@@ -84,7 +84,7 @@ where
         self.entries_seen += chunk_stats.len();
 
         let chunk_total = chunk_stats.into_iter().fold(
-            data::decode_entry::Outcome::default_from_kind(git_object::Kind::Tree),
+            data::decode::entry::Outcome::default_from_kind(git_object::Kind::Tree),
             |mut total, stats| {
                 *self.stats.objects_per_chain_length.entry(stats.num_deltas).or_insert(0) += 1;
                 self.stats.total_decompressed_entries_size += stats.decompressed_size;

--- a/git-pack/src/index/traverse/types.rs
+++ b/git-pack/src/index/traverse/types.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Statistics {
     /// The average over all decoded objects
-    pub average: crate::data::decode_entry::Outcome,
+    pub average: crate::data::decode::entry::Outcome,
     /// A mapping of the length of the chain to the amount of objects at that length.
     ///
     /// A length of 0 indicates full objects, and everything above that involves the given amount
@@ -32,7 +32,7 @@ pub struct Statistics {
 impl Default for Statistics {
     fn default() -> Self {
         Statistics {
-            average: crate::data::decode_entry::Outcome::default_from_kind(git_object::Kind::Tree),
+            average: crate::data::decode::entry::Outcome::default_from_kind(git_object::Kind::Tree),
             objects_per_chain_length: Default::default(),
             total_compressed_entries_size: 0,
             total_decompressed_entries_size: 0,

--- a/git-pack/src/index/traverse/with_lookup.rs
+++ b/git-pack/src/index/traverse/with_lookup.rs
@@ -122,7 +122,7 @@ impl index::File {
                     state_per_thread,
                     |entries: &[index::Entry],
                      (cache, ref mut processor, buf, progress)|
-                     -> Result<Vec<data::decode_entry::Outcome>, Error<_>> {
+                     -> Result<Vec<data::decode::entry::Outcome>, Error<_>> {
                         progress.init(
                             Some(entries.len()),
                             Some(unit::dynamic(unit::Human::new(

--- a/git-pack/tests/pack/data/file.rs
+++ b/git-pack/tests/pack/data/file.rs
@@ -108,6 +108,54 @@ mod decode_entry {
     }
 }
 
+/// All hardcoded offsets are obtained via `git pack-verify --verbose  tests/fixtures/packs/pack-a2bf8e71d8c18879e499335762dd95119d93d9f1.idx`
+mod resolve_header {
+    use crate::pack::{data::file::pack_at, SMALL_PACK};
+
+    #[test]
+    fn commit() {
+        let out = resolve_header_at_offset(1968);
+        assert_eq!(out.kind, git_object::Kind::Commit);
+        assert_eq!(out.object_size, 187);
+        assert_eq!(out.num_deltas, 0);
+    }
+
+    #[test]
+    fn blob_ofs_delta_two_links() {
+        let out = resolve_header_at_offset(3033);
+        assert_eq!(out.kind, git_object::Kind::Blob);
+        assert_eq!(out.object_size, 173);
+        assert_eq!(out.num_deltas, 2);
+    }
+
+    #[test]
+    fn blob_ofs_delta_single_link() {
+        let out = resolve_header_at_offset(3569);
+        assert_eq!(out.kind, git_object::Kind::Blob);
+        assert_eq!(out.object_size, 1163);
+        assert_eq!(out.num_deltas, 1);
+    }
+
+    #[test]
+    fn tree() {
+        let out = resolve_header_at_offset(2097);
+        assert_eq!(out.kind, git_object::Kind::Tree);
+        assert_eq!(out.object_size, 34);
+        assert_eq!(out.num_deltas, 0);
+    }
+
+    fn resolve_header_at_offset(offset: u64) -> git_pack::data::resolve_header::Outcome {
+        fn resolve_with_panic(_oid: &git_hash::oid) -> Option<git_pack::data::resolve_header::ResolvedBase> {
+            panic!("should not want to resolve an id here")
+        }
+
+        let p = pack_at(SMALL_PACK);
+        let entry = p.entry(offset);
+        p.resolve_header(entry, resolve_with_panic)
+            .expect("valid offset provides valid entry")
+    }
+}
+
 mod decompress_entry {
     use git_object::bstr::ByteSlice;
 

--- a/git-pack/tests/pack/data/file.rs
+++ b/git-pack/tests/pack/data/file.rs
@@ -42,7 +42,7 @@ mod method {
 /// All hardcoded offsets are obtained via `git pack-verify --verbose  tests/fixtures/packs/pack-a2bf8e71d8c18879e499335762dd95119d93d9f1.idx`
 mod decode_entry {
     use bstr::ByteSlice;
-    use git_pack::{cache, data::ResolvedBase};
+    use git_pack::{cache, data::decode::entry::ResolvedBase};
 
     use crate::{
         fixture_path, fixup,
@@ -144,14 +144,14 @@ mod resolve_header {
         assert_eq!(out.num_deltas, 0);
     }
 
-    fn resolve_header_at_offset(offset: u64) -> git_pack::data::resolve_header::Outcome {
-        fn resolve_with_panic(_oid: &git_hash::oid) -> Option<git_pack::data::resolve_header::ResolvedBase> {
+    fn resolve_header_at_offset(offset: u64) -> git_pack::data::decode::header::Outcome {
+        fn resolve_with_panic(_oid: &git_hash::oid) -> Option<git_pack::data::decode::header::ResolvedBase> {
             panic!("should not want to resolve an id here")
         }
 
         let p = pack_at(SMALL_PACK);
         let entry = p.entry(offset);
-        p.resolve_header(entry, resolve_with_panic)
+        p.decode_header(entry, resolve_with_panic)
             .expect("valid offset provides valid entry")
     }
 }

--- a/git-pack/tests/pack/index.rs
+++ b/git-pack/tests/pack/index.rs
@@ -274,7 +274,7 @@ fn traverse_with_index_and_forward_ref_deltas() {
 }
 
 use git_features::progress;
-use git_pack::{cache, data::decode_entry::Outcome, index};
+use git_pack::{cache, data::decode::entry::Outcome, index};
 use maplit::btreemap;
 
 use crate::pack::{INDEX_V2, PACK_FOR_INDEX_V2};

--- a/git-pack/tests/pack/multi_index/verify.rs
+++ b/git-pack/tests/pack/multi_index/verify.rs
@@ -25,7 +25,7 @@ fn integrity() {
     assert_eq!(
         outcome.pack_traverse_statistics,
         vec![git_pack::index::traverse::Statistics {
-            average: git_pack::data::decode_entry::Outcome {
+            average: git_pack::data::decode::entry::Outcome {
                 kind: git_object::Kind::Tree,
                 num_deltas: 1,
                 decompressed_size: 47,

--- a/git-repository/src/lib.rs
+++ b/git-repository/src/lib.rs
@@ -82,9 +82,10 @@
 //! * [`hash`]
 //! * [`url`]
 //! * [`actor`]
-//! * [`bstr`][bstr]
+//! * [`bstr`]
 //! * [`date`]
 //! * [`mod@discover`]
+//! * [`features`]
 //! * [`index`]
 //! * [`glob`]
 //! * [`path`]
@@ -129,6 +130,7 @@ pub use git_attributes as attrs;
 pub use git_credentials as credentials;
 pub use git_date as date;
 pub use git_diff as diff;
+pub use git_features as features;
 use git_features::threading::OwnShared;
 pub use git_features::{parallel, progress::Progress, threading};
 pub use git_glob as glob;
@@ -158,7 +160,7 @@ mod ext;
 ///
 pub mod prelude {
     pub use git_features::parallel::reduce::Finalize;
-    pub use git_odb::{Find, FindExt, Write};
+    pub use git_odb::{Find, FindExt, Header, HeaderExt, Write};
 
     pub use crate::ext::*;
 }

--- a/git-repository/src/revision/spec/parse/delegate/revision.rs
+++ b/git-repository/src/revision/spec/parse/delegate/revision.rs
@@ -9,7 +9,6 @@ use git_revision::spec::parse::{
 use crate::{
     bstr::{BStr, BString, ByteSlice},
     ext::ReferenceExt,
-    object,
     revision::spec::parse::{Delegate, Error, RefsHint},
 };
 
@@ -51,7 +50,7 @@ impl<'repo> delegate::Revision for Delegate<'repo> {
 
         match res {
             Err(err) => {
-                self.err.push(object::find::existing::Error::Find(err).into());
+                self.err.push(err.into());
                 None
             }
             Ok(None) => {

--- a/git-repository/src/revision/spec/parse/types.rs
+++ b/git-repository/src/revision/spec/parse/types.rs
@@ -143,6 +143,8 @@ pub enum Error {
     #[error(transparent)]
     FindObject(#[from] object::find::existing::Error),
     #[error(transparent)]
+    LookupPrefix(#[from] git_odb::store::prefix::lookup::Error),
+    #[error(transparent)]
     PeelToKind(#[from] object::peel::to_kind::Error),
     #[error("Object {oid} was a {actual}, but needed it to be a {expected}")]
     ObjectKind {

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -31,7 +31,7 @@ async-client = ["git-repository/async-network-client-async-std", "git-transport-
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["git-commitgraph/serde1", "git-repository/serde1", "serde_json", "serde"]
+serde1 = ["git-commitgraph/serde1", "git-repository/serde1", "serde_json", "serde", "bytesize/serde"]
 
 
 [dependencies]

--- a/gitoxide-core/src/pack/verify.rs
+++ b/gitoxide-core/src/pack/verify.rs
@@ -212,7 +212,7 @@ fn print_statistics(out: &mut impl io::Write, stats: &index::traverse::Statistic
     }
     writeln!(out, "\t->: {}", total_object_count)?;
 
-    let pack::data::decode_entry::Outcome {
+    let pack::data::decode::entry::Outcome {
         kind: _,
         num_deltas,
         decompressed_size,

--- a/gitoxide-core/src/repository/odb.rs
+++ b/gitoxide-core/src/repository/odb.rs
@@ -5,21 +5,6 @@ use git_repository as git;
 
 use crate::OutputFormat;
 
-mod info {
-    use std::path::PathBuf;
-
-    use git_repository::odb::store;
-
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
-    pub struct Statistics {
-        pub path: PathBuf,
-        pub object_hash: String,
-        pub use_multi_pack_index: bool,
-        pub structure: Vec<store::structure::Record>,
-        pub metrics: store::Metrics,
-    }
-}
-
 #[cfg_attr(not(feature = "serde1"), allow(unused_variables))]
 pub fn info(
     repo: git::Repository,
@@ -31,14 +16,186 @@ pub fn info(
         writeln!(err, "Only JSON is implemented - using that instead")?;
     }
 
+    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+    pub struct Statistics {
+        pub path: std::path::PathBuf,
+        pub object_hash: String,
+        pub use_multi_pack_index: bool,
+        pub structure: Vec<git::odb::store::structure::Record>,
+        pub metrics: git::odb::store::Metrics,
+    }
+
     let store = repo.objects.store_ref();
-    let stats = info::Statistics {
+    let stats = Statistics {
         path: store.path().into(),
         object_hash: store.object_hash().to_string(),
         use_multi_pack_index: store.use_multi_pack_index(),
         structure: store.structure()?,
         metrics: store.metrics(),
     };
+
+    #[cfg(feature = "serde1")]
+    {
+        serde_json::to_writer_pretty(out, &stats)?;
+    }
+
+    Ok(())
+}
+
+pub mod statistics {
+    use crate::OutputFormat;
+
+    pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 0..=3;
+
+    #[derive(Debug, Copy, Clone)]
+    pub struct Options {
+        pub format: OutputFormat,
+        pub thread_limit: Option<usize>,
+    }
+}
+
+#[cfg_attr(not(feature = "serde1"), allow(unused_variables))]
+pub fn statistics(
+    repo: git::Repository,
+    mut progress: impl git::Progress,
+    out: impl io::Write,
+    mut err: impl io::Write,
+    statistics::Options { format, thread_limit }: statistics::Options,
+) -> anyhow::Result<()> {
+    use bytesize::ByteSize;
+    use git::odb::find;
+    use git::odb::HeaderExt;
+
+    if format == OutputFormat::Human {
+        writeln!(err, "Only JSON is implemented - using that instead")?;
+    }
+
+    progress.init(None, git::progress::count("objects"));
+    progress.set_name("counting");
+    let counter = progress.counter();
+    let start = std::time::Instant::now();
+
+    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+    #[derive(Default)]
+    struct Statistics {
+        total_objects: usize,
+        loose_objects: usize,
+        packed_objects: usize,
+        packed_delta_objects: usize,
+        total_delta_chain_length: u64,
+        trees: usize,
+        trees_size: ByteSize,
+        tags: usize,
+        tags_size: ByteSize,
+        commits: usize,
+        commits_size: ByteSize,
+        blobs: usize,
+        blobs_size: ByteSize,
+    }
+
+    impl Statistics {
+        fn count(&mut self, kind: git::object::Kind, size: u64) {
+            use git::object::Kind::*;
+            match kind {
+                Commit => {
+                    self.commits += 1;
+                    self.commits_size += size;
+                }
+                Tree => {
+                    self.trees += 1;
+                    self.trees_size += size;
+                }
+                Tag => {
+                    self.tags += 1;
+                    self.tags_size += size;
+                }
+                Blob => {
+                    self.blobs += 1;
+                    self.blobs_size += size;
+                }
+            }
+        }
+        fn consume(&mut self, item: git::odb::find::Header) {
+            match item {
+                find::Header::Loose { size, kind } => {
+                    self.loose_objects += 1;
+                    self.count(kind, size)
+                }
+                find::Header::Packed(packed) => {
+                    self.packed_objects += 1;
+                    self.packed_delta_objects += usize::from(packed.num_deltas > 0);
+                    self.total_delta_chain_length += packed.num_deltas as u64;
+                    self.count(packed.kind, packed.object_size);
+                }
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct Reduce {
+        stats: Statistics,
+    }
+
+    impl git::parallel::Reduce for Reduce {
+        type Input = Result<Vec<git::odb::find::Header>, anyhow::Error>;
+        type FeedProduce = ();
+        type Output = Statistics;
+        type Error = anyhow::Error;
+
+        fn feed(&mut self, items: Self::Input) -> Result<Self::FeedProduce, Self::Error> {
+            for item in items? {
+                self.stats.consume(item);
+            }
+            Ok(())
+        }
+
+        fn finalize(mut self) -> Result<Self::Output, Self::Error> {
+            self.stats.total_objects = self.stats.loose_objects + self.stats.packed_objects;
+            Ok(self.stats)
+        }
+    }
+
+    let cancelled = || anyhow::anyhow!("Cancelled by user");
+    let object_ids = repo.objects.store_ref().iter()?.filter_map(Result::ok);
+    let chunk_size = 1_000;
+    let stats = if git::parallel::num_threads(thread_limit) > 1 {
+        git::parallel::in_parallel(
+            git::interrupt::Iter::new(
+                git::features::iter::Chunks {
+                    inner: object_ids,
+                    size: chunk_size,
+                },
+                cancelled,
+            ),
+            thread_limit,
+            move |_| (repo.objects.clone().into_inner(), counter.clone()),
+            |ids, (handle, counter)| {
+                let ids = ids?;
+                if let Some(counter) = counter {
+                    counter.fetch_add(ids.len(), std::sync::atomic::Ordering::SeqCst);
+                }
+                let out = ids
+                    .into_iter()
+                    .map(|id| handle.header(id))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(out)
+            },
+            Reduce::default(),
+        )?
+    } else {
+        let mut stats = Statistics::default();
+
+        for (count, id) in object_ids.enumerate() {
+            if count % chunk_size == 0 && git::interrupt::is_triggered() {
+                return Err(cancelled());
+            }
+            stats.consume(repo.objects.header(id)?);
+            progress.inc();
+        }
+        stats
+    };
+
+    progress.show_throughput(start);
 
     #[cfg(feature = "serde1")]
     {

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -775,6 +775,22 @@ pub fn main() -> Result<()> {
             ),
         },
         Subcommands::Odb(cmd) => match cmd {
+            odb::Subcommands::Stats => prepare_and_run(
+                "odb-stats",
+                auto_verbose,
+                progress,
+                progress_keep_open,
+                core::repository::odb::statistics::PROGRESS_RANGE,
+                move |progress, out, err| {
+                    core::repository::odb::statistics(
+                        repository(Mode::Strict)?,
+                        progress,
+                        out,
+                        err,
+                        core::repository::odb::statistics::Options { format, thread_limit },
+                    )
+                },
+            ),
             odb::Subcommands::Entries => prepare_and_run(
                 "odb-entries",
                 verbose,

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -239,6 +239,9 @@ pub mod odb {
         Entries,
         /// Provide general information about the object database.
         Info,
+        /// Count and obtain information on all, possibly duplicate, objects in the database.
+        #[clap(visible_alias = "statistics")]
+        Stats,
     }
 }
 


### PR DESCRIPTION
### Tasks

* [x] loose store can obtain header only.
* [x] pack can obtain header only either with or without following through to the base entry.
* [x] `Find` trait gains `try_header(id)` method.
      It is made so that one can also understand how long the delta chain is if it's not limited to obtain statistical information that is otherwise only available when doing a full pack verification or a full decompression.
* [x] `gix odb stats` to traverse all objects and obtain stats by aggregating header information, with progress, and in parallel.
* [x] `HeaderExt` for convenience.