### PR TITLE
fix(git-url): scp-like URLs should preserve relative and home-relative paths

### DIFF
--- a/cargo-smart-release/src/changelog/write.rs
+++ b/cargo-smart-release/src/changelog/write.rs
@@ -55,7 +55,12 @@ impl RepositoryUrl {
 
     fn cleaned_path(&self) -> String {
         let path = self.inner.path.to_str_lossy().into_owned();
-        path.strip_suffix(".git").map(ToOwned::to_owned).unwrap_or(path)
+        let path = path.strip_suffix(".git").map(ToOwned::to_owned).unwrap_or(path);
+        if !path.starts_with('/') {
+            format!("/{}", path)
+        } else {
+            path
+        }
     }
 
     pub fn github_https(&self) -> Option<String> {

--- a/git-url/src/lib.rs
+++ b/git-url/src/lib.rs
@@ -116,6 +116,14 @@ impl Url {
         self
     }
 
+    /// Set the path (for scp-like). Relative path is kept as it is.
+    fn with_path(mut self, path: Option<&str>) -> Self {
+        if let Some(p) = path {
+            self.path = p.into();
+        }
+        self
+    }
+
     /// Turn a file url like `file://relative` into `file:///root/relative`, hence it assures the url's path component is absolute.
     pub fn canonicalize(&mut self) -> Result<(), git_path::realpath::Error> {
         if self.scheme == Scheme::File {
@@ -192,10 +200,8 @@ impl Url {
         }
         if self.serialize_alternative_form && self.scheme == Scheme::Ssh {
             out.write_all(b":")?;
-            out.write_all(&self.path[1..])?;
-        } else {
-            out.write_all(&self.path)?;
         }
+        out.write_all(&self.path)?;
         Ok(())
     }
 

--- a/git-url/tests/parse/ssh.rs
+++ b/git-url/tests/parse/ssh.rs
@@ -48,10 +48,18 @@ fn with_user_and_without_port() -> crate::Result {
 }
 
 #[test]
+fn with_user_and_with_port() -> crate::Result {
+    assert_url_roundtrip(
+        "ssh://user@host.xz:42/.git",
+        url(Scheme::Ssh, "user", "host.xz", 42, b"/.git"),
+    )
+}
+
+#[test]
 fn scp_like_without_user() -> crate::Result {
     let url = assert_url(
         "host.xz:path/to/git",
-        url_alternate(Scheme::Ssh, None, "host.xz", None, b"/path/to/git"),
+        url_alternate(Scheme::Ssh, None, "host.xz", None, b"path/to/git"),
     )?
     .to_bstring();
     assert_eq!(url, "host.xz:path/to/git");
@@ -59,10 +67,21 @@ fn scp_like_without_user() -> crate::Result {
 }
 
 #[test]
+fn scp_like_with_absolute_path() -> crate::Result {
+    let url = assert_url(
+        "host.xz:/path/to/git",
+        url_alternate(Scheme::Ssh, None, "host.xz", None, b"/path/to/git"),
+    )?
+    .to_bstring();
+    assert_eq!(url, "host.xz:/path/to/git");
+    Ok(())
+}
+
+#[test]
 fn scp_like_without_user_and_username_expansion_without_username() -> crate::Result {
     let url = assert_url(
         "host.xz:~/to/git",
-        url_alternate(Scheme::Ssh, None, "host.xz", None, b"/~/to/git"),
+        url_alternate(Scheme::Ssh, None, "host.xz", None, b"~/to/git"),
     )?
     .to_bstring();
     assert_eq!(url, "host.xz:~/to/git");
@@ -73,7 +92,7 @@ fn scp_like_without_user_and_username_expansion_without_username() -> crate::Res
 fn scp_like_without_user_and_username_expansion_with_username() -> crate::Result {
     let url = assert_url(
         "host.xz:~byron/to/git",
-        url_alternate(Scheme::Ssh, None, "host.xz", None, b"/~byron/to/git"),
+        url_alternate(Scheme::Ssh, None, "host.xz", None, b"~byron/to/git"),
     )?
     .to_bstring();
     assert_eq!(url, "host.xz:~byron/to/git");
@@ -81,19 +100,26 @@ fn scp_like_without_user_and_username_expansion_with_username() -> crate::Result
 }
 
 #[test]
-fn scp_like_with_user_and_relative_path_turns_into_absolute_path() -> crate::Result {
+fn scp_like_with_user_and_relative_path_keep_relative_path() -> crate::Result {
+    let url = assert_url(
+        "user@host.xz:relative",
+        url_alternate(Scheme::Ssh, "user", "host.xz", None, b"relative"),
+    )?
+    .to_bstring();
+    assert_eq!(url, "user@host.xz:relative");
+
     let url = assert_url(
         "user@host.xz:./relative",
-        url_alternate(Scheme::Ssh, "user", "host.xz", None, b"/relative"),
+        url_alternate(Scheme::Ssh, "user", "host.xz", None, b"./relative"),
     )?
     .to_bstring();
     assert_eq!(url, "user@host.xz:relative");
 
     let url = assert_url(
         "user@host.xz:../relative",
-        url_alternate(Scheme::Ssh, "user", "host.xz", None, b"/../relative"),
+        url_alternate(Scheme::Ssh, "user", "host.xz", None, b"../relative"),
     )?
     .to_bstring();
-    assert_eq!(url, "user@host.xz:relative");
+    assert_eq!(url, "user@host.xz:../relative");
     Ok(())
 }


### PR DESCRIPTION
Hello

This PR fixes the relative path handling on SCP-like URLs

SCP-like URLs path part (after the `:`) is relative unless it starts exsplicitely with `/` (or with `~` making it user home relative instead of cwd relative). 

So test have been updated to be consistent with this statement (added some missing cases) and `git-url` implementation fixed to preserve both relative paths and home-relative paths.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
