### PR TITLE
object iteration performance

### DIFF
--- a/git-odb/src/find.rs
+++ b/git-odb/src/find.rs
@@ -87,6 +87,13 @@ mod header {
                 Header::Loose { size, .. } => *size,
             }
         }
+        /// Return the amount of deltas decoded to obtain this header, if the object was packed.
+        pub fn num_deltas(&self) -> Option<u32> {
+            match self {
+                Header::Packed(out) => out.num_deltas.into(),
+                Header::Loose { .. } => None,
+            }
+        }
     }
 
     impl From<git_pack::data::decode::header::Outcome> for Header {

--- a/git-odb/src/store_impls/dynamic/handle.rs
+++ b/git-odb/src/store_impls/dynamic/handle.rs
@@ -77,7 +77,8 @@ pub(crate) mod index_lookup {
     }
 
     impl handle::IndexLookup {
-        /// Return an iterator over the entries of the given pack. The `pack_id` is only required to
+        /// Return an iterator over the entries of the given pack. The `pack_id` is required to identify a pack uniquely within
+        /// a potential multi-pack index.
         pub(crate) fn iter(
             &self,
             pack_id: types::PackId,

--- a/git-odb/src/store_impls/dynamic/header.rs
+++ b/git-odb/src/store_impls/dynamic/header.rs
@@ -82,7 +82,7 @@ where
                                 // multi-pack. Otherwise this would constitute a thin pack which is only allowed in transit.
                                 // However, if we somehow end up with that, we will resolve it safely, even though we could
                                 // avoid handling this case and error instead.
-                                let obj_kind = self
+                                let hdr = self
                                     .try_header_inner(
                                         &base_id,
                                         snapshot,
@@ -98,8 +98,7 @@ where
                                     .ok_or_else(|| Error::DeltaBaseMissing {
                                         base_id,
                                         id: id.to_owned(),
-                                    })?
-                                    .kind();
+                                    })?;
                                 let handle::index_lookup::Outcome {
                                     object_index:
                                         handle::IndexForObjectInPack {
@@ -139,7 +138,8 @@ where
                                         .or_else(|| {
                                             (id == base_id).then(|| {
                                                 git_pack::data::decode::header::ResolvedBase::OutOfPack {
-                                                    kind: obj_kind,
+                                                    kind: hdr.kind(),
+                                                    num_deltas: hdr.num_deltas(),
                                                 }
                                             })
                                         })

--- a/git-odb/src/store_impls/dynamic/iter.rs
+++ b/git-odb/src/store_impls/dynamic/iter.rs
@@ -2,12 +2,21 @@ use std::{ops::Deref, option::Option::None, sync::Arc, vec::IntoIter};
 
 use git_hash::ObjectId;
 
+use crate::store::handle::SingleOrMultiIndex;
+use crate::store::types::PackId;
 use crate::{loose, store::handle, store_impls::dynamic};
+
+struct EntryForOrdering {
+    pack_offset: u64,
+    entry_index: u32,
+    pack_index: u16,
+}
 
 enum State {
     Pack {
         index_iter: IntoIter<handle::IndexLookup>,
         index: handle::IndexLookup,
+        ordered_entries: Option<Vec<EntryForOrdering>>,
         entry_index: u32,
         num_objects: u32,
     },
@@ -18,11 +27,49 @@ enum State {
     Depleted,
 }
 
-/// An iterator over all objects of an object store.
+/// Define the order in which objects are returned.
+#[derive(Debug, Copy, Clone)]
+pub enum Ordering {
+    /// Traverse packs first as sorted by their index files in lexicographical order (sorted by object id), then traverse loose objects
+    /// as sorted by their names as well.
+    ///
+    /// This mode uses no memory as it's the natural ordering of objects, and is best to obtain all object ids as quickly as possible,
+    /// while noting that these may contain duplicates. However, it's very costly to obtain object information or decode them with this
+    /// scheme as cache-hits are unlikely with it and memory maps are less efficient when loading them in random order.
+    PackLexicographicalThenLooseLexicographical,
+    /// Traverse packs first yielding object ids sorted by their position in the pack, with those at the beginning of the pack file coming first.
+    /// Then follow loose objects sorted by their names.
+    ///
+    /// This mode allocates and as to pre-sort objects by their offsets, delaying the start of the iteration once per pack while keeping
+    /// memory allocated once per pack. This price is usually worth paying once querying object information is planned as pack caches
+    /// are more efficiently used that way.
+    PackAscendingOffsetThenLooseLexicographical,
+}
+
+impl Default for Ordering {
+    fn default() -> Self {
+        Ordering::PackLexicographicalThenLooseLexicographical
+    }
+}
+
+/// An iterator over all, _possibly duplicate_, objects of an object store, which by default uses no extra memory but yields an
+/// order that is costly to traverse when querying object information or decoding them.
+///
+/// Use [`with_ordering()`][AllObjects::with_ordering()] to choose a performance trade-off.
 pub struct AllObjects {
     state: State,
     num_objects: usize,
     loose_dbs: Arc<Vec<loose::Store>>,
+    order: Ordering,
+}
+
+/// Builder
+impl AllObjects {
+    /// Set the ordering of the objects returned, trading off memory and latency for object query performance.
+    pub fn with_ordering(mut self, order: Ordering) -> Self {
+        self.order = order;
+        self
+    }
 }
 
 impl AllObjects {
@@ -36,11 +83,13 @@ impl AllObjects {
             .fold(0usize, |dbc, index| dbc.saturating_add(index.num_objects() as usize));
         let mut index_iter = snapshot.indices.into_iter();
         let loose_dbs = snapshot.loose_dbs;
+        let order = Default::default();
         let state = match index_iter.next() {
             Some(index) => {
                 let num_objects = index.num_objects();
                 State::Pack {
                     index_iter,
+                    ordered_entries: maybe_sort_entries(&index, order),
                     index,
                     entry_index: 0,
                     num_objects,
@@ -58,8 +107,48 @@ impl AllObjects {
             state,
             loose_dbs,
             num_objects: packed_objects,
+            order,
         })
     }
+}
+
+fn maybe_sort_entries(index: &handle::IndexLookup, order: Ordering) -> Option<Vec<EntryForOrdering>> {
+    let mut order: Vec<_> = match order {
+        Ordering::PackLexicographicalThenLooseLexicographical => return None,
+        Ordering::PackAscendingOffsetThenLooseLexicographical => match &index.file {
+            // We know that we cannot have more than u32 entry indices per pack.
+            SingleOrMultiIndex::Single { index, .. } => index
+                .iter()
+                .enumerate()
+                .map(|(idx, e)| EntryForOrdering {
+                    pack_offset: e.pack_offset,
+                    entry_index: idx as u32,
+                    pack_index: 0,
+                })
+                .collect(),
+            SingleOrMultiIndex::Multi { index, .. } => index
+                .iter()
+                .enumerate()
+                .map(|(idx, e)| EntryForOrdering {
+                    pack_offset: e.pack_offset,
+                    entry_index: idx as u32,
+                    pack_index: {
+                        debug_assert!(
+                            e.pack_index < PackId::max_packs_in_multi_index(),
+                            "this shows the relation between u16 and pack_index (u32) and why this is OK"
+                        );
+                        e.pack_index as u16
+                    },
+                })
+                .collect(),
+        },
+    };
+    order.sort_by(|a, b| {
+        a.pack_index
+            .cmp(&b.pack_index)
+            .then_with(|| a.pack_offset.cmp(&b.pack_offset))
+    });
+    Some(order)
 }
 
 impl Iterator for AllObjects {
@@ -70,17 +159,23 @@ impl Iterator for AllObjects {
             State::Depleted => None,
             State::Pack {
                 index_iter,
+                ordered_entries,
                 index,
                 entry_index,
                 num_objects,
             } => {
                 if *entry_index < *num_objects {
-                    let oid = index.oid_at_index(*entry_index).to_owned();
+                    let oid = match ordered_entries {
+                        Some(entries) => index.oid_at_index(entries[*entry_index as usize].entry_index),
+                        None => index.oid_at_index(*entry_index),
+                    }
+                    .to_owned();
                     *entry_index += 1;
                     Some(Ok(oid))
                 } else {
                     match index_iter.next() {
                         Some(new_index) => {
+                            *ordered_entries = maybe_sort_entries(&new_index, self.order);
                             *index = new_index;
                             *entry_index = 0;
                             *num_objects = index.num_objects();

--- a/git-odb/src/store_impls/dynamic/types.rs
+++ b/git-odb/src/store_impls/dynamic/types.rs
@@ -49,6 +49,9 @@ impl PackId {
     }
     /// Packs have a built-in identifier to make data structures simpler, and this method represents ourselves as such id
     /// to be convertible back and forth. We essentially compress ourselves into a u32.
+    ///
+    /// Bit 16 is a marker to tell us if it's a mult-pack or not, the ones before are the index file itself, the ones after
+    /// are used to encode the pack index within the multi-pack.
     pub(crate) fn to_intrinsic_pack_id(self) -> git_pack::data::Id {
         assert!(self.index < (1 << 15), "There shouldn't be more than 2^15 indices");
         match self.multipack_index {

--- a/git-odb/tests/odb/find/mod.rs
+++ b/git-odb/tests/odb/find/mod.rs
@@ -1,6 +1,6 @@
 use crate::fixture_path;
 
-fn new_store() -> git_odb::Handle {
+fn db() -> git_odb::Handle {
     git_odb::at(fixture_path("objects")).expect("valid object path")
 }
 
@@ -16,12 +16,12 @@ fn can_find(db: impl git_odb::Find, hex_id: &str) {
 
 #[test]
 fn loose_object() {
-    can_find(&new_store(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
+    can_find(&db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
 }
 
 #[test]
 fn pack_object() {
-    let db = new_store();
+    let db = db();
     can_find(&db, "501b297447a8255d3533c6858bb692575cdefaa0"); // pack 11fd
     can_find(&db, "4dac9989f96bc5b5b1263b582c08f0c5f0b58542"); // pack a2bf
     can_find(&db, "dd25c539efbb0ab018caa4cda2d133285634e9b5"); // pack c043

--- a/git-odb/tests/odb/header/mod.rs
+++ b/git-odb/tests/odb/header/mod.rs
@@ -1,10 +1,5 @@
-use crate::fixture_path;
-
-fn new_store() -> git_odb::Handle {
-    git_odb::at(fixture_path("objects")).expect("valid object path")
-}
-
 use crate::hex_to_id;
+use crate::odb::db;
 
 fn find_header(db: impl git_odb::Header, hex_id: &str) -> git_odb::find::Header {
     db.try_header(hex_to_id(hex_id))
@@ -14,12 +9,12 @@ fn find_header(db: impl git_odb::Header, hex_id: &str) -> git_odb::find::Header 
 
 #[test]
 fn loose_object() {
-    find_header(&new_store(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
+    find_header(&db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
 }
 
 #[test]
 fn pack_object() {
-    let db = new_store();
+    let db = db();
     assert_eq!(
         find_header(&db, "501b297447a8255d3533c6858bb692575cdefaa0"), // pack 11fd
         git_odb::find::Header::Packed(git_pack::data::decode::header::Outcome {

--- a/git-odb/tests/odb/mod.rs
+++ b/git-odb/tests/odb/mod.rs
@@ -2,6 +2,14 @@ pub use git_testtools::{fixture_path, hex_to_id, scripted_fixture_read_only};
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+fn db() -> git_odb::Handle {
+    git_odb::at(fixture_path("objects")).expect("valid object path")
+}
+
+fn db_small_packs() -> git_odb::Handle {
+    git_odb::at(fixture_path("repos/small-packs.git/objects")).unwrap()
+}
+
 pub mod alternate;
 pub mod find;
 pub mod header;

--- a/git-odb/tests/odb/regression/mod.rs
+++ b/git-odb/tests/odb/regression/mod.rs
@@ -1,11 +1,11 @@
 mod repo_with_small_packs {
     use git_odb::Find;
 
-    use crate::odb::{fixture_path, hex_to_id};
+    use crate::odb::{db_small_packs, hex_to_id};
 
     #[test]
     fn all_packed_objects_can_be_found() -> crate::Result {
-        let store = git_odb::at(fixture_path("repos/small-packs.git/objects"))?;
+        let store = db_small_packs();
         let mut buf = Vec::new();
         assert!(
             store
@@ -18,24 +18,23 @@ mod repo_with_small_packs {
 
     #[test]
     #[cfg(feature = "internal-testing-git-features-parallel")]
-    fn multi_threaded_access_will_not_panic() {
+    fn multi_threaded_access_will_not_panic() -> crate::Result {
         for arg in ["no", "without-multi-index"] {
-            let base = git_testtools::scripted_fixture_read_only_with_args("make_repo_multi_index.sh", Some(arg))
-                .unwrap()
+            let base = git_testtools::scripted_fixture_read_only_with_args("make_repo_multi_index.sh", Some(arg))?
                 .join(".git")
                 .join("objects");
-            let store = git_odb::at(base).unwrap();
+            let store = git_odb::at(base)?;
             let (tx, barrier) = crossbeam_channel::unbounded::<()>();
             let handles = (0..num_cpus::get()).map(|tid| {
                 std::thread::spawn({
                     let store = store.clone();
                     let barrier = barrier.clone();
-                    move || {
+                    move || -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
                         barrier.recv().ok();
                         let mut buf = Vec::new();
                         let mut count = 0;
-                        for id in store.iter().unwrap() {
-                            let id = id.unwrap();
+                        for id in store.iter()? {
+                            let id = id?;
                             assert!(
                                 store.try_find(id, &mut buf).is_ok(),
                                 "Thread {} could not find {}",
@@ -44,18 +43,27 @@ mod repo_with_small_packs {
                             );
                             count += 1;
                         }
-                        count
+                        Ok(count)
                     }
                 })
             });
 
             std::thread::sleep(std::time::Duration::from_millis(50));
             drop(tx);
-            let expected = store.iter().unwrap().count();
+            let expected = store.iter()?.count();
+            assert_eq!(
+                store
+                    .iter()?
+                    .with_ordering(git_odb::store::iter::Ordering::PackAscendingOffsetThenLooseLexicographical)
+                    .count(),
+                expected,
+                "different ordering doesn't change the count"
+            );
             for handle in handles {
-                let actual = handle.join().expect("no panic");
+                let actual = handle.join().expect("no panic").expect("no error in thread");
                 assert_eq!(actual, expected);
             }
         }
+        Ok(())
     }
 }

--- a/git-odb/tests/odb/store/compound.rs
+++ b/git-odb/tests/odb/store/compound.rs
@@ -2,16 +2,11 @@
 //! to be sure we don't loose coverage. This might, however, be overlapping with much more thorough
 //! tests o the general store itself, so they can possibly be removed at some point.
 
-use crate::fixture_path;
-
-fn db() -> git_odb::Handle {
-    git_odb::at(fixture_path("objects")).expect("valid object path")
-}
-
 mod locate {
     use git_odb::Find;
 
-    use crate::{hex_to_id, odb::store::compound::db};
+    use crate::hex_to_id;
+    use crate::odb::db;
 
     fn can_locate(db: &git_odb::Handle, hex_id: &str) {
         let mut buf = vec![];

--- a/git-odb/tests/odb/store/linked.rs
+++ b/git-odb/tests/odb/store/linked.rs
@@ -1,17 +1,10 @@
 //! These are old tests of the now removed linked odb, but executed on the general store
 //! to be sure we don't loose coverage. This might, however, be overlapping with much more thorough
 //! tests o the general store itself, so they can possibly be removed at some point.
-use crate::fixture_path;
-
-fn db() -> git_odb::Handle {
-    git_odb::at(fixture_path("objects")).expect("valid object path")
-}
-
 mod iter {
+    use crate::odb::db;
     use git_odb::Header;
     use git_pack::Find;
-
-    use crate::odb::store::linked::db;
 
     #[test]
     fn a_bunch_of_loose_and_packed_objects() -> crate::Result {
@@ -36,7 +29,8 @@ mod locate {
     use git_odb::Handle;
     use git_pack::Find;
 
-    use crate::{hex_to_id, odb::store::linked::db};
+    use crate::hex_to_id;
+    use crate::odb::db;
 
     fn can_locate(db: &Handle, hex_id: &str) {
         let mut buf = vec![];
@@ -60,10 +54,11 @@ mod locate {
 }
 
 mod init {
+    use crate::odb::alternate::alternate;
     use git_hash::ObjectId;
     use git_odb::Find;
 
-    use crate::odb::{alternate::alternate, store::linked::db};
+    use crate::odb::db;
 
     #[test]
     fn multiple_linked_repositories_via_alternates() -> crate::Result {

--- a/git-pack/src/data/entry/mod.rs
+++ b/git-pack/src/data/entry/mod.rs
@@ -13,7 +13,7 @@ const REF_DELTA: u8 = 7;
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Location {
-    /// The id of the pack containing the object. It's unique within its frame of reference which is he owning object database.
+    /// The id of the pack containing the object. It's unique within its frame of reference which is the owning object database.
     pub pack_id: u32,
     /// The size of the entry of disk so that the range of bytes of the entry is `pack_offset..pack_offset + entry_size`.
     pub entry_size: usize,


### PR DESCRIPTION
### Tasks

* [x] ordering for `AllObjects` iterator
* ~~optional delta chain cache for `header()` similar to the pack cache for `find()`~~ - the cache doesn't speed up anything unfortunately.