### PR TITLE
open::Options::open_path_as_is()

### DIFF
--- a/git-repository/src/open/mod.rs
+++ b/git-repository/src/open/mod.rs
@@ -23,6 +23,7 @@ pub struct Options {
     pub(crate) bail_if_untrusted: bool,
     pub(crate) api_config_overrides: Vec<BString>,
     pub(crate) cli_config_overrides: Vec<BString>,
+    pub(crate) open_path_as_is: bool,
     /// Internal to pass an already obtained CWD on to where it may also be used. This avoids the CWD being queried more than once per repo.
     pub(crate) current_dir: Option<PathBuf>,
 }

--- a/git-repository/src/open/options.rs
+++ b/git-repository/src/open/options.rs
@@ -13,6 +13,7 @@ impl Default for Options {
             lossy_config: None,
             lenient_config: true,
             bail_if_untrusted: false,
+            open_path_as_is: false,
             api_config_overrides: Vec::new(),
             cli_config_overrides: Vec::new(),
             current_dir: None,
@@ -66,6 +67,15 @@ impl Options {
     /// Set the given permissions, which are typically derived by a `Trust` level.
     pub fn permissions(mut self, permissions: Permissions) -> Self {
         self.permissions = permissions;
+        self
+    }
+
+    /// If `true`, default `false`, we will not modify the incoming path to open to assure it is a `.git` directory.
+    ///
+    /// If `false`, we will try to open the input directory as is, even though it doesn't appear to be a `git` repository
+    /// due to the lack of `.git` suffix or because its basename is not `.git` as in `worktree/.git`.
+    pub fn open_path_as_is(mut self, enable: bool) -> Self {
+        self.open_path_as_is = enable;
         self
     }
 
@@ -146,6 +156,7 @@ impl git_sec::trust::DefaultForLevel for Options {
                 lossy_config: None,
                 bail_if_untrusted: false,
                 lenient_config: true,
+                open_path_as_is: false,
                 api_config_overrides: Vec::new(),
                 cli_config_overrides: Vec::new(),
                 current_dir: None,
@@ -157,6 +168,7 @@ impl git_sec::trust::DefaultForLevel for Options {
                 filter_config_section: Some(config::section::is_trusted),
                 bail_if_untrusted: false,
                 lenient_config: true,
+                open_path_as_is: false,
                 lossy_config: None,
                 api_config_overrides: Vec::new(),
                 cli_config_overrides: Vec::new(),

--- a/git-repository/tests/repository/open.rs
+++ b/git-repository/tests/repository/open.rs
@@ -46,6 +46,34 @@ mod not_a_repository {
     }
 }
 
+mod open_path_as_is {
+    use crate::util::{named_subrepo_opts, repo_opts};
+    use git_repository as git;
+
+    fn open_path_as_is() -> git::open::Options {
+        git::open::Options::isolated().open_path_as_is(true)
+    }
+
+    #[test]
+    fn bare_repos_open_normally() -> crate::Result {
+        assert!(named_subrepo_opts("make_basic_repo.sh", "bare.git", open_path_as_is())?.is_bare());
+        Ok(())
+    }
+
+    #[test]
+    fn worktrees_cannot_be_opened() -> crate::Result {
+        let err = repo_opts("make_basic_repo.sh", open_path_as_is()).unwrap_err();
+        assert!(matches!(err, git::open::Error::NotARepository { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn git_dir_within_worktrees_open_normally() -> crate::Result {
+        assert!(!named_subrepo_opts("make_basic_repo.sh", ".git", open_path_as_is())?.is_bare());
+        Ok(())
+    }
+}
+
 mod submodules {
     use std::path::Path;
 

--- a/git-repository/tests/util/mod.rs
+++ b/git-repository/tests/util/mod.rs
@@ -18,6 +18,11 @@ pub fn repo(name: &str) -> Result<ThreadSafeRepository> {
     Ok(ThreadSafeRepository::open_opts(repo_path, restricted())?)
 }
 
+pub fn repo_opts(name: &str, opts: open::Options) -> std::result::Result<ThreadSafeRepository, open::Error> {
+    let repo_path = git_testtools::scripted_fixture_read_only(name).unwrap();
+    ThreadSafeRepository::open_opts(repo_path, opts)
+}
+
 pub fn named_repo(name: &str) -> Result<Repository> {
     let repo_path = git_testtools::scripted_fixture_read_only(name)?;
     Ok(ThreadSafeRepository::open_opts(repo_path, restricted())?.to_thread_local())


### PR DESCRIPTION
The path to git repositories is well-known as they either end in `.git` or `.../.git`.
If this is not the case, by default we append `/.git` to the path.

With this new option enabled, no path transformations apply to open the given path as is,
which is preferable if you know it's a non-standard git repository folder name.
