### PR TITLE
fix(ssh): fixes SSH clones

### DIFF
--- a/git-repository/Cargo.toml
+++ b/git-repository/Cargo.toml
@@ -152,3 +152,8 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 [package.metadata.docs.rs]
 features = ["document-features", "max-performance", "blocking-network-client", "serde1"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+
+[[example]]
+name = "clone"
+required-features = ["blocking-network-client"]

--- a/git-repository/examples/clone.rs
+++ b/git-repository/examples/clone.rs
@@ -1,0 +1,51 @@
+// Clone a repository from any URL or Path to a given taget directory
+
+use anyhow::Context;
+use git_repository as git;
+
+fn main() -> anyhow::Result<()> {
+    let repo_url = std::env::args_os()
+        .nth(1)
+        .context("First argument needs to be the repository URL")?;
+
+    let dst = std::env::args_os()
+        .nth(2)
+        .context("Second argument needs to be the directory to clone the repository in")?;
+
+    std::fs::create_dir_all(&dst)?;
+
+    let url = git_url::parse(repo_url.to_str().unwrap().into())?;
+
+    println!("Url: {:?}", url.to_bstring());
+
+    let mut prepare = git::prepare_clone(url, &dst)?;
+
+    println!("Cloning {repo_url:?} into {dst:?}...");
+
+    let (mut checkout, _) =
+        prepare.fetch_then_checkout(git::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
+
+    println!(
+        "Checking out into {:?} ...",
+        checkout.repo().work_dir().expect("should be there")
+    );
+
+    let (repo, _) = checkout.main_worktree(git::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
+
+    println!("Repo cloned into {:?}", repo.work_dir().expect("Should be there"));
+
+    let remote = repo
+        .find_default_remote(git::remote::Direction::Fetch)
+        .expect("Should be there")?;
+
+    println!(
+        "Default remote: {} -> {}",
+        remote.name().expect("should be origin").as_bstr(),
+        remote
+            .url(git::remote::Direction::Fetch)
+            .expect("should be the remote URL")
+            .to_bstring(),
+    );
+
+    Ok(())
+}

--- a/git-transport/src/client/blocking_io/file.rs
+++ b/git-transport/src/client/blocking_io/file.rs
@@ -131,7 +131,7 @@ impl client::Transport for SpawnProcessOnDemand {
         if self.ssh_program.is_some() {
             cmd.arg(service.as_str());
         }
-        cmd.arg("--strict").arg("--timeout=0").arg(self.path.to_os_str_lossy());
+        cmd.arg(self.path.to_os_str_lossy());
 
         let mut child = cmd.spawn()?;
         self.connection = Some(git::Connection::new_for_spawned_process(

--- a/git-url/src/lib.rs
+++ b/git-url/src/lib.rs
@@ -149,7 +149,7 @@ impl Url {
             Some(match self.scheme {
                 Http => 80,
                 Https => 443,
-                Ssh => 21,
+                Ssh => 22,
                 Git => 9418,
                 File | Ext(_) => return None,
             })

--- a/git-url/tests/parse/ssh.rs
+++ b/git-url/tests/parse/ssh.rs
@@ -56,6 +56,15 @@ fn with_user_and_port_and_absolute_path() -> crate::Result {
 }
 
 #[test]
+fn default_port_is_22() -> crate::Result {
+    let url = url_alternate(Scheme::Ssh, None, "host.xz", None, b"path/to/git");
+
+    assert_eq!(url.port_or_default(), Some(22));
+
+    Ok(())
+}
+
+#[test]
 fn scp_like_without_user() -> crate::Result {
     let url = assert_url(
         "host.xz:path/to/git",


### PR DESCRIPTION
This PR fixes SSH cloning handling by:

- Settings the default SSH port to 22 (was set to 21)
- Removing git-upload-pack extra parameters (rejected by both github and gitlab, the original `git` client is not sending those, can be verified by cloning any repository with github/gitlab `GIT_SSH_COMMAND="ssh -vvvv"`)
- Removing the double user inclusion in URL (resulting in `git@git@github:` URLs as well as broken paths given as SSH parameters)
- Properly handling relative paths in URL reconstruction on `connect()`

This PR follows #663 but while #663 was focusing on SCP-like URLs handling with some predefined test cases, this PR was done directly including the code in a project: results in the ability to clone directly from copy-pasted github and gitlab SCP-like provided repositories URLs 🎉 

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
