### PR TITLE
build(rust-toolchain): fix rust-toolchain.toml extension and format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,9 @@ jobs:
       - name: "Install prerequisites"
         run: vcpkg install  zlib:x64-windows-static-md
       - name: "Installation from crates.io: gitoxide"
-        run: cargo install --target ${{ matrix.target }} --target-dir install-artifacts --debug --force gitoxide
+        run: cargo +${{ matrix.rust }} install --target ${{ matrix.target }} --target-dir install-artifacts --debug --force gitoxide
       - name: "Installation from crates.io: cargo-smart-release"
-        run: cargo install --target ${{ matrix.target }} --target-dir install-artifacts --debug --force cargo-smart-release
+        run: cargo +${{ matrix.rust }} install --target ${{ matrix.target }} --target-dir install-artifacts --debug --force cargo-smart-release
 
   lint:
     runs-on: ubuntu-latest

--- a/rust-toolchain.tml
+++ b/rust-toolchain.tml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable-1.65"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.65"


### PR DESCRIPTION
This PR fixes the `rust-toolchain.yaml` file having a typo in the extension (`tml` instead of `toml`) and a format not handled by `Cargo` nor `rustup`: 
`channel` was `stable-1.65` and should be either `stable` or `1.65`, I choose to stick with `1.65` for the same Clippy issue than CI, see:
- https://github.com/Byron/gitoxide/blob/main/.github/workflows/ci.yml#L123
- 680c1436d0a8cb1d2f602369120c5bc0e36815b1

CI jobs command with a specific toolchain (Windows jobs) have been updated to force the toolchain from command line with `cargo +<toolchain>` syntax.

This fixes the `make tests` command for local development (aka. `clippy` more precisely)

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
