### PR TITLE
fix: remove panic-assertions in `loose` `lookup_prefix`

### DIFF
--- a/git-repository/tests/revision/spec/from_bytes/mod.rs
+++ b/git-repository/tests/revision/spec/from_bytes/mod.rs
@@ -105,7 +105,7 @@ fn bad_objects_are_valid_until_they_are_actually_read_from_the_odb() {
         );
         assert_eq!(
             &format!("{:?}", parse_spec("cafea^{object}", &repo).unwrap_err())[..80],
-            r#"FindObject(Find(Loose(DecompressFile { source: Inflate(DecompressError(General {"#
+            r#"FindObject(Find(Loose(DecompressFile { source: Zlib(Inflate(DecompressError(Gene"#
         );
     }
 }


### PR DESCRIPTION
(Potentially partial) fix for starship/starship#4755

The release assertions in `git-odb/src/store_impls/loose/find.rs` could lead to panics in corrupted git repositories. I replaced them with explicit error variants.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
