### PR TITLE
Fix default author and committer times

### DIFF
--- a/git-config/tests/file/init/from_paths/includes/conditional/mod.rs
+++ b/git-config/tests/file/init/from_paths/includes/conditional/mod.rs
@@ -145,7 +145,7 @@ fn git_init(path: impl AsRef<std::path::Path>, bare: bool) -> crate::Result<git:
         bare.then(|| git::create::Kind::Bare)
             .unwrap_or(git::create::Kind::WithWorktree),
         git::create::Options::default(),
-        git::open::Options::isolated(),
+        git::open::Options::isolated().config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"]),
     )?
     .to_thread_local())
 }

--- a/git-config/tests/file/init/from_paths/includes/conditional/onbranch.rs
+++ b/git-config/tests/file/init/from_paths/includes/conditional/onbranch.rs
@@ -287,7 +287,7 @@ value = branch-override-by-include
             git::lock::acquire::Fail::Immediately,
             git::lock::acquire::Fail::Immediately,
         )?
-        .commit(repo.committer_or_default())?;
+        .commit(repo.committer().expect("pre-configured"))?;
 
     let dir = assure_git_agrees(expect, dir)?;
     Ok(GitEnv { repo, dir })

--- a/git-repository/src/clone/fetch/mod.rs
+++ b/git-repository/src/clone/fetch/mod.rs
@@ -28,6 +28,8 @@ pub enum Error {
         source: git_validate::refname::Error,
         head_ref_name: BString,
     },
+    #[error("The committer identity is required to produce a ref-log is not configured.")]
+    ReflogCommitterMissing,
     #[error("Failed to update HEAD with values from remote")]
     HeadUpdate(#[from] crate::reference::edit::Error),
 }

--- a/git-repository/src/clone/fetch/util.rs
+++ b/git-repository/src/clone/fetch/util.rs
@@ -131,7 +131,7 @@ pub fn update_head(
                     git_lock::acquire::Fail::Immediately,
                 )
                 .map_err(crate::reference::edit::Error::from)?
-                .commit(repo.committer_or_default())
+                .commit(repo.committer().ok_or(Error::ReflogCommitterMissing)?)
                 .map_err(crate::reference::edit::Error::from)?;
 
             if let Some(head_peeled_id) = head_peeled_id {

--- a/git-repository/src/commit.rs
+++ b/git-repository/src/commit.rs
@@ -7,6 +7,10 @@ pub const NO_PARENT_IDS: [git_hash::ObjectId; 0] = [];
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("Committer identity is not configured")]
+    CommitterMissing,
+    #[error("Author identity is not conifgured")]
+    AuthorMissing,
     #[error(transparent)]
     ReferenceNameValidation(#[from] git_ref::name::Error),
     #[error(transparent)]

--- a/git-repository/src/open/options.rs
+++ b/git-repository/src/open/options.rs
@@ -26,9 +26,7 @@ impl Options {
     /// Options configured to prevent accessing anything else than the repository configuration file, prohibiting
     /// accessing the environment or spreading beyond the git repository location.
     pub fn isolated() -> Self {
-        Options::default()
-            .permissions(Permissions::isolated())
-            .config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"])
+        Options::default().permissions(Permissions::isolated())
     }
 }
 

--- a/git-repository/src/open/options.rs
+++ b/git-repository/src/open/options.rs
@@ -26,7 +26,9 @@ impl Options {
     /// Options configured to prevent accessing anything else than the repository configuration file, prohibiting
     /// accessing the environment or spreading beyond the git repository location.
     pub fn isolated() -> Self {
-        Options::default().permissions(Permissions::isolated())
+        Options::default()
+            .permissions(Permissions::isolated())
+            .config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"])
     }
 }
 

--- a/git-repository/src/reference/errors.rs
+++ b/git-repository/src/reference/errors.rs
@@ -13,6 +13,8 @@ pub mod edit {
         NameValidation(#[from] git_validate::reference::name::Error),
         #[error("Could not interpret core.filesRefLockTimeout or core.packedRefsTimeout, it must be the number in milliseconds to wait for locks or negative to wait forever")]
         LockTimeoutConfiguration(#[from] git_config::value::Error),
+        #[error("The committer identity is required to produce a ref-log is not configured.")]
+        ReflogCommitterMissing,
     }
 }
 

--- a/git-repository/src/remote/connection/fetch/update_refs/mod.rs
+++ b/git-repository/src/remote/connection/fetch/update_refs/mod.rs
@@ -246,7 +246,7 @@ pub(crate) fn update(
                 )
                 .prepare(edits, file_lock_fail, packed_refs_lock_fail)
                 .map_err(crate::reference::edit::Error::from)?
-                .commit(repo.committer_or_default())
+                .commit(repo.committer().ok_or(crate::reference::edit::Error::ReflogCommitterMissing)?)
                 .map_err(crate::reference::edit::Error::from)?
         }
         fetch::DryRun::Yes => edits,

--- a/git-repository/src/remote/connection/fetch/update_refs/tests.rs
+++ b/git-repository/src/remote/connection/fetch/update_refs/tests.rs
@@ -1,3 +1,7 @@
+pub fn restricted() -> crate::open::Options {
+    crate::open::Options::isolated().config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"])
+}
+
 mod update {
     use std::convert::TryInto;
 
@@ -19,7 +23,7 @@ mod update {
     fn repo(name: &str) -> git::Repository {
         let dir =
             git_testtools::scripted_fixture_read_only_with_args("make_fetch_repos.sh", [base_repo_path()]).unwrap();
-        git::open_opts(dir.join(name), git::open::Options::isolated()).unwrap()
+        git::open_opts(dir.join(name), restricted()).unwrap()
     }
     fn repo_rw(name: &str) -> (git::Repository, git_testtools::tempfile::TempDir) {
         let dir = git_testtools::scripted_fixture_writable_with_args(
@@ -28,11 +32,12 @@ mod update {
             git_testtools::Creation::ExecuteScript,
         )
         .unwrap();
-        let repo = git::open_opts(dir.path().join(name), git::open::Options::isolated()).unwrap();
+        let repo = git::open_opts(dir.path().join(name), restricted()).unwrap();
         (repo, dir)
     }
     use git_ref::{transaction::Change, TargetRef};
 
+    use crate::remote::fetch::refs::tests::restricted;
     use crate::{
         bstr::BString,
         remote::{
@@ -176,7 +181,7 @@ mod update {
             [base_repo_path()],
         )?)?;
         let repo = root.join("worktree-root");
-        let repo = git::open_opts(repo, git::open::Options::isolated())?;
+        let repo = git::open_opts(repo, restricted())?;
         for (branch, path_from_root) in [
             ("main", "worktree-root"),
             ("wt-a-nested", "prev/wt-a-nested"),

--- a/git-repository/src/repository/identity.rs
+++ b/git-repository/src/repository/identity.rs
@@ -1,39 +1,23 @@
 use std::time::SystemTime;
 
-use crate::bstr::{BStr, BString, ByteSlice};
+use crate::bstr::{BString, ByteSlice};
 
 /// Identity handling.
+///
+/// # Deviation
+///
+/// There is no notion of a default user like in git, and instead failing to provide a user
+/// is fatal. That way, we enforce correctness and force application developers to take care
+/// of this issue which can be done in various ways, for instance by setting
+/// `gitoxide.committer.nameFallback` and similar.
 impl crate::Repository {
-    /// Return a crate-specific constant signature with [`Time`][git_actor::Time] set to now, or whatever
-    /// was overridden via `GIT_COMMITTER_TIME` or `GIT_AUTHOR_TIME` if these variables are allowed to be read,
-    /// in a similar vein as the default that git chooses if there is nothing configured.
-    ///
-    /// This can be useful as fallback for an unset `committer` or `author`.
-    ///
-    /// # Note
-    ///
-    /// The values are cached when the repository is instantiated.
-    pub fn user_default(&self) -> git_actor::SignatureRef<'_> {
-        let (name, email) = self.default_actor();
-        git_actor::SignatureRef {
-            name,
-            email,
-            time: git_date::Time::now_local_or_utc(),
-        }
-    }
-
-    fn default_actor(&self) -> (&BStr, &BStr) {
-        ("gitoxide".into(), "gitoxide@localhost".into())
-    }
-
     /// Return the committer as configured by this repository, which is determined by…
     ///
     /// * …the git configuration `committer.name|email`…
     /// * …the `GIT_COMMITTER_(NAME|EMAIL|DATE)` environment variables…
     /// * …the configuration for `user.name|email` as fallback…
     ///
-    /// …and in that order, or `None` if there was nothing configured. In that case, one may use the
-    /// [`committer_or_default()`][Self::committer_or_default()] method.
+    /// …and in that order, or `None` if there was nothing configured.
     ///
     /// # Note
     ///
@@ -54,28 +38,13 @@ impl crate::Repository {
         .into()
     }
 
-    /// Like [`committer()`][Self::committer()], but may use a default value in case nothing is configured.
-    pub fn committer_or_default(&self) -> git_actor::SignatureRef<'_> {
-        self.committer().unwrap_or_else(|| {
-            let (name, email) = self.default_actor();
-            let time = self
-                .config
-                .personas()
-                .committer
-                .time
-                .unwrap_or_else(git_date::Time::now_local_or_utc);
-            git_actor::SignatureRef { name, email, time }
-        })
-    }
-
     /// Return the author as configured by this repository, which is determined by…
     ///
     /// * …the git configuration `author.name|email`…
     /// * …the `GIT_AUTHOR_(NAME|EMAIL|DATE)` environment variables…
     /// * …the configuration for `user.name|email` as fallback…
     ///
-    /// …and in that order, or `None` if there was nothing configured. In that case, one may use the
-    /// [`author_or_default()`][Self::author_or_default()] method.
+    /// …and in that order, or `None` if there was nothing configured.
     ///
     /// # Note
     ///
@@ -89,20 +58,6 @@ impl crate::Repository {
             time: p.author.time.unwrap_or_else(git_date::Time::now_local_or_utc),
         }
         .into()
-    }
-
-    /// Like [`author()`][Self::author()], but may use a default value in case nothing is configured.
-    pub fn author_or_default(&self) -> git_actor::SignatureRef<'_> {
-        self.author().unwrap_or_else(|| {
-            let (name, email) = self.default_actor();
-            let time = self
-                .config
-                .personas()
-                .author
-                .time
-                .unwrap_or_else(git_date::Time::now_local_or_utc);
-            git_actor::SignatureRef { name, email, time }
-        })
     }
 }
 

--- a/git-repository/src/repository/object.rs
+++ b/git-repository/src/repository/object.rs
@@ -196,8 +196,8 @@ impl crate::Repository {
         Name: TryInto<FullName, Error = E>,
         commit::Error: From<E>,
     {
-        let author = self.author_or_default();
-        let committer = self.committer_or_default();
+        let author = self.author().ok_or(commit::Error::AuthorMissing)?;
+        let committer = self.committer().ok_or(commit::Error::CommitterMissing)?;
         self.commit_as(committer, author, reference, message, tree, parents)
     }
 

--- a/git-repository/src/repository/reference.rs
+++ b/git-repository/src/repository/reference.rs
@@ -136,7 +136,7 @@ impl crate::Repository {
         self.refs
             .transaction()
             .prepare(edits, file_lock_fail, packed_refs_lock_fail)?
-            .commit(self.committer_or_default())
+            .commit(self.committer().ok_or(reference::edit::Error::ReflogCommitterMissing)?)
             .map_err(Into::into)
     }
 

--- a/git-repository/tests/clone/mod.rs
+++ b/git-repository/tests/clone/mod.rs
@@ -25,6 +25,8 @@ mod blocking_io {
             git::open::Options::isolated().config_overrides([
                 "init.defaultBranch=unused-as-overridden-by-remote",
                 "core.logAllRefUpdates",
+                "user.name=a",
+                "user.email=b",
             ]),
         )?
         .with_remote_name(remote_name)?

--- a/git-repository/tests/init/mod.rs
+++ b/git-repository/tests/init/mod.rs
@@ -62,7 +62,11 @@ mod non_bare {
             tmp.path(),
             git::create::Kind::Bare,
             git::create::Options::default(),
-            git::open::Options::isolated().config_overrides(Some("init.defaultBranch=special")),
+            git::open::Options::isolated().config_overrides([
+                "user.name=a",
+                "user.email=b",
+                "init.defaultBranch=special",
+            ]),
         )?
         .into();
         assert_eq!(

--- a/git-repository/tests/remote/fetch.rs
+++ b/git-repository/tests/remote/fetch.rs
@@ -34,7 +34,7 @@ mod blocking_and_async_io {
             git_testtools::Creation::ExecuteScript,
         )
         .unwrap();
-        let repo = git::open_opts(dir.path().join(name), git::open::Options::isolated()).unwrap();
+        let repo = git::open_opts(dir.path().join(name), crate::restricted()).unwrap();
         (repo, dir)
     }
 

--- a/git-repository/tests/repository/config/identity.rs
+++ b/git-repository/tests/repository/config/identity.rs
@@ -136,8 +136,8 @@ fn author_from_different_config_sections() {
     let work_dir = repo.work_dir().unwrap().canonicalize().unwrap();
 
     let _env = Env::new()
-        .set("GIT_CONFIG_GLOBAL", work_dir.join("global.config").to_string_lossy())
-        .set("GIT_CONFIG_SYSTEM", work_dir.join("system.config").to_string_lossy())
+        .set("GIT_CONFIG_GLOBAL", work_dir.join("global.config").to_str().unwrap())
+        .set("GIT_CONFIG_SYSTEM", work_dir.join("system.config").to_str().unwrap())
         .set("GIT_AUTHOR_DATE", "1979-02-26 18:30:00")
         .set("GIT_COMMITTER_DATE", "1980-02-26 18:30:00 +0000")
         .set("EMAIL", "general@email-unused");
@@ -169,6 +169,8 @@ fn author_from_different_config_sections() {
                 sign: git_date::time::Sign::Plus
             }
         }),
+        "author name comes from global config, \
+         but email comes from repository-local config",
     );
     assert_eq!(
         repo.committer(),
@@ -180,7 +182,9 @@ fn author_from_different_config_sections() {
                 offset_in_seconds: 0,
                 sign: git_date::time::Sign::Plus,
             }
-        })
+        }),
+        "committer name comes from repository-local config, \
+         but committer email comes from global config"
     );
     assert_eq!(
         repo.user_default().actor(),

--- a/git-repository/tests/repository/config/identity.rs
+++ b/git-repository/tests/repository/config/identity.rs
@@ -59,12 +59,6 @@ fn author_and_committer_and_fallback() {
             assert_eq!(actual.name, "committer");
             assert_eq!(actual.email, "committer@email");
         }
-        {
-            let actual = repo.user_default();
-            assert_eq!(actual.name, "gitoxide");
-            assert_eq!(actual.email, "gitoxide@localhost");
-        }
-
         let config = repo.config_snapshot();
 
         assert_eq!(config.boolean("core.bare"), Some(false));
@@ -146,6 +140,7 @@ fn author_from_different_config_sections() {
         repo.git_dir(),
         repo.open_options()
             .clone()
+            .config_overrides(None::<&str>)
             .with(git_sec::Trust::Full)
             .permissions(git::Permissions {
                 env: git::permissions::Environment {
@@ -185,9 +180,5 @@ fn author_from_different_config_sections() {
         }),
         "committer name comes from repository-local config, \
          but committer email comes from global config"
-    );
-    assert_eq!(
-        repo.user_default().actor(),
-        ("gitoxide".into(), "gitoxide@localhost".into())
     );
 }

--- a/git-repository/tests/repository/object.rs
+++ b/git-repository/tests/repository/object.rs
@@ -127,7 +127,7 @@ mod tag {
             "v1.0.0",
             current_head_id,
             git_object::Kind::Commit,
-            Some(repo.committer_or_default()),
+            Some(repo.committer().expect("present")),
             message,
             git_ref::transaction::PreviousValue::MustNotExist,
         )?;
@@ -140,7 +140,7 @@ mod tag {
         assert_eq!(tag.target_kind, git_object::Kind::Commit);
         assert_eq!(
             tag.tagger.as_ref().expect("tagger").actor(),
-            repo.committer_or_default().actor()
+            repo.committer().expect("present").actor()
         );
         assert_eq!(tag.message, message);
         Ok(())

--- a/git-repository/tests/util/mod.rs
+++ b/git-repository/tests/util/mod.rs
@@ -34,11 +34,11 @@ pub fn named_subrepo_opts(fixture: &str, name: &str, opts: open::Options) -> Res
 }
 
 pub fn restricted() -> open::Options {
-    open::Options::isolated()
+    open::Options::isolated().config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"])
 }
 
 pub fn restricted_and_git() -> open::Options {
-    let mut opts = open::Options::isolated();
+    let mut opts = restricted();
     opts.permissions.env.git_prefix = git_sec::Permission::Allow;
     opts.permissions.env.identity = git_sec::Permission::Allow;
     opts


### PR DESCRIPTION
The commit message for a05b1c4d82bc6c7758989a3bbe326ea610903820 tells the whole story.

One aside, however, is that it is not apparent to me how much utility `Repository::user_default()` has. This public method was only used in `author_or_default()` and `committer_or_default()` and is now not used at all within gitoxide. I cannot think of any circumstances where a user of the git-repository crate would ever want to call `user_default()`. But the presence of `user_default()` could cause people to miss `author()` or `committer()`. Point being: consider whether to remove `user_default()` from `Repository`.

Second aside: the static default user name and email of "gitoxide" and "gitoxide@localhost" differ from git's fallbacks. If no user name is configured, it then interrogates the OS via `getpwuid()` before finally falling back to "Unknown". And in the case of no user email being configured, it interrogates the OS for the hostname via `gethostname()` and joins the previously discovered username or "unknown" with the hostname which might thus ultimately fall back to "unknown@localhost". I don't think gitoxide should be doing the same dance as git for divining user and email identity because it ends up being platform dependent, additional crate dependencies, and, even with the effort, almost certainly the wrong user identity. But the static "gitoxide"/"gitoxide@localhost" fallbacks are also always wrong. My argument here is to also consider removing the `author_or_default()`** and `committer_or_default()` methods from `Repository`. So just have `author()` and `committer()` and leave it the application to decide what to do if `author()` or `committer()` fail.

For StGit, I am doing what git also ultimately does if there is no identity configured: fail, showing the user an error message encouraging them to configure `user.name` and `user.email`.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
