### PR TITLE
Break cyclical dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,8 +1192,9 @@ dependencies = [
  "bstr",
  "btoi",
  "document-features",
- "git-date",
- "git-features",
+ "git-date 0.4.1",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
  "git-testtools",
  "itoa",
  "nom",
@@ -1203,18 +1204,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-actor"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e5fd7bc63ad527d64584f8d01f99b89c051f5fbb8144b58ae5f812775065cf"
+dependencies = [
+ "bstr",
+ "btoi",
+ "git-date 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "nom",
+ "quick-error 2.0.1",
+]
+
+[[package]]
 name = "git-attributes"
 version = "0.8.1"
 dependencies = [
  "bstr",
  "compact_str",
  "document-features",
- "git-features",
- "git-glob",
- "git-path",
- "git-quote",
+ "git-features 0.26.1",
+ "git-glob 0.5.2",
+ "git-path 0.7.0",
+ "git-quote 0.4.0",
  "git-testtools",
  "serde",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "git-attributes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c9687a890892650e8574e123b4b633d277b99953cb877dc02aba852a0139fa"
+dependencies = [
+ "bstr",
+ "compact_str",
+ "git-features 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-glob 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-path 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-quote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "unicode-bom",
 ]
@@ -1224,6 +1255,15 @@ name = "git-bitmap"
 version = "0.2.0"
 dependencies = [
  "git-testtools",
+ "quick-error 2.0.1",
+]
+
+[[package]]
+name = "git-bitmap"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44304093ac66a0ada1b243c15c3a503a165a1d0f50bec748f4e5a9b84a0d0722"
+dependencies = [
  "quick-error 2.0.1",
 ]
 
@@ -1249,8 +1289,8 @@ dependencies = [
  "bstr",
  "document-features",
  "git-chunk",
- "git-features",
- "git-hash",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
  "git-testtools",
  "memmap2",
  "serde",
@@ -1265,23 +1305,34 @@ dependencies = [
  "criterion",
  "document-features",
  "git-config-value",
- "git-features",
- "git-glob",
- "git-path",
- "git-ref",
- "git-repository",
- "git-sec",
- "git-testtools",
+ "git-features 0.26.1",
+ "git-glob 0.5.2",
+ "git-path 0.7.0",
+ "git-ref 0.23.1",
+ "git-sec 0.6.1",
  "memchr",
  "nom",
  "once_cell",
  "serde",
- "serde_derive",
- "serial_test",
  "smallvec",
- "tempfile",
  "thiserror",
  "unicode-bom",
+]
+
+[[package]]
+name = "git-config-tests"
+version = "0.0.0"
+dependencies = [
+ "bstr",
+ "criterion",
+ "git-config",
+ "git-path 0.7.0",
+ "git-ref 0.23.1",
+ "git-repository",
+ "git-testtools",
+ "serde_derive",
+ "serial_test",
+ "tempfile",
 ]
 
 [[package]]
@@ -1291,7 +1342,7 @@ dependencies = [
  "bitflags",
  "bstr",
  "document-features",
- "git-path",
+ "git-path 0.7.0",
  "libc",
  "serde",
  "thiserror",
@@ -1316,9 +1367,9 @@ dependencies = [
  "document-features",
  "git-command",
  "git-config-value",
- "git-path",
+ "git-path 0.7.0",
  "git-prompt",
- "git-sec",
+ "git-sec 0.6.1",
  "git-testtools",
  "git-url",
  "serde",
@@ -1331,6 +1382,7 @@ version = "0.4.1"
 dependencies = [
  "bstr",
  "document-features",
+ "git-hash 0.10.1",
  "git-testtools",
  "itoa",
  "once_cell",
@@ -1340,17 +1392,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-date"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3777ed3a92334193bc5032d468dee2ddb7d1101263e58e0d2edcc308c06948b5"
+dependencies = [
+ "bstr",
+ "itoa",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "git-diff"
 version = "0.26.0"
 dependencies = [
- "git-hash",
- "git-object",
- "git-odb",
- "git-testtools",
- "git-traverse",
+ "git-hash 0.10.1",
+ "git-object 0.26.0",
  "imara-diff",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "git-diff-test"
+version = "0.0.0"
+dependencies = [
+ "git-diff",
+ "git-hash 0.10.1",
+ "git-object 0.26.0",
+ "git-odb",
+ "git-testtools",
+ "git-traverse 0.22.0",
 ]
 
 [[package]]
@@ -1359,14 +1432,28 @@ version = "0.12.1"
 dependencies = [
  "bstr",
  "defer",
- "git-hash",
- "git-path",
- "git-ref",
- "git-sec",
+ "git-hash 0.10.1",
+ "git-path 0.7.0",
+ "git-ref 0.23.1",
+ "git-sec 0.6.1",
  "git-testtools",
  "is_ci",
  "serial_test",
  "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "git-discover"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2738a9941f1411cff31e6ea4399a6c7304cc3ea34fb8c1c6f1aef1f667d46cc"
+dependencies = [
+ "bstr",
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-path 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-ref 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-sec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -1381,7 +1468,7 @@ dependencies = [
  "crossbeam-utils",
  "document-features",
  "flate2",
- "git-hash",
+ "git-hash 0.10.1",
  "jwalk",
  "libc",
  "num_cpus",
@@ -1390,6 +1477,19 @@ dependencies = [
  "prodash",
  "quick-error 2.0.1",
  "sha1",
+ "sha1_smol",
+ "walkdir",
+]
+
+[[package]]
+name = "git-features"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0019327672cb759f851d1b18fdcc36bb797dc62b925cb93c8c881b54735eb2c2"
+dependencies = [
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "prodash",
  "sha1_smol",
  "walkdir",
 ]
@@ -1414,6 +1514,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-glob"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa73cf9c9c1a66e28de1cf250fc1ebe323e7c7c59768c1a2331e3b3308e783a3"
+dependencies = [
+ "bitflags",
+ "bstr",
+]
+
+[[package]]
 name = "git-hash"
 version = "0.10.1"
 dependencies = [
@@ -1425,10 +1535,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-hash"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1532d82bf830532f8d545c5b7b568e311e3593f16cf7ee9dd0ce03c74b12b99d"
+dependencies = [
+ "hex",
+ "thiserror",
+]
+
+[[package]]
 name = "git-hashtable"
 version = "0.1.0"
 dependencies = [
- "git-hash",
+ "git-hash 0.10.1",
+ "hashbrown 0.13.1",
+]
+
+[[package]]
+name = "git-hashtable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52b625ad8cc360a0b7f426266f21fb07bd49b8f4ccf1b3ca7bc89424db1dec4"
+dependencies = [
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.13.1",
 ]
 
@@ -1441,19 +1571,52 @@ dependencies = [
  "bstr",
  "document-features",
  "filetime",
- "git-bitmap",
- "git-features",
- "git-hash",
- "git-lock",
- "git-object",
- "git-repository",
- "git-testtools",
- "git-traverse",
+ "git-bitmap 0.2.0",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-lock 3.0.1",
+ "git-object 0.26.0",
+ "git-traverse 0.22.0",
  "itoa",
  "memmap2",
  "serde",
  "smallvec",
  "thiserror",
+]
+
+[[package]]
+name = "git-index"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82fd3d70ed6fbceb7573f145fbf79371e4d0c8dbdf7ad46f3a03328239ddda7"
+dependencies = [
+ "atoi",
+ "bitflags",
+ "bstr",
+ "filetime",
+ "git-bitmap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-features 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-lock 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-object 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-traverse 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-index-tests"
+version = "0.0.0"
+dependencies = [
+ "bstr",
+ "filetime",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-index 0.12.2",
+ "git-repository",
+ "git-testtools",
 ]
 
 [[package]]
@@ -1465,9 +1628,20 @@ name = "git-lock"
 version = "3.0.1"
 dependencies = [
  "fastrand",
- "git-tempfile",
+ "git-tempfile 3.0.1",
  "quick-error 2.0.1",
  "tempfile",
+]
+
+[[package]]
+name = "git-lock"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7cf6a3c9d1a9932bb9bcb7e0044e2e429f9d94711969a7d2a09e34ae21f6437"
+dependencies = [
+ "fastrand",
+ "git-tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -1476,7 +1650,7 @@ version = "0.9.1"
 dependencies = [
  "bstr",
  "document-features",
- "git-actor",
+ "git-actor 0.17.0",
  "git-testtools",
  "quick-error 2.0.1",
  "serde",
@@ -1493,16 +1667,35 @@ dependencies = [
  "bstr",
  "btoi",
  "document-features",
- "git-actor",
- "git-features",
- "git-hash",
+ "git-actor 0.17.0",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
  "git-testtools",
- "git-validate",
+ "git-validate 0.7.1",
  "hex",
  "itoa",
  "nom",
  "pretty_assertions",
  "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-object"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8563e2d6f524d7053f3106714f99ecdc3adbba2cb7108c09d71a02579f2e19"
+dependencies = [
+ "bstr",
+ "btoi",
+ "git-actor 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-features 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-validate 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "itoa",
+ "nom",
  "smallvec",
  "thiserror",
 ]
@@ -1515,13 +1708,13 @@ dependencies = [
  "crossbeam-channel",
  "document-features",
  "filetime",
- "git-actor",
- "git-features",
- "git-hash",
- "git-object",
+ "git-actor 0.17.0",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-object 0.26.0",
  "git-pack",
- "git-path",
- "git-quote",
+ "git-path 0.7.0",
+ "git-quote 0.4.0",
  "git-testtools",
  "maplit",
  "num_cpus",
@@ -1536,30 +1729,43 @@ dependencies = [
 name = "git-pack"
 version = "0.30.1"
 dependencies = [
- "bstr",
  "bytesize",
  "clru",
  "dashmap",
  "document-features",
  "git-chunk",
  "git-diff",
- "git-features",
- "git-hash",
- "git-hashtable",
- "git-object",
- "git-odb",
- "git-path",
- "git-tempfile",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-hashtable 0.1.0",
+ "git-object 0.26.0",
+ "git-path 0.7.0",
+ "git-tempfile 3.0.1",
  "git-testtools",
- "git-traverse",
- "maplit",
+ "git-traverse 0.22.0",
  "memmap2",
  "parking_lot 0.12.1",
  "serde",
  "smallvec",
- "tempfile",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "git-pack-tests"
+version = "0.30.1"
+dependencies = [
+ "bstr",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-object 0.26.0",
+ "git-odb",
+ "git-pack",
+ "git-testtools",
+ "git-traverse 0.22.0",
+ "maplit",
+ "memmap2",
+ "tempfile",
 ]
 
 [[package]]
@@ -1571,7 +1777,7 @@ dependencies = [
  "document-features",
  "futures-io",
  "futures-lite",
- "git-hash",
+ "git-hash 0.10.1",
  "git-odb",
  "hex",
  "maybe-async",
@@ -1590,13 +1796,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40e68481a06da243d3f4dfd86a4be39c24eefb535017a862e845140dcdb878a"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
 name = "git-pathspec"
 version = "0.1.0"
 dependencies = [
  "bitflags",
  "bstr",
- "git-attributes",
- "git-glob",
+ "git-attributes 0.8.1",
+ "git-glob 0.5.2",
  "git-testtools",
  "once_cell",
  "thiserror",
@@ -1628,8 +1844,8 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "git-credentials",
- "git-features",
- "git-hash",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
  "git-packetline",
  "git-testtools",
  "git-transport",
@@ -1649,6 +1865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-quote"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd11f4e7f251ab297545faa4c5a4517f4985a43b9c16bf96fa49107f58e837f"
+dependencies = [
+ "bstr",
+ "btoi",
+ "quick-error 2.0.1",
+]
+
+[[package]]
 name = "git-rebase"
 version = "0.0.0"
 
@@ -1657,18 +1884,15 @@ name = "git-ref"
 version = "0.23.1"
 dependencies = [
  "document-features",
- "git-actor",
- "git-discover",
- "git-features",
- "git-hash",
- "git-lock",
- "git-object",
- "git-odb",
- "git-path",
- "git-tempfile",
+ "git-actor 0.17.0",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-lock 3.0.1",
+ "git-object 0.26.0",
+ "git-path 0.7.0",
+ "git-tempfile 3.0.1",
  "git-testtools",
- "git-validate",
- "git-worktree",
+ "git-validate 0.7.1",
  "memmap2",
  "nom",
  "serde",
@@ -1677,14 +1901,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-ref"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2c29bab109acaf626d49a54f1f85ab7f0911268fbf62c2b39680ef4ef19069"
+dependencies = [
+ "git-actor 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-features 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-lock 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-object 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-path 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-validate 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap2",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "git-ref-tests"
+version = "0.0.0"
+dependencies = [
+ "git-actor 0.17.0",
+ "git-discover 0.12.1",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
+ "git-lock 3.0.1",
+ "git-object 0.26.0",
+ "git-odb",
+ "git-ref 0.23.1",
+ "git-testtools",
+ "git-validate 0.7.1",
+ "git-worktree 0.12.1",
+ "tempfile",
+]
+
+[[package]]
 name = "git-refspec"
 version = "0.7.1"
 dependencies = [
  "bstr",
- "git-hash",
+ "git-hash 0.10.1",
  "git-revision",
  "git-testtools",
- "git-validate",
+ "git-validate 0.7.1",
  "smallvec",
  "thiserror",
 ]
@@ -1696,37 +1957,37 @@ dependencies = [
  "anyhow",
  "async-std",
  "document-features",
- "git-actor",
- "git-attributes",
+ "git-actor 0.17.0",
+ "git-attributes 0.8.1",
  "git-config",
  "git-credentials",
- "git-date",
+ "git-date 0.4.1",
  "git-diff",
- "git-discover",
- "git-features",
- "git-glob",
- "git-hash",
- "git-hashtable",
- "git-index",
- "git-lock",
+ "git-discover 0.12.1",
+ "git-features 0.26.1",
+ "git-glob 0.5.2",
+ "git-hash 0.10.1",
+ "git-hashtable 0.1.0",
+ "git-index 0.12.2",
+ "git-lock 3.0.1",
  "git-mailmap",
- "git-object",
+ "git-object 0.26.0",
  "git-odb",
  "git-pack",
- "git-path",
+ "git-path 0.7.0",
  "git-prompt",
  "git-protocol",
- "git-ref",
+ "git-ref 0.23.1",
  "git-refspec",
  "git-revision",
- "git-sec",
- "git-tempfile",
+ "git-sec 0.6.1",
+ "git-tempfile 3.0.1",
  "git-testtools",
  "git-transport",
- "git-traverse",
+ "git-traverse 0.22.0",
  "git-url",
- "git-validate",
- "git-worktree",
+ "git-validate 0.7.1",
+ "git-worktree 0.12.1",
  "is_ci",
  "log",
  "once_cell",
@@ -1748,14 +2009,24 @@ version = "0.10.1"
 dependencies = [
  "bstr",
  "document-features",
- "git-date",
- "git-hash",
- "git-hashtable",
- "git-object",
- "git-repository",
- "git-testtools",
+ "git-date 0.4.1",
+ "git-hash 0.10.1",
+ "git-hashtable 0.1.0",
+ "git-object 0.26.0",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "git-revision-tests"
+version = "0.0.0"
+dependencies = [
+ "bstr",
+ "git-hash 0.10.1",
+ "git-object 0.26.0",
+ "git-repository",
+ "git-revision",
+ "git-testtools",
 ]
 
 [[package]]
@@ -1765,10 +2036,23 @@ dependencies = [
  "bitflags",
  "dirs",
  "document-features",
- "git-path",
+ "git-path 0.7.0",
  "libc",
  "serde",
  "tempfile",
+ "windows 0.43.0",
+]
+
+[[package]]
+name = "git-sec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6696a816445a51f76995d579a3122f98247377cc45cd681764f740f3a2666004"
+dependencies = [
+ "bitflags",
+ "dirs",
+ "git-path 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "windows 0.43.0",
 ]
 
@@ -1793,6 +2077,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-tempfile"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d851911a2b043dc1ab6cd5432ce7a3ee3a2fd614ed87428cec1b15f5abb7e0c"
+dependencies = [
+ "dashmap",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
 name = "git-testtools"
 version = "0.11.0"
 dependencies = [
@@ -1800,11 +2098,10 @@ dependencies = [
  "crc",
  "fastrand",
  "fs_extra",
- "git-attributes",
- "git-discover",
- "git-hash",
- "git-lock",
- "git-worktree",
+ "git-attributes 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-discover 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-lock 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-worktree 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-close",
  "is_ci",
  "nom",
@@ -1834,11 +2131,11 @@ dependencies = [
  "futures-lite",
  "git-command",
  "git-credentials",
- "git-features",
- "git-hash",
+ "git-features 0.26.1",
+ "git-hash 0.10.1",
  "git-pack",
  "git-packetline",
- "git-sec",
+ "git-sec 0.6.1",
  "git-url",
  "maybe-async",
  "pin-project-lite",
@@ -1851,12 +2148,33 @@ dependencies = [
 name = "git-traverse"
 version = "0.22.0"
 dependencies = [
- "git-hash",
- "git-hashtable",
- "git-object",
+ "git-hash 0.10.1",
+ "git-hashtable 0.1.0",
+ "git-object 0.26.0",
+ "thiserror",
+]
+
+[[package]]
+name = "git-traverse"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd356da21ec00f69b9d4f105df4cb85543c746b18f4b7fc81529ce77713cdb29"
+dependencies = [
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-hashtable 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-object 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "git-traverse-tests"
+version = "0.0.0"
+dependencies = [
+ "git-hash 0.10.1",
+ "git-object 0.26.0",
  "git-odb",
  "git-testtools",
- "thiserror",
+ "git-traverse 0.22.0",
 ]
 
 [[package]]
@@ -1869,8 +2187,8 @@ version = "0.13.1"
 dependencies = [
  "bstr",
  "document-features",
- "git-features",
- "git-path",
+ "git-features 0.26.1",
+ "git-path 0.7.0",
  "home",
  "serde",
  "thiserror",
@@ -1887,19 +2205,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-validate"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431cf9352c596dc7c8ec9066ee551ce54e63c86c3c767e5baf763f6019ff3c2"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
 name = "git-worktree"
 version = "0.12.1"
 dependencies = [
  "bstr",
  "document-features",
- "git-attributes",
- "git-features",
- "git-glob",
- "git-hash",
- "git-index",
- "git-object",
+ "git-attributes 0.8.1",
+ "git-features 0.26.1",
+ "git-glob 0.5.2",
+ "git-hash 0.10.1",
+ "git-index 0.12.2",
+ "git-object 0.26.0",
  "git-odb",
- "git-path",
+ "git-path 0.7.0",
  "git-testtools",
  "io-close",
  "serde",
@@ -1907,6 +2235,24 @@ dependencies = [
  "tempfile",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "git-worktree"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c28b292694c98bba8225c39d4e86605843882ba7117ca98491841761e710547"
+dependencies = [
+ "bstr",
+ "git-attributes 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-features 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-glob 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-hash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-index 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-object 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-path 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-close",
+ "thiserror",
 ]
 
 [[package]]
@@ -1934,7 +2280,7 @@ dependencies = [
  "document-features",
  "env_logger",
  "futures-lite",
- "git-features",
+ "git-features 0.26.1",
  "git-repository",
  "gitoxide-core",
  "is-terminal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,7 +1415,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-diff-test"
+name = "git-diff-tests"
 version = "0.0.0"
 dependencies = [
  "git-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,15 @@ members = [
     "git-tix",
 
     "cargo-smart-release",
-
     "tests/tools",
+
+    "git-revision/tests",
+    "git-diff/tests",
+    "git-pack/tests",
+    "git-index/tests",
+    "git-ref/tests",
+    "git-config/tests",
+    "git-traverse/tests",
 ]
 exclude = ["cargo-smart-release/tests/fixtures/tri-depth-workspace/a",
            "cargo-smart-release/tests/fixtures/tri-depth-workspace/b",

--- a/Makefile
+++ b/Makefile
@@ -138,12 +138,12 @@ check: ## Build all code in suitable configurations
 unit-tests: ## run all unit tests
 	cargo test --all
 	cd git-features && cargo test && cargo test --all-features
-	cd git-ref && cargo test --all-features
+	cd git-ref/tests && cargo test --all-features
 	cd git-odb && cargo test && cargo test --all-features
 	cd git-object && cargo test && cargo test --features verbose-object-parsing-errors
-	cd git-pack && cargo test --features internal-testing-to-avoid-being-run-by-cargo-test-all \
+	cd git-pack/tests && cargo test --features internal-testing-to-avoid-being-run-by-cargo-test-all \
 				&& cargo test --features "internal-testing-git-features-parallel"
-	cd git-index && cargo test --features internal-testing-to-avoid-being-run-by-cargo-test-all \
+	cd git-index/tests && cargo test --features internal-testing-to-avoid-being-run-by-cargo-test-all \
 				&& cargo test --features "internal-testing-git-features-parallel"
 	cd git-worktree && cargo test --features internal-testing-to-avoid-being-run-by-cargo-test-all \
 				&& cargo test --features "internal-testing-git-features-parallel"

--- a/cargo-smart-release/tests/changelog/merge.rs
+++ b/cargo-smart-release/tests/changelog/merge.rs
@@ -3,8 +3,9 @@ use cargo_smart_release::{
     changelog::{section, Section},
     ChangeLog,
 };
-use git_testtools::hex_to_id;
 use time::OffsetDateTime;
+
+use crate::changelog::hex_to_id;
 
 #[test]
 fn sections() {

--- a/cargo-smart-release/tests/changelog/mod.rs
+++ b/cargo-smart-release/tests/changelog/mod.rs
@@ -1,5 +1,11 @@
+use git_repository::ObjectId;
+
 mod parse;
 
 mod write_and_parse;
 
 mod merge;
+
+fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}

--- a/cargo-smart-release/tests/changelog/write_and_parse/mod.rs
+++ b/cargo-smart-release/tests/changelog/write_and_parse/mod.rs
@@ -5,9 +5,9 @@ use cargo_smart_release::{
     changelog::{section, section::segment::conventional, Section},
     ChangeLog,
 };
-use git_testtools::{bstr::ByteSlice, hex_to_id};
+use git_testtools::bstr::ByteSlice;
 
-use crate::Result;
+use crate::{changelog::hex_to_id, Result};
 
 #[test]
 fn conventional_write_empty_messages() -> Result {

--- a/git-actor/Cargo.toml
+++ b/git-actor/Cargo.toml
@@ -32,6 +32,7 @@ document-features = { version = "0.2.0", optional = true }
 [dev-dependencies]
 pretty_assertions = "1.0.0"
 git-testtools = { path = "../tests/tools"}
+git-hash = { path = "../git-hash" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/git-actor/tests/actor.rs
+++ b/git-actor/tests/actor.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
 
-pub use git_testtools::hex_to_id;
+use git_hash::ObjectId;
+
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+pub fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 pub fn fixture(path: &str) -> PathBuf {
     PathBuf::from("tests/fixtures").join(path)

--- a/git-config/Cargo.toml
+++ b/git-config/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["git-config", "git", "config", "gitoxide"]
 categories = ["config", "parser-implementations"]
 include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 rust-version = "1.64"
+autotests = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
@@ -35,12 +36,7 @@ once_cell = "1.14.0"
 document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
-git-testtools = { path = "../tests/tools"}
-git-repository = { path = "../git-repository" }
-serial_test = "0.10.0"
-serde_derive = "1.0"
 criterion = "0.4.0"
-tempfile = "3.2.0"
 
 [[bench]]
 name = "large_config_file"

--- a/git-config/tests/Cargo.toml
+++ b/git-config/tests/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "git-config-tests"
+version = "0.0.0"
+repository = "https://github.com/Byron/gitoxide"
+description = "A git-config file parser and editor from the gitoxide project"
+license = "MIT OR Apache-2.0"
+authors = ["Edward Shen <code@eddie.sh>"]
+edition = "2021"
+keywords = ["git-config", "git", "config", "gitoxide"]
+categories = ["config", "parser-implementations"]
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
+rust-version = "1.64"
+publish = false
+
+
+[[test]]
+name = "config"
+path = "config.rs"
+
+[features]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+serde1 = ["git-config/serde1"]
+
+[dev-dependencies]
+git-config = { path = ".."}
+git-testtools = { path = "../../tests/tools"}
+git-repository = { path = "../../git-repository" }
+git-ref = { path = "../../git-ref" }
+git-path = { path = "../../git-path" }
+serial_test = "0.10.0"
+serde_derive = "1.0"
+criterion = "0.4.0"
+tempfile = "3.2.0"
+bstr = { version = "1.0.1", default-features = false, features = ["std"] }
+
+[package.metadata.docs.rs]
+all-features = true
+features = ["document-features"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-config/tests/file/init/comfort.rs
+++ b/git-config/tests/file/init/comfort.rs
@@ -21,7 +21,7 @@ fn from_environment_overrides() {
 #[test]
 #[serial]
 fn from_git_dir() -> crate::Result {
-    let worktree_dir = git_testtools::scripted_fixture_read_only("make_config_repo.sh")?;
+    let worktree_dir = git_testtools::scripted_fixture_read_only_standalone("make_config_repo.sh")?;
     let git_dir = worktree_dir.join(".git");
     let worktree_dir = worktree_dir.canonicalize()?;
     let _env = Env::new()
@@ -84,7 +84,7 @@ fn from_git_dir() -> crate::Result {
 #[test]
 #[serial]
 fn from_git_dir_with_worktree_extension() -> crate::Result {
-    let git_dir = git_testtools::scripted_fixture_read_only("config_with_worktree_extension.sh")?
+    let git_dir = git_testtools::scripted_fixture_read_only_standalone("config_with_worktree_extension.sh")?
         .join("main-worktree")
         .join(".git");
     let config = git_config::File::from_git_dir(git_dir)?;

--- a/git-config/tests/file/mod.rs
+++ b/git-config/tests/file/mod.rs
@@ -18,11 +18,11 @@ fn size_in_memory() {
 
 mod open {
     use git_config::File;
-    use git_testtools::fixture_path;
+    use git_testtools::fixture_path_standalone;
 
     #[test]
     fn parse_config_with_windows_line_endings_successfully() {
-        File::from_path_no_includes(&fixture_path("repo-config.crlf"), git_config::Source::Local).unwrap();
+        File::from_path_no_includes(&fixture_path_standalone("repo-config.crlf"), git_config::Source::Local).unwrap();
     }
 }
 

--- a/git-date/Cargo.toml
+++ b/git-date/Cargo.toml
@@ -28,6 +28,7 @@ document-features = { version = "0.2.0", optional = true }
 [dev-dependencies]
 git-testtools = { path = "../tests/tools"}
 once_cell = "1.12.0"
+git-hash = { path = "../git-hash" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/git-date/tests/date.rs
+++ b/git-date/tests/date.rs
@@ -1,3 +1,6 @@
-pub use git_testtools::hex_to_id;
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+pub fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 mod time;

--- a/git-diff/Cargo.toml
+++ b/git-diff/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*"]
 rust-version = "1.64"
+autotests = false
 
 [features]
 serde1 = ["serde", "git-hash/serde1", "git-object/serde1"]
@@ -21,8 +22,3 @@ git-object = { version = "^0.26.0", path = "../git-object" }
 thiserror = "1.0.32"
 imara-diff = "0.1.3"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
-
-[dev-dependencies]
-git-odb = { path = "../git-odb" }
-git-traverse = { path = "../git-traverse" }
-git-testtools = { path = "../tests/tools" }

--- a/git-diff/tests/Cargo.toml
+++ b/git-diff/tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "git-diff-test"
+name = "git-diff-tests"
 version = "0.0.0"
 publish = false
 repository = "https://github.com/Byron/gitoxide"
@@ -15,6 +15,7 @@ serde1 = ["git-diff/serde", "git-hash/serde1", "git-object/serde1"]
 
 [[test]]
 name = "diff"
+doctest = false
 path = "diff.rs"
 
 [dev-dependencies]

--- a/git-diff/tests/Cargo.toml
+++ b/git-diff/tests/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "git-diff-test"
+version = "0.0.0"
+publish = false
+repository = "https://github.com/Byron/gitoxide"
+license = "MIT/Apache-2.0"
+description = "Calculate differences between various git objects"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+edition = "2021"
+include = ["src/**/*"]
+rust-version = "1.64"
+
+[features]
+serde1 = ["git-diff/serde", "git-hash/serde1", "git-object/serde1"]
+
+[[test]]
+name = "diff"
+path = "diff.rs"
+
+[dev-dependencies]
+git-diff = { path = ".." }
+git-hash = { path = "../../git-hash" }
+git-object = { path = "../../git-object" }
+git-odb = { path = "../../git-odb" }
+git-traverse = { path = "../../git-traverse" }
+git-testtools = { path = "../../tests/tools" }

--- a/git-diff/tests/diff.rs
+++ b/git-diff/tests/diff.rs
@@ -1,6 +1,8 @@
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-pub use git_testtools::hex_to_id;
+fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 mod blob;
 mod tree;

--- a/git-diff/tests/tree/mod.rs
+++ b/git-diff/tests/tree/mod.rs
@@ -11,7 +11,7 @@ mod changes {
 
         fn db(args: impl IntoIterator<Item = &'static str>) -> crate::Result<git_odb::Handle> {
             git_odb::at(
-                git_testtools::scripted_fixture_read_only_with_args("make_diff_repo.sh", args)?
+                git_testtools::scripted_fixture_read_only_with_args_standalone("make_diff_repo.sh", args)?
                     .join(".git")
                     .join("objects"),
             )

--- a/git-hash/tests/prefix/mod.rs
+++ b/git-hash/tests/prefix/mod.rs
@@ -1,7 +1,7 @@
 mod cmp_oid {
     use std::cmp::Ordering;
 
-    use git_testtools::hex_to_id;
+    use crate::hex_to_id;
 
     #[test]
     fn it_detects_inequality() {
@@ -34,7 +34,8 @@ mod new {
     use std::cmp::Ordering;
 
     use git_hash::{Kind, ObjectId};
-    use git_testtools::hex_to_id;
+
+    use crate::hex_to_id;
 
     #[test]
     fn various_valid_inputs() {
@@ -75,7 +76,8 @@ mod try_from {
     use std::{cmp::Ordering, convert::TryFrom};
 
     use git_hash::{prefix::from_hex::Error, Prefix};
-    use git_testtools::hex_to_id;
+
+    use crate::hex_to_id;
 
     #[test]
     fn id_8_chars() {

--- a/git-index/Cargo.toml
+++ b/git-index/Cargo.toml
@@ -8,27 +8,16 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 rust-version = "1.64"
+autotests = false
+
 
 [lib]
 doctest = false
 test = true
 
-[[test]]
-name = "multi-threaded"
-path = "tests/index-multi-threaded.rs"
-required-features = ["internal-testing-git-features-parallel"]
-
-[[test]]
-name = "single-threaded"
-path = "tests/index-single-threaded.rs"
-required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
-
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "smallvec/serde", "git-hash/serde1"]
-
-internal-testing-git-features-parallel = ["git-features/parallel"]
-internal-testing-to-avoid-being-run-by-cargo-test-all = []
 
 [dependencies]
 git-features = { version = "^0.26.1", path = "../git-features", features = ["rustsha1", "progress"] }
@@ -50,10 +39,6 @@ itoa = "1.0.3"
 bitflags = "1.3.2"
 
 document-features = { version = "0.2.0", optional = true }
-
-[dev-dependencies]
-git-testtools = { path = "../tests/tools"}
-git-repository = { path = "../git-repository"}
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde1"]

--- a/git-index/tests/Cargo.toml
+++ b/git-index/tests/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "git-index-tests"
+version = "0.0.0"
+publish = false
+repository = "https://github.com/Byron/gitoxide"
+license = "MIT/Apache-2.0"
+description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+edition = "2021"
+include = ["src/**/*", "README.md", "CHANGELOG.md"]
+rust-version = "1.64"
+
+[[test]]
+name = "multi-threaded"
+path = "index-multi-threaded.rs"
+required-features = ["internal-testing-git-features-parallel"]
+
+[[test]]
+name = "single-threaded"
+path = "index-single-threaded.rs"
+required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
+
+[features]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+serde1 = ["git-index/serde"]
+
+internal-testing-git-features-parallel = ["git-features/parallel"]
+internal-testing-to-avoid-being-run-by-cargo-test-all = []
+
+[dependencies]
+
+[dev-dependencies]
+git-index = { version = "^0.12.1", path = ".." }
+git-features = { version = "^0.26.1", path = "../../git-features", features = ["rustsha1", "progress"] }
+git-testtools = { path = "../../tests/tools"}
+git-repository = { path = "../../git-repository"}
+git-hash = { path = "../../git-hash"}
+filetime = "0.2.15"
+bstr = { version = "1.0.1", default-features = false }
+
+[package.metadata.docs.rs]
+features = ["document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-index/tests/index/file/read.rs
+++ b/git-index/tests/index/file/read.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
 
+use crate::hex_to_id;
 use bstr::ByteSlice;
 use git_index::{
     entry::{self, Flags, Mode},
     Version,
 };
-use git_testtools::hex_to_id;
 
 use crate::loose_file_path;
 
@@ -303,8 +303,10 @@ fn v2_split_index_recursion_is_handled_gracefully() {
 
 #[test]
 fn split_index_and_regular_index_of_same_content_are_indeed_the_same() {
-    let base = git_testtools::scripted_fixture_read_only(Path::new("make_index").join("v2_split_vs_regular_index.sh"))
-        .unwrap();
+    let base = git_testtools::scripted_fixture_read_only_standalone(
+        Path::new("make_index").join("v2_split_vs_regular_index.sh"),
+    )
+    .unwrap();
 
     let split =
         verify(git_index::File::at(base.join("split/.git/index"), git_hash::Kind::Sha1, Default::default()).unwrap());

--- a/git-index/tests/index/init.rs
+++ b/git-index/tests/index/init.rs
@@ -1,7 +1,7 @@
 use git_index::{verify::extensions::no_find, State};
 use git_repository as git;
 use git_repository::prelude::FindExt;
-use git_testtools::scripted_fixture_read_only;
+use git_testtools::scripted_fixture_read_only_standalone;
 
 #[test]
 fn from_tree() -> crate::Result {
@@ -13,7 +13,7 @@ fn from_tree() -> crate::Result {
     ];
 
     for fixture in fixtures {
-        let repo_dir = scripted_fixture_read_only(fixture)?;
+        let repo_dir = scripted_fixture_read_only_standalone(fixture)?;
         let repo = git::open(&repo_dir)?;
 
         let tree_id = repo.head_commit()?.tree_id()?;

--- a/git-index/tests/index/mod.rs
+++ b/git-index/tests/index/mod.rs
@@ -1,3 +1,4 @@
+use git_hash::ObjectId;
 use std::path::{Path, PathBuf};
 
 mod access;
@@ -5,14 +6,19 @@ mod entry;
 mod file;
 mod init;
 
+pub fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
+
 pub fn fixture_index_path(name: &str) -> PathBuf {
-    let dir = git_testtools::scripted_fixture_read_only(Path::new("make_index").join(name).with_extension("sh"))
-        .expect("script works");
+    let dir =
+        git_testtools::scripted_fixture_read_only_standalone(Path::new("make_index").join(name).with_extension("sh"))
+            .expect("script works");
     dir.join(".git").join("index")
 }
 
 pub fn loose_file_path(name: &str) -> PathBuf {
-    git_testtools::fixture_path(Path::new("loose_index").join(name).with_extension("git-index"))
+    git_testtools::fixture_path_standalone(Path::new("loose_index").join(name).with_extension("git-index"))
 }
 
 #[test]

--- a/git-object/tests/object.rs
+++ b/git-object/tests/object.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use git_hash::ObjectId;
+
 mod encode;
 mod immutable;
 
@@ -18,8 +20,6 @@ fn fixup(v: Vec<u8>) -> Vec<u8> {
     v.replace(b"\r\n", "\n")
 }
 
-pub use git_testtools::hex_to_id;
-
 pub fn fixture(path: &str) -> PathBuf {
     PathBuf::from("tests/fixtures").join(path)
 }
@@ -36,4 +36,8 @@ fn size_in_memory() {
         "{} <= 264: Prevent unexpected growth of what should be lightweight objects",
         actual
     )
+}
+
+pub fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
 }

--- a/git-odb/tests/odb/mod.rs
+++ b/git-odb/tests/odb/mod.rs
@@ -1,4 +1,9 @@
-pub use git_testtools::{fixture_path, hex_to_id, scripted_fixture_read_only};
+use git_hash::ObjectId;
+pub use git_testtools::{fixture_path, scripted_fixture_read_only};
+
+pub fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/git-odb/tests/odb/store/dynamic.rs
+++ b/git-odb/tests/odb/store/dynamic.rs
@@ -2,8 +2,9 @@ use std::process::Command;
 
 use git_hash::ObjectId;
 use git_odb::{store, store::iter::Ordering, Find, FindExt, Header, Write};
-use git_testtools::{fixture_path, hex_to_id};
+use git_testtools::fixture_path;
 
+use crate::hex_to_id;
 use crate::odb::db;
 
 fn all_orderings() -> [Ordering; 2] {
@@ -502,10 +503,9 @@ mod disambiguate_prefix {
     use std::cmp::Ordering;
 
     use git_odb::store::prefix::disambiguate::Candidate;
-    use git_testtools::hex_to_id;
 
     use crate::{
-        odb::store::dynamic::all_orderings,
+        odb::{hex_to_id, store::dynamic::all_orderings},
         store::dynamic::{assert_all_indices_loaded, db_with_all_object_sources},
     };
 
@@ -622,11 +622,10 @@ mod iter {
 mod lookup_prefix {
     use std::collections::HashSet;
 
-    use git_testtools::hex_to_id;
     use maplit::hashset;
 
     use crate::{
-        odb::store::dynamic::all_orderings,
+        odb::{hex_to_id, store::dynamic::all_orderings},
         store::dynamic::{assert_all_indices_loaded, db_with_all_object_sources},
     };
 

--- a/git-odb/tests/odb/store/loose.rs
+++ b/git-odb/tests/odb/store/loose.rs
@@ -87,9 +87,10 @@ mod contains {
 mod lookup_prefix {
     use std::collections::HashSet;
 
-    use git_testtools::{fixture_path, hex_to_id};
+    use git_testtools::fixture_path;
     use maplit::hashset;
 
+    use crate::odb::hex_to_id;
     use crate::store::loose::ldb;
 
     #[test]
@@ -329,8 +330,7 @@ cjHJZXWmV4CcRfmLsXzU8s2cR9A0DBvOxhPD1TlKC2JhBFXigjuL9U4Rbq9tdegB
     }
 
     mod header {
-        use git_testtools::hex_to_id;
-
+        use crate::odb::hex_to_id;
         use crate::odb::store::loose::ldb;
 
         #[test]

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -8,6 +8,7 @@ description = "Implements git packs and related data structures"
 edition = "2018"
 include = ["src/**/*", "CHANGELOG.md"]
 rust-version = "1.64"
+autotests = false
 
 [lib]
 doctest = false
@@ -23,19 +24,6 @@ pack-cache-lru-dynamic = ["clru"]
 object-cache-dynamic = ["clru"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "git-object/serde1"]
-
-internal-testing-git-features-parallel = ["git-features/parallel"]
-internal-testing-to-avoid-being-run-by-cargo-test-all = []
-
-[[test]]
-name = "multi-threaded"
-path = "tests/pack-multi-threaded.rs"
-required-features = ["internal-testing-git-features-parallel"]
-
-[[test]]
-name = "single-threaded"
-path = "tests/pack-single-threaded.rs"
-required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
 
 [dependencies]
 git-features = { version = "^0.26.1", path = "../git-features", features = ["crc32", "rustsha1", "progress", "zlib"] }
@@ -62,10 +50,6 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 git-testtools = { path = "../tests/tools"}
-git-odb = { path = "../git-odb" }
-tempfile = "3.1.0"
-bstr = { version = "1.0.1", default-features = false, features = ["std"] }
-maplit = "1.0.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/git-pack/src/cache/delta/mod.rs
+++ b/git-pack/src/cache/delta/mod.rs
@@ -156,7 +156,7 @@ mod tests {
         mod from_offsets_in_pack {
             use std::sync::atomic::AtomicBool;
 
-            use git_odb::pack;
+            use crate as pack;
 
             const SMALL_PACK_INDEX: &str = "objects/pack/pack-a2bf8e71d8c18879e499335762dd95119d93d9f1.idx";
             const SMALL_PACK: &str = "objects/pack/pack-a2bf8e71d8c18879e499335762dd95119d93d9f1.pack";
@@ -200,11 +200,9 @@ mod tests {
 
     #[test]
     fn size_of_pack_verify_data_structure() {
-        use git_odb::pack;
-
         use super::Item;
         pub struct EntryWithDefault {
-            _index_entry: pack::index::Entry,
+            _index_entry: crate::index::Entry,
             _kind: git_object::Kind,
             _object_size: u64,
             _decompressed_size: u64,

--- a/git-pack/tests/Cargo.toml
+++ b/git-pack/tests/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "git-pack-tests"
+version = "0.30.1"
+repository = "https://github.com/Byron/gitoxide"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+license = "MIT/Apache-2.0"
+description = "Implements git packs and related data structures"
+edition = "2018"
+include = ["src/**/*", "CHANGELOG.md"]
+rust-version = "1.64"
+
+[features]
+
+## Provide a fixed-size allocation-free LRU cache for packs. It's useful if caching is desired while keeping the memory footprint
+## for the LRU-cache itself low.
+pack-cache-lru-static = ["git-pack/uluru"]
+## Provide a hash-map based LRU cache whose eviction is based a memory cap calculated from object data.
+pack-cache-lru-dynamic = ["git-pack/pack-cache-lru-dynamic"]
+## If set, select algorithms may additionally use a full-object cache which is queried before the pack itself.
+object-cache-dynamic = ["git-pack/object-cache-dynamic"]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+serde1 = ["git-pack/serde1"]
+
+internal-testing-git-features-parallel = ["git-features/parallel"]
+internal-testing-to-avoid-being-run-by-cargo-test-all = []
+
+[[test]]
+name = "multi-threaded"
+path = "pack-multi-threaded.rs"
+required-features = ["internal-testing-git-features-parallel"]
+
+[[test]]
+name = "single-threaded"
+path = "pack-single-threaded.rs"
+required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
+
+[dev-dependencies]
+git-pack = { path = ".." }
+git-features = { version = "^0.26.1", path = "../../git-features" }
+git-testtools = { path = "../../tests/tools"}
+git-odb = { path = "../../git-odb" }
+tempfile = "3.1.0"
+bstr = { version = "1.0.1", default-features = false, features = ["std"] }
+maplit = "1.0.2"
+git-object = {  path = "../../git-object" }
+git-traverse = {  path = "../../git-traverse" }
+git-hash = {  path = "../../git-hash" }
+memmap2 = "0.5.0"

--- a/git-pack/tests/pack/data/file.rs
+++ b/git-pack/tests/pack/data/file.rs
@@ -9,8 +9,8 @@ fn pack_at(at: &str) -> pack::data::File {
 mod method {
     use std::sync::atomic::AtomicBool;
 
+    use crate::hex_to_id;
     use git_features::progress;
-    use git_testtools::hex_to_id;
 
     use crate::pack::{data::file::pack_at, SMALL_PACK};
 

--- a/git-pack/tests/pack/data/output/mod.rs
+++ b/git-pack/tests/pack/data/output/mod.rs
@@ -31,9 +31,7 @@ fn db(kind: DbKind) -> crate::Result<git_odb::HandleArc> {
         DeterministicGeneratedContent => "make_pack_gen_repo.sh",
         DeterministicGeneratedContentMultiIndex => "make_pack_gen_repo_multi_index.sh",
     };
-    let path: PathBuf = git_testtools::scripted_fixture_read_only(name)?
-        .join(".git")
-        .join("objects");
+    let path: PathBuf = crate::scripted_fixture_read_only(name)?.join(".git").join("objects");
     git_odb::Store::at_opts(path, Vec::new(), git_odb::store::init::Options::default())
         .map_err(Into::into)
         .map(|store| {

--- a/git-pack/tests/pack/mod.rs
+++ b/git-pack/tests/pack/mod.rs
@@ -13,7 +13,14 @@ const PACKS_AND_INDICES: &[(&'static str, &'static str)] =
 const V2_PACKS_AND_INDICES: &[(&'static str, &'static str)] =
     &[(SMALL_PACK_INDEX, SMALL_PACK), (INDEX_V2, PACK_FOR_INDEX_V2)];
 
-pub use git_testtools::{fixture_path, hex_to_id, scripted_fixture_read_only};
+use git_hash::ObjectId;
+pub use git_testtools::{
+    fixture_path_standalone as fixture_path, scripted_fixture_read_only_standalone as scripted_fixture_read_only,
+};
+
+pub fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/git-pack/tests/pack/multi_index/access.rs
+++ b/git-pack/tests/pack/multi_index/access.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use git_testtools::hex_to_id;
+use crate::hex_to_id;
 
 use super::multi_index;
 

--- a/git-pack/tests/pack/multi_index/mod.rs
+++ b/git-pack/tests/pack/multi_index/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use git_pack::multi_index::File;
 
 fn multi_index() -> (File, PathBuf) {
-    let path = git_testtools::scripted_fixture_read_only("make_pack_gen_repo_multi_index.sh")
+    let path = crate::scripted_fixture_read_only("make_pack_gen_repo_multi_index.sh")
         .expect("test fixture exists")
         .join(".git/objects/pack/multi-pack-index");
     let file = git_pack::multi_index::File::at(&path).unwrap();

--- a/git-pack/tests/pack/multi_index/write.rs
+++ b/git-pack/tests/pack/multi_index/write.rs
@@ -1,12 +1,13 @@
 use std::{path::PathBuf, sync::atomic::AtomicBool};
 
+use crate::hex_to_id;
 use git_features::progress;
-use git_testtools::{fixture_path, hex_to_id};
+use git_testtools::fixture_path_standalone;
 
 #[test]
 fn from_paths() -> crate::Result {
     let dir = tempfile::TempDir::new()?;
-    let input_indices = std::fs::read_dir(fixture_path("objects/pack"))?
+    let input_indices = std::fs::read_dir(fixture_path_standalone("objects/pack"))?
         .filter_map(|r| {
             r.ok()
                 .map(|e| e.path())

--- a/git-protocol/src/handshake/refs/tests.rs
+++ b/git-protocol/src/handshake/refs/tests.rs
@@ -1,5 +1,9 @@
-use git_testtools::hex_to_id as oid;
 use git_transport::{client, client::Capabilities};
+
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+fn oid(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 use crate::handshake::{refs, refs::shared::InternalRef, Ref};
 

--- a/git-ref/Cargo.toml
+++ b/git-ref/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*"]
 rust-version = "1.64"
+autotests = false
 
 [lib]
 doctest = false
@@ -16,12 +17,6 @@ test = true
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "git-hash/serde1", "git-actor/serde1", "git-object/serde1"]
-internal-testing-git-features-parallel = ["git-features/parallel"] # test sorted parallel loose file traversal
-
-[[test]]
-name = "refs-parallel-fs-traversal"
-path = "tests/refs-parallel.rs"
-required-features = ["internal-testing-git-features-parallel"]
 
 [dependencies]
 git-features = { version = "^0.26.1", path = "../git-features", features = ["walkdir"]}
@@ -44,9 +39,6 @@ document-features = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 git-testtools = { path = "../tests/tools" }
-git-discover = { path = "../git-discover" }
-git-worktree = { path = "../git-worktree" }
-git-odb = { path = "../git-odb" }
 tempfile = "3.2.0"
 
 

--- a/git-ref/src/store/file/log/line.rs
+++ b/git-ref/src/store/file/log/line.rs
@@ -169,13 +169,13 @@ pub mod decode {
     #[cfg(test)]
     mod test {
         use git_actor::{Sign, Time};
-        use git_hash::ObjectId;
         use git_object::bstr::ByteSlice;
 
         use super::*;
 
-        fn hex_to_oid(hex: &str) -> ObjectId {
-            ObjectId::from_hex(hex.as_bytes()).unwrap()
+        /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+        fn hex_to_oid(hex: &str) -> git_hash::ObjectId {
+            git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
         }
 
         fn with_newline(mut v: Vec<u8>) -> Vec<u8> {

--- a/git-ref/src/store/file/loose/reflog/create_or_update/tests.rs
+++ b/git-ref/src/store/file/loose/reflog/create_or_update/tests.rs
@@ -2,13 +2,17 @@ use std::{convert::TryInto, path::Path};
 
 use git_actor::{Sign, Signature, Time};
 use git_object::bstr::ByteSlice;
-use git_testtools::hex_to_id;
 use tempfile::TempDir;
 
 use super::*;
 use crate::{file::WriteReflog, FullNameRef};
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 fn empty_store(writemode: WriteReflog) -> Result<(TempDir, file::Store)> {
     let dir = TempDir::new()?;

--- a/git-ref/src/store/packed/decode/tests.rs
+++ b/git-ref/src/store/packed/decode/tests.rs
@@ -1,7 +1,6 @@
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 mod reference {
-    use git_testtools::hex_to_id;
     use nom::error::VerboseError;
 
     use super::Result;
@@ -9,6 +8,11 @@ mod reference {
         store_impl::{packed, packed::decode},
         FullNameRef,
     };
+
+    /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+    fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+        git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+    }
 
     #[test]
     fn invalid() {

--- a/git-ref/tests/Cargo.toml
+++ b/git-ref/tests/Cargo.toml
@@ -16,6 +16,11 @@ serde1 = ["git-ref/serde"]
 internal-testing-git-features-parallel = ["git-features/parallel"] # test sorted parallel loose file traversal
 
 [[test]]
+name = "refs-single-threaded"
+path = "refs.rs"
+required-features = []
+
+[[test]]
 name = "refs-parallel-fs-traversal"
 path = "refs-parallel.rs"
 required-features = ["internal-testing-git-features-parallel"]

--- a/git-ref/tests/Cargo.toml
+++ b/git-ref/tests/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "git-ref-tests"
+version = "0.0.0"
+publish = false
+repository = "https://github.com/Byron/gitoxide"
+license = "MIT/Apache-2.0"
+description = "A crate to handle git references"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+edition = "2021"
+include = ["src/**/*"]
+rust-version = "1.64"
+
+[features]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+serde1 = ["git-ref/serde"]
+internal-testing-git-features-parallel = ["git-features/parallel"] # test sorted parallel loose file traversal
+
+[[test]]
+name = "refs-parallel-fs-traversal"
+path = "refs-parallel.rs"
+required-features = ["internal-testing-git-features-parallel"]
+
+[dev-dependencies]
+git-ref = { path = ".." }
+git-features = { version = "^0.26.1", path = "../../git-features", features = ["walkdir"]}
+git-testtools = { path = "../../tests/tools" }
+git-discover = { path = "../../git-discover" }
+git-worktree = { path = "../../git-worktree" }
+git-odb = { path = "../../git-odb" }
+git-actor = { path = "../../git-actor" }
+git-hash = { path = "../../git-hash" }
+git-validate = { path = "../../git-validate" }
+git-lock = { path = "../../git-lock" }
+git-object = { path = "../../git-object" }
+tempfile = "3.2.0"
+
+
+[package.metadata.docs.rs]
+features = ["document-features", "serde1"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/git-ref/tests/file/log.rs
+++ b/git-ref/tests/file/log.rs
@@ -35,9 +35,11 @@ mod iter {
     use std::path::PathBuf;
 
     fn reflog_dir() -> crate::Result<PathBuf> {
-        Ok(git_testtools::scripted_fixture_read_only("make_repo_for_reflog.sh")?
-            .join(".git")
-            .join("logs"))
+        Ok(
+            git_testtools::scripted_fixture_read_only_standalone("make_repo_for_reflog.sh")?
+                .join(".git")
+                .join("logs"),
+        )
     }
     fn reflog(name: &str) -> crate::Result<Vec<u8>> {
         Ok(std::fs::read(reflog_dir()?.join(name))?)
@@ -89,7 +91,8 @@ mod iter {
 
         mod with_buffer_big_enough_for_largest_line {
             use git_ref::log::Line;
-            use git_testtools::hex_to_id;
+
+            use crate::util::hex_to_id;
 
             #[test]
             fn single_line() -> crate::Result {

--- a/git-ref/tests/file/mod.rs
+++ b/git-ref/tests/file/mod.rs
@@ -14,7 +14,7 @@ pub fn store_with_packed_refs() -> crate::Result<Store> {
 }
 
 pub fn store_at(name: &str) -> crate::Result<Store> {
-    let path = git_testtools::scripted_fixture_read_only(name)?;
+    let path = git_testtools::scripted_fixture_read_only_standalone(name)?;
     Ok(Store::at(
         path.join(".git"),
         git_ref::store::WriteReflog::Normal,
@@ -23,7 +23,7 @@ pub fn store_at(name: &str) -> crate::Result<Store> {
 }
 
 fn store_writable(name: &str) -> crate::Result<(git_testtools::tempfile::TempDir, Store)> {
-    let dir = git_testtools::scripted_fixture_writable(name)?;
+    let dir = git_testtools::scripted_fixture_writable_standalone(name)?;
     let git_dir = dir.path().join(".git");
     Ok((
         dir,

--- a/git-ref/tests/file/reference.rs
+++ b/git-ref/tests/file/reference.rs
@@ -47,9 +47,9 @@ mod reflog {
 }
 
 mod peel {
+    use crate::util::hex_to_id;
     use git_odb::pack::Find;
     use git_ref::{file::ReferenceExt, peel, Reference};
-    use git_testtools::hex_to_id;
 
     use crate::{file, file::store_with_packed_refs};
 
@@ -180,9 +180,9 @@ mod parse {
         mktest!(ref_tag, b"reff: hello", "\"reff: hello\" could not be parsed");
     }
     mod valid {
+        use crate::util::hex_to_id;
         use git_object::bstr::ByteSlice;
         use git_ref::file::loose::Reference;
-        use git_testtools::hex_to_id;
 
         macro_rules! mktest {
             ($name:ident, $input:literal, $kind:path, $id:expr, $ref:expr) => {

--- a/git-ref/tests/file/store/find.rs
+++ b/git-ref/tests/file/store/find.rs
@@ -2,9 +2,9 @@ mod existing {
     use std::convert::{TryFrom, TryInto};
 
     use git_ref::{PartialName, PartialNameRef};
-    use git_testtools::hex_to_id;
 
     use crate::file::store_at;
+    use crate::util::hex_to_id;
 
     #[test]
     fn with_packed_refs() -> crate::Result {

--- a/git-ref/tests/file/store/iter.rs
+++ b/git-ref/tests/file/store/iter.rs
@@ -1,9 +1,9 @@
 use std::convert::TryInto;
 
 use git_object::bstr::ByteSlice;
-use git_testtools::hex_to_id;
 
 use crate::file::{store, store_at, store_with_packed_refs};
+use crate::util::hex_to_id;
 
 mod with_namespace {
     use git_object::bstr::{BString, ByteSlice};

--- a/git-ref/tests/file/store/reflog.rs
+++ b/git-ref/tests/file/store/reflog.rs
@@ -1,6 +1,6 @@
 fn store() -> crate::Result<crate::file::Store> {
     Ok(crate::file::Store::at(
-        git_testtools::scripted_fixture_read_only("make_repo_for_reflog.sh")?.join(".git"),
+        git_testtools::scripted_fixture_read_only_standalone("make_repo_for_reflog.sh")?.join(".git"),
         git_ref::store::WriteReflog::Disable,
         git_hash::Kind::Sha1,
     ))

--- a/git-ref/tests/file/transaction/mod.rs
+++ b/git-ref/tests/file/transaction/mod.rs
@@ -9,7 +9,8 @@ pub(crate) mod prepare_and_commit {
         transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
         Target,
     };
-    use git_testtools::hex_to_id;
+
+    use crate::util::hex_to_id;
 
     fn reflog_lines(store: &file::Store, name: &str) -> crate::Result<Vec<git_ref::log::Line>> {
         let mut buf = Vec::new();

--- a/git-ref/tests/file/transaction/prepare_and_commit/create_or_update/collisions.rs
+++ b/git-ref/tests/file/transaction/prepare_and_commit/create_or_update/collisions.rs
@@ -6,9 +6,11 @@ use git_ref::{
     transaction::{Change, LogChange, PreviousValue, RefEdit},
     Target,
 };
-use git_testtools::hex_to_id;
 
-use crate::file::transaction::prepare_and_commit::{committer, create_at, create_symbolic_at, delete_at, empty_store};
+use crate::{
+    file::transaction::prepare_and_commit::{committer, create_at, create_symbolic_at, delete_at, empty_store},
+    util::hex_to_id,
+};
 
 fn case_sensitive(tmp_dir: &std::path::Path) -> bool {
     std::fs::write(tmp_dir.join("config"), "").expect("can create file once");

--- a/git-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/git-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -13,13 +13,15 @@ use git_ref::{
     transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
     Target,
 };
-use git_testtools::hex_to_id;
 
-use crate::file::{
-    store_with_packed_refs, store_writable,
-    transaction::prepare_and_commit::{
-        committer, create_at, create_symbolic_at, delete_at, empty_store, log_line, reflog_lines,
+use crate::{
+    file::{
+        store_with_packed_refs, store_writable,
+        transaction::prepare_and_commit::{
+            committer, create_at, create_symbolic_at, delete_at, empty_store, log_line, reflog_lines,
+        },
     },
+    util::hex_to_id,
 };
 
 mod collisions;

--- a/git-ref/tests/file/transaction/prepare_and_commit/delete.rs
+++ b/git-ref/tests/file/transaction/prepare_and_commit/delete.rs
@@ -1,12 +1,12 @@
 use std::convert::TryInto;
 
+use crate::util::hex_to_id;
 use git_lock::acquire::Fail;
 use git_ref::{
     file::ReferenceExt,
     transaction::{Change, PreviousValue, RefEdit, RefLog},
     Reference, Target,
 };
-use git_testtools::hex_to_id;
 
 use crate::file::{
     store_writable,

--- a/git-ref/tests/file/worktree.rs
+++ b/git-ref/tests/file/worktree.rs
@@ -11,10 +11,10 @@ fn dir(packed: bool, writable: bool) -> crate::Result<(PathBuf, Option<tempfile:
         args.push("packed");
     }
     if writable {
-        git_testtools::scripted_fixture_writable_with_args(name, args, Creation::ExecuteScript)
+        git_testtools::scripted_fixture_writable_with_args_standalone(name, args, Creation::ExecuteScript)
             .map(|tmp| (tmp.path().to_owned(), tmp.into()))
     } else {
-        git_testtools::scripted_fixture_read_only_with_args(name, args).map(|p| (p, None))
+        git_testtools::scripted_fixture_read_only_with_args_standalone(name, args).map(|p| (p, None))
     }
 }
 
@@ -193,13 +193,13 @@ mod read_only {
 mod writable {
     use std::convert::TryInto;
 
+    use crate::util::hex_to_id;
     use git_lock::acquire::Fail;
     use git_ref::{
         file::{transaction::PackedRefs, Store},
         transaction::{Change, LogChange, PreviousValue, RefEdit},
         FullName, FullNameRef, Target,
     };
-    use git_testtools::hex_to_id;
 
     use crate::file::{
         transaction::prepare_and_commit::committer,

--- a/git-ref/tests/packed/find.rs
+++ b/git-ref/tests/packed/find.rs
@@ -1,7 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use git_ref::packed;
-use git_testtools::fixture_path;
+use git_testtools::fixture_path_standalone;
 
 use crate::{
     file::{store_at, store_with_packed_refs},
@@ -33,7 +33,10 @@ fn all_iterable_refs_can_be_found() -> crate::Result {
 
 #[test]
 fn binary_search_a_name_past_the_end_of_the_packed_refs_file() -> crate::Result {
-    let packed_refs = packed::Buffer::open(fixture_path("packed-refs").join("triggers-out-of-bounds"), 32)?;
+    let packed_refs = packed::Buffer::open(
+        fixture_path_standalone("packed-refs").join("triggers-out-of-bounds"),
+        32,
+    )?;
     assert!(packed_refs.try_find("v0.0.1")?.is_none());
     Ok(())
 }

--- a/git-ref/tests/packed/iter.rs
+++ b/git-ref/tests/packed/iter.rs
@@ -17,7 +17,7 @@ fn empty() -> crate::Result {
 
 #[test]
 fn packed_refs_with_header() -> crate::Result {
-    let dir = git_testtools::scripted_fixture_read_only("make_packed_ref_repository.sh")?;
+    let dir = git_testtools::scripted_fixture_read_only_standalone("make_packed_ref_repository.sh")?;
     let buf = std::fs::read(dir.join(".git").join("packed-refs"))?;
     let iter = packed::Iter::new(&buf)?;
     assert_eq!(iter.count(), 8, "it finds the right amount of items");

--- a/git-ref/tests/packed/open.rs
+++ b/git-ref/tests/packed/open.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use git_testtools::fixture_path;
+use git_testtools::fixture_path_standalone;
 
 use crate::{file::store_with_packed_refs, packed::write_packed_refs_with};
 
@@ -21,7 +21,7 @@ fn empty_buffers_should_not_exist_but_are_fine_to_open() -> crate::Result {
 fn unsorted_buffers_or_those_without_a_header_can_be_opened_and_searched() {
     for (fixture, cutoff) in [("without-header", 20u64), ("unsorted", 32 * 1024)] {
         let buffer = git_ref::packed::Buffer::open(
-            fixture_path(Path::new("packed-refs").join(fixture).to_str().expect("utf8")),
+            fixture_path_standalone(Path::new("packed-refs").join(fixture).to_str().expect("utf8")),
             cutoff,
         )
         .unwrap();

--- a/git-ref/tests/refs-parallel.rs
+++ b/git-ref/tests/refs-parallel.rs
@@ -7,3 +7,4 @@ mod packed;
 mod reference;
 mod store;
 mod transaction;
+mod util;

--- a/git-ref/tests/refs.rs
+++ b/git-ref/tests/refs.rs
@@ -15,3 +15,5 @@ mod reference;
 mod store;
 #[cfg(not(feature = "internal-testing-git-features-parallel"))]
 mod transaction;
+#[cfg(not(feature = "internal-testing-git-features-parallel"))]
+mod util;

--- a/git-ref/tests/store/mod.rs
+++ b/git-ref/tests/store/mod.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "internal-testing-git-features-parallel")]
 fn is_send_and_sync() {
     pub fn store_at(name: &str) -> crate::Result<git_ref::file::Store> {
-        let path = git_testtools::scripted_fixture_read_only(name)?;
+        let path = git_testtools::scripted_fixture_read_only_standalone(name)?;
         Ok(git_ref::file::Store::at(
             path.join(".git"),
             git_ref::store::WriteReflog::Normal,

--- a/git-ref/tests/transaction/mod.rs
+++ b/git-ref/tests/transaction/mod.rs
@@ -98,11 +98,11 @@ mod refedit_ext {
     mod splitting {
         use std::{cell::Cell, convert::TryInto};
 
+        use crate::util::hex_to_id;
         use git_ref::{
             transaction::{Change, LogChange, PreviousValue, RefEdit, RefEditsExt, RefLog},
             FullNameRef, PartialNameRef, Target,
         };
-        use git_testtools::hex_to_id;
 
         use crate::transaction::refedit_ext::MockStore;
 

--- a/git-ref/tests/util.rs
+++ b/git-ref/tests/util.rs
@@ -1,10 +1,5 @@
 use git_hash::ObjectId;
 
-mod kind;
-mod object_id;
-mod oid;
-mod prefix;
-
 pub fn hex_to_id(hex: &str) -> ObjectId {
     ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
 }

--- a/git-repository/src/remote/connection/fetch/update_refs/tests.rs
+++ b/git-repository/src/remote/connection/fetch/update_refs/tests.rs
@@ -2,10 +2,16 @@ pub fn restricted() -> crate::open::Options {
     crate::open::Options::isolated().config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"])
 }
 
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
+
 mod update {
     use std::convert::TryInto;
 
-    use git_testtools::{hex_to_id, Result};
+    use super::hex_to_id;
+    use git_testtools::Result;
 
     use crate as git;
 

--- a/git-repository/tests/id/mod.rs
+++ b/git-repository/tests/id/mod.rs
@@ -2,7 +2,11 @@ use std::cmp::Ordering;
 
 use git_repository as git;
 use git_repository::prelude::ObjectIdExt;
-use git_testtools::hex_to_id;
+
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 #[test]
 fn prefix() -> crate::Result {

--- a/git-repository/tests/object/commit.rs
+++ b/git-repository/tests/object/commit.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
 
-use git_testtools::hex_to_id;
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 use crate::basic_repo;
 

--- a/git-repository/tests/reference/mod.rs
+++ b/git-repository/tests/reference/mod.rs
@@ -25,7 +25,8 @@ mod find {
 
     use git_ref as refs;
     use git_ref::FullNameRef;
-    use git_testtools::hex_to_id;
+
+    use crate::util::hex_to_id;
 
     fn repo() -> crate::Result<git_repository::Repository> {
         crate::repo("make_references_repo.sh").map(Into::into)

--- a/git-repository/tests/remote/fetch.rs
+++ b/git-repository/tests/remote/fetch.rs
@@ -2,11 +2,11 @@
 mod blocking_and_async_io {
     use std::sync::atomic::AtomicBool;
 
+    use crate::util::hex_to_id;
     use git_features::progress;
     use git_protocol::maybe_async;
     use git_repository as git;
     use git_repository::remote::{fetch, Direction::Fetch};
-    use git_testtools::hex_to_id;
 
     use crate::remote::{into_daemon_remote_if_async, spawn_git_daemon_if_async};
 

--- a/git-repository/tests/repository/object.rs
+++ b/git-repository/tests/repository/object.rs
@@ -20,7 +20,7 @@ mod write_object {
 mod write_blob {
     use std::io::{Seek, SeekFrom};
 
-    use git_testtools::hex_to_id;
+    use crate::util::hex_to_id;
 
     use crate::repository::object::empty_bare_repo;
 
@@ -184,8 +184,9 @@ mod commit_as {
 }
 
 mod commit {
+    use crate::util::hex_to_id;
     use git_repository as git;
-    use git_testtools::{hex_to_id, tempfile};
+    use git_testtools::tempfile;
 
     use crate::{freeze_time, restricted_and_git};
 

--- a/git-repository/tests/repository/reference.rs
+++ b/git-repository/tests/repository/reference.rs
@@ -82,8 +82,8 @@ mod set_namespace {
 }
 
 mod iter_references {
+    use crate::util::hex_to_id;
     use git_repository as git;
-    use git_testtools::hex_to_id;
 
     fn repo() -> crate::Result<git::Repository> {
         crate::repo("make_references_repo.sh").map(|r| r.to_thread_local())
@@ -187,9 +187,9 @@ mod iter_references {
 
 mod head {
 
+    use crate::util::hex_to_id;
     use git_ref::transaction::PreviousValue;
     use git_repository as git;
-    use git_testtools::hex_to_id;
 
     #[test]
     fn symbolic() -> crate::Result {

--- a/git-repository/tests/revision/spec/from_bytes/ambiguous.rs
+++ b/git-repository/tests/revision/spec/from_bytes/ambiguous.rs
@@ -1,3 +1,4 @@
+use crate::util::hex_to_id;
 use git_repository::{
     prelude::{ObjectIdExt, RevSpecExt},
     revision::{
@@ -5,7 +6,6 @@ use git_repository::{
         Spec,
     },
 };
-use git_testtools::hex_to_id;
 
 use super::repo;
 use crate::revision::spec::from_bytes::{

--- a/git-repository/tests/revision/spec/from_bytes/mod.rs
+++ b/git-repository/tests/revision/spec/from_bytes/mod.rs
@@ -1,5 +1,5 @@
+use crate::util::hex_to_id;
 use git_repository::{prelude::ObjectIdExt, revision::Spec};
-use git_testtools::hex_to_id;
 pub use util::*;
 
 mod ambiguous;
@@ -32,8 +32,8 @@ mod sibling_branch {
 }
 
 mod index {
+    use crate::util::hex_to_id;
     use git_repository::{prelude::ObjectIdExt, revision::Spec};
-    use git_testtools::hex_to_id;
 
     use crate::revision::spec::from_bytes::{parse_spec, repo};
 

--- a/git-repository/tests/revision/spec/from_bytes/peel.rs
+++ b/git-repository/tests/revision/spec/from_bytes/peel.rs
@@ -1,5 +1,5 @@
+use crate::util::hex_to_id;
 use git_repository::{prelude::ObjectIdExt, revision::Spec};
-use git_testtools::hex_to_id;
 
 use crate::revision::spec::from_bytes::{parse_spec, repo};
 

--- a/git-repository/tests/revision/spec/from_bytes/reflog.rs
+++ b/git-repository/tests/revision/spec/from_bytes/reflog.rs
@@ -1,8 +1,8 @@
+use crate::util::hex_to_id;
 use git_repository::{
     prelude::ObjectIdExt,
     revision::{spec::parse::Error, Spec},
 };
-use git_testtools::hex_to_id;
 
 use crate::revision::spec::from_bytes::{parse_spec, parse_spec_no_baseline, repo};
 

--- a/git-repository/tests/revision/spec/from_bytes/regex.rs
+++ b/git-repository/tests/revision/spec/from_bytes/regex.rs
@@ -1,5 +1,5 @@
+use crate::util::hex_to_id;
 use git_repository::prelude::ObjectIdExt;
-use git_testtools::hex_to_id;
 
 use crate::revision::spec::from_bytes::{parse_spec_no_baseline, repo};
 

--- a/git-repository/tests/revision/spec/from_bytes/traverse.rs
+++ b/git-repository/tests/revision/spec/from_bytes/traverse.rs
@@ -1,5 +1,5 @@
+use crate::util::hex_to_id;
 use git_repository::{prelude::ObjectIdExt, revision::Spec};
-use git_testtools::hex_to_id;
 
 use crate::revision::spec::from_bytes::{parse_spec, repo};
 

--- a/git-repository/tests/util/mod.rs
+++ b/git-repository/tests/util/mod.rs
@@ -3,6 +3,11 @@ use git_testtools::tempfile;
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+pub fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
+
 pub fn freeze_time() -> git_testtools::Env<'static> {
     let frozen_time = "1979-02-26 18:30:00";
     git_testtools::Env::new()

--- a/git-revision/Cargo.toml
+++ b/git-revision/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "CHANGELOG.md", "README.md"]
 rust-version = "1.64"
+autotests = false
 
 [lib]
 doctest = false
@@ -26,10 +27,6 @@ bstr = { version = "1.0.1", default-features = false, features = ["std"]}
 thiserror = "1.0.26"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 document-features = { version = "0.2.1", optional = true }
-
-[dev-dependencies]
-git-testtools = { path = "../tests/tools" }
-git-repository = { path = "../git-repository", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/git-revision/tests/Cargo.toml
+++ b/git-revision/tests/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "git-revision-tests"
+version = "0.0.0"
+publish = false
+repository = "https://github.com/Byron/gitoxide"
+license = "MIT/Apache-2.0"
+description = "A WIP crate of the gitoxide project dealing with finding names for revisions and parsing specifications"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+edition = "2021"
+include = ["src/**/*", "CHANGELOG.md", "README.md"]
+rust-version = "1.64"
+
+[[test]]
+name = "revision"
+doctest = false
+path = "revision.rs"
+
+[features]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+serde1 = [ "git-revision/serde", "git-hash/serde1", "git-object/serde1" ]
+
+[dev-dependencies]
+git-revision = { path = "..", default-features = false }
+git-hash = { path = "../../git-hash" }
+git-object = { path = "../../git-object" }
+git-testtools = { path = "../../tests/tools" }
+git-repository = { path = "../../git-repository", default-features = false }
+
+bstr = { version = "1.0.1", default-features = false, features = ["std"]}

--- a/git-revision/tests/describe/format.rs
+++ b/git-revision/tests/describe/format.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
+use crate::hex_to_id;
 use git_object::bstr::ByteSlice;
 use git_revision::describe;
-use git_testtools::hex_to_id;
 
 #[test]
 fn exact_match_with_dirty_and_long() {

--- a/git-revision/tests/describe/mod.rs
+++ b/git-revision/tests/describe/mod.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
+use crate::hex_to_id;
 use git_object::bstr::ByteSlice;
 use git_repository::{
     odb::{Find, FindExt},
     Repository,
 };
 use git_revision::describe;
-use git_testtools::hex_to_id;
 
 mod format;
 
@@ -194,6 +194,6 @@ fn typical_usecases() {
 }
 
 fn repo() -> Repository {
-    let dir = git_testtools::scripted_fixture_read_only("make_repo_with_branches.sh").unwrap();
+    let dir = git_testtools::scripted_fixture_read_only_standalone("make_repo_with_branches.sh").unwrap();
     git_repository::open(dir).unwrap()
 }

--- a/git-revision/tests/revision.rs
+++ b/git-revision/tests/revision.rs
@@ -2,3 +2,8 @@ mod describe;
 mod spec;
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
+
+/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+pub fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}

--- a/git-revision/tests/spec/display.rs
+++ b/git-revision/tests/spec/display.rs
@@ -1,4 +1,4 @@
-use git_testtools::hex_to_id;
+use crate::hex_to_id;
 
 fn oid() -> git_hash::ObjectId {
     hex_to_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")

--- a/git-traverse/Cargo.toml
+++ b/git-traverse/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*"]
 rust-version = "1.64"
+autotests = false
 
 [lib]
 doctest = false
@@ -17,7 +18,3 @@ git-hash = { version = "^0.10.1", path = "../git-hash" }
 git-object = { version = "^0.26.0", path = "../git-object" }
 git-hashtable = { version = "^0.1.0", path = "../git-hashtable" }
 thiserror = "1.0.32"
-
-[dev-dependencies]
-git-testtools = { path = "../tests/tools" }
-git-odb = { path = "../git-odb" }

--- a/git-traverse/tests/Cargo.toml
+++ b/git-traverse/tests/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "git-traverse-tests"
+version = "0.0.0"
+repository = "https://github.com/Byron/gitoxide"
+license = "MIT/Apache-2.0"
+description = "A WIP crate of the gitoxide project"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+edition = "2021"
+include = ["src/**/*"]
+rust-version = "1.64"
+
+[[test]]
+name ="test"
+path = "traverse.rs"
+
+[dev-dependencies]
+git-traverse = { path = ".." }
+git-testtools = { path = "../../tests/tools" }
+git-odb = { path = "../../git-odb" }
+git-hash = { path = "../../git-hash" }
+git-object = { path = "../../git-object" }

--- a/git-traverse/tests/commit/mod.rs
+++ b/git-traverse/tests/commit/mod.rs
@@ -37,7 +37,7 @@ mod ancestor {
 
     impl TraversalAssertion<'_> {
         fn setup(&self) -> crate::Result<(git_odb::Handle, Vec<ObjectId>, Vec<ObjectId>)> {
-            let dir = git_testtools::scripted_fixture_read_only(self.init_script)?;
+            let dir = git_testtools::scripted_fixture_read_only_standalone(self.init_script)?;
             let store = git_odb::at(dir.join(".git").join("objects"))?;
             let tips: Vec<_> = self.tips.iter().copied().map(hex_to_id).collect();
             let expected: Vec<ObjectId> = tips
@@ -237,7 +237,8 @@ mod ancestor {
 
     #[test]
     fn committer_date_sorted_commits_with_cutoff_is_applied_to_starting_position() -> crate::Result {
-        let dir = git_testtools::scripted_fixture_read_only("make_traversal_repo_for_commits_with_dates.sh")?;
+        let dir =
+            git_testtools::scripted_fixture_read_only_standalone("make_traversal_repo_for_commits_with_dates.sh")?;
         let store = git_odb::at(dir.join(".git").join("objects"))?;
         let iter = commit::Ancestors::new(
             Some(hex_to_id("9902e3c3e8f0c569b4ab295ddf473e6de763e1e7")),

--- a/git-traverse/tests/traverse.rs
+++ b/git-traverse/tests/traverse.rs
@@ -1,6 +1,8 @@
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-pub use git_testtools::hex_to_id;
+fn hex_to_id(hex: &str) -> git_hash::ObjectId {
+    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 mod commit;
 mod tree;

--- a/git-traverse/tests/tree/mod.rs
+++ b/git-traverse/tests/tree/mod.rs
@@ -4,7 +4,7 @@ use git_traverse::tree;
 use crate::hex_to_id;
 
 fn db() -> crate::Result<git_odb::Handle> {
-    let dir = git_testtools::scripted_fixture_read_only("make_traversal_repo_for_trees.sh")?;
+    let dir = git_testtools::scripted_fixture_read_only_standalone("make_traversal_repo_for_trees.sh")?;
     let db = git_odb::at(dir.join(".git").join("objects"))?;
     Ok(db)
 }

--- a/git-worktree/tests/worktree/fs/cache/ignore_and_attributes.rs
+++ b/git-worktree/tests/worktree/fs/cache/ignore_and_attributes.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
+use crate::hex_to_id;
 use bstr::{BStr, ByteSlice};
 use git_glob::pattern::Case;
 use git_index::entry::Mode;
 use git_odb::{pack::bundle::write::Options, FindExt};
-use git_testtools::hex_to_id;
 use git_worktree::fs;
 use tempfile::{tempdir, TempDir};
 

--- a/git-worktree/tests/worktree/mod.rs
+++ b/git-worktree/tests/worktree/mod.rs
@@ -1,8 +1,13 @@
 mod fs;
 mod index;
 
+use git_hash::ObjectId;
 use std::path::{Path, PathBuf};
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub fn hex_to_id(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+}
 
 pub fn fixture_path(name: &str) -> PathBuf {
     let dir = git_testtools::scripted_fixture_read_only(Path::new(name).with_extension("sh")).expect("script works");

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -14,11 +14,10 @@ path = "src/main.rs"
 doctest = false
 
 [dependencies]
-git-hash = { version = "^0.10.1", path = "../../git-hash" }
-git-lock = { version = "^3.0.0", path = "../../git-lock" }
-git-discover = { version = "^0.12.1", path = "../../git-discover" }
-git-attributes = { version = "^0.8.1", path = "../../git-attributes" }
-git-worktree = { version = "^0.12.1", path = "../../git-worktree" }
+git-lock = "^3.0.0"
+git-discover = "^0.12.1"
+git-attributes = "^0.8.1"
+git-worktree = "^0.12.1"
 
 nom = { version = "7", default-features = false, features = ["std"]}
 fastrand = "1.8.0"

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -187,19 +187,36 @@ pub fn spawn_git_daemon(working_dir: impl AsRef<Path>) -> std::io::Result<GitDae
     })
 }
 
-/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
-pub fn hex_to_id(hex: &str) -> git_hash::ObjectId {
-    git_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
-}
-
 /// Return the path to the `<crate-root>/tests/fixtures/<path>` directory.
 pub fn fixture_path(path: impl AsRef<Path>) -> PathBuf {
-    PathBuf::from("tests").join("fixtures").join(path.as_ref())
+    fixture_path_inner(path, false)
+}
+
+/// Return the path to the `<crate-root>/fixtures/<path>` directory.
+pub fn fixture_path_standalone(path: impl AsRef<Path>) -> PathBuf {
+    fixture_path_inner(path, true)
+}
+/// Return the path to the `<crate-root>/tests/fixtures/<path>` directory.
+fn fixture_path_inner(path: impl AsRef<Path>, standalone_test: bool) -> PathBuf {
+    if standalone_test {
+        PathBuf::from("fixtures").join(path.as_ref())
+    } else {
+        PathBuf::from("tests").join("fixtures").join(path.as_ref())
+    }
 }
 
 /// Load the fixture from `<crate-root>/tests/fixtures/<path>` and return its data, or _panic_.
 pub fn fixture_bytes(path: impl AsRef<Path>) -> Vec<u8> {
-    match std::fs::read(fixture_path(path.as_ref())) {
+    fixture_bytes_inner(path, false)
+}
+
+/// Like [`scripted_fixture_writable`], but does not prefix the fixture directory with `tests`
+pub fn fixture_bytes_standalone(path: impl AsRef<Path>) -> Vec<u8> {
+    fixture_bytes_inner(path, true)
+}
+
+fn fixture_bytes_inner(path: impl AsRef<Path>, standalone_test: bool) -> Vec<u8> {
+    match std::fs::read(fixture_path_inner(path.as_ref(), standalone_test)) {
         Ok(res) => res,
         Err(_) => panic!("File at '{}' not found", path.as_ref().display()),
     }
@@ -231,12 +248,22 @@ pub fn scripted_fixture_read_only(script_name: impl AsRef<Path>) -> Result<PathB
     scripted_fixture_read_only_with_args(script_name, None::<String>)
 }
 
+/// Like [`scripted_fixture_read_only`], but does not prefix the fixture directory with `tests`
+pub fn scripted_fixture_read_only_standalone(script_name: impl AsRef<Path>) -> Result<PathBuf> {
+    scripted_fixture_read_only_with_args_standalone(script_name, None::<String>)
+}
+
 /// Run the executable at `script_name`, like `make_repo.sh` to produce a writable directory to which
 /// the tempdir is returned. It will be removed automatically, courtesy of [`tempfile::TempDir`].
 ///
 /// Note that `script_name` is only executed once, so the data can be copied from its read-only location.
 pub fn scripted_fixture_writable(script_name: &str) -> Result<tempfile::TempDir> {
     scripted_fixture_writable_with_args(script_name, None::<String>, Creation::CopyFromReadOnly)
+}
+
+/// Like [`scripted_fixture_writable`], but does not prefix the fixture directory with `tests`
+pub fn scripted_fixture_writable_standalone(script_name: &str) -> Result<tempfile::TempDir> {
+    scripted_fixture_writable_with_args_standalone(script_name, None::<String>, Creation::CopyFromReadOnly)
 }
 
 /// Like [`scripted_fixture_writable()`], but passes `args` to `script_name` while providing control over
@@ -246,15 +273,33 @@ pub fn scripted_fixture_writable_with_args(
     args: impl IntoIterator<Item = impl Into<String>>,
     mode: Creation,
 ) -> Result<tempfile::TempDir> {
+    scripted_fixture_writable_with_args_inner(script_name, args, mode, false)
+}
+
+/// Like [`scripted_fixture_writable_with_args`], but does not prefix the fixture directory with `tests`
+pub fn scripted_fixture_writable_with_args_standalone(
+    script_name: &str,
+    args: impl IntoIterator<Item = impl Into<String>>,
+    mode: Creation,
+) -> Result<tempfile::TempDir> {
+    scripted_fixture_writable_with_args_inner(script_name, args, mode, true)
+}
+
+fn scripted_fixture_writable_with_args_inner(
+    script_name: &str,
+    args: impl IntoIterator<Item = impl Into<String>>,
+    mode: Creation,
+    standalone_test: bool,
+) -> Result<tempfile::TempDir> {
     let dst = tempfile::TempDir::new()?;
     Ok(match mode {
         Creation::CopyFromReadOnly => {
-            let ro_dir = scripted_fixture_read_only_with_args_inner(script_name, args, None)?;
+            let ro_dir = scripted_fixture_read_only_with_args_inner(script_name, args, None, standalone_test)?;
             copy_recursively_into_existing_dir(ro_dir, dst.path())?;
             dst
         }
         Creation::ExecuteScript => {
-            scripted_fixture_read_only_with_args_inner(script_name, args, dst.path().into())?;
+            scripted_fixture_read_only_with_args_inner(script_name, args, dst.path().into(), standalone_test)?;
             dst
         }
     })
@@ -284,13 +329,22 @@ pub fn scripted_fixture_read_only_with_args(
     script_name: impl AsRef<Path>,
     args: impl IntoIterator<Item = impl Into<String>>,
 ) -> Result<PathBuf> {
-    scripted_fixture_read_only_with_args_inner(script_name, args, None)
+    scripted_fixture_read_only_with_args_inner(script_name, args, None, false)
+}
+
+/// Like [`scripted_fixture_read_only_with_args()`], but does not prefix the fixture directory with `tests`
+pub fn scripted_fixture_read_only_with_args_standalone(
+    script_name: impl AsRef<Path>,
+    args: impl IntoIterator<Item = impl Into<String>>,
+) -> Result<PathBuf> {
+    scripted_fixture_read_only_with_args_inner(script_name, args, None, true)
 }
 
 fn scripted_fixture_read_only_with_args_inner(
     script_name: impl AsRef<Path>,
     args: impl IntoIterator<Item = impl Into<String>>,
     destination_dir: Option<&Path>,
+    standalone_test: bool,
 ) -> Result<PathBuf> {
     // Assure tempfiles get removed when aborting the test.
     git_lock::tempfile::setup(
@@ -298,7 +352,7 @@ fn scripted_fixture_read_only_with_args_inner(
     );
 
     let script_location = script_name.as_ref();
-    let script_path = fixture_path(script_location);
+    let script_path = fixture_path_inner(script_location, standalone_test);
 
     // keep this lock to assure we don't return unfinished directories for threaded callers
     let args: Vec<String> = args.into_iter().map(Into::into).collect();
@@ -323,15 +377,19 @@ fn scripted_fixture_read_only_with_args_inner(
     };
 
     let script_basename = script_location.file_stem().unwrap_or(script_location.as_os_str());
-    let archive_file_path = fixture_path(
+    let archive_file_path = fixture_path_inner(
         Path::new("generated-archives").join(format!("{}.tar.xz", script_basename.to_str().expect("valid UTF-8"))),
+        standalone_test,
     );
     let (force_run, script_result_directory) = destination_dir.map(|d| (true, d.to_owned())).unwrap_or_else(|| {
-        let dir = fixture_path(Path::new("generated-do-not-edit").join(script_basename).join(format!(
-            "{}-{}",
-            script_identity,
-            family_name()
-        )));
+        let dir = fixture_path_inner(
+            Path::new("generated-do-not-edit").join(script_basename).join(format!(
+                "{}-{}",
+                script_identity,
+                family_name()
+            )),
+            standalone_test,
+        );
         (false, dir)
     });
 
@@ -483,6 +541,7 @@ fn create_archive_if_not_on_ci(source_dir: &Path, archive: &Path, script_identit
     std::fs::remove_dir_all(meta_dir)?;
     #[cfg(windows)]
     std::fs::remove_dir_all(meta_dir).ok(); // it really can't delete these directories for some reason (even after 10 seconds)
+
     res
 }
 


### PR DESCRIPTION
Supercedes #699

This PR breaks cyclical dev-dependencies.
These cause problems with rust analyzer which makes gitoxide development with RA basically impossible.
git-testools is mostly used as a utility we can simply use the crates.io version of the respective gitoxide crates to circumvent that problem. However, most other crates require matching crate versions. Here the integration tests were simply moved to a subcrate in the same folder by adding a Cargo.toml file in the tests folder.

The hex_to_id function in git-testtools is a specical case because that function returns a git_hash::ObjectId instance. This ObjectId would belong to the crates.io version of git-hash and can not be used in tests. To work around that hex_to_id is moved into the individual tests as it's a very small one-line function.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
