### PR TITLE
fix(git-transport): Place port for PuTTY and derivates in separate argument

### DIFF
--- a/git-transport/src/client/blocking_io/ssh/program_kind.rs
+++ b/git-transport/src/client/blocking_io/ssh/program_kind.rs
@@ -49,7 +49,8 @@ impl ProgramKind {
                     prepare = prepare.arg("-batch");
                 }
                 if let Some(port) = url.port {
-                    prepare = prepare.arg(format!("-P{}", port));
+                    prepare = prepare.arg("-P");
+                    prepare = prepare.arg(port.to_string());
                 }
             }
             ProgramKind::Simple => {

--- a/git-transport/src/client/blocking_io/ssh/tests.rs
+++ b/git-transport/src/client/blocking_io/ssh/tests.rs
@@ -134,14 +134,14 @@ mod program_kind {
         fn tortoise_plink_has_batch_command() {
             assert_eq!(
                 call_args(ProgramKind::TortoisePlink, "ssh://user@host:42/p", Protocol::V2),
-                quoted(&["tortoiseplink.exe", "-batch", "-P42", "user@host"])
+                quoted(&["tortoiseplink.exe", "-batch", "-P", "42", "user@host"])
             );
         }
 
         #[test]
         fn port_for_all() {
             for kind in [ProgramKind::TortoisePlink, ProgramKind::Plink, ProgramKind::Putty] {
-                assert!(call_args(kind, "ssh://user@host:43/p", Protocol::V2).ends_with(r#""-P43" "user@host""#));
+                assert!(call_args(kind, "ssh://user@host:43/p", Protocol::V2).ends_with(r#""-P" "43" "user@host""#));
             }
         }
 


### PR DESCRIPTION
All three PuTTY clients require the port to be separated from the "-P" argument

----
- [x] I give my permission to record review and upload on YouTube publicly
