### PR TITLE
fix(git-discover): split `GIT_CEILING_DIRECTORIES` by semicolon on Windows

### DIFF
--- a/git-discover/Cargo.toml
+++ b/git-discover/Cargo.toml
@@ -29,5 +29,5 @@ is_ci = "1.1.1"
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 defer = "0.1.0"
 
-[target.'cfg(unix)'.dev-dependencies]
+[target.'cfg(any(unix, windows))'.dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
Git splits `GIT_CEILING_DIRECTORIES` by `PATH_SEP` ([source](https://github.com/git/git/blob/2fc9e9ca3c7505bc60069f11e7ef09b1aeeee473/setup.c#L1260)). `PATH_SEP` is `;` on Windows (`:` anywhere else). 

This PR adds a check for the platform and uses `;` on Windows.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
