### PR TITLE
Permit ceiling dirs not to match if `apply_environment` is used

### DIFF
--- a/git-discover/src/upwards/types.rs
+++ b/git-discover/src/upwards/types.rs
@@ -77,12 +77,16 @@ impl Options<'_> {
     ///
     /// Note that `GIT_DISCOVERY_ACROSS_FILESYSTEM` for `cross_fs` is **not** read,
     /// as it requires parsing of `git-config` style boolean values.
+    ///
+    /// In addition, this function disables `match_ceiling_dir_or_error` to allow
+    /// discovery if an outside environment variable sets non-matching ceiling directories.
     // TODO: test
     pub fn apply_environment(mut self) -> Self {
         let name = "GIT_CEILING_DIRECTORIES";
         if let Some(ceiling_dirs) = env::var_os(name) {
             self.ceiling_dirs = parse_ceiling_dirs(&ceiling_dirs);
         }
+        self.match_ceiling_dir_or_error = false;
         self
     }
 }


### PR DESCRIPTION
If values for `ceiling_dirs` are pulled from the environment instead of explicit `Options` configuration, I feel that it makes sense to permit non-matching `ceiling_dir` the same way git does.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
