### PR TITLE
adjustments for cargo

### DIFF
--- a/git-repository/src/config/tree/keys.rs
+++ b/git-repository/src/config/tree/keys.rs
@@ -125,8 +125,8 @@ impl<T: Validate> Key for Any<T> {
         self.name
     }
 
-    fn validate(&self, value: &BStr) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        self.validate.validate(value)
+    fn validate(&self, value: &BStr) -> Result<(), config::tree::key::validate::Error> {
+        Ok(self.validate.validate(value)?)
     }
 
     fn section(&self) -> &dyn Section {

--- a/git-repository/src/config/tree/mod.rs
+++ b/git-repository/src/config/tree/mod.rs
@@ -92,5 +92,32 @@ pub use sections::{
 /// Generic value implementations for static instantiation.
 pub mod keys;
 
+///
+pub mod key {
+    ///
+    pub mod validate {
+        /// The error returned by [Key::validate()][crate::config::tree::Key::validate()].
+        #[derive(Debug, thiserror::Error)]
+        #[error(transparent)]
+        #[allow(missing_docs)]
+        pub struct Error {
+            #[from]
+            source: Box<dyn std::error::Error + Send + Sync + 'static>,
+        }
+    }
+    ///
+    pub mod validate_assignment {
+        /// The error returned by [Key::validated_assignment*()][crate::config::tree::Key::validated_assignment_fmt()].
+        #[derive(Debug, thiserror::Error)]
+        #[allow(missing_docs)]
+        pub enum Error {
+            #[error("Failed to validate the value to be assigned to this key")]
+            Validate(#[from] super::validate::Error),
+            #[error("{message}")]
+            Name { message: String },
+        }
+    }
+}
+
 mod traits;
 pub use traits::{Key, Link, Note, Section, SubSectionRequirement};

--- a/git-repository/src/env.rs
+++ b/git-repository/src/env.rs
@@ -34,3 +34,96 @@ pub fn args_os() -> impl Iterator<Item = OsString> {
 pub fn os_str_to_bstring(input: &OsStr) -> Option<BString> {
     Vec::from_os_string(input.into()).map(Into::into).ok()
 }
+
+/// Utilities to collate errors of common operations into one error type.
+///
+/// This is useful as this type can present an API to answer common questions, like whether a network request seems to have failed
+/// spuriously or if the underlying repository seems to be corrupted.
+/// Error collation supports all operations, including opening the repository.
+///
+/// ### Usage
+///
+/// The caller may define a function that specifies the result type as `Result<T, git::env::collate::{operation}::Error>` to collect
+/// errors into a well-known error type which provides an API for simple queries.
+pub mod collate {
+
+    ///
+    pub mod fetch {
+        /// An error which combines all possible errors when opening a repository, finding remotes and using them to fetch.
+        ///
+        /// It can be used to detect if the repository is likely be corrupted in some way, or if the fetch failed spuriously
+        /// and thus can be retried.
+        #[derive(Debug, thiserror::Error)]
+        #[allow(missing_docs)]
+        pub enum Error<E: std::error::Error + Send + Sync + 'static = std::convert::Infallible> {
+            #[error(transparent)]
+            Open(#[from] crate::open::Error),
+            #[error(transparent)]
+            FindExistingReference(#[from] crate::reference::find::existing::Error),
+            #[error(transparent)]
+            RemoteInit(#[from] crate::remote::init::Error),
+            #[error(transparent)]
+            FindExistingRemote(#[from] crate::remote::find::existing::Error),
+            #[error(transparent)]
+            CredentialHelperConfig(#[from] crate::config::credential_helpers::Error),
+            #[cfg(any(feature = "blocking-network-client", feature = "async-network-client"))]
+            #[error(transparent)]
+            Connect(#[from] crate::remote::connect::Error),
+            #[cfg(any(feature = "blocking-network-client", feature = "async-network-client"))]
+            #[error(transparent)]
+            PrepareFetch(#[from] crate::remote::fetch::prepare::Error),
+            #[cfg(any(feature = "blocking-network-client", feature = "async-network-client"))]
+            #[error(transparent)]
+            Fetch(#[from] crate::remote::fetch::Error),
+            #[error(transparent)]
+            Other(E),
+        }
+
+        #[cfg(any(feature = "async-network-client", feature = "blocking-network-client"))]
+        impl<E> crate::protocol::transport::IsSpuriousError for Error<E>
+        where
+            E: std::error::Error + Send + Sync + 'static,
+        {
+            fn is_spurious(&self) -> bool {
+                match self {
+                    Error::Open(_)
+                    | Error::CredentialHelperConfig(_)
+                    | Error::RemoteInit(_)
+                    | Error::FindExistingReference(_)
+                    | Error::FindExistingRemote(_)
+                    | Error::Other(_) => false,
+                    Error::Connect(err) => err.is_spurious(),
+                    Error::PrepareFetch(err) => err.is_spurious(),
+                    Error::Fetch(err) => err.is_spurious(),
+                }
+            }
+        }
+
+        /// Queries
+        impl<E> Error<E>
+        where
+            E: std::error::Error + Send + Sync + 'static,
+        {
+            /// Return true if repository corruption caused the failure.
+            pub fn is_corrupted(&self) -> bool {
+                match self {
+                    Error::Open(crate::open::Error::NotARepository { .. } | crate::open::Error::Config(_)) => true,
+                    #[cfg(any(feature = "async-network-client", feature = "blocking-network-client"))]
+                    Error::PrepareFetch(crate::remote::fetch::prepare::Error::RefMap(
+                        // Configuration couldn't be accessed or was incomplete.
+                        crate::remote::ref_map::Error::GatherTransportConfig { .. }
+                        | crate::remote::ref_map::Error::ConfigureCredentials(_),
+                    )) => true,
+                    // Maybe the value of the configuration was corrupted, or a file couldn't be removed.
+                    #[cfg(any(feature = "async-network-client", feature = "blocking-network-client"))]
+                    Error::Fetch(
+                        crate::remote::fetch::Error::PackThreads(_)
+                        | crate::remote::fetch::Error::PackIndexVersion(_)
+                        | crate::remote::fetch::Error::RemovePackKeepFile { .. },
+                    ) => true,
+                    _ => false,
+                }
+            }
+        }
+    }
+}

--- a/git-repository/tests/config/tree.rs
+++ b/git-repository/tests/config/tree.rs
@@ -431,6 +431,19 @@ mod protocol {
 }
 
 mod gitoxide {
+    mod http {
+        use git_repository::config::tree::{gitoxide, Key};
+        use std::time::Duration;
+
+        #[test]
+        fn connect_timeout() -> crate::Result {
+            assert_eq!(
+                gitoxide::Http::CONNECT_TIMEOUT.validated_assignment_fmt(&Duration::from_millis(1000).as_millis())?,
+                "gitoxide.http.connectTimeout=1000"
+            );
+            Ok(())
+        }
+    }
     mod allow {
         use git_repository::config::tree::{gitoxide, Key};
 


### PR DESCRIPTION
### Tasks

* [x] add a perform_fetch(cb) -> Result<…, OneCombinedError> method which combines all possible errors of related fetch calls into one with .is_spurious(). That way the set of errors is contained and spuriousness is maintained in gitoxide. Should be 'repo-corrupted' and 'is-spurious'