### PR TITLE
fix: ignore ceiling directories equal to cwd

### DIFF
--- a/git-discover/src/upwards/util.rs
+++ b/git-discover/src/upwards/util.rs
@@ -56,6 +56,7 @@ pub(crate) fn find_ceiling_height(search_dir: &Path, ceiling_dirs: &[PathBuf], c
                 .strip_prefix(ceiling_dir.as_ref())
                 .ok()
                 .map(|path_relative_to_ceiling| path_relative_to_ceiling.components().count())
+                .filter(|height| *height > 0)
         })
         .min()
 }

--- a/git-discover/tests/isolated.rs
+++ b/git-discover/tests/isolated.rs
@@ -52,10 +52,7 @@ fn upwards_with_relative_directories_and_optional_ceiling() -> git_testtools::Re
         .unwrap_err();
 
         assert!(
-            matches!(
-                err,
-                git_discover::upwards::Error::NoGitRepositoryWithinCeiling { ceiling_height: 1, .. }
-            ),
+            matches!(err, git_discover::upwards::Error::NoMatchingCeilingDir),
             "limiting the ceiling to the CWD cannot work as it's just an empty dir"
         );
     }

--- a/git-discover/tests/upwards/ceiling_dirs.rs
+++ b/git-discover/tests/upwards/ceiling_dirs.rs
@@ -32,6 +32,24 @@ fn git_dir_candidate_within_ceiling_allows_discovery() -> crate::Result {
 }
 
 #[test]
+fn git_dir_candidate_with_cwd_ceiling() -> crate::Result {
+    let work_dir = repo_path()?;
+    let dir = work_dir.join("some/very/deeply/nested/subdir");
+    let (repo_path, _trust) = git_discover::upwards_opts(
+        dir.clone(),
+        Options {
+            ceiling_dirs: vec![dir],
+            match_ceiling_dir_or_error: false,
+            ..Default::default()
+        },
+    )
+    .expect("ceiling dir should be skipped");
+    assert_repo_is_current_workdir(repo_path, &work_dir);
+
+    Ok(())
+}
+
+#[test]
 fn ceiling_dir_limits_are_respected_and_prevent_discovery() -> crate::Result {
     let work_dir = repo_path()?;
     let dir = work_dir.join("some/very/deeply/nested/subdir");


### PR DESCRIPTION
[The git documentation](https://git-scm.com/docs/git) says about the ceiling directory: "It will not exclude the current working directory...". Currently, if a ceiling directory is equal the cwd, the [`max_height`](https://github.com/Byron/gitoxide/blob/f774027fcbd777df2ac60215aa47a11fb0066e54/git-discover/src/upwards/mod.rs#L67) will be `Some(0)` making the [check against the `current_height`](https://github.com/Byron/gitoxide/blob/f774027fcbd777df2ac60215aa47a11fb0066e54/git-discover/src/upwards/mod.rs#L82) always fail, and thus no repository will be discovered.

The git client, however, will discover a repo:

Repo location: `C:\Users\User\AppData\Local\Temp\.tmpZZuL2L`, `GIT_CEILING_DIRECTORIES="C:\Users\User\AppData\Local\Temp\.tmpZZuL2L\level1\level2"`
```powershell
> C:\Users\User\AppData\Local\Temp\.tmpZZuL2L\level1\level2
╰─ git rev-parse HEAD
35dc38f922e4b6d6596cc7c5a0bb5caf00f1db64
```

The git client [uses `longest_ancestor_length`](https://github.com/git/git/blob/a6a323b31e2bcbac2518bddec71ea7ad558870eb/setup.c#L1263) to check the ceiling height. This returns -1 (no ceiling) in the case above.

<details>
<summary>Reproduction</summary>

```c
#include <stdio.h>
#include <string.h>

// from git source
struct string_list_item {
  char *string;
  void *util;
};

struct string_list {
  struct string_list_item *items;
  size_t nr;
  // addidional fields omitted
};

int longest_ancestor_length(const char *path, struct string_list *prefixes) {
  int i, max_len = -1;

  if (!strcmp(path, "/"))
    return -1;

  for (i = 0; i < prefixes->nr; i++) {
    const char *ceil = prefixes->items[i].string;
    int len = strlen(ceil);

    /*
     * For root directories (`/`, `C:/`, `//server/share/`)
     * adjust the length to exclude the trailing slash.
     */
    if (len > 0 && ceil[len - 1] == '/')
      len--;

    if (strncmp(path, ceil, len) || path[len] != '/' || !path[len + 1])
      continue; /* no match */

    if (len > max_len)
      max_len = len;
  }

  return max_len;
}

int main() {
  struct string_list_item it = {
      .string =
          "C:/Users/User/User/Local/Temp/.tmpZZuL2L/level1/level2"};
  struct string_list lst = {.items = &it, .nr = 1};
  // this will print -1 (no ceiling)
  printf("%d\n",
         longest_ancestor_length(
             "C:/Users/User/AppData/Local/Temp/.tmpZZuL2L/level1/level2",
             &lst));
  return 0;
}
``` 
</details>

This PR adjusts the behavior to match.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
