### PR TITLE
preliminary wasm32 support for git-pack

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -32,6 +32,7 @@ jobs:
         name: crates without feature toggles
       - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd git-features && cargo build --features $feature --target ${{ matrix.target }}); done
         name: features of git-features
-      - run: set +x; for name in git-diff; do (cd $name && cargo build --features wasm --target ${{ matrix.target }}); done
+      - run: set +x; for name in git-diff git-pack; do (cd $name && cargo build --features wasm --target ${{ matrix.target }}); done
         name: crates with 'wasm' feature
-#      - run: cargo build -p git-pack --target ${{ matrix.target }} // TODO: make something like it work
+      - run: cd git-pack && cargo build --all-features --target ${{ matrix.target }}
+        name: git-pack with all features (including wasm)

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -32,4 +32,6 @@ jobs:
         name: crates without feature toggles
       - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd git-features && cargo build --features $feature --target ${{ matrix.target }}); done
         name: features of git-features
+      - run: set +x; for name in git-diff; do (cd $name && cargo build --features wasm --target ${{ matrix.target }}); done
+        name: crates with 'wasm' feature
 #      - run: cargo build -p git-pack --target ${{ matrix.target }} // TODO: make something like it work

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,35 @@
+name: WASM
+
+on:
+  push:
+    branches: [ main ]
+    tags-ignore: [ '*' ]
+    paths:
+      - '.github/**'
+      - 'git-pack/**'
+      - '*.toml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/**'
+      - 'git-pack/**'
+      - '*.toml'
+
+jobs:
+  wasm:
+    name: WebAssembly
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        target: [ wasm32-unknown-unknown, wasm32-wasi ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - run: set +x; for name in git-actor git-attributes git-bitmap git-chunk git-command git-commitgraph git-date git-glob git-hash git-hashtable git-mailmap git-object git-packetline git-path git-pathspec git-quote git-refspec git-revision git-traverse git-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
+        name: crates without feature toggles
+      - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd git-features && cargo build --features $feature --target ${{ matrix.target }}); done
+        name: features of git-features
+#      - run: cargo build -p git-pack --target ${{ matrix.target }} // TODO: make something like it work

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,8 +1181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1407,6 +1409,7 @@ dependencies = [
 name = "git-diff"
 version = "0.26.1"
 dependencies = [
+ "getrandom",
  "git-hash 0.10.2",
  "git-object 0.26.1",
  "imara-diff",

--- a/git-diff/Cargo.toml
+++ b/git-diff/Cargo.toml
@@ -11,7 +11,10 @@ rust-version = "1.64"
 autotests = false
 
 [features]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "git-hash/serde1", "git-object/serde1"]
+## Make it possible to compile to the `wasm32-unknown-unknown` target.
+wasm = ["dep:getrandom"]
 
 [lib]
 doctest = false
@@ -22,3 +25,4 @@ git-object = { version = "^0.26.1", path = "../git-object" }
 thiserror = "1.0.32"
 imara-diff = "0.1.3"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
+getrandom = { version = "0.2.8", optional = true, default-features = false, features = ["js"] }

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -24,6 +24,8 @@ pack-cache-lru-dynamic = ["clru"]
 object-cache-dynamic = ["clru"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde1 = ["serde", "git-object/serde1"]
+## Make it possible to compile to the `wasm32-unknown-unknown` target.
+wasm = ["git-diff/wasm"]
 
 [dependencies]
 git-features = { version = "^0.26.4", path = "../git-features", features = ["crc32", "rustsha1", "progress", "zlib"] }

--- a/git-pack/Cargo.toml
+++ b/git-pack/Cargo.toml
@@ -17,13 +17,13 @@ doctest = false
 
 ## Provide a fixed-size allocation-free LRU cache for packs. It's useful if caching is desired while keeping the memory footprint
 ## for the LRU-cache itself low.
-pack-cache-lru-static = ["uluru"]
+pack-cache-lru-static = ["dep:uluru"]
 ## Provide a hash-map based LRU cache whose eviction is based a memory cap calculated from object data.
-pack-cache-lru-dynamic = ["clru"]
+pack-cache-lru-dynamic = ["dep:clru"]
 ## If set, select algorithms may additionally use a full-object cache which is queried before the pack itself.
-object-cache-dynamic = ["clru"]
+object-cache-dynamic = ["dep:clru"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "git-object/serde1"]
+serde1 = ["dep:serde", "git-object/serde1"]
 ## Make it possible to compile to the `wasm32-unknown-unknown` target.
 wasm = ["git-diff/wasm"]
 
@@ -35,20 +35,24 @@ git-chunk = { version = "^0.4.1", path = "../git-chunk" }
 git-object = { version = "^0.26.1", path = "../git-object" }
 git-traverse = { version = "^0.22.1", path = "../git-traverse" }
 git-diff = { version = "^0.26.1", path = "../git-diff" }
-git-tempfile = { version = "^3.0.0", path = "../git-tempfile" }
 git-hashtable = { version = "^0.1.1", path = "../git-hashtable" }
 
-smallvec = "1.3.0"
 memmap2 = "0.5.0"
-serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
+smallvec = "1.3.0"
 bytesize = "1.0.1"
 parking_lot = { version = "0.12.0", default-features = false }
 thiserror = "1.0.26"
 uluru = { version = "3.0.0", optional = true }
 clru = { version = "0.6.1", optional = true }
+
+serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
+## If enabled, `cargo doc` will see feature documentation from this manifest.
+document-features = { version = "0.2.0", optional = true }
 dashmap = "5.1.0"
 
-document-features = { version = "0.2.0", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+git-tempfile = { version = "^3.0.0", path = "../git-tempfile" }
 
 [dev-dependencies]
 git-testtools = { path = "../tests/tools"}

--- a/git-pack/src/bundle/mod.rs
+++ b/git-pack/src/bundle/mod.rs
@@ -3,6 +3,7 @@ pub mod init;
 
 mod find;
 ///
+#[cfg(not(feature = "wasm"))]
 pub mod write;
 
 ///

--- a/git-pack/src/lib.rs
+++ b/git-pack/src/lib.rs
@@ -17,17 +17,15 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
-#![cfg(all(target_arch = "wasm32", target_os = "unknown", not(feature = "wasm")))]
-compile_error!("the wasm32-unknown-unknown target is not supported by default,  and the \"wasm\" feature is required.");
 
 ///
 pub mod bundle;
 /// A bundle of pack data and the corresponding pack index
 pub struct Bundle {
     /// The pack file corresponding to `index`
-    pub pack: crate::data::File,
+    pub pack: data::File,
     /// The index file corresponding to `pack`
-    pub index: crate::index::File,
+    pub index: index::File,
 }
 
 ///
@@ -39,7 +37,6 @@ pub mod cache;
 pub mod data;
 
 mod find_traits;
-
 pub use find_traits::{Find, FindExt};
 
 ///

--- a/git-pack/src/lib.rs
+++ b/git-pack/src/lib.rs
@@ -17,6 +17,8 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
+#![cfg(all(target_arch = "wasm32", target_os = "unknown", not(feature = "wasm")))]
+compile_error!("the wasm32-unknown-unknown target is not supported by default,  and the \"wasm\" feature is required.");
 
 ///
 pub mod bundle;

--- a/git-pack/tests/Cargo.toml
+++ b/git-pack/tests/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.64"
 
 ## Provide a fixed-size allocation-free LRU cache for packs. It's useful if caching is desired while keeping the memory footprint
 ## for the LRU-cache itself low.
-pack-cache-lru-static = ["git-pack/uluru"]
+pack-cache-lru-static = ["git-pack/pack-cache-lru-static"]
 ## Provide a hash-map based LRU cache whose eviction is based a memory cap calculated from object data.
 pack-cache-lru-dynamic = ["git-pack/pack-cache-lru-dynamic"]
 ## If set, select algorithms may additionally use a full-object cache which is queried before the pack itself.

--- a/git-path/src/convert.rs
+++ b/git-path/src/convert.rs
@@ -54,7 +54,7 @@ pub fn try_into_bstr<'a>(path: impl Into<Cow<'a, Path>>) -> Result<Cow<'a, BStr>
                 use std::os::wasi::ffi::OsStringExt;
                 path.into_os_string().into_vec().into()
             };
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, target_os = "wasi")))]
             let p: BString = path.into_os_string().into_string().map_err(|_| Utf8Error)?.into();
             p
         }),
@@ -69,7 +69,7 @@ pub fn try_into_bstr<'a>(path: impl Into<Cow<'a, Path>>) -> Result<Cow<'a, BStr>
                 use std::os::wasi::ffi::OsStrExt;
                 path.as_os_str().as_bytes().into()
             };
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, target_os = "wasi")))]
             let p: &BStr = path.to_str().ok_or(Utf8Error)?.as_bytes().into();
             p
         }),
@@ -94,11 +94,11 @@ pub fn try_from_byte_slice(input: &[u8]) -> Result<&Path, Utf8Error> {
         OsStr::from_bytes(input).as_ref()
     };
     #[cfg(target_os = "wasi")]
-    let p = {
+    let p: &Path = {
         use std::os::wasi::ffi::OsStrExt;
         OsStr::from_bytes(input).as_ref()
     };
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, target_os = "wasi")))]
     let p = Path::new(std::str::from_utf8(input).map_err(|_| Utf8Error)?);
     Ok(p)
 }
@@ -126,11 +126,11 @@ pub fn try_from_bstring(input: impl Into<BString>) -> Result<PathBuf, Utf8Error>
         std::ffi::OsString::from_vec(input.into()).into()
     };
     #[cfg(target_os = "wasi")]
-    let p = {
+    let p: PathBuf = {
         use std::os::wasi::ffi::OsStringExt;
         std::ffi::OsString::from_vec(input.into()).into()
     };
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, target_os = "wasi")))]
     let p = {
         use bstr::ByteVec;
         PathBuf::from(


### PR DESCRIPTION
The goal of this PR is to make accelerated pack resolution available in WASM. This includes the following steps

* an iterator of entries that were decoded from a pack (the pack decoding is excluded here)
* resolve thin-packs on the fly
* create a an index for accelerated pack resolution
* run pack resolution with user-definable code (it will see the decoded object in full to do whatever it needs to)

From there it should be possible to have a WASM server receive a pack assuming it has a way to decode the pack into entries. 
Maybe the decoding step must be possible here too for convenience.

### Tasks

* [x] CI validation of WASM support (or the lack of it)
* [x] Crates that work already and should keep working

It seems it's best to extract parts into their own crate

### Tasks for Extraction

All of what follows should compile as`WASM-unknown-unknown` target

* **std** - probably these work out of the box, needed by `cache::delta::Tree`
     - [x] `AtomicBool` for interruptions
     - [x] `io::BufRead`
     - [x] `io::Write`
* **git-features** - mostly for decoding that pack
    - [x] `crc32`
    - [x] SHA1 hashing (should work)
    - [x] flate2 (minizoxide backend only) - [should already work](https://github.com/rust-lang/flate2-rs/issues/161)
    - [x] progress (and with that much of `prodash` with `Arc` and `AtomicUsize` for counters
* [x] **git-hash** for `Kind` and `ObjectId`
* **git-pack**
    - [x] LookupRefDeltaObjectsIter
    - [x] BytesToEntriesIter
        - [x] decoding machinery
    - ~~EntriesToBytesIter~~ - writes a pack right back to disk for lookup, but there is no disk
    - [x] `cache::delta::Tree` - used to see each packed object and its hash for connectivity checks knowing what's in the pack
    - ~~`index::File::write_data_iter_to_stream(…)`~~ - not needed as the delta::Tree is doing all the work. It does, however, contain the core algorithm on bringing everything together and in theory can be used to create a pack index file in memory.


### Research

Blockers: everything with IO, namely

* `git-lock` and `git-tempfile`
* `libc` seems to support only `wasm32-unknown-emscripten`

To circumvent, some crates might have to be split. Problem here is type ownership - WASM compatible crates probably shouldn't own the type in question so must provide pure functions with a lot of parameters or contexts.

There might be duplication of documentation unless these are just referring to each other. It's still a slightly strange setup to have WASM in different crates, but inclusion seems easier to handle than exclusion.

### Learnings

* using `wasm32-wasi` seems to generally produce better error messages as it supports more out of the box. This can pinpoint locations where incompatible crates are being used.

### Interesting Reads

- [relationship between `std` and `asm`](https://www.reddit.com/r/rust/comments/kyae22/is_possible_to_compile_the_std_lib_of_rust_to_wasm/)
- Could [`WASI`](https://docs.wasmtime.dev/wasm-rust.html) help?