### PR TITLE
add missing 'not' in error messages

### DIFF
--- a/gix-discover/src/upwards/types.rs
+++ b/gix-discover/src/upwards/types.rs
@@ -10,15 +10,15 @@ pub enum Error {
     InvalidInput { directory: PathBuf },
     #[error("Failed to access a directory, or path is not a directory: '{}'", .path.display())]
     InaccessibleDirectory { path: PathBuf },
-    #[error("Could find a git repository in '{}' or in any of its parents", .path.display())]
+    #[error("Could not find a git repository in '{}' or in any of its parents", .path.display())]
     NoGitRepository { path: PathBuf },
-    #[error("Could find a git repository in '{}' or in any of its parents within ceiling height of {}", .path.display(), .ceiling_height)]
+    #[error("Could not find a git repository in '{}' or in any of its parents within ceiling height of {}", .path.display(), .ceiling_height)]
     NoGitRepositoryWithinCeiling { path: PathBuf, ceiling_height: usize },
-    #[error("Could find a git repository in '{}' or in any of its parents within device limits below '{}'", .path.display(), .limit.display())]
+    #[error("Could not find a git repository in '{}' or in any of its parents within device limits below '{}'", .path.display(), .limit.display())]
     NoGitRepositoryWithinFs { path: PathBuf, limit: PathBuf },
     #[error("None of the passed ceiling directories prefixed the git-dir candidate, making them ineffective.")]
     NoMatchingCeilingDir,
-    #[error("Could find a trusted git repository in '{}' or in any of its parents, candidate at '{}' discarded", .path.display(), .candidate.display())]
+    #[error("Could not find a trusted git repository in '{}' or in any of its parents, candidate at '{}' discarded", .path.display(), .candidate.display())]
     NoTrustedGitRepository {
         path: PathBuf,
         candidate: PathBuf,


### PR DESCRIPTION
Adds missing 'not' in some error messages.

Fixes #771  

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [ ] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
