### PR TITLE
various fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,12 +145,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
- "futures-lite",
 ]
 
 [[package]]
@@ -200,9 +199,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -255,9 +254,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -317,18 +316,18 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytesize"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "camino"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -350,7 +349,7 @@ dependencies = [
  "bitflags",
  "cargo_metadata",
  "cargo_toml",
- "clap 4.1.6",
+ "clap 4.1.8",
  "crates-index",
  "env_logger",
  "git-conventional",
@@ -382,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189929343288eb08d1f418bfbc022a5bddc6889e4a8f8dfaf06035fd3adf6fed"
+checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
 dependencies = [
  "serde",
  "toml",
@@ -467,13 +466,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -482,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -504,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -594,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.19.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9215c1ea7200e68d292d57a84f7992e66752a9bc719c48d67d7f11ee34e5a47a"
+checksum = "51ddd986d8b0405750d3da55a36cfa5ddad74a6dbf8826dec1cae40bf1218bd4"
 dependencies = [
  "git2",
  "hex",
@@ -689,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -699,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -710,14 +709,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -733,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -751,7 +750,7 @@ dependencies = [
  "futures-core",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -819,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
+version = "0.4.60+curl-7.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
+checksum = "717abe2cb465a5da6ce06617388a3980c9a2844196734bec8ccb8e575250f13f"
 dependencies = [
  "cc",
  "libc",
@@ -842,7 +841,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1087,9 +1086,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1102,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1112,15 +1111,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1129,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
@@ -1150,21 +1149,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1211,13 +1210,13 @@ dependencies = [
 
 [[package]]
 name = "git-conventional"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2033e90bdceee1540826d126c95461a90b9411624f110feab6fcd5149790231"
+checksum = "47f12808f7f7aed1a42d1c3a2c9f7cfc17dd169b41733506aba160c93b39c80c"
 dependencies = [
  "doc-comment",
- "nom",
  "unicase",
+ "winnow",
 ]
 
 [[package]]
@@ -1240,7 +1239,7 @@ name = "gitoxide"
 version = "0.24.0"
 dependencies = [
  "anyhow",
- "clap 4.1.6",
+ "clap 4.1.8",
  "crosstermion",
  "document-features",
  "env_logger",
@@ -1381,7 +1380,7 @@ dependencies = [
  "gix-features 0.26.5",
  "gix-glob 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-path 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-quote 0.4.2",
+ "gix-quote 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "unicode-bom",
 ]
@@ -1404,18 +1403,18 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5229fd26e288f417c8dd2385c5bc740415eb55aba4d6f529db7ad4b526771e06"
+version = "0.2.2"
 dependencies = [
- "quick-error 2.0.1",
+ "gix-testtools",
+ "thiserror",
 ]
 
 [[package]]
 name = "gix-bitmap"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "024bca0c7187517bda5ea24ab148c9ca8208dd0c3e2bea88cdb2008f91791a6d"
 dependencies = [
- "gix-testtools",
  "thiserror",
 ]
 
@@ -1630,7 +1629,7 @@ dependencies = [
  "jwalk",
  "libc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "prodash",
  "sha1",
  "sha1_smol",
@@ -1691,21 +1690,22 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a256cceeea0f0d7f42a0c3ac649535644a04395d9f415518f4008ef6bb331b5"
+version = "0.1.2"
 dependencies = [
- "gix-hash 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.10.3",
  "hashbrown 0.13.2",
+ "parking_lot",
 ]
 
 [[package]]
 name = "gix-hashtable"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9609c1b8f36f12968e6a6098f7cdb52004f7d42d570f47a2d6d7c16612f19acb"
 dependencies = [
- "gix-hash 0.10.3",
+ "gix-hash 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.13.2",
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1718,12 +1718,12 @@ dependencies = [
  "bitflags",
  "bstr",
  "filetime",
- "gix-bitmap 0.2.1",
+ "gix-bitmap 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-features 0.26.5",
  "gix-hash 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-lock 3.0.2",
- "gix-object 0.26.2",
- "gix-traverse 0.22.1",
+ "gix-object 0.26.4",
+ "gix-traverse 0.22.2",
  "itoa",
  "memmap2",
  "smallvec",
@@ -1808,9 +1808,9 @@ version = "0.0.0"
 
 [[package]]
 name = "gix-object"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b04e3028ddab838d005104f234f4d2c26ecd51f2d72d96747c878094c4619"
+checksum = "edce7170ebcf6fc1487304631556f8bc2b70c8bcbf997a2d73634688bcc92f4e"
 dependencies = [
  "bstr",
  "btoi",
@@ -1863,7 +1863,7 @@ dependencies = [
  "gix-quote 0.4.3",
  "gix-testtools",
  "maplit",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pretty_assertions",
  "serde",
  "tempfile",
@@ -1887,7 +1887,7 @@ dependencies = [
  "gix-testtools",
  "gix-traverse 0.24.0",
  "memmap2",
- "parking_lot 0.12.1",
+ "parking_lot",
  "serde",
  "smallvec",
  "thiserror",
@@ -1970,7 +1970,7 @@ dependencies = [
  "gix-config-value",
  "gix-testtools",
  "nix 0.26.2",
- "parking_lot 0.12.1",
+ "parking_lot",
  "serial_test",
  "thiserror",
 ]
@@ -2000,18 +2000,18 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34cffcf5dd0ddf06a768b697a0f29319284deffba970e4355b51b0fee61ffa2"
+version = "0.4.3"
 dependencies = [
  "bstr",
  "btoi",
- "quick-error 2.0.1",
+ "thiserror",
 ]
 
 [[package]]
 name = "gix-quote"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a282f5a8d9ee0b09ec47390ac727350c48f2f5c76d803cd8da6b3e7ad56e0bcb"
 dependencies = [
  "bstr",
  "btoi",
@@ -2032,7 +2032,7 @@ dependencies = [
  "gix-features 0.26.5",
  "gix-hash 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-lock 3.0.2",
- "gix-object 0.26.2",
+ "gix-object 0.26.4",
  "gix-path 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-tempfile 3.0.2",
  "gix-validate 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2176,7 +2176,7 @@ dependencies = [
  "document-features",
  "libc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-registry",
  "tempfile",
@@ -2198,7 +2198,7 @@ dependencies = [
  "is_ci",
  "nom",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "tar",
  "tempfile",
  "xz2",
@@ -2239,13 +2239,13 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ee7eee98b6e196fba1f34751d4399e0daa4e61892a78f634d0901e52dd739b"
+checksum = "2b86456d713143fac5aea6787eb3ec6efc0f6dd90ed625fb3f0badf7936ef084"
 dependencies = [
  "gix-hash 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.1.1",
- "gix-object 0.26.2",
+ "gix-hashtable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-object 0.26.4",
  "thiserror",
 ]
 
@@ -2319,7 +2319,7 @@ dependencies = [
  "gix-glob 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-hash 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-index 0.12.4",
- "gix-object 0.26.2",
+ "gix-object 0.26.4",
  "gix-path 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-close",
  "thiserror",
@@ -2362,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2470,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -2516,9 +2516,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2639,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -2667,9 +2667,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -2694,15 +2694,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -2743,9 +2743,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libgit2-sys"
@@ -2889,9 +2889,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -2907,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -3022,15 +3022,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3158,37 +3149,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3258,16 +3224,18 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
+ "bitflags",
  "cfg-if",
+ "concurrent-queue",
  "libc",
  "log",
- "wepoll-ffi",
- "windows-sys 0.42.0",
+ "pin-project-lite",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3323,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "23.1.0"
+version = "23.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ee4651b19ce9933cb6077977767f44d332f14603f00d455ce9284e709493d0"
+checksum = "9516b775656bc3e8985e19cd4b8c0c0de045095074e453d2c0a513b5f978392d"
 dependencies = [
  "async-io",
  "atty",
@@ -3336,7 +3304,7 @@ dependencies = [
  "human_format",
  "humantime",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
  "signal-hook",
  "time",
  "tui",
@@ -3419,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -3429,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3572,9 +3540,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -3607,15 +3575,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -3685,18 +3653,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3705,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -3745,7 +3713,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "serial_test_derive",
 ]
 
@@ -3825,9 +3793,9 @@ checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3852,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3886,9 +3854,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3945,18 +3913,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3965,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -3985,9 +3953,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -4019,9 +3987,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4031,7 +3999,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4092,15 +4060,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.3"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+checksum = "7082a95d48029677a28f181e5f6422d0c8339ad8396a39d3f33d62a90c1f6c30"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4177,7 +4145,7 @@ dependencies = [
  "ipconfig",
  "lazy_static",
  "lru-cache",
- "parking_lot 0.12.1",
+ "parking_lot",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -4243,9 +4211,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-bom"
@@ -4255,9 +4223,9 @@ checksum = "63ec69f541d875b783ca40184d655f2927c95f0bffd486faa83cd3ac3529ec32"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -4448,15 +4416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,6 +4590,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ unit-tests: ## run all unit tests
 					&& cargo test --features blocking-network-client \
 					&& cargo test --features regex
 	cd gitoxide-core && cargo test --lib
+# cd gix && cargo test --features async-network-client-async-std \ not being run as it's flaky even locally
 
 nextest: ## run tests with `cargo nextest` (all unit-tests, no doc-tests, faster)
 	cargo nextest run --all

--- a/crate-status.md
+++ b/crate-status.md
@@ -638,11 +638,13 @@ See its [README.md](https://github.com/Byron/gitoxide/blob/main/gix-lock/README.
             - [ ] respect `branch.<name>.merge` in the returned remote.
     * **remotes**  
         * [x] clone 
-          * [ ] shallow
+          * [x] shallow
             * [ ] include-tags when shallow is used (needs separate fetch)
             * [ ] prune non-existing shallow commits
           * [ ] [bundles](https://git-scm.com/docs/git-bundle)
         * [x] fetch
+           * [x] shallow (remains shallow, options to adjust shallow boundary)
+           * [ ] a way to auto-explode small packs to avoid them to pile up
            * [ ] 'ref-in-want'
            * [ ] standard negotiation algorithms (right now we only have a 'naive' one)
         * [ ] push

--- a/gix-packetline/src/read/async_io.rs
+++ b/gix-packetline/src/read/async_io.rs
@@ -4,6 +4,7 @@ use bstr::ByteSlice;
 use futures_io::AsyncRead;
 use futures_lite::AsyncReadExt;
 
+use crate::read::ProgressAction;
 use crate::{
     decode,
     read::{ExhaustiveOutcome, WithSidebands},
@@ -150,7 +151,8 @@ where
     /// Same as [`as_read_with_sidebands(…)`][StreamingPeekableIter::as_read_with_sidebands()], but for channels without side band support.
     ///
     /// Due to the preconfigured function type this method can be called without 'turbofish'.
-    pub fn as_read(&mut self) -> WithSidebands<'_, T, fn(bool, &[u8])> {
+    #[allow(clippy::type_complexity)]
+    pub fn as_read(&mut self) -> WithSidebands<'_, T, fn(bool, &[u8]) -> ProgressAction> {
         WithSidebands::new(self)
     }
 
@@ -161,7 +163,7 @@ where
     /// being true in case the `text` is to be interpreted as error.
     ///
     /// _Please note_ that side bands need to be negotiated with the server.
-    pub fn as_read_with_sidebands<F: FnMut(bool, &[u8]) + Unpin>(
+    pub fn as_read_with_sidebands<F: FnMut(bool, &[u8]) -> ProgressAction + Unpin>(
         &mut self,
         handle_progress: F,
     ) -> WithSidebands<'_, T, F> {
@@ -172,7 +174,9 @@ where
     ///
     /// The type parameter `F` needs to be configured for this method to be callable using the 'turbofish' operator.
     /// Use [`as_read()`][StreamingPeekableIter::as_read()].
-    pub fn as_read_without_sidebands<F: FnMut(bool, &[u8]) + Unpin>(&mut self) -> WithSidebands<'_, T, F> {
+    pub fn as_read_without_sidebands<F: FnMut(bool, &[u8]) -> ProgressAction + Unpin>(
+        &mut self,
+    ) -> WithSidebands<'_, T, F> {
         WithSidebands::without_progress_handler(self)
     }
 }

--- a/gix-packetline/src/read/blocking_io.rs
+++ b/gix-packetline/src/read/blocking_io.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use bstr::ByteSlice;
 
+use crate::read::ProgressAction;
 use crate::{
     decode,
     read::{ExhaustiveOutcome, WithSidebands},
@@ -146,7 +147,10 @@ where
     /// being true in case the `text` is to be interpreted as error.
     ///
     /// _Please note_ that side bands need to be negotiated with the server.
-    pub fn as_read_with_sidebands<F: FnMut(bool, &[u8])>(&mut self, handle_progress: F) -> WithSidebands<'_, T, F> {
+    pub fn as_read_with_sidebands<F: FnMut(bool, &[u8]) -> ProgressAction>(
+        &mut self,
+        handle_progress: F,
+    ) -> WithSidebands<'_, T, F> {
         WithSidebands::with_progress_handler(self, handle_progress)
     }
 
@@ -154,14 +158,15 @@ where
     ///
     /// The type parameter `F` needs to be configured for this method to be callable using the 'turbofish' operator.
     /// Use [`as_read()`][StreamingPeekableIter::as_read()].
-    pub fn as_read_without_sidebands<F: FnMut(bool, &[u8])>(&mut self) -> WithSidebands<'_, T, F> {
+    pub fn as_read_without_sidebands<F: FnMut(bool, &[u8]) -> ProgressAction>(&mut self) -> WithSidebands<'_, T, F> {
         WithSidebands::without_progress_handler(self)
     }
 
     /// Same as [`as_read_with_sidebands(…)`][StreamingPeekableIter::as_read_with_sidebands()], but for channels without side band support.
     ///
     /// Due to the preconfigured function type this method can be called without 'turbofish'.
-    pub fn as_read(&mut self) -> WithSidebands<'_, T, fn(bool, &[u8])> {
+    #[allow(clippy::type_complexity)]
+    pub fn as_read(&mut self) -> WithSidebands<'_, T, fn(bool, &[u8]) -> ProgressAction> {
         WithSidebands::new(self)
     }
 }

--- a/gix-packetline/src/read/mod.rs
+++ b/gix-packetline/src/read/mod.rs
@@ -2,6 +2,15 @@
 use crate::MAX_LINE_LEN;
 use crate::{PacketLineRef, StreamingPeekableIter, U16_HEX_BYTES};
 
+/// Allow the read-progress handler to determine how to continue.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ProgressAction {
+    /// Continue reading the next progress if available.
+    Continue,
+    /// Abort all IO even if more would be available, claiming the operation was interrupted.
+    Interrupt,
+}
+
 #[cfg(any(feature = "blocking-io", feature = "async-io"))]
 type ExhaustiveOutcome<'a> = (
     bool,                                                                     // is_done

--- a/gix-packetline/src/read/sidebands/async_io.rs
+++ b/gix-packetline/src/read/sidebands/async_io.rs
@@ -7,6 +7,7 @@ use std::{
 use futures_io::{AsyncBufRead, AsyncRead};
 use futures_lite::ready;
 
+use crate::read::ProgressAction;
 use crate::{decode, BandRef, PacketLineRef, StreamingPeekableIter, TextRef, U16_HEX_BYTES};
 
 type ReadLineResult<'a> = Option<std::io::Result<Result<PacketLineRef<'a>, decode::Error>>>;
@@ -37,7 +38,7 @@ where
     }
 }
 
-impl<'a, T> WithSidebands<'a, T, fn(bool, &[u8])>
+impl<'a, T> WithSidebands<'a, T, fn(bool, &[u8]) -> ProgressAction>
 where
     T: AsyncRead,
 {
@@ -93,7 +94,7 @@ mod tests {
 impl<'a, T, F> WithSidebands<'a, T, F>
 where
     T: AsyncRead + Unpin,
-    F: FnMut(bool, &[u8]) + Unpin,
+    F: FnMut(bool, &[u8]) -> ProgressAction + Unpin,
 {
     /// Create a new instance with the given `parent` provider and the `handle_progress` function.
     ///
@@ -201,7 +202,7 @@ pub struct ReadDataLineFuture<'a, 'b, T: AsyncRead, F> {
 impl<'a, 'b, T, F> Future for ReadDataLineFuture<'a, 'b, T, F>
 where
     T: AsyncRead + Unpin,
-    F: FnMut(bool, &[u8]) + Unpin,
+    F: FnMut(bool, &[u8]) -> ProgressAction + Unpin,
 {
     type Output = std::io::Result<usize>;
 
@@ -228,7 +229,7 @@ pub struct ReadLineFuture<'a, 'b, T: AsyncRead, F> {
 impl<'a, 'b, T, F> Future for ReadLineFuture<'a, 'b, T, F>
 where
     T: AsyncRead + Unpin,
-    F: FnMut(bool, &[u8]) + Unpin,
+    F: FnMut(bool, &[u8]) -> ProgressAction + Unpin,
 {
     type Output = std::io::Result<usize>;
 
@@ -251,7 +252,7 @@ where
 impl<'a, T, F> AsyncBufRead for WithSidebands<'a, T, F>
 where
     T: AsyncRead + Unpin,
-    F: FnMut(bool, &[u8]) + Unpin,
+    F: FnMut(bool, &[u8]) -> ProgressAction + Unpin,
 {
     fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
         use std::io;
@@ -310,11 +311,27 @@ where
                                         }
                                         BandRef::Progress(d) => {
                                             let text = TextRef::from(d).0;
-                                            handle_progress(false, text);
+                                            match handle_progress(false, text) {
+                                                ProgressAction::Continue => {}
+                                                ProgressAction::Interrupt => {
+                                                    return Poll::Ready(Err(io::Error::new(
+                                                        std::io::ErrorKind::Other,
+                                                        "interrupted by user",
+                                                    )))
+                                                }
+                                            };
                                         }
                                         BandRef::Error(d) => {
                                             let text = TextRef::from(d).0;
-                                            handle_progress(true, text);
+                                            match handle_progress(true, text) {
+                                                ProgressAction::Continue => {}
+                                                ProgressAction::Interrupt => {
+                                                    return Poll::Ready(Err(io::Error::new(
+                                                        io::ErrorKind::Other,
+                                                        "interrupted by user",
+                                                    )))
+                                                }
+                                            };
                                         }
                                     };
                                 }
@@ -353,7 +370,7 @@ where
 impl<'a, T, F> AsyncRead for WithSidebands<'a, T, F>
 where
     T: AsyncRead + Unpin,
-    F: FnMut(bool, &[u8]) + Unpin,
+    F: FnMut(bool, &[u8]) -> ProgressAction + Unpin,
 {
     fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
         let nread = {

--- a/gix-protocol/src/fetch_fn.rs
+++ b/gix-protocol/src/fetch_fn.rs
@@ -49,6 +49,8 @@ impl Default for FetchConnection {
 /// _Note_ that depending on the `delegate`, the actual action performed can be `ls-refs`, `clone` or `fetch`.
 #[allow(clippy::result_large_err)]
 #[maybe_async]
+// TODO: remove this without losing test coverage - we have the same but better in `gix` and it's
+//       not really worth it to maintain the delegates here.
 pub async fn fetch<F, D, T, P>(
     mut transport: T,
     mut delegate: D,
@@ -162,7 +164,8 @@ where
     reader.set_progress_handler(Some(Box::new({
         let mut remote_progress = progress.add_child("remote");
         move |is_err: bool, data: &[u8]| {
-            crate::RemoteProgress::translate_to_progress(is_err, data, &mut remote_progress)
+            crate::RemoteProgress::translate_to_progress(is_err, data, &mut remote_progress);
+            gix_transport::packetline::read::ProgressAction::Continue
         }
     }) as gix_transport::client::HandleProgress));
 }

--- a/gix-protocol/tests/fetch/response.rs
+++ b/gix-protocol/tests/fetch/response.rs
@@ -193,6 +193,7 @@ mod v2 {
 
         #[cfg(feature = "async-client")]
         use futures_lite::io::AsyncReadExt;
+        use gix_packetline::read::ProgressAction;
         use gix_protocol::fetch::{
             self,
             response::{Acknowledgement, ShallowUpdate},
@@ -213,7 +214,9 @@ mod v2 {
                 let r = fetch::Response::from_line_reader(Protocol::V2, &mut reader).await?;
                 assert!(r.acknowledgements().is_empty(), "it should go straight to the packfile");
                 assert!(r.has_pack());
-                reader.set_progress_handler(Some(Box::new(|_is_err, _text| ())));
+                reader.set_progress_handler(Some(Box::new(|_is_err, _text| {
+                    gix_transport::packetline::read::ProgressAction::Continue
+                })));
                 let mut buf = Vec::new();
                 let bytes_read = reader.read_to_end(&mut buf).await?;
                 assert_eq!(bytes_read, 876, "should be able to read the whole pack");
@@ -295,6 +298,7 @@ mod v2 {
             let mut buf = Vec::new();
             reader.set_progress_handler(Some(Box::new(|is_err: bool, _data: &[u8]| {
                 assert!(!is_err, "fixture does not have an error");
+                ProgressAction::Continue
             }) as gix_transport::client::HandleProgress));
             let bytes_read = reader.read_to_end(&mut buf).await?;
             assert_eq!(bytes_read, 1643, "should be able to read the whole pack");
@@ -346,7 +350,8 @@ mod v2 {
             assert!(r.has_pack());
             let mut buf = Vec::new();
             reader.set_progress_handler(Some(Box::new(|a: bool, b: &[u8]| {
-                gix_protocol::RemoteProgress::translate_to_progress(a, b, &mut gix_features::progress::Discard)
+                gix_protocol::RemoteProgress::translate_to_progress(a, b, &mut gix_features::progress::Discard);
+                ProgressAction::Continue
             }) as gix_transport::client::HandleProgress));
             let bytes_read = reader.read_to_end(&mut buf).await?;
             assert_eq!(bytes_read, 5360, "should be able to read the whole pack");

--- a/gix-transport/src/client/blocking_io/bufread_ext.rs
+++ b/gix-transport/src/client/blocking_io/bufread_ext.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use gix_packetline::read::ProgressAction;
 use gix_packetline::PacketLineRef;
 
 use crate::{
@@ -10,7 +11,7 @@ use crate::{
     Protocol,
 };
 /// A function `f(is_error, text)` receiving progress or error information.
-pub type HandleProgress = Box<dyn FnMut(bool, &[u8])>;
+pub type HandleProgress = Box<dyn FnMut(bool, &[u8]) -> ProgressAction>;
 
 /// This trait exists to get a version of a `gix_packetline::Provider` without type parameters,
 /// but leave support for reading lines directly without forcing them through `String`.
@@ -79,7 +80,7 @@ impl<'a, T: ExtendedBufRead + ?Sized + 'a> ExtendedBufRead for Box<T> {
     }
 }
 
-impl<T: io::Read> ReadlineBufRead for gix_packetline::read::WithSidebands<'_, T, fn(bool, &[u8])> {
+impl<T: io::Read> ReadlineBufRead for gix_packetline::read::WithSidebands<'_, T, fn(bool, &[u8]) -> ProgressAction> {
     fn readline(&mut self) -> Option<io::Result<Result<PacketLineRef<'_>, gix_packetline::decode::Error>>> {
         self.read_data_line()
     }

--- a/gix-transport/tests/client/blocking_io/http/mod.rs
+++ b/gix-transport/tests/client/blocking_io/http/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use bstr::ByteSlice;
+use gix_packetline::read::ProgressAction;
 use gix_transport::{
     client::{self, http, SetServiceResponse, Transport, TransportV2Ext, TransportWithoutIO},
     Protocol, Service,
@@ -391,7 +392,8 @@ fn clone_v1() -> crate::Result {
             assert!(!is_err);
             sb.deref()
                 .borrow_mut()
-                .push(std::str::from_utf8(data).expect("valid utf8").to_owned())
+                .push(std::str::from_utf8(data).expect("valid utf8").to_owned());
+            ProgressAction::Continue
         }
     })));
     let mut pack = Vec::new();
@@ -621,7 +623,8 @@ Git-Protocol: version=2
             assert!(!is_err);
             sb.deref()
                 .borrow_mut()
-                .push(std::str::from_utf8(data).expect("valid utf8").to_owned())
+                .push(std::str::from_utf8(data).expect("valid utf8").to_owned());
+            ProgressAction::Continue
         }
     })));
 

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -8,6 +8,7 @@ use std::{
 use bstr::ByteSlice;
 #[cfg(feature = "async-client")]
 use futures_lite::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
+use gix_packetline::read::ProgressAction;
 use gix_transport::{
     client,
     client::{git, Transport, TransportV2Ext, TransportWithoutIO},
@@ -112,7 +113,8 @@ async fn handshake_v1_and_request() -> crate::Result {
             sb.deref()
                 .lock()
                 .expect("no poison")
-                .push(std::str::from_utf8(data).expect("valid utf8").to_owned())
+                .push(std::str::from_utf8(data).expect("valid utf8").to_owned());
+            ProgressAction::Continue
         }
     })));
 
@@ -174,7 +176,8 @@ async fn push_v1_simulated() -> crate::Result {
                 sb.deref()
                     .lock()
                     .expect("no panic in other threads")
-                    .push(std::str::from_utf8(data).expect("valid utf8").to_owned())
+                    .push(std::str::from_utf8(data).expect("valid utf8").to_owned());
+                ProgressAction::Continue
             }
         })));
         let mut lines = read.lines();
@@ -387,7 +390,8 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
             sb.deref()
                 .lock()
                 .expect("no poison")
-                .push(std::str::from_utf8(data).expect("valid utf8").to_owned())
+                .push(std::str::from_utf8(data).expect("valid utf8").to_owned());
+            ProgressAction::Continue
         }
     })));
 

--- a/gix/src/remote/connection/fetch/negotiate.rs
+++ b/gix/src/remote/connection/fetch/negotiate.rs
@@ -1,5 +1,4 @@
 use crate::remote::fetch;
-use gix_refspec::RefSpec;
 
 /// The way the negotiation is performed
 #[derive(Copy, Clone)]
@@ -28,19 +27,15 @@ pub(crate) fn one_round(
     fetch_tags: crate::remote::fetch::Tags,
     arguments: &mut gix_protocol::fetch::Arguments,
     _previous_response: Option<&gix_protocol::fetch::Response>,
-    wants_shallow_change: Option<(&fetch::Shallow, &[RefSpec])>,
+    shallow: Option<&fetch::Shallow>,
 ) -> Result<bool, Error> {
     let tag_refspec_to_ignore = fetch_tags
         .to_refspec()
         .filter(|_| matches!(fetch_tags, crate::remote::fetch::Tags::Included));
-    let (shallow, non_wildcard_specs_only) = wants_shallow_change
-        .map(|(a, b)| (Some(a), Some(b)))
-        .unwrap_or_default();
-
-    if let Some(shallow) = shallow {
-        if *shallow == fetch::Shallow::Deepen(0) {
-            return Ok(true);
-        }
+    if let Some(fetch::Shallow::Deepen(0)) = shallow {
+        // Avoid deepening (relative) with zero as it seems to upset the server. Git also doesn't actually
+        // perform the negotiation for some reason (couldn't find it in code).
+        return Ok(true);
     }
 
     match algo {
@@ -57,14 +52,6 @@ pub(crate) fn one_round(
                 }) {
                     continue;
                 }
-                if non_wildcard_specs_only
-                    .and_then(|refspecs| mapping.spec_index.get(refspecs, &ref_map.extra_refspecs))
-                    .map_or(false, |spec| {
-                        spec.to_ref().local().map_or(false, |ref_| ref_.contains(&b'*'))
-                    })
-                {
-                    continue;
-                }
                 let have_id = mapping.local.as_ref().and_then(|name| {
                     repo.find_reference(name)
                         .ok()
@@ -73,7 +60,7 @@ pub(crate) fn one_round(
                 match have_id {
                     Some(have_id) => {
                         if let Some(want_id) = mapping.remote.as_id() {
-                            if want_id != have_id || wants_shallow_change.is_some() {
+                            if want_id != have_id {
                                 arguments.want(want_id);
                                 arguments.have(have_id);
                             }
@@ -88,7 +75,7 @@ pub(crate) fn one_round(
                 }
             }
 
-            if has_missing_tracking_branch || (wants_shallow_change.is_some() && arguments.is_empty()) {
+            if has_missing_tracking_branch || (shallow.is_some() && arguments.is_empty()) {
                 if let Ok(Some(r)) = repo.head_ref() {
                     if let Some(id) = r.target().try_id() {
                         arguments.have(id);

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -118,8 +118,7 @@ where
                 con.remote.fetch_tags,
                 &mut arguments,
                 previous_response.as_ref(),
-                (self.shallow != Shallow::NoChange)
-                    .then(|| (&self.shallow, con.remote.refspecs(remote::Direction::Fetch))),
+                (self.shallow != Shallow::NoChange).then_some(&self.shallow),
             ) {
                 Ok(_) if arguments.is_empty() => {
                     gix_protocol::indicate_end_of_interaction(&mut con.transport).await.ok();

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -118,7 +118,8 @@ where
                 con.remote.fetch_tags,
                 &mut arguments,
                 previous_response.as_ref(),
-                (self.shallow != Shallow::NoChange).then(|| con.remote.refspecs(remote::Direction::Fetch)),
+                (self.shallow != Shallow::NoChange)
+                    .then(|| (&self.shallow, con.remote.refspecs(remote::Direction::Fetch))),
             ) {
                 Ok(_) if arguments.is_empty() => {
                     gix_protocol::indicate_end_of_interaction(&mut con.transport).await.ok();

--- a/gix/tests/clone/mod.rs
+++ b/gix/tests/clone/mod.rs
@@ -2,6 +2,7 @@ use crate::{remote, util::restricted};
 
 #[cfg(feature = "blocking-network-client")]
 mod blocking_io {
+    use gix::bstr::BString;
     use gix::config::tree::{Clone, Core, Init, Key};
     use gix::remote::Direction;
     use gix_object::bstr::ByteSlice;
@@ -25,9 +26,14 @@ mod blocking_io {
                 let called_configure_remote = called_configure_remote;
                 move |r| {
                     called_configure_remote.store(true, std::sync::atomic::Ordering::Relaxed);
-                    let r = r
-                        .with_refspecs(Some("+refs/tags/b-tag:refs/tags/b-tag"), gix::remote::Direction::Fetch)?
-                        .with_fetch_tags(desired_fetch_tags);
+                    let mut r = r.with_fetch_tags(desired_fetch_tags);
+                    r.replace_refspecs(
+                        [
+                            BString::from(format!("refs/heads/main:refs/remotes/{remote_name}/main")),
+                            "+refs/tags/b-tag:refs/tags/b-tag".to_owned().into(),
+                        ],
+                        Direction::Fetch,
+                    )?;
                     Ok(r)
                 }
             })
@@ -111,6 +117,10 @@ mod blocking_io {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let (repo, _change) = gix::prepare_clone_bare(remote::repo("base").path(), tmp.path())?
             .with_shallow(Shallow::DepthAtRemote(2.try_into()?))
+            .configure_remote(|mut r| {
+                r.replace_refspecs(Some("refs/heads/main:refs/remotes/origin/main"), Direction::Fetch)?;
+                Ok(r)
+            })
             .fetch_only(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
 
         assert!(repo.is_shallow());

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -181,7 +181,7 @@ pub mod fetch {
         pub shallow_exclude: Vec<gix::refs::PartialName>,
 
         /// Remove the shallow boundary and fetch the entire history available on the remote.
-        #[clap(long, conflicts_with_all = ["shallow_since", "shallow_exclude", "depth", "deepen", "unshallow"])]
+        #[clap(long, conflicts_with_all = ["shallow_since", "shallow_exclude", "depth", "deepen"])]
         pub unshallow: bool,
     }
 


### PR DESCRIPTION
### Tasks

* [x] fix 'remote' phase un-interruptibility due to inner loop
* [x] fix progress bar responsiveness
* [x] `--deepen 0` should not have a server reply error (git does not fail at all)
* [x] ~~try to fetch a couple of shallow repos with `gix` and check why `.keep` files remain often~~ - not reproducible anymore
* [x] ~~figure out a way to deal with empty pack files, let's not leave them on disk ideally as they currently aren't ignored due to lazy loading~~ - there is only ever one empty pack, and small pack handling is separate from this issue which includes empty packs. Do nothing for now.
* [x] figure out which refs to fetch in shallow mode to not unnecessarily fetch more than we need (compare that to git to see what's right or what the logic is)

<details>

### git clone [crates.io](http://crates.io/) depth 1

* doesn't write refspec for some reason
* really only gets one branch even though theoretically it should try to get two

```
0011command=fetch0026agent=git/2.37.1.(Apple.Git-137.1)0016object-format=sha10001000dthin-pack000finclude-tag000dofs-delta000cdeepen 10032want 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9
0032want 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9
0009done
0000
```

### git fetch origin 'refs/heads/*:refs/heads/*' --depth 1

* wants the extra-branch, but only with --depth 1 it grafts it. Makes sense, it would just be nice to not accidentally pull new branches. Maybe refspecs needs to be edited properly then.

```
0011command=fetch0026agent=git/2.37.1.(Apple.Git-137.1)0016object-format=sha10001000dthin-pack000finclude-tag000dofs-delta0034shallow 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9000cdeepen 10032want aaa68a94682bcfd8a250629de9984331a537dbe0
0032want 84bda51168d3b5266b8e8fe8624aa89e3511f8ea
0032have 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9
0009done
0000
```

### gix clone [crates.io](http://crates.io/) depth 1
```
0012command=fetch
001bagent=git/oxide-0.41.0
0001000ethin-pack
000eofs-delta
000ddeepen 1
0032want 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9
0009done
0000
```

### git fetch (in gix clone with refspecs) 

```
0011command=fetch0026agent=git/2.37.1.(Apple.Git-137.1)0016object-format=sha10001000dthin-pack000finclude-tag000dofs-delta0034shallow 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e90032want fc2b98960b5dfea1f1697042dab51ceb28b0aa8f
0032want 84bda51168d3b5266b8e8fe8624aa89e3511f8ea
0032have 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9
0000
0011command=fetch0026agent=git/2.37.1.(Apple.Git-137.1)0016object-format=sha10001000dthin-pack000finclude-tag000dofs-delta0034shallow 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e90032want fc2b98960b5dfea1f1697042dab51ceb28b0aa8f
0032want 84bda51168d3b5266b8e8fe8624aa89e3511f8ea
0032have 213bb98f34ba470d4ba1217bc8f9d0bfccdbf5e9
0009done
0000
```
</details>
