### PR TITLE
CI on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,15 +85,15 @@ jobs:
         build: [ win-msvc, win-gnu, win32-msvc ]
         include:
           - build: win-msvc
-            os: windows-2019
+            os: windows-latest
             rust: stable
             target: x86_64-pc-windows-msvc
           - build: win-gnu
-            os: windows-2019
+            os: windows-latest
             rust: stable-x86_64-gnu
             target: x86_64-pc-windows-gnu
           - build: win32-msvc
-            os: windows-2019
+            os: windows-latest
             rust: stable
             target: i686-pc-windows-msvc
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Previously these had some issues, and maybe it's time to fix them if they can reproduce issues that helix is seeing related to repository discovery.
