### PR TITLE
fix: uncategorized refs should not be per-worktree

### DIFF
--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -186,10 +186,10 @@ impl file::Store {
                             }
                         })
                         .unwrap_or((commondir.into(), sn)),
-                    PseudoRef | Bisect | Rewritten | WorktreePrivate => return None,
+                    PseudoRef | Bisect | Rewritten | WorktreePrivate => (self.git_dir.as_path().into(), name),
                 })
             })
-            .unwrap_or((self.git_dir.as_path().into(), name))
+            .unwrap_or((commondir.into(), name))
     }
 
     /// Implements the logic required to transform a fully qualified refname into a filesystem path


### PR DESCRIPTION
When creating a new ref from using a Repository instantiated from a linked worktree, if the ref did not fit one of the well-known categories, it would be incorrectly stored as a per-worktree reference instead of a shared reference.

For example, the reference "refs/stacks/linked" does not fit any of the well known categories. According to git-worktree(1), this ref should be shared across all worktrees; i.e. located at $GIT_COMMON_DIR/refs/stacks/linked and *not* in $GIT_COMMON_DIR/worktrees/linked/refs/stacks/linked.

This change tweaks the control flow so that uncategorized refs correctly fallback to being relative to commondir while still placing refs that are supposed to be per-worktree in the per-worktree location.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
