### PR TITLE
rename the serde1 feature to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ fast = ["gix/max-performance", "gix/comfort"]
 ## Use `clap` 3.0 to build the prettiest, best documented and most user-friendly CLI at the expense of binary size.
 ## Provides a terminal user interface for detailed and exhaustive progress.
 ## Provides a line renderer for leaner progress display, without the need for a full-blown TUI.
-pretty-cli = [ "gitoxide-core/serde1", "prodash/progress-tree", "prodash/progress-tree-log", "prodash/local-time", "env_logger/humantime", "env_logger/color", "env_logger/auto-color" ]
+pretty-cli = [ "gitoxide-core/serde", "prodash/progress-tree", "prodash/progress-tree-log", "prodash/local-time", "env_logger/humantime", "env_logger/color", "env_logger/auto-color" ]
 
 ## The `--verbose` flag will be powered by an interactive progress mechanism that doubles as log as well as interactive progress
 ## that appears after a short duration.

--- a/Makefile
+++ b/Makefile
@@ -77,17 +77,17 @@ check: ## Build all code in suitable configurations
 					&& cargo check
 	cd gix-object && cargo check --all-features \
                   && cargo check --features verbose-object-parsing-errors
-	cd gix-index && cargo check --features serde1
-	cd gix-credentials && cargo check --features serde1
-	cd gix-sec && cargo check --features serde1
-	cd gix-revision && cargo check --features serde1
-	cd gix-attributes && cargo check --features serde1
-	cd gix-glob && cargo check --features serde1
-	cd gix-mailmap && cargo check --features serde1
-	cd gix-worktree && cargo check --features serde1
-	cd gix-actor && cargo check --features serde1
-	cd gix-date && cargo check --features serde1
-	cd gix-pack && cargo check --features serde1 \
+	cd gix-index && cargo check --features serde
+	cd gix-credentials && cargo check --features serde
+	cd gix-sec && cargo check --features serde
+	cd gix-revision && cargo check --features serde
+	cd gix-attributes && cargo check --features serde
+	cd gix-glob && cargo check --features serde
+	cd gix-mailmap && cargo check --features serde
+	cd gix-worktree && cargo check --features serde
+	cd gix-actor && cargo check --features serde
+	cd gix-date && cargo check --features serde
+	cd gix-pack && cargo check --features serde \
 			   && cargo check --features pack-cache-lru-static \
 			   && cargo check --features pack-cache-lru-dynamic \
 			   && cargo check --features object-cache-dynamic \
@@ -138,7 +138,7 @@ check: ## Build all code in suitable configurations
 					  && cargo check --no-default-features --features max-performance-safe \
 					  && cargo check --no-default-features --features progress-tree \
 					  && cargo check --no-default-features
-	cd gix-odb && cargo check --features serde1
+	cd gix-odb && cargo check --features serde
 	cd cargo-smart-release && cargo check --all
 
 unit-tests: ## run all unit tests

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -33,7 +33,7 @@ async-client = ["gix/async-network-client-async-std", "gix-transport-configurati
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["gix-commitgraph/serde1", "gix/serde1", "serde_json", "serde", "bytesize/serde"]
+serde = ["gix-commitgraph/serde", "gix/serde", "serde_json", "dep:serde", "bytesize/serde"]
 
 
 [dependencies]
@@ -73,5 +73,5 @@ rusqlite = { version = "0.29.0", optional = true, features = ["bundled"] }
 document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
-features = ["document-features", "blocking-client", "organize", "estimate-hours", "serde1"]
+features = ["document-features", "blocking-client", "organize", "estimate-hours", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -46,10 +46,10 @@ where
         .verify_integrity(noop_processor)
         .with_context(|| "Verification failure")?;
 
-    #[cfg_attr(not(feature = "serde1"), allow(clippy::single_match))]
+    #[cfg_attr(not(feature = "serde"), allow(clippy::single_match))]
     match output_statistics {
         Some(OutputFormat::Human) => drop(print_human_output(&mut out, &stats)),
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         Some(OutputFormat::Json) => serde_json::to_writer_pretty(out, &stats)?,
         _ => {}
     }

--- a/gitoxide-core/src/index/entries.rs
+++ b/gitoxide-core/src/index/entries.rs
@@ -10,7 +10,7 @@ pub fn entries(
     use crate::OutputFormat::*;
     let file = parse_file(index_path, object_hash)?;
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     if let Json = format {
         out.write_all(b"[\n")?;
     }
@@ -19,19 +19,19 @@ pub fn entries(
     while let Some(entry) = entries.next() {
         match format {
             Human => to_human(&mut out, &file, entry)?,
-            #[cfg(feature = "serde1")]
+            #[cfg(feature = "serde")]
             Json => to_json(&mut out, &file, entry, entries.peek().is_none())?,
         }
     }
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     if let Json = format {
         out.write_all(b"]\n")?;
     }
     Ok(())
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 pub(crate) fn to_json(
     mut out: &mut impl std::io::Write,
     file: &gix::index::File,
@@ -40,7 +40,7 @@ pub(crate) fn to_json(
 ) -> anyhow::Result<()> {
     use gix::bstr::ByteSlice;
 
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     struct Entry<'a> {
         stat: &'a gix::index::entry::Stat,
         hex_id: String,

--- a/gitoxide-core/src/index/information.rs
+++ b/gitoxide-core/src/index/information.rs
@@ -4,7 +4,7 @@ pub struct Options {
     pub extension_details: bool,
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 mod serde_only {
 
     mod ext {
@@ -153,5 +153,5 @@ mod serde_only {
         }
     }
 }
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 pub(crate) use serde_only::Collection;

--- a/gitoxide-core/src/index/mod.rs
+++ b/gitoxide-core/src/index/mod.rs
@@ -39,14 +39,14 @@ pub fn verify(
     file.verify_integrity()?;
     file.verify_entries()?;
     file.verify_extensions(false, gix::index::verify::extensions::no_find)?;
-    #[cfg_attr(not(feature = "serde1"), allow(irrefutable_let_patterns))]
+    #[cfg_attr(not(feature = "serde"), allow(irrefutable_let_patterns))]
     if let crate::OutputFormat::Human = format {
         writeln!(out, "OK").ok();
     }
     Ok(())
 }
 
-#[cfg_attr(not(feature = "serde1"), allow(unused_variables, unused_mut))]
+#[cfg_attr(not(feature = "serde"), allow(unused_variables, unused_mut))]
 pub fn information(
     index_path: impl AsRef<Path>,
     out: impl std::io::Write,
@@ -60,7 +60,7 @@ pub fn information(
     }: information::Options,
 ) -> anyhow::Result<()> {
     use crate::OutputFormat::*;
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     if let Human = format {
         writeln!(err, "Defaulting to JSON printing as nothing else will be implemented.").ok();
         format = Json;
@@ -69,7 +69,7 @@ pub fn information(
         Human => {
             anyhow::bail!("Cannot print information using 'human' format.")
         }
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         Json => {
             let info = information::Collection::try_from_file(parse_file(index_path, object_hash)?, extension_details)?;
             serde_json::to_writer_pretty(out, &info)?;

--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -35,7 +35,7 @@ use std::str::FromStr;
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum OutputFormat {
     Human,
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     Json,
 }
 
@@ -43,7 +43,7 @@ impl OutputFormat {
     pub fn variants() -> &'static [&'static str] {
         &[
             "human",
-            #[cfg(feature = "serde1")]
+            #[cfg(feature = "serde")]
             "json",
         ]
     }
@@ -56,7 +56,7 @@ impl FromStr for OutputFormat {
         let s_lc = s.to_ascii_lowercase();
         Ok(match s_lc.as_str() {
             "human" => OutputFormat::Human,
-            #[cfg(feature = "serde1")]
+            #[cfg(feature = "serde")]
             "json" => OutputFormat::Json,
             _ => return Err(format!("Invalid output format: '{}'", s)),
         })

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -314,7 +314,7 @@ where
 fn print(stats: Statistics, format: OutputFormat, out: impl std::io::Write) -> anyhow::Result<()> {
     match format {
         OutputFormat::Human => human_output(stats, out).map_err(Into::into),
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         OutputFormat::Json => serde_json::to_writer_pretty(out, &stats).map_err(Into::into),
     }
 }
@@ -365,7 +365,7 @@ fn human_output(
 }
 
 #[derive(Default)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Statistics {
     counts: pack::data::output::count::objects::Outcome,
     entries: pack::data::output::entry::iter_from_counts::Outcome,

--- a/gitoxide-core/src/pack/index.rs
+++ b/gitoxide-core/src/pack/index.rs
@@ -121,7 +121,7 @@ where
     .with_context(|| "Failed to write pack and index")?;
     match format {
         OutputFormat::Human => drop(human_output(out, res)),
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         OutputFormat::Json => serde_json::to_writer_pretty(out, &res)?,
     };
     Ok(())

--- a/gitoxide-core/src/pack/multi_index.rs
+++ b/gitoxide-core/src/pack/multi_index.rs
@@ -35,7 +35,7 @@ pub fn create(
     Ok(())
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 mod info {
     use std::path::PathBuf;
 
@@ -48,7 +48,7 @@ mod info {
     }
 }
 
-#[cfg_attr(not(feature = "serde1"), allow(unused_variables))]
+#[cfg_attr(not(feature = "serde"), allow(unused_variables))]
 pub fn info(
     multi_index_path: PathBuf,
     format: OutputFormat,
@@ -58,7 +58,7 @@ pub fn info(
     if format == OutputFormat::Human {
         writeln!(err, "Defaulting to JSON as human format isn't implemented").ok();
     }
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     {
         let file = gix::odb::pack::multi_index::File::at(&multi_index_path)?;
         serde_json::to_writer_pretty(

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -272,7 +272,7 @@ mod async_io {
 #[cfg(feature = "async-client")]
 pub use self::async_io::receive;
 
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct JsonBundleWriteOutcome {
     pub index_version: pack::index::Version,
     pub index_hash: String,
@@ -292,7 +292,7 @@ impl From<pack::index::write::Outcome> for JsonBundleWriteOutcome {
     }
 }
 
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct JsonOutcome {
     pub index: JsonBundleWriteOutcome,
     pub pack_kind: pack::data::Version,
@@ -385,7 +385,7 @@ fn receive_pack_blocking<W: io::Write>(
 
     match ctx.format {
         OutputFormat::Human => drop(print(&mut ctx.out, outcome, refs)),
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         OutputFormat::Json => {
             serde_json::to_writer_pretty(&mut ctx.out, &JsonOutcome::from_outcome_and_refs(outcome, refs))?
         }

--- a/gitoxide-core/src/pack/verify.rs
+++ b/gitoxide-core/src/pack/verify.rs
@@ -174,7 +174,7 @@ where
                                 drop(print_statistics(&mut out, &stats));
                             }
                         },
-                        #[cfg(feature = "serde1")]
+                        #[cfg(feature = "serde")]
                         Some(OutputFormat::Json) => serde_json::to_writer_pretty(out, &multi_index.index_names().iter().zip(res.pack_traverse_statistics).collect::<Vec<_>>())?,
                         _ => {}
                     };
@@ -189,10 +189,10 @@ where
         ext => return Err(anyhow!("Unknown extension {:?}, expecting 'idx' or 'pack'", ext)),
     };
     if let Some(stats) = res.1.as_ref() {
-        #[cfg_attr(not(feature = "serde1"), allow(clippy::single_match))]
+        #[cfg_attr(not(feature = "serde"), allow(clippy::single_match))]
         match output_statistics {
             Some(OutputFormat::Human) => drop(print_statistics(&mut out, stats)),
-            #[cfg(feature = "serde1")]
+            #[cfg(feature = "serde")]
             Some(OutputFormat::Json) => serde_json::to_writer_pretty(out, stats)?,
             _ => {}
         };

--- a/gitoxide-core/src/repository/mailmap.rs
+++ b/gitoxide-core/src/repository/mailmap.rs
@@ -1,12 +1,12 @@
 use std::io;
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use gix::mailmap::Entry;
 
 use crate::OutputFormat;
 
-#[cfg(feature = "serde1")]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+#[cfg(feature = "serde")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 struct JsonEntry {
     new_name: Option<String>,
     new_email: Option<String>,
@@ -14,7 +14,7 @@ struct JsonEntry {
     old_email: String,
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 impl<'a> From<Entry<'a>> for JsonEntry {
     fn from(v: Entry<'a>) -> Self {
         use gix::bstr::ByteSlice;
@@ -30,7 +30,7 @@ impl<'a> From<Entry<'a>> for JsonEntry {
 pub fn entries(
     repo: gix::Repository,
     format: OutputFormat,
-    #[cfg_attr(not(feature = "serde1"), allow(unused_variables))] out: impl io::Write,
+    #[cfg_attr(not(feature = "serde"), allow(unused_variables))] out: impl io::Write,
     mut err: impl io::Write,
 ) -> anyhow::Result<()> {
     if format == OutputFormat::Human {
@@ -42,7 +42,7 @@ pub fn entries(
         writeln!(err, "Error while loading mailmap, the first error is: {}", e).ok();
     }
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     serde_json::to_writer_pretty(
         out,
         &mailmap.entries().into_iter().map(JsonEntry::from).collect::<Vec<_>>(),

--- a/gitoxide-core/src/repository/odb.rs
+++ b/gitoxide-core/src/repository/odb.rs
@@ -4,7 +4,7 @@ use anyhow::bail;
 
 use crate::OutputFormat;
 
-#[cfg_attr(not(feature = "serde1"), allow(unused_variables))]
+#[cfg_attr(not(feature = "serde"), allow(unused_variables))]
 pub fn info(
     repo: gix::Repository,
     format: OutputFormat,
@@ -15,7 +15,7 @@ pub fn info(
         writeln!(err, "Only JSON is implemented - using that instead")?;
     }
 
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     pub struct Statistics {
         pub path: std::path::PathBuf,
         pub object_hash: String,
@@ -33,7 +33,7 @@ pub fn info(
         metrics: store.metrics(),
     };
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     {
         serde_json::to_writer_pretty(out, &stats)?;
     }
@@ -53,7 +53,7 @@ pub mod statistics {
     }
 }
 
-#[cfg_attr(not(feature = "serde1"), allow(unused_variables))]
+#[cfg_attr(not(feature = "serde"), allow(unused_variables))]
 pub fn statistics(
     repo: gix::Repository,
     mut progress: impl gix::Progress,
@@ -73,7 +73,7 @@ pub fn statistics(
     let counter = progress.counter();
     let start = std::time::Instant::now();
 
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     #[derive(Default)]
     struct Statistics {
         total_objects: usize,
@@ -195,7 +195,7 @@ pub fn statistics(
 
     progress.show_throughput(start);
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     {
         serde_json::to_writer_pretty(out, &stats)?;
     }

--- a/gitoxide-core/src/repository/remote.rs
+++ b/gitoxide-core/src/repository/remote.rs
@@ -97,7 +97,7 @@ mod refs_impl {
             refs::Kind::Remote => {
                 match format {
                     OutputFormat::Human => drop(print(out, &map.remote_refs)),
-                    #[cfg(feature = "serde1")]
+                    #[cfg(feature = "serde")]
                     OutputFormat::Json => serde_json::to_writer_pretty(
                         out,
                         &map.remote_refs.into_iter().map(JsonRef::from).collect::<Vec<_>>(),
@@ -224,7 +224,7 @@ mod refs_impl {
         Ok(())
     }
 
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub enum JsonRef {
         Peeled {
             path: String,

--- a/gitoxide-core/src/repository/revision/previous_branches.rs
+++ b/gitoxide-core/src/repository/revision/previous_branches.rs
@@ -17,7 +17,7 @@ pub fn previous_branches(
                 writeln!(out, "{} {}", id, name)?;
             }
         }
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         OutputFormat::Json => {
             serde_json::to_writer_pretty(&mut out, &branches)?;
         }

--- a/gitoxide-core/src/repository/revision/resolve.rs
+++ b/gitoxide-core/src/repository/revision/resolve.rs
@@ -40,7 +40,7 @@ pub(crate) mod function {
                     writeln!(out, "{spec}", spec = spec.detach())?;
                 }
             }
-            #[cfg(feature = "serde1")]
+            #[cfg(feature = "serde")]
             OutputFormat::Json => {
                 if explain {
                     anyhow::bail!("Explanations are only for human consumption")

--- a/gitoxide-core/src/repository/tree.rs
+++ b/gitoxide-core/src/repository/tree.rs
@@ -16,7 +16,7 @@ mod entries {
 
     use crate::repository::tree::format_entry;
 
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     #[derive(Default)]
     pub struct Statistics {
         pub num_trees: usize,
@@ -24,9 +24,9 @@ mod entries {
         pub num_blobs: usize,
         pub num_blobs_exec: usize,
         pub num_submodules: usize,
-        #[cfg_attr(feature = "serde1", serde(skip_serializing_if = "Option::is_none"))]
+        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
         pub bytes: Option<u64>,
-        #[cfg_attr(feature = "serde1", serde(skip))]
+        #[cfg_attr(feature = "serde", serde(skip))]
         pub num_bytes: u64,
     }
 
@@ -112,7 +112,7 @@ mod entries {
     }
 }
 
-#[cfg_attr(not(feature = "serde1"), allow(unused_variables))]
+#[cfg_attr(not(feature = "serde"), allow(unused_variables))]
 pub fn info(
     repo: gix::Repository,
     treeish: Option<&str>,
@@ -130,7 +130,7 @@ pub fn info(
     let mut delegate = entries::Traverse::new(extended.then_some(&repo), None);
     tree.traverse().breadthfirst(&mut delegate)?;
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     {
         delegate.stats.bytes = extended.then_some(delegate.stats.num_bytes);
         serde_json::to_writer_pretty(out, &delegate.stats)?;

--- a/gitoxide-core/src/repository/verify.rs
+++ b/gitoxide-core/src/repository/verify.rs
@@ -30,7 +30,7 @@ pub fn integrity(
         algorithm,
     }: Context,
 ) -> anyhow::Result<()> {
-    #[cfg_attr(not(feature = "serde1"), allow(unused))]
+    #[cfg_attr(not(feature = "serde"), allow(unused))]
     let mut outcome = repo.objects.store_ref().verify_integrity(
         progress,
         should_interrupt,
@@ -56,7 +56,7 @@ pub fn integrity(
     }
     match output_statistics {
         Some(OutputFormat::Human) => writeln!(out, "Human output is currently unsupported, use JSON instead")?,
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         Some(OutputFormat::Json) => {
             serde_json::to_writer_pretty(
                 out,

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-date/serde1"]
+serde = ["dep:serde", "bstr/serde", "gix-date/serde"]
 
 [dependencies]
 gix-features = { version = "^0.28.0", path = "../gix-features", optional = true }

--- a/gix-actor/src/lib.rs
+++ b/gix-actor/src/lib.rs
@@ -19,7 +19,7 @@ pub mod signature;
 ///
 /// Note that this is not a cryptographical signature.
 #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature {
     /// The actors name.
     pub name: BString,
@@ -33,10 +33,10 @@ pub struct Signature {
 ///
 /// Note that this is not a cryptographical signature.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy, Default)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SignatureRef<'a> {
     /// The actor's name.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub name: &'a BStr,
     /// The actor's email.
     pub email: &'a BStr,

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-glob/serde1", "kstring/serde"]
+serde = ["dep:serde", "bstr/serde", "gix-glob/serde", "kstring/serde"]
 
 [dependencies]
 gix-path = { version = "^0.7.3", path = "../gix-path" }

--- a/gix-attributes/src/lib.rs
+++ b/gix-attributes/src/lib.rs
@@ -34,7 +34,7 @@ pub fn parse(bytes: &[u8]) -> parse::Lines<'_> {
 ///
 /// Note that this doesn't contain the name.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StateRef<'a> {
     /// The attribute is listed, or has the special value 'true'
     Set,
@@ -42,7 +42,7 @@ pub enum StateRef<'a> {
     Unset,
     /// The attribute is set to the given value, which followed the `=` sign.
     /// Note that values can be empty.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     Value(state::ValueRef<'a>),
     /// The attribute isn't mentioned with a given path or is explicitly set to `Unspecified` using the `!` sign.
     Unspecified,
@@ -52,7 +52,7 @@ pub enum StateRef<'a> {
 ///
 /// Note that this doesn't contain the name.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum State {
     /// The attribute is listed, or has the special value 'true'
     Set,
@@ -67,7 +67,7 @@ pub enum State {
 
 /// Represents a validated attribute name
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Name(pub(crate) KString);
 
 /// Holds a validated attribute name as a reference
@@ -76,7 +76,7 @@ pub struct NameRef<'a>(KStringRef<'a>);
 
 /// Name an attribute and describe it's assigned state.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Assignment {
     /// The validated name of the attribute.
     pub name: Name,

--- a/gix-attributes/src/parse.rs
+++ b/gix-attributes/src/parse.rs
@@ -7,7 +7,7 @@ use crate::{name, AssignmentRef, Name, NameRef, StateRef};
 
 /// The kind of attribute that was parsed.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Kind {
     /// A pattern to match paths against
     Pattern(gix_glob::Pattern),

--- a/gix-attributes/src/state.rs
+++ b/gix-attributes/src/state.rs
@@ -5,13 +5,13 @@ use crate::{State, StateRef};
 
 /// A container to encapsulate a tightly packed and typically unallocated byte value that isn't necessarily UTF8 encoded.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Value(KString);
 
 /// A reference container to encapsulate a tightly packed and typically unallocated byte value that isn't necessarily UTF8 encoded.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
-pub struct ValueRef<'a>(#[cfg_attr(feature = "serde1", serde(borrow))] KStringRef<'a>);
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ValueRef<'a>(#[cfg_attr(feature = "serde", serde(borrow))] KStringRef<'a>);
 
 /// Conversions
 impl<'a> ValueRef<'a> {

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`
-serde1 = ["serde", "gix-hash/serde1", "bstr/serde"]
+serde = ["dep:serde", "gix-hash/serde", "bstr/serde"]
 
 [dependencies]
 gix-features = { version = "^0.28.1", path = "../gix-features", features = ["rustsha1"] }

--- a/gix-commitgraph/src/file/verify.rs
+++ b/gix-commitgraph/src/file/verify.rs
@@ -47,7 +47,7 @@ pub enum Error<E: std::error::Error + 'static> {
 
 /// The positive result of [`File::traverse()`] providing some statistical information.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Outcome {
     /// The largest encountered [`file::Commit`] generation number.
     pub max_generation: u32,

--- a/gix-commitgraph/src/graph/verify.rs
+++ b/gix-commitgraph/src/graph/verify.rs
@@ -57,7 +57,7 @@ pub enum Error<E: std::error::Error + 'static> {
 
 /// Statistics gathered while verifying the integrity of the graph as returned by [`Graph::verify_integrity()`].
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Outcome {
     /// The length of the longest path between any two commits in this graph.
     ///

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde"]
+serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
 gix-path = { version = "^0.7.3", path = "../gix-path" }

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-sec/serde1", "gix-ref/serde1", "gix-glob/serde1", "gix-config-value/serde1"]
+serde = ["dep:serde", "bstr/serde", "gix-sec/serde", "gix-ref/serde", "gix-glob/serde", "gix-config-value/serde"]
 
 [dependencies]
 gix-features = { version = "^0.28.0", path = "../gix-features"}

--- a/gix-config/tests/Cargo.toml
+++ b/gix-config/tests/Cargo.toml
@@ -19,7 +19,7 @@ path = "config.rs"
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["gix-config/serde1"]
+serde = ["gix-config/serde"]
 
 [dev-dependencies]
 gix-config = { path = ".."}

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-sec/serde1"]
+serde = ["dep:serde", "bstr/serde", "gix-sec/serde"]
 
 [dependencies]
 gix-sec = { version = "^0.6.2", path = "../gix-sec" }

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde"]
+serde= ["dep:serde", "bstr/serde"]
 
 [dependencies]
 bstr = { version = "1.3.0", default-features = false, features = ["std"]}

--- a/gix-date/src/lib.rs
+++ b/gix-date/src/lib.rs
@@ -19,7 +19,7 @@ pub use parse::function::parse;
 
 /// A timestamp with timezone.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Time {
     /// time in seconds since epoch.
     pub seconds_since_unix_epoch: u32,

--- a/gix-date/src/time/mod.rs
+++ b/gix-date/src/time/mod.rs
@@ -15,7 +15,7 @@ impl Time {
 
 /// Indicates if a number is positive or negative for use in [`Time`].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Sign {
     Plus,

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -12,7 +12,7 @@ autotests = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "gix-hash/serde1", "gix-object/serde1"]
+serde = ["dep:serde", "gix-hash/serde", "gix-object/serde"]
 ## Make it possible to compile to the `wasm32-unknown-unknown` target.
 wasm = ["dep:getrandom"]
 

--- a/gix-diff/tests/Cargo.toml
+++ b/gix-diff/tests/Cargo.toml
@@ -11,7 +11,7 @@ include = ["src/**/*"]
 rust-version = "1.64"
 
 [features]
-serde1 = ["gix-diff/serde", "gix-hash/serde1", "gix-object/serde1"]
+serde = ["gix-diff/serde", "gix-hash/serde", "gix-object/serde"]
 
 [[test]]
 name = "diff"

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "bitflags/serde"]
+serde= ["dep:serde", "bstr/serde", "bitflags/serde"]
 
 [dependencies]
 gix-path = { version = "^0.7.2", path = "../gix-path" }

--- a/gix-glob/src/lib.rs
+++ b/gix-glob/src/lib.rs
@@ -14,7 +14,7 @@ use bstr::BString;
 ///
 /// For normal globbing, use [`wildmatch()`] instead.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pattern {
     /// the actual pattern bytes
     pub text: BString,

--- a/gix-glob/src/pattern.rs
+++ b/gix-glob/src/pattern.rs
@@ -12,7 +12,7 @@ bitflags! {
     /// keep special rules only applicable when matching paths.
     ///
     /// The mode is typically created when parsing the pattern by inspecting it and isn't typically handled by the user.
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Ord, PartialOrd)]
     pub struct Mode: u32 {
         /// The pattern does not contain a sub-directory and - it doesn't contain slashes after removing the trailing one.

--- a/gix-glob/src/wildmatch.rs
+++ b/gix-glob/src/wildmatch.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 bitflags! {
     /// The match mode employed in [`Pattern::matches()`][crate::Pattern::matches()].
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
     pub struct Mode: u8 {
         /// Let globs like `*` and `?` not match the slash `/` literal, which is useful when matching paths.

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde"]
+serde= ["dep:serde"]
 
 [dependencies]
 thiserror = "1.0.33"

--- a/gix-hash/src/lib.rs
+++ b/gix-hash/src/lib.rs
@@ -22,7 +22,7 @@ pub mod prefix;
 /// An partial owned hash possibly identifying an object uniquely,
 /// whose non-prefix bytes are zeroed.
 #[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Prefix {
     bytes: ObjectId,
     hex_len: usize,
@@ -33,7 +33,7 @@ const SIZE_OF_SHA1_DIGEST: usize = 20;
 
 /// Denotes the kind of function to produce a `Id`
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Kind {
     /// The Sha1 hash with 160 bits.
     Sha1 = 1,

--- a/gix-hash/src/object_id.rs
+++ b/gix-hash/src/object_id.rs
@@ -10,7 +10,7 @@ use crate::{borrowed::oid, Kind, SIZE_OF_SHA1_DIGEST};
 
 /// An owned hash identifying objects, most commonly Sha1
 #[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ObjectId {
     /// A SHA 1 hash digest
     Sha1([u8; SIZE_OF_SHA1_DIGEST]),

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -17,7 +17,7 @@ use crate::{ObjectId, SIZE_OF_SHA1_DIGEST};
 #[derive(PartialEq, Eq, Ord, PartialOrd)]
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct oid {
     bytes: [u8],
 }
@@ -207,7 +207,7 @@ impl PartialEq<crate::ObjectId> for &oid {
 /// Manually created from a version that uses a slice, and we forcefully try to convert it into a borrowed array of the desired size
 /// Could be improved by fitting this into serde
 /// Unfortunately the serde::Deserialize derive wouldn't work for borrowed arrays.
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 impl<'de: 'a, 'a> serde::Deserialize<'de> for &'a oid {
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
     where

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-glob/serde1"]
+serde = ["dep:serde", "bstr/serde", "gix-glob/serde"]
 
 [dependencies]
 gix-glob = { version = "^0.5.5", path = "../gix-glob" }

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -17,7 +17,7 @@ test = true
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "smallvec/serde", "gix-hash/serde1"]
+serde = ["dep:serde", "smallvec/serde", "gix-hash/serde"]
 
 [dependencies]
 gix-features = { version = "^0.28.0", path = "../gix-features", features = ["rustsha1", "progress"] }
@@ -41,5 +41,5 @@ bitflags = "2"
 document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
-features = ["document-features", "serde1"]
+features = ["document-features", "dep:serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-index/src/entry/mod.rs
+++ b/gix-index/src/entry/mod.rs
@@ -12,7 +12,7 @@ mod write;
 
 /// The time component in a [`Stat`] struct.
 #[derive(Debug, Default, PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Time {
     /// The amount of seconds elapsed since EPOCH
     pub secs: u32,
@@ -22,7 +22,7 @@ pub struct Time {
 
 /// An entry's filesystem stat information.
 #[derive(Debug, Default, PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Stat {
     /// Modification time
     pub mtime: Time,

--- a/gix-index/src/lib.rs
+++ b/gix-index/src/lib.rs
@@ -35,7 +35,7 @@ pub mod write;
 
 /// All known versions of a git index file.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Version {
     /// Supports entries and various extensions.
     V2 = 2,

--- a/gix-index/tests/Cargo.toml
+++ b/gix-index/tests/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["gix-index/serde"]
+serde= ["gix-index/serde"]
 
 internal-testing-gix-features-parallel = ["gix-features/parallel"]
 internal-testing-to-avoid-being-run-by-cargo-test-all = []
@@ -39,5 +39,5 @@ filetime = "0.2.15"
 bstr = { version = "1.3.0", default-features = false }
 
 [package.metadata.docs.rs]
-features = ["document-features", "serde1"]
+features = ["document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-actor/serde1"]
+serde= ["dep:serde", "bstr/serde", "gix-actor/serde"]
 
 [dependencies]
 gix-actor = { version = "^0.19.0", path = "../gix-actor" }

--- a/gix-mailmap/src/lib.rs
+++ b/gix-mailmap/src/lib.rs
@@ -49,9 +49,9 @@ pub struct Snapshot {
 ///
 /// Typically created by [parse()].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy, Default)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry<'a> {
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     /// The name to map to.
     pub(crate) new_name: Option<&'a BStr>,
     /// The email map to.

--- a/gix-mailmap/src/snapshot/signature.rs
+++ b/gix-mailmap/src/snapshot/signature.rs
@@ -4,7 +4,7 @@ use bstr::{BStr, BString, ByteSlice};
 
 /// A signature like [`gix_actor::Signature`], but with all string fields being a `Cow`.
 #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature<'a> {
     /// The possibly mapped name.
     pub name: Cow<'a, BStr>,

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "smallvec/serde", "gix-hash/serde1", "gix-actor/serde1"]
+serde = ["dep:serde", "bstr/serde", "smallvec/serde", "gix-hash/serde", "gix-actor/serde"]
 ## When parsing objects by default errors will only be available on the granularity of success or failure, and with the above flag enabled
 ## details information about the error location will be collected.
 ## Use it in applications which expect broken or invalid objects or for debugging purposes. Incorrectly formatted objects aren't at all

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -22,10 +22,10 @@ pub struct Trailers<'a> {
 
 /// A trailer as parsed from the commit message body.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrailerRef<'a> {
     /// The name of the trailer, like "Signed-off-by", up to the separator ": "
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub token: &'a BStr,
     /// The value right after the separator ": ", with leading and trailing whitespace trimmed.
     /// Note that multi-line values aren't currently supported.

--- a/gix-object/src/commit/mod.rs
+++ b/gix-object/src/commit/mod.rs
@@ -10,10 +10,10 @@ pub mod message;
 ///
 /// Titles can have any amount of whitespace
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MessageRef<'a> {
     /// The title of the commit, as separated from the body with two consecutive newlines. The newlines are not included.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub title: &'a BStr,
     /// All bytes not consumed by the title, excluding the separating newlines.
     ///

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -38,7 +38,7 @@ pub(crate) mod parse;
 pub mod kind;
 
 /// The four types of objects that git differentiates. #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[allow(missing_docs)]
 pub enum Kind {
@@ -49,7 +49,7 @@ pub enum Kind {
 }
 /// A chunk of any [`data`][BlobRef::data].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlobRef<'a> {
     /// The bytes themselves.
     pub data: &'a [u8],
@@ -57,7 +57,7 @@ pub struct BlobRef<'a> {
 
 /// A mutable chunk of any [`data`][Blob::data].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Blob {
     /// The data itself.
     pub data: Vec<u8>,
@@ -68,12 +68,12 @@ pub struct Blob {
 /// A commit encapsulates information about a point in time at which the state of the repository is recorded, usually after a
 /// change which is documented in the commit `message`.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommitRef<'a> {
     /// HEX hash of tree object we point to. Usually 40 bytes long.
     ///
     /// Use [`tree()`][CommitRef::tree()] to obtain a decoded version of it.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub tree: &'a BStr,
     /// HEX hash of each parent commit. Empty for first commit in repository.
     pub parents: SmallVec<[&'a BStr; 1]>,
@@ -106,7 +106,7 @@ pub struct CommitRefIter<'a> {
 
 /// A mutable git commit, representing an annotated state of a working tree along with a reference to its historical commits.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Commit {
     /// The hash of recorded working tree state.
     pub tree: gix_hash::ObjectId,
@@ -130,10 +130,10 @@ pub struct Commit {
 
 /// Represents a git tag, commonly indicating a software release.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TagRef<'a> {
     /// The hash in hexadecimal being the object this tag points to. Use [`target()`][TagRef::target()] to obtain a byte representation.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub target: &'a BStr,
     /// The kind of object that `target` points to.
     pub target_kind: Kind,
@@ -157,7 +157,7 @@ pub struct TagRefIter<'a> {
 
 /// A mutable git tag.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tag {
     /// The hash this tag is pointing to.
     pub target: gix_hash::ObjectId,
@@ -181,10 +181,10 @@ pub struct Tag {
 ///
 /// An `ObjectRef` is representing [`Trees`][TreeRef], [`Blobs`][BlobRef], [`Commits`][CommitRef], or [`Tags`][TagRef].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum ObjectRef<'a> {
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     Tree(TreeRef<'a>),
     Blob(BlobRef<'a>),
     Commit(CommitRef<'a>),
@@ -200,7 +200,7 @@ pub enum ObjectRef<'a> {
 ///
 /// An `Object` is representing [`Trees`][Tree], [`Blobs`][Blob], [`Commits`][Commit] or [`Tags`][Tag].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::large_enum_variant, missing_docs)]
 pub enum Object {
     Tree(Tree),
@@ -210,10 +210,10 @@ pub enum Object {
 }
 /// A directory snapshot containing files (blobs), directories (trees) and submodules (commits).
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TreeRef<'a> {
     /// The directories and files contained in this tree.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub entries: Vec<tree::EntryRef<'a>>,
 }
 
@@ -226,7 +226,7 @@ pub struct TreeRefIter<'a> {
 
 /// A mutable Tree, containing other trees, blobs or commits.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tree {
     /// The directories and files contained in this tree. They must be and remain sorted by [`filename`][tree::Entry::filename].
     pub entries: Vec<tree::Entry>,

--- a/gix-object/src/tree/mod.rs
+++ b/gix-object/src/tree/mod.rs
@@ -14,7 +14,7 @@ pub mod write;
 /// Used in [mutable::Entry][crate::tree::Entry] and [EntryRef].
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash)]
 #[repr(u16)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EntryMode {
     /// A tree, or directory
     Tree = 0o040000u16,
@@ -64,7 +64,7 @@ impl EntryMode {
 
 /// An element of a [`TreeRef`][crate::TreeRef::entries].
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntryRef<'a> {
     /// The kind of object to which `oid` is pointing.
     pub mode: tree::EntryMode,
@@ -73,7 +73,7 @@ pub struct EntryRef<'a> {
     /// The id of the object representing the entry.
     // TODO: figure out how these should be called. id or oid? It's inconsistent around the codebase.
     // Answer: make it 'id', as in `git2`
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub oid: &'a gix_hash::oid,
 }
 
@@ -94,7 +94,7 @@ impl<'a> Ord for EntryRef<'a> {
 
 /// An entry in a [`Tree`][crate::Tree], similar to an entry in a directory.
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry {
     /// The kind of object to which `oid` is pointing to.
     pub mode: EntryMode,

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [features]
 internal-testing-gix-features-parallel = ["gix-features/parallel"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "gix-hash/serde1", "gix-object/serde1", "gix-pack/serde1" ]
+serde= ["dep:serde", "gix-hash/serde", "gix-object/serde", "gix-pack/serde"]
 
 [[test]]
 name = "multi-threaded"
@@ -52,5 +52,5 @@ maplit = "1.0.2"
 crossbeam-channel = "0.5.6"
 
 [package.metadata.docs.rs]
-features = ["document-features", "serde1"]
+features = ["document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-odb/src/store_impls/dynamic/mod.rs
+++ b/gix-odb/src/store_impls/dynamic/mod.rs
@@ -94,7 +94,7 @@ pub mod structure {
 
     /// A record of a structural element of an object database.
     #[derive(Debug, Clone, PartialEq, Eq)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub enum Record {
         /// A loose object database.
         LooseObjectDatabase {
@@ -123,7 +123,7 @@ pub mod structure {
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     /// Possible stats of pack indices.
     pub enum IndexState {
         /// The index is active in memory because a mapping exists.

--- a/gix-odb/src/store_impls/dynamic/types.rs
+++ b/gix-odb/src/store_impls/dynamic/types.rs
@@ -394,7 +394,7 @@ pub(crate) struct MutableIndexAndPack {
 
 /// A snapshot about resource usage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Metrics {
     /// The total amount of handles which can be used to access object information.
     pub num_handles: usize,

--- a/gix-odb/src/store_impls/dynamic/verify.rs
+++ b/gix-odb/src/store_impls/dynamic/verify.rs
@@ -44,7 +44,7 @@ pub mod integrity {
     }
 
     #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     /// Integrity information about loose object databases
     pub struct LooseObjectStatistics {
         /// The path to the root directory of the loose objects database
@@ -54,7 +54,7 @@ pub mod integrity {
     }
 
     #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     /// Traversal statistics of packs governed by single indices or multi-pack indices.
     #[allow(missing_docs)]
     pub enum SingleOrMultiStatistics {
@@ -64,7 +64,7 @@ pub mod integrity {
 
     /// Statistics gathered when traversing packs of various kinds of indices.
     #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct IndexStatistics {
         /// The path to the index or multi-pack index for which statics were gathered.
         pub path: PathBuf,

--- a/gix-odb/src/store_impls/loose/verify.rs
+++ b/gix-odb/src/store_impls/loose/verify.rs
@@ -33,7 +33,7 @@ pub mod integrity {
 
     /// The outcome returned by [`verify_integrity()`][super::Store::verify_integrity()].
     #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Statistics {
         /// The amount of loose objects we checked.
         pub num_objects: usize,

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -23,7 +23,7 @@ pack-cache-lru-dynamic = ["dep:clru"]
 ## If set, select algorithms may additionally use a full-object cache which is queried before the pack itself.
 object-cache-dynamic = ["dep:clru"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["dep:serde", "gix-object/serde1"]
+serde = ["dep:serde", "gix-object/serde"]
 ## Make it possible to compile to the `wasm32-unknown-unknown` target.
 wasm = ["gix-diff/wasm"]
 
@@ -57,5 +57,5 @@ gix-testtools = { path = "../tests/tools"}
 
 [package.metadata.docs.rs]
 all-features = true
-features = ["document-features", "pack-cache-lru-dynamic", "object-cache-dynamic", "serde1"]
+features = ["document-features", "pack-cache-lru-dynamic", "object-cache-dynamic", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-pack/src/bundle/write/types.rs
+++ b/gix-pack/src/bundle/write/types.rs
@@ -31,7 +31,7 @@ impl Default for Options {
 /// Returned by [write_to_directory][crate::Bundle::write_to_directory()] or
 /// [write_to_directory_eagerly][crate::Bundle::write_to_directory_eagerly()]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The successful result of the index write operation
     pub index: crate::index::write::Outcome,

--- a/gix-pack/src/data/entry/header.rs
+++ b/gix-pack/src/data/entry/header.rs
@@ -5,7 +5,7 @@ use crate::data;
 
 /// The header portion of a pack data entry, identifying the kind of stored object.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Header {
     /// The object is a commit

--- a/gix-pack/src/data/entry/mod.rs
+++ b/gix-pack/src/data/entry/mod.rs
@@ -11,7 +11,7 @@ const REF_DELTA: u8 = 7;
 
 /// A way to uniquely identify the location of an entry within a pack bundle
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Location {
     /// The id of the pack containing the object. It's unique within its frame of reference which is the owning object database.
     pub pack_id: u32,

--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// A return value of a resolve function, which given an [`ObjectId`][gix_hash::ObjectId] determines where an object can be found.
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResolvedBase {
     /// Indicate an object is within this pack, at the given entry, and thus can be looked up locally.
     InPack(data::Entry),
@@ -34,7 +34,7 @@ struct Delta {
 ///
 /// Useful to understand the effectiveness of the pack compression or the cost of decompression.
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The kind of resolved object.
     pub kind: gix_object::Kind,

--- a/gix-pack/src/data/file/decode/header.rs
+++ b/gix-pack/src/data/file/decode/header.rs
@@ -5,7 +5,7 @@ use crate::{
 
 /// A return value of a resolve function, which given an [`ObjectId`][gix_hash::ObjectId] determines where an object can be found.
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResolvedBase {
     /// Indicate an object is within this pack, at the given entry, and thus can be looked up locally.
     InPack(data::Entry),
@@ -22,7 +22,7 @@ pub enum ResolvedBase {
 ///
 /// Useful to understand the effectiveness of the pack compression or the cost of decompression.
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The kind of resolved object.
     pub kind: gix_object::Kind,

--- a/gix-pack/src/data/input/mod.rs
+++ b/gix-pack/src/data/input/mod.rs
@@ -1,6 +1,6 @@
 /// An item of the iteration produced by [`BytesToEntriesIter`]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry {
     /// The header of a pack entry
     pub header: crate::data::entry::Header,

--- a/gix-pack/src/data/input/types.rs
+++ b/gix-pack/src/data/input/types.rs
@@ -22,7 +22,7 @@ pub enum Error {
 
 /// Iteration Mode
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Mode {
     /// Provide the trailer as read from the pack
     AsIs,
@@ -43,7 +43,7 @@ pub enum Mode {
 
 /// Define what to do with the compressed bytes portion of a pack [`Entry`][super::Entry]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EntryDataMode {
     /// Do nothing with the compressed bytes we read
     Ignore,

--- a/gix-pack/src/data/mod.rs
+++ b/gix-pack/src/data/mod.rs
@@ -11,7 +11,7 @@ use memmap2::Mmap;
 
 /// An representing an full- or delta-object within a pack
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry {
     /// The entry's header
     pub header: entry::Header,
@@ -49,7 +49,7 @@ pub type EntryRange = std::ops::Range<Offset>;
 
 /// Supported versions of a pack data file
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Version {
     V2,

--- a/gix-pack/src/data/output/count/mod.rs
+++ b/gix-pack/src/data/output/count/mod.rs
@@ -4,7 +4,7 @@ use crate::data::output::Count;
 
 /// Specifies how the pack location was handled during counting
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PackLocation {
     /// We did not lookup this object
     NotLookedUp,

--- a/gix-pack/src/data/output/count/objects/types.rs
+++ b/gix-pack/src/data/output/count/objects/types.rs
@@ -1,6 +1,6 @@
 /// Information gathered during the run of [`iter_from_objects()`][super::objects()].
 #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The amount of objects provided to start the iteration.
     pub input_objects: usize,
@@ -33,7 +33,7 @@ impl Outcome {
 
 /// The way input objects are handled
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ObjectExpansion {
     /// Don't do anything with the input objects except for transforming them into pack entries
     AsIs,
@@ -60,7 +60,7 @@ impl Default for ObjectExpansion {
 
 /// Configuration options for the pack generation functions provided in [this module][crate::data::output].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Options {
     /// The amount of threads to use at most when resolving the pack. If `None`, all logical cores are used.
     /// If more than one thread is used, the order of returned [counts][crate::data::output::Count] is not deterministic anymore

--- a/gix-pack/src/data/output/entry/iter_from_counts.rs
+++ b/gix-pack/src/data/output/entry/iter_from_counts.rs
@@ -317,7 +317,7 @@ mod types {
 
     /// Information gathered during the run of [`iter_from_counts()`][crate::data::output::entry::iter_from_counts()].
     #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Outcome {
         /// The amount of fully decoded objects. These are the most expensive as they are fully decoded.
         pub decoded_and_recompressed_objects: usize,
@@ -349,7 +349,7 @@ mod types {
 
     /// The way the iterator operates.
     #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub enum Mode {
         /// Copy base objects and deltas from packs, while non-packed objects will be treated as base objects
         /// (i.e. without trying to delta compress them). This is a fast way of obtaining a back while benefiting
@@ -360,7 +360,7 @@ mod types {
 
     /// Configuration options for the pack generation functions provided in [`iter_from_counts()`][crate::data::output::entry::iter_from_counts()].
     #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Options {
         /// The amount of threads to use at most when resolving the pack. If `None`, all logical cores are used.
         pub thread_limit: Option<usize>,

--- a/gix-pack/src/data/output/entry/mod.rs
+++ b/gix-pack/src/data/output/entry/mod.rs
@@ -10,7 +10,7 @@ pub use iter_from_counts::function::iter_from_counts;
 
 /// The kind of pack entry to be written
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Kind {
     /// A complete base object, including its kind
     Base(gix_object::Kind),

--- a/gix-pack/src/data/output/mod.rs
+++ b/gix-pack/src/data/output/mod.rs
@@ -8,7 +8,7 @@ pub mod count;
 /// One can expect to have one of these in memory when building big objects, so smaller is better here.
 /// They should contain everything of importance to generate a pack as fast as possible.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Count {
     /// The hash of the object to write
     pub id: ObjectId,
@@ -21,7 +21,7 @@ pub struct Count {
 /// Some of these will be in-flight and in memory while waiting to be written. Memory requirements depend on the amount of compressed
 /// data they hold.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry {
     /// The hash of the object to write
     pub id: ObjectId,

--- a/gix-pack/src/find.rs
+++ b/gix-pack/src/find.rs
@@ -53,7 +53,7 @@ pub mod existing_iter {
 ///
 /// Its commonly retrieved by reading from a pack index file followed by a read from a pack data file.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub struct Entry {
     /// The pack-data encoded bytes of the pack data entry as present in the pack file, including the header followed by compressed data.

--- a/gix-pack/src/index/access.rs
+++ b/gix-pack/src/index/access.rs
@@ -13,7 +13,7 @@ const N32_HIGH_BIT: u32 = 1 << 31;
 
 /// Represents an entry within a pack index file, effectively mapping object [`IDs`][gix_hash::ObjectId] to pack data file locations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry {
     /// The ID of the object
     pub oid: gix_hash::ObjectId,

--- a/gix-pack/src/index/mod.rs
+++ b/gix-pack/src/index/mod.rs
@@ -77,7 +77,7 @@ use memmap2::Mmap;
 
 /// The version of an index file
 #[derive(PartialEq, Eq, Ord, PartialOrd, Debug, Hash, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Version {
     V1 = 1,

--- a/gix-pack/src/index/traverse/types.rs
+++ b/gix-pack/src/index/traverse/types.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, marker::PhantomData};
 
 /// Statistics regarding object encountered during execution of the [`traverse()`][crate::index::File::traverse()] method.
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Statistics {
     /// The average over all decoded objects
     pub average: crate::data::decode::entry::Outcome,
@@ -48,7 +48,7 @@ impl Default for Statistics {
 
 /// The ways to validate decoded objects before passing them to the processor.
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SafetyCheck {
     /// Don't verify the validity of the checksums stored in the index and pack file
     SkipFileChecksumVerification,
@@ -91,7 +91,7 @@ impl Default for SafetyCheck {
 
 /// The way we verify the pack
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Algorithm {
     /// Build an index to allow decoding each delta and base exactly once, saving a lot of computational
     /// resource at the expense of resident memory, as we will use an additional `DeltaTree` to accelerate

--- a/gix-pack/src/index/write/mod.rs
+++ b/gix-pack/src/index/write/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct TreeEntry {
 
 /// Information gathered while executing [`write_data_iter_to_stream()`][crate::index::File::write_data_iter_to_stream]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The version of the verified index
     pub index_version: crate::index::Version,

--- a/gix-pack/src/multi_index/access.rs
+++ b/gix-pack/src/multi_index/access.rs
@@ -12,7 +12,7 @@ use crate::{
 /// Represents an entry within a multi index file, effectively mapping object [`IDs`][gix_hash::ObjectId] to pack data
 /// files and the offset within.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Entry {
     /// The ID of the object.
     pub oid: gix_hash::ObjectId,

--- a/gix-pack/src/multi_index/mod.rs
+++ b/gix-pack/src/multi_index/mod.rs
@@ -4,7 +4,7 @@ use memmap2::Mmap;
 
 /// Known multi-index file versions
 #[derive(PartialEq, Eq, Ord, PartialOrd, Debug, Hash, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Version {
     V1 = 1,

--- a/gix-pack/tests/Cargo.toml
+++ b/gix-pack/tests/Cargo.toml
@@ -19,7 +19,7 @@ pack-cache-lru-dynamic = ["gix-pack/pack-cache-lru-dynamic"]
 ## If set, select algorithms may additionally use a full-object cache which is queried before the pack itself.
 object-cache-dynamic = ["gix-pack/object-cache-dynamic"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["gix-pack/serde1"]
+serde = ["gix-pack/serde"]
 
 internal-testing-gix-features-parallel = ["gix-features/parallel"]
 internal-testing-to-avoid-being-run-by-cargo-test-all = []

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -26,7 +26,7 @@ async-io = ["futures-io", "futures-lite", "pin-project-lite"]
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde"]
+serde = ["dep:serde", "bstr/serde"]
 
 [[test]]
 name = "async-packetline"
@@ -57,5 +57,5 @@ async-std = { version = "1.9.0", features = ["attributes"] }
 maybe-async = "0.2.6"
 
 [package.metadata.docs.rs]
-features = ["document-features", "blocking-io", "serde1"]
+features = ["document-features", "blocking-io", "dep:serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-packetline/src/lib.rs
+++ b/gix-packetline/src/lib.rs
@@ -19,7 +19,7 @@ const ERR_PREFIX: &[u8] = b"ERR ";
 
 /// One of three side-band types allowing to multiplex information over a single connection.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Channel {
     /// The usable data itself in any format.
     Data = 1,
@@ -43,7 +43,7 @@ pub use write::blocking_io::Writer;
 
 /// A borrowed packet line as it refers to a slice of data by reference.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PacketLineRef<'a> {
     /// A chunk of raw data.
     Data(&'a [u8]),
@@ -57,17 +57,17 @@ pub enum PacketLineRef<'a> {
 
 /// A packet line representing an Error in a side-band channel.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ErrorRef<'a>(pub &'a [u8]);
 
 /// A packet line representing text, which may include a trailing newline.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextRef<'a>(pub &'a [u8]);
 
 /// A band in a side-band channel.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BandRef<'a> {
     /// A band carrying data.
     Data(&'a [u8]),

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -27,7 +27,7 @@ async-client = ["gix-transport/async-client", "async-trait", "futures-io", "futu
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde", "gix-transport/serde1", "gix-hash/serde1"]
+serde = ["dep:serde", "bstr/serde", "gix-transport/serde", "gix-hash/serde"]
 
 [[test]]
 name = "blocking-client-protocol"
@@ -65,5 +65,5 @@ gix-packetline = { path = "../gix-packetline" ,version = "^0.15.1" }
 gix-testtools = { path = "../tests/tools" }
 
 [package.metadata.docs.rs]
-features = ["blocking-client", "document-features", "serde1"]
+features = ["blocking-client", "document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-protocol/src/fetch/response/mod.rs
+++ b/gix-protocol/src/fetch/response/mod.rs
@@ -49,7 +49,7 @@ impl gix_transport::IsSpuriousError for Error {
 
 /// An 'ACK' line received from the server.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Acknowledgement {
     /// The contained `id` is in common.
     Common(gix_hash::ObjectId),
@@ -61,7 +61,7 @@ pub enum Acknowledgement {
 
 /// A shallow line received from the server.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShallowUpdate {
     /// Shallow the given `id`.
     Shallow(gix_hash::ObjectId),
@@ -71,7 +71,7 @@ pub enum ShallowUpdate {
 
 /// A wanted-ref line received from the server.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WantedRef {
     /// The object id of the wanted ref, as seen by the server.
     pub id: gix_hash::ObjectId,

--- a/gix-protocol/src/handshake/mod.rs
+++ b/gix-protocol/src/handshake/mod.rs
@@ -3,7 +3,7 @@ use gix_transport::client::Capabilities;
 
 /// A git reference, commonly referred to as 'ref', as returned by a git server before sending a pack.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Ref {
     /// A ref pointing to a `tag` object, which in turns points to an `object`, usually a commit
     Peeled {
@@ -46,7 +46,7 @@ pub enum Ref {
 
 /// The result of the [`handshake()`][super::handshake()] function.
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {
     /// The protocol version the server responded with. It might have downgraded the desired version.
     pub server_protocol_version: gix_transport::Protocol,

--- a/gix-protocol/src/remote_progress.rs
+++ b/gix-protocol/src/remote_progress.rs
@@ -10,9 +10,9 @@ use nom::{
 /// The information usually found in remote progress messages as sent by a git server during
 /// fetch, clone and push operations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RemoteProgress<'a> {
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     /// The name of the action, like "clone".
     pub action: &'a bstr::BStr,
     /// The percentage to indicate progress, between 0 and 100.

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -16,7 +16,7 @@ test = true
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "gix-hash/serde1", "gix-actor/serde1", "gix-object/serde1"]
+serde = ["dep:serde", "gix-hash/serde", "gix-actor/serde", "gix-object/serde"]
 
 [dependencies]
 gix-features = { version = "^0.28.1", path = "../gix-features", features = ["walkdir"]}
@@ -45,5 +45,5 @@ tempfile = "3.2.0"
 
 
 [package.metadata.docs.rs]
-features = ["document-features", "serde1"]
+features = ["document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-ref/src/lib.rs
+++ b/gix-ref/src/lib.rs
@@ -106,7 +106,7 @@ pub(crate) struct Store {
 
 /// A validated complete and fully qualified referenced reference name, safe to use for all operations.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FullName(pub(crate) BString);
 
 /// A validated complete and fully qualified referenced reference name, safe to use for all operations.
@@ -133,7 +133,7 @@ pub struct Namespace(BString);
 
 /// Denotes the kind of reference.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Kind {
     /// A ref that points to an object id
     Peeled,
@@ -184,7 +184,7 @@ pub enum Category<'a> {
 
 /// Denotes a ref target, equivalent to [`Kind`], but with mutable data.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Target {
     /// A ref that points to an object id
     Peeled(ObjectId),

--- a/gix-ref/src/log.rs
+++ b/gix-ref/src/log.rs
@@ -3,7 +3,7 @@ use gix_object::bstr::BString;
 
 /// A parsed ref log line that can be changed
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Line {
     /// The previous object id. Can be a null-sha to indicate this is a line for a new ref.
     pub previous_oid: ObjectId,

--- a/gix-ref/src/raw.rs
+++ b/gix-ref/src/raw.rs
@@ -4,7 +4,7 @@ use crate::{FullName, Target};
 
 /// A fully owned backend agnostic reference
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Reference {
     /// The path to uniquely identify this ref within its store.
     pub name: FullName,

--- a/gix-ref/src/store/file/log/mod.rs
+++ b/gix-ref/src/store/file/log/mod.rs
@@ -8,7 +8,7 @@ mod line;
 
 /// A parsed ref log line.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub struct LineRef<'a> {
     /// The previous object id in hexadecimal. Use [`LineRef::previous_oid()`] to get a more usable form.
@@ -16,7 +16,7 @@ pub struct LineRef<'a> {
     /// The new object id in hexadecimal. Use [`LineRef::new_oid()`] to get a more usable form.
     pub new_oid: &'a BStr,
     /// The signature of the currently configured committer.
-    #[cfg_attr(feature = "serde1", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub signature: gix_actor::SignatureRef<'a>,
     /// The message providing details about the operation performed in this log line.
     pub message: &'a BStr,

--- a/gix-ref/tests/Cargo.toml
+++ b/gix-ref/tests/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.64"
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["gix-ref/serde"]
+serde= ["gix-ref/serde"]
 internal-testing-gix-features-parallel = ["gix-features/parallel"] # test sorted parallel loose file traversal
 
 [[test]]
@@ -42,5 +42,5 @@ tempfile = "3.2.0"
 
 
 [package.metadata.docs.rs]
-features = ["document-features", "serde1"]
+features = ["document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = [ "serde", "gix-hash/serde1", "gix-object/serde1" ]
+serde = [ "dep:serde", "gix-hash/serde", "gix-object/serde" ]
 
 [dependencies]
 gix-hash = { version = "^0.10.4", path = "../gix-hash" }

--- a/gix-revision/src/spec/mod.rs
+++ b/gix-revision/src/spec/mod.rs
@@ -2,7 +2,7 @@ use crate::Spec;
 
 /// How to interpret a revision specification, or `revspec`.
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Kind {
     /// Include commits reachable from this revision, the default when parsing revision `a` for example, i.e. `a` and its ancestors.
     /// Example: `a`.

--- a/gix-revision/src/types.rs
+++ b/gix-revision/src/types.rs
@@ -3,7 +3,7 @@
 /// Note that all [object ids][gix_hash::ObjectId] should be a committish, but don't have to be.
 /// Unless the field name contains `_exclusive`, the respective objects are included in the set.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Spec {
     /// Include commits reachable from this revision, i.e. `a` and its ancestors.
     ///

--- a/gix-revision/tests/Cargo.toml
+++ b/gix-revision/tests/Cargo.toml
@@ -17,7 +17,7 @@ path = "revision.rs"
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = [ "gix-revision/serde", "gix-hash/serde1", "gix-object/serde1" ]
+serde = [ "gix-revision/serde", "gix-hash/serde", "gix-object/serde" ]
 
 [dev-dependencies]
 gix-revision = { path = "..", default-features = false }

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = [ "serde", "bitflags/serde" ]
+serde = [ "dep:serde", "bitflags/serde" ]
 
 [dependencies]
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// An account based identity
 pub struct Account {
     /// The user's name

--- a/gix-sec/src/lib.rs
+++ b/gix-sec/src/lib.rs
@@ -13,7 +13,7 @@ use std::fmt::{Display, Formatter};
 
 /// A way to specify how 'safe' we feel about a resource, typically about a git repository.
 #[derive(Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Debug, Hash)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Trust {
     /// Caution is warranted when using the resource.
     Reduced,
@@ -26,7 +26,7 @@ pub mod trust;
 
 /// Allow, deny or forbid using a resource or performing an action.
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Permission {
     /// Fail outright when trying to load a resource or performing an action.
     Forbid,
@@ -41,7 +41,7 @@ pub mod permission;
 
 bitflags::bitflags! {
     /// Whether something can be read or written.
-    #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Debug)]
     pub struct ReadWrite: u8 {
         /// The item can be read.

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -35,7 +35,7 @@ async-client = ["gix-packetline/async-io", "async-trait", "futures-lite", "futur
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde"]
+serde= ["dep:serde"]
 
 [[test]]
 name = "blocking-transport"
@@ -94,5 +94,5 @@ maybe-async = "0.2.6"
 blocking = "1.0.2"
 
 [package.metadata.docs.rs]
-features = ["http-client-curl", "document-features", "serde1"]
+features = ["http-client-curl", "document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-transport/src/client/capabilities.rs
+++ b/gix-transport/src/client/capabilities.rs
@@ -24,7 +24,7 @@ pub enum Error {
 
 /// A structure to represent multiple [capabilities][Capability] or features supported by the server.
 #[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Capabilities {
     data: BString,
     value_sep: u8,

--- a/gix-transport/src/client/non_io_types.rs
+++ b/gix-transport/src/client/non_io_types.rs
@@ -1,6 +1,6 @@
 /// Configure how the [`RequestWriter`][crate::client::RequestWriter] behaves when writing bytes.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum WriteMode {
     /// Each [write()][std::io::Write::write()] call writes the bytes verbatim as one or more packet lines.
     ///
@@ -23,7 +23,7 @@ impl Default for WriteMode {
 /// The kind of packet line to write when transforming a [`RequestWriter`][crate::client::RequestWriter] into an
 /// [`ExtendedBufRead`][crate::client::ExtendedBufRead].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MessageKind {
     /// A `flush` packet.
     Flush,

--- a/gix-transport/src/lib.rs
+++ b/gix-transport/src/lib.rs
@@ -20,7 +20,7 @@ pub use gix_packetline as packetline;
 
 /// The version of the way client and server communicate.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Protocol {
     /// Version 1 was the first one conceived, is stateful, and our implementation was seen to cause deadlocks. Prefer V2
@@ -38,7 +38,7 @@ impl Default for Protocol {
 
 /// The kind of service to invoke on the client or the server side.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Service {
     /// The service sending packs from a server to the client. Used for fetching pack data.
     UploadPack,

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = ["serde", "bstr/serde"]
+serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
 gix-features = { version = "^0.28.0", path = "../gix-features" }

--- a/gix-url/src/expand_path.rs
+++ b/gix-url/src/expand_path.rs
@@ -5,7 +5,7 @@ use bstr::{BStr, BString, ByteSlice};
 
 /// Whether a repository is resolving for the current user, or the given one.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ForUser {
     /// The currently logged in user.
     Current,

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -32,7 +32,7 @@ pub use scheme::Scheme;
 ///
 /// Note that we do not support passing the password using the URL as it's likely leading to accidents.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Url {
     /// The URL scheme.
     pub scheme: Scheme,

--- a/gix-url/src/scheme.rs
+++ b/gix-url/src/scheme.rs
@@ -2,7 +2,7 @@
 ///
 /// It defines how to talk to a given repository.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum Scheme {
     /// A local resource that is accessible on the current host.

--- a/gix-utils/src/lib.rs
+++ b/gix-utils/src/lib.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 
 /// Common knowledge about the worktree that is needed across most interactions with the work tree
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 pub struct FilesystemCapabilities {
     /// If true, the filesystem will store paths as decomposed unicode, i.e. `ä` becomes `"a\u{308}"`, which means that

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["internal-testing-to-avoid-being-run-by-cargo-test-all"]
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = [ "serde", "bstr/serde", "gix-index/serde1", "gix-hash/serde1", "gix-object/serde1", "gix-attributes/serde1", "gix-ignore/serde1" ]
+serde = [ "dep:serde", "bstr/serde", "gix-index/serde", "gix-hash/serde", "gix-object/serde", "gix-attributes/serde", "gix-ignore/serde" ]
 
 internal-testing-gix-features-parallel = ["gix-features/parallel"]
 internal-testing-to-avoid-being-run-by-cargo-test-all = []
@@ -57,5 +57,5 @@ walkdir = "2.3.2"
 tempfile = "3.2.0"
 
 [package.metadata.docs.rs]
-features = ["document-features", "serde1"]
+features = ["document-features", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -54,20 +54,20 @@ blocking-http-transport-reqwest-native-tls = ["blocking-http-transport-reqwest",
 #! ### Other
 
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde1 = [  "serde",
-            "gix-pack/serde1",
-            "gix-object/serde1",
-            "gix-protocol?/serde1",
-            "gix-transport?/serde1",
-            "gix-ref/serde1",
-            "gix-odb/serde1",
-            "gix-index/serde1",
-            "gix-mailmap/serde1",
-            "gix-url/serde1",
-            "gix-attributes/serde1",
-            "gix-ignore/serde1",
-            "gix-revision/serde1",
-            "gix-credentials/serde1" ]
+serde = [   "dep:serde",
+            "gix-pack/serde",
+            "gix-object/serde",
+            "gix-protocol?/serde",
+            "gix-transport?/serde",
+            "gix-ref/serde",
+            "gix-odb/serde",
+            "gix-index/serde",
+            "gix-mailmap/serde",
+            "gix-url/serde",
+            "gix-attributes/serde",
+            "gix-ignore/serde",
+            "gix-revision/serde",
+            "gix-credentials/serde"]
 
 ## Re-export the progress tree root which allows to obtain progress from various functions which take `impl gix::Progress`.
 progress-tree = ["prodash/progress-tree"]
@@ -179,5 +179,5 @@ serial_test = { version = "2.0.0", default-features = false }
 async-std = { version = "1.12.0", features = ["attributes"] }
 
 [package.metadata.docs.rs]
-features = ["document-features", "max-performance", "blocking-network-client", "serde1"]
+features = ["document-features", "max-performance", "blocking-network-client", "serde"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Uses Cargo weak-deps (stabilized in 1.60) to declare serde and thus avoid the awkward serde1 feature. 

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
