### PR TITLE
Support native zlib-ng via flate2's zlib-ng feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ check: ## Build all code in suitable configurations
 			   && cargo check --features io-pipe \
 			   && cargo check --features crc32 \
 			   && cargo check --features zlib \
+			   && cargo check --features zlib,zlib-ng \
 			   && cargo check --features zlib,zlib-ng-compat \
 			   && cargo check --features zlib-stock \
 			   && cargo check --features zlib,zlib-stock \

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -46,19 +46,21 @@ crc32 = ["dep:crc32fast"]
 #! ### Mutually Exclusive ZLIB
 
 ## Enable the usage of zlib related utilities to compress or decompress data.
-## By default it uses a pure rust implementation which is slower than the **zlib-ng-compat** or **zlib-stock** versions, but might be relevant if you prefer a pure-rust build
-## and reduced performance is acceptable. **zlib-stock** can be used if dynamic linking of an external zlib library is desired or if cmake is not available.
+## The base `zlib` feature uses the `flate2` Rust crate; the other mutually exclusive features select the `flate2 backend.
 ## Note that a competitive Zlib implementation is critical to `gitoxide's` object database performance.
-## Additional backends are supported, each of which overriding the default Rust backend.
+## Enabling this without enabling one of the other features below will use a low-performance pure-Rust backend.
 zlib = ["dep:flate2", "flate2?/rust_backend", "dep:thiserror"]
-## Use zlib-ng (libz-ng-sys) with native API (no compat mode) that can co-exist with system libz.
-zlib-ng= ["zlib", "flate2?/zlib-ng"]
-## Use a C-based backend which can compress and decompress significantly faster than the other options.
+## Use the C-based zlib-ng backend, which can compress and decompress significantly faster.
+zlib-ng = ["zlib", "flate2?/zlib-ng"]
+## Use zlib-ng via its zlib-compat API. Useful if you already need zlib for C
+## code elsewhere in your dependencies. Otherwise, use zlib-ng.
 zlib-ng-compat = ["zlib", "flate2?/zlib-ng-compat"]
 ## Use a slower C-based backend which can compress and decompress significantly faster than the rust version.
 ## Unlike `zlib-ng-compat`, this allows using dynamic linking with system `zlib` libraries and doesn't require cmake.
 zlib-stock = ["zlib", "flate2?/zlib"]
-## available for completeness even though it's the default - it may be chosen for more specific feature flag names, instead of a bare `zlib`.
+## Pure Rust backend, available for completeness even though it's the default
+## if neither of the above options are set. Low performance, but pure Rust, so it
+## may build in environments where other backends don't.
 zlib-rust-backend = ["zlib", "flate2?/rust_backend"]
 
 #! ### Mutually Exclusive SHA1
@@ -128,7 +130,7 @@ bytesize = { version = "1.0.1", optional = true }
 bytes = { version = "1.0.0", optional = true }
 
 # zlib module
-flate2 = { version = "1.0.17", optional = true, default-features = false }
+flate2 = { version = "1.0.25", optional = true, default-features = false }
 thiserror = { version = "1.0.38", optional = true }
 
 once_cell = { version = "1.13.0", optional = true }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -103,7 +103,7 @@ pack-cache-lru-dynamic = ["gix-pack/pack-cache-lru-dynamic"]
 
 ## Activate other features that maximize performance, like usage of threads, `zlib-ng` and access to caching in object databases.
 ## Note that some platforms might suffer from compile failures, which is when `max-performance-safe` should be used.
-max-performance = [ "max-performance-safe", "gix-features/zlib-ng-compat", "fast-sha1" ]
+max-performance = [ "max-performance-safe", "gix-features/zlib-ng", "fast-sha1" ]
 
 ## If enabled, use assembly versions of sha1 on supported platforms.
 ## This might cause compile failures as well which is why it can be turned off separately.


### PR DESCRIPTION
In addition to the zlib-ng-compat feature, flate2 now supports zlib-ng
via its native API and the libz-ng-sys crate. This avoids potential
symbol conflicts with dependencies on system C libraries that link to
system zlib. Using zlib-ng increases compatibility, avoids those
conflicts, and allows using zlib-ng in more circumstances.

(zlib-ng-compat is still useful when you have dependencies that need the
zlib C ABI and don't support zlib-ng, such as curl; git-transport still
uses zlib-ng-compat.)

----
**Rebased follow-up of**: #434