### PR TITLE
attributes for worktree-cache

### DIFF
--- a/gix-attributes/src/search/attributes.rs
+++ b/gix-attributes/src/search/attributes.rs
@@ -81,7 +81,7 @@ impl Search {
         &'a self,
         relative_path: impl Into<&'b BStr>,
         case: gix_glob::pattern::Case,
-        out: &mut Outcome<'a>,
+        out: &mut Outcome,
     ) -> bool {
         let relative_path = relative_path.into();
         let basename_pos = relative_path.rfind(b"/").map(|p| p + 1);
@@ -174,12 +174,12 @@ fn macro_mode() -> gix_glob::pattern::Mode {
 /// `is_dir` is true if `relative_path` is a directory.
 /// Return `true` if at least one pattern matched.
 #[allow(unused_variables)]
-fn pattern_matching_relative_path<'a>(
-    list: &'a gix_glob::search::pattern::List<Attributes>,
+fn pattern_matching_relative_path(
+    list: &gix_glob::search::pattern::List<Attributes>,
     relative_path: &BStr,
     basename_pos: Option<usize>,
     case: gix_glob::pattern::Case,
-    out: &mut Outcome<'a>,
+    out: &mut Outcome,
 ) -> bool {
     let (relative_path, basename_start_pos) =
         match list.strip_base_handle_recompute_basename_pos(relative_path, basename_pos, case) {
@@ -207,7 +207,7 @@ fn pattern_matching_relative_path<'a>(
         if out.has_unspecified_attributes(attrs.iter().map(|attr| attr.id))
             && pattern.matches_repo_relative_path(relative_path, basename_start_pos, None, case)
         {
-            let all_filled = out.fill_attributes(attrs.iter(), pattern, list.source.as_deref(), *sequence_number);
+            let all_filled = out.fill_attributes(attrs.iter(), pattern, list.source.as_ref(), *sequence_number);
             if all_filled {
                 break 'outer;
             }

--- a/gix-attributes/src/search/attributes.rs
+++ b/gix-attributes/src/search/attributes.rs
@@ -11,11 +11,14 @@ use crate::{
 
 /// Instantiation and initialization.
 impl Search {
-    /// Create a search instance preloaded with *built-ins* as well as attribute `files` from various global locations.
+    /// Create a search instance preloaded with *built-ins* followed by attribute `files` from various global locations.
+    ///
     /// See [`Source`][crate::Source] for a way to obtain these paths.
+    ///
     /// Note that parsing is lenient and errors are logged.
-    /// `buf` is used to read `files` from disk which will be ignored if they do not exist.
-    /// `collection` will be updated with information necessary to perform lookups later.
+    ///
+    /// * `buf` is used to read `files` from disk which will be ignored if they do not exist.
+    /// * `collection` will be updated with information necessary to perform lookups later.
     pub fn new_globals(
         files: impl IntoIterator<Item = impl Into<PathBuf>>,
         buf: &mut Vec<u8>,
@@ -36,7 +39,7 @@ impl Search {
     /// Add the given file at `source` to our patterns if it exists, otherwise do nothing.
     /// Update `collection` with newly added attribute names.
     /// If a `root` is provided, it's not considered a global file anymore.
-    /// Returns true if the file was added, or false if it didn't exist.
+    /// Returns `true` if the file was added, or `false` if it didn't exist.
     pub fn add_patterns_file(
         &mut self,
         source: impl Into<PathBuf>,
@@ -63,12 +66,17 @@ impl Search {
         self.patterns.push(pattern::List::from_bytes(bytes, source, root));
         collection.update_from_list(self.patterns.last_mut().expect("just added"));
     }
+
+    /// Pop the last attribute patterns list from our queue.
+    pub fn pop_pattern_list(&mut self) -> Option<gix_glob::search::pattern::List<Attributes>> {
+        self.patterns.pop()
+    }
 }
 
 /// Access and matching
 impl Search {
     /// Match `relative_path`, a path relative to the repository, while respective `case`-sensitivity and write them to `out`
-    /// Return true if at least one pattern matched.
+    /// Return `true` if at least one pattern matched.
     pub fn pattern_matching_relative_path<'a, 'b>(
         &'a self,
         relative_path: impl Into<&'b BStr>,

--- a/gix-attributes/src/search/outcome.rs
+++ b/gix-attributes/src/search/outcome.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Initialization
 impl<'pattern> Outcome<'pattern> {
     /// Initialize this instance to collect outcomes for all names in `collection`, which represents all possible attributes
-    /// or macros we may visit.
+    /// or macros we may visit, and [`reset`][Self::reset()] it unconditionally.
     ///
     /// This must be called after each time `collection` changes.
     pub fn initialize(&mut self, collection: &MetadataCollection) {
@@ -125,6 +125,11 @@ impl<'pattern> Outcome<'pattern> {
     pub fn match_by_id(&self, id: AttributeId) -> Option<&Match<'pattern>> {
         self.matches_by_id.get(id.0).and_then(|m| m.r#match.as_ref())
     }
+
+    /// Return `true` if there is nothing more to be done as all attributes were filled.
+    pub fn is_done(&self) -> bool {
+        self.remaining() == 0
+    }
 }
 
 /// Mutation
@@ -199,11 +204,6 @@ impl<'attr> Outcome<'attr> {
     pub(crate) fn remaining(&self) -> usize {
         self.remaining
             .expect("BUG: instance must be initialized for each search set")
-    }
-
-    /// Return true if there is nothing more to be done as all attributes were filled.
-    pub(crate) fn is_done(&self) -> bool {
-        self.remaining() == 0
     }
 
     fn reduce_and_check_if_done(&mut self, attr: AttributeId) -> bool {

--- a/gix-attributes/src/search/outcome.rs
+++ b/gix-attributes/src/search/outcome.rs
@@ -1,19 +1,18 @@
-use std::{borrow::Cow, path::Path};
-
 use bstr::{BString, ByteSlice};
 use gix_glob::Pattern;
 use kstring::{KString, KStringRef};
 
+use crate::search::refmap::RefMapKey;
 use crate::{
     search::{
-        Assignments, AttributeId, Attributes, Match, MatchKind, MatchLocation, Metadata, MetadataCollection, Outcome,
-        TrackedAssignment, Value,
+        Assignments, AttributeId, Attributes, MatchKind, Metadata, MetadataCollection, Outcome, TrackedAssignment,
+        Value,
     },
-    Assignment, NameRef, State,
+    AssignmentRef, NameRef, StateRef,
 };
 
 /// Initialization
-impl<'pattern> Outcome<'pattern> {
+impl Outcome {
     /// Initialize this instance to collect outcomes for all names in `collection`, which represents all possible attributes
     /// or macros we may visit, and [`reset`][Self::reset()] it unconditionally.
     ///
@@ -74,7 +73,7 @@ impl<'pattern> Outcome<'pattern> {
 }
 
 /// Access
-impl<'pattern> Outcome<'pattern> {
+impl Outcome {
     /// Return an iterator over all filled attributes we were initialized with.
     ///
     /// ### Note
@@ -88,42 +87,44 @@ impl<'pattern> Outcome<'pattern> {
     /// the same as what `git` provides.
     /// Ours is in order of declaration, whereas `git` seems to list macros first somehow. Since the values are the same, this
     /// shouldn't be an issue.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a Match<'pattern>> + 'a {
-        self.matches_by_id.iter().filter_map(|item| item.r#match.as_ref())
+    pub fn iter(&self) -> impl Iterator<Item = crate::search::Match<'_>> {
+        self.matches_by_id
+            .iter()
+            .filter_map(|item| item.r#match.as_ref().map(|m| m.to_outer(self)))
     }
 
     /// Iterate over all matches of the attribute selection in their original order.
-    pub fn iter_selected<'a>(&'a self) -> impl Iterator<Item = Cow<'a, Match<'pattern>>> + 'a {
+    ///
+    /// This only yields values if this instance was initialized with [`Outcome::initialize_with_selection()`].
+    pub fn iter_selected(&self) -> impl Iterator<Item = crate::search::Match<'_>> {
         static DUMMY: Pattern = Pattern {
             text: BString::new(Vec::new()),
             mode: gix_glob::pattern::Mode::empty(),
             first_wildcard_pos: None,
         };
         self.selected.iter().map(|(name, id)| {
-            id.and_then(|id| self.matches_by_id[id.0].r#match.as_ref())
-                .map(Cow::Borrowed)
-                .unwrap_or_else(|| {
-                    Cow::Owned(Match {
-                        pattern: &DUMMY,
-                        assignment: Assignment {
-                            name: NameRef::try_from(name.as_bytes().as_bstr())
-                                .unwrap_or_else(|_| NameRef("invalid".into()))
-                                .to_owned(),
-                            state: State::Unspecified,
-                        },
-                        kind: MatchKind::Attribute { macro_id: None },
-                        location: MatchLocation {
-                            source: None,
-                            sequence_number: 0,
-                        },
-                    })
+            id.and_then(|id| self.matches_by_id[id.0].r#match.as_ref().map(|m| m.to_outer(self)))
+                .unwrap_or_else(|| crate::search::Match {
+                    pattern: &DUMMY,
+                    assignment: AssignmentRef {
+                        name: NameRef::try_from(name.as_bytes().as_bstr())
+                            .unwrap_or_else(|_| NameRef("invalid".into())),
+                        state: StateRef::Unspecified,
+                    },
+                    kind: MatchKind::Attribute { macro_id: None },
+                    location: crate::search::MatchLocation {
+                        source: None,
+                        sequence_number: 0,
+                    },
                 })
         })
     }
 
     /// Obtain a match by the order of its attribute, if the order exists in our initialized attribute list and there was a match.
-    pub fn match_by_id(&self, id: AttributeId) -> Option<&Match<'pattern>> {
-        self.matches_by_id.get(id.0).and_then(|m| m.r#match.as_ref())
+    pub fn match_by_id(&self, id: AttributeId) -> Option<crate::search::Match<'_>> {
+        self.matches_by_id
+            .get(id.0)
+            .and_then(|m| m.r#match.as_ref().map(|m| m.to_outer(self)))
     }
 
     /// Return `true` if there is nothing more to be done as all attributes were filled.
@@ -133,7 +134,7 @@ impl<'pattern> Outcome<'pattern> {
 }
 
 /// Mutation
-impl<'pattern> Outcome<'pattern> {
+impl Outcome {
     /// Fill all `attrs` and resolve them recursively if they are macros. Return `true` if there is no attribute left to be resolved and
     /// we are totally done.
     /// `pattern` is what matched a patch and is passed for contextual information,
@@ -141,8 +142,8 @@ impl<'pattern> Outcome<'pattern> {
     pub(crate) fn fill_attributes<'a>(
         &mut self,
         attrs: impl Iterator<Item = &'a TrackedAssignment>,
-        pattern: &'pattern gix_glob::Pattern,
-        source: Option<&'pattern Path>,
+        pattern: &gix_glob::Pattern,
+        source: Option<&std::path::PathBuf>,
         sequence_number: usize,
     ) -> bool {
         self.attrs_stack.extend(attrs.filter_map(|attr| {
@@ -160,8 +161,8 @@ impl<'pattern> Outcome<'pattern> {
             let is_macro = !slot.macro_attributes.is_empty();
 
             slot.r#match = Some(Match {
-                pattern,
-                assignment: assignment.to_owned(),
+                pattern: self.patterns.insert(pattern),
+                assignment: self.assignments.insert_owned(assignment),
                 kind: if is_macro {
                     MatchKind::Macro {
                         parent_macro_id: parent_order,
@@ -170,7 +171,7 @@ impl<'pattern> Outcome<'pattern> {
                     MatchKind::Attribute { macro_id: parent_order }
                 },
                 location: MatchLocation {
-                    source,
+                    source: source.map(|path| self.source_paths.insert(path)),
                     sequence_number,
                 },
             });
@@ -193,7 +194,7 @@ impl<'pattern> Outcome<'pattern> {
     }
 }
 
-impl<'attr> Outcome<'attr> {
+impl Outcome {
     /// Given a list of `attrs` by order, return true if at least one of them is not set
     pub(crate) fn has_unspecified_attributes(&self, mut attrs: impl Iterator<Item = AttributeId>) -> bool {
         attrs.any(|order| self.matches_by_id[order.0].r#match.is_none())
@@ -311,6 +312,54 @@ impl MatchKind {
     pub fn source_id(&self) -> Option<AttributeId> {
         match self {
             MatchKind::Attribute { macro_id: id } | MatchKind::Macro { parent_macro_id: id } => *id,
+        }
+    }
+}
+
+/// A version of `Match` without references.
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]
+pub struct Match {
+    /// The glob pattern itself, like `/target/*`.
+    pub pattern: RefMapKey,
+    /// The key=value pair of the attribute that matched at the pattern. There can be multiple matches per pattern.
+    pub assignment: RefMapKey,
+    /// Additional information about the kind of match.
+    pub kind: MatchKind,
+    /// Information about the location of the match.
+    pub location: MatchLocation,
+}
+
+impl Match {
+    fn to_outer<'a>(&self, out: &'a Outcome) -> crate::search::Match<'a> {
+        crate::search::Match {
+            pattern: out.patterns.resolve(self.pattern).expect("pattern still present"),
+            assignment: out
+                .assignments
+                .resolve(self.assignment)
+                .expect("assignment present")
+                .as_ref(),
+            kind: self.kind,
+            location: self.location.to_outer(out),
+        }
+    }
+}
+
+/// A version of `MatchLocation` without references.
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]
+pub struct MatchLocation {
+    /// The path to the source from which the pattern was loaded, or `None` if it was specified by other means.
+    pub source: Option<RefMapKey>,
+    /// The line at which the pattern was found in its `source` file, or the occurrence in which it was provided.
+    pub sequence_number: usize,
+}
+
+impl MatchLocation {
+    fn to_outer<'a>(&self, out: &'a Outcome) -> crate::search::MatchLocation<'a> {
+        crate::search::MatchLocation {
+            source: self
+                .source
+                .and_then(|source| out.source_paths.resolve(source).map(|p| p.as_path())),
+            sequence_number: self.sequence_number,
         }
     }
 }

--- a/gix-attributes/src/search/refmap.rs
+++ b/gix-attributes/src/search/refmap.rs
@@ -1,0 +1,52 @@
+//! A utility to store objects by identity, which deduplicates them while avoiding lifetimes.
+//!
+//! We chose to use hashing/identity over pointers as it's possible that different objects end up in the same memory location,
+//! which would create obscure bugs. The same could happen with hash collisions, but they these are designed to be less likely.
+use std::collections::btree_map::Entry;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
+
+pub(crate) type RefMapKey = u64;
+pub(crate) struct RefMap<T>(BTreeMap<RefMapKey, T>);
+
+impl<T> Default for RefMap<T> {
+    fn default() -> Self {
+        RefMap(Default::default())
+    }
+}
+
+impl<T> RefMap<T>
+where
+    T: Hash + Clone,
+{
+    pub(crate) fn insert(&mut self, value: &T) -> RefMapKey {
+        let mut s = DefaultHasher::new();
+        value.hash(&mut s);
+        let key = s.finish();
+        match self.0.entry(key) {
+            Entry::Vacant(e) => {
+                e.insert(value.clone());
+                key
+            }
+            Entry::Occupied(_) => key,
+        }
+    }
+
+    pub(crate) fn insert_owned(&mut self, value: T) -> RefMapKey {
+        let mut s = DefaultHasher::new();
+        value.hash(&mut s);
+        let key = s.finish();
+        match self.0.entry(key) {
+            Entry::Vacant(e) => {
+                e.insert(value);
+                key
+            }
+            Entry::Occupied(_) => key,
+        }
+    }
+
+    pub(crate) fn resolve(&self, key: RefMapKey) -> Option<&T> {
+        self.0.get(&key)
+    }
+}

--- a/gix-attributes/src/state.rs
+++ b/gix-attributes/src/state.rs
@@ -64,10 +64,10 @@ impl Value {
 }
 
 /// Access
-impl State {
+impl StateRef<'_> {
     /// Return `true` if the associated attribute was set to be unspecified using the `!attr` prefix or it wasn't mentioned.
     pub fn is_unspecified(&self) -> bool {
-        matches!(self, State::Unspecified)
+        matches!(self, StateRef::Unspecified)
     }
 }
 

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -103,7 +103,7 @@ fn baseline() -> crate::Result {
         assert_references(&actual);
         let actual: Vec<_> = actual
             .iter()
-            .filter_map(|m| (!m.assignment.state.is_unspecified()).then(|| m.assignment.as_ref()))
+            .filter_map(|m| (!m.assignment.state.is_unspecified()).then_some(m.assignment))
             .collect();
         assert_eq!(actual, expected, "we have the same matches: {rela_path:?}");
         assert_ne!(has_match, actual.is_empty());
@@ -196,7 +196,7 @@ fn all_attributes_are_listed_in_declaration_order() -> crate::Result {
         out.reset();
         group.pattern_matching_relative_path(rela_path, Case::Sensitive, &mut out);
         assert_references(&out);
-        let actual: Vec<_> = out.iter().map(|m| m.assignment.as_ref()).collect();
+        let actual: Vec<_> = out.iter().map(|m| m.assignment).collect();
         assert_eq!(
             by_name(actual),
             by_name(expected),
@@ -226,10 +226,9 @@ fn given_attributes_are_made_available_in_given_order() -> crate::Result {
         out.reset();
         group.pattern_matching_relative_path(rela_path, Case::Sensitive, &mut out);
         assert_references(&out);
-        let actual: Vec<_> = out.iter_selected().map(|m| m.into_owned().assignment).collect();
+        let actual: Vec<_> = out.iter_selected().map(|m| m.assignment).collect();
         assert_eq!(
-            actual.iter().map(|a| a.as_ref()).collect::<Vec<_>>(),
-            expected,
+            actual, expected,
             "{rela_path}: the order of everything matches perfectly"
         );
     }
@@ -241,7 +240,7 @@ fn given_attributes_are_made_available_in_given_order() -> crate::Result {
     Ok(())
 }
 
-fn by_name(assignments: Vec<AssignmentRef<'_>>) -> BTreeMap<NameRef<'_>, StateRef<'_>> {
+fn by_name(assignments: Vec<AssignmentRef>) -> BTreeMap<NameRef, StateRef> {
     assignments.into_iter().map(|a| (a.name, a.state)).collect()
 }
 

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -258,6 +258,8 @@ fn assignments<'a>(
 
 mod baseline {
     use bstr::{BStr, ByteSlice};
+    use gix_attributes::{search::MetadataCollection, AssignmentRef, StateRef};
+    use std::path::PathBuf;
 
     /// Read user-attributes and baseline in one go.
     pub fn user_attributes_named_baseline(
@@ -274,9 +276,6 @@ mod baseline {
 
         Ok((group, collection, base, input))
     }
-    use std::path::PathBuf;
-
-    use gix_attributes::{search::MetadataCollection, AssignmentRef, StateRef};
 
     /// Read user-attributes and baseline in one go.
     pub fn user_attributes(

--- a/gix-glob/src/search/mod.rs
+++ b/gix-glob/src/search/mod.rs
@@ -23,7 +23,7 @@ pub trait Pattern: Clone + PartialEq + Eq + std::fmt::Debug + std::hash::Hash + 
 
 /// Add the given file at `source` if it exists, otherwise do nothing.
 /// If a `root` is provided, it's not considered a global file anymore.
-/// Returns true if the file was added, or false if it didn't exist.
+/// Returns `true` if the file was added, or `false` if it didn't exist.
 pub fn add_patterns_file<T: Pattern>(
     patterns: &mut Vec<pattern::List<T>>,
     source: impl Into<PathBuf>,

--- a/gix-path/src/convert.rs
+++ b/gix-path/src/convert.rs
@@ -82,6 +82,16 @@ pub fn into_bstr<'a>(path: impl Into<Cow<'a, Path>>) -> Cow<'a, BStr> {
     try_into_bstr(path).expect("prefix path doesn't contain ill-formed UTF-8")
 }
 
+/// Join `path` to `base` such that they are separated with a `/`, i.e. `base/path`.
+pub fn join_bstr_unix_pathsep<'a, 'b>(base: impl Into<Cow<'a, BStr>>, path: impl Into<&'b BStr>) -> Cow<'a, BStr> {
+    let mut base = base.into();
+    if base.last() != Some(&b'/') {
+        base.to_mut().push(b'/');
+    }
+    base.to_mut().extend_from_slice(path.into());
+    base
+}
+
 /// Given `input` bytes, produce a `Path` from them ignoring encoding entirely if on unix.
 ///
 /// On windows, the input is required to be valid UTF-8, which is guaranteed if we wrote it before. There are some potential

--- a/gix-path/tests/convert/mod.rs
+++ b/gix-path/tests/convert/mod.rs
@@ -19,3 +19,46 @@ fn assure_windows_separators() {
 }
 
 mod normalize;
+
+mod join_bstr_unix_pathsep {
+    use bstr::BStr;
+    use gix_path::join_bstr_unix_pathsep;
+
+    fn b(s: &str) -> &BStr {
+        s.into()
+    }
+
+    #[test]
+    fn typical_with_double_slash_avoidance() {
+        assert_eq!(join_bstr_unix_pathsep(b("base"), "path"), b("base/path"));
+        assert_eq!(
+            join_bstr_unix_pathsep(b("base/"), "path"),
+            b("base/path"),
+            "no double slashes"
+        );
+        assert_eq!(join_bstr_unix_pathsep(b("/base"), "path"), b("/base/path"));
+        assert_eq!(join_bstr_unix_pathsep(b("/base/"), "path"), b("/base/path"));
+    }
+    #[test]
+    fn relative_base_or_path_are_nothing_special() {
+        assert_eq!(join_bstr_unix_pathsep(b("base"), "."), b("base/."));
+        assert_eq!(join_bstr_unix_pathsep(b("base"), ".."), b("base/.."));
+        assert_eq!(join_bstr_unix_pathsep(b("base"), "../dir"), b("base/../dir"));
+    }
+    #[test]
+    fn absolute_path_produces_double_slashes() {
+        assert_eq!(join_bstr_unix_pathsep(b("/base"), "/root"), b("/base//root"));
+        assert_eq!(join_bstr_unix_pathsep(b("base/"), "/root"), b("base//root"));
+    }
+    #[test]
+    fn empty_path_makes_base_end_with_a_slash() {
+        assert_eq!(join_bstr_unix_pathsep(b("base"), ""), b("base/"));
+        assert_eq!(join_bstr_unix_pathsep(b("base/"), ""), b("base/"));
+    }
+    #[test]
+    fn empty_base_creates_absolute_paths() {
+        assert_eq!(join_bstr_unix_pathsep(b(""), ""), b("/"));
+        assert_eq!(join_bstr_unix_pathsep(b(""), "hi"), b("/hi"));
+        assert_eq!(join_bstr_unix_pathsep(b(""), "/hi"), b("//hi"));
+    }
+}

--- a/gix-worktree/src/cache/delegate.rs
+++ b/gix-worktree/src/cache/delegate.rs
@@ -1,0 +1,136 @@
+use crate::cache::State;
+use crate::PathIdMapping;
+
+pub struct StackDelegate<'a, Find> {
+    pub state: &'a mut State,
+    pub buf: &'a mut Vec<u8>,
+    pub is_dir: bool,
+    pub id_mappings: &'a Vec<PathIdMapping>,
+    pub find: Find,
+}
+
+impl<'a, Find, E> gix_fs::stack::Delegate for StackDelegate<'a, Find>
+where
+    Find: for<'b> FnMut(&gix_hash::oid, &'b mut Vec<u8>) -> Result<gix_object::BlobRef<'b>, E>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn push_directory(&mut self, stack: &gix_fs::Stack) -> std::io::Result<()> {
+        match &mut self.state {
+            State::CreateDirectoryAndAttributesStack { attributes, .. } => {
+                attributes.push_directory(
+                    stack.root(),
+                    stack.current(),
+                    self.buf,
+                    self.id_mappings,
+                    &mut self.find,
+                )?;
+            }
+            State::AttributesAndIgnoreStack { ignore, attributes } => {
+                attributes.push_directory(
+                    stack.root(),
+                    stack.current(),
+                    self.buf,
+                    self.id_mappings,
+                    &mut self.find,
+                )?;
+                ignore.push_directory(
+                    stack.root(),
+                    stack.current(),
+                    self.buf,
+                    self.id_mappings,
+                    &mut self.find,
+                )?
+            }
+            State::IgnoreStack(ignore) => ignore.push_directory(
+                stack.root(),
+                stack.current(),
+                self.buf,
+                self.id_mappings,
+                &mut self.find,
+            )?,
+        }
+        Ok(())
+    }
+
+    fn push(&mut self, is_last_component: bool, stack: &gix_fs::Stack) -> std::io::Result<()> {
+        match &mut self.state {
+            State::CreateDirectoryAndAttributesStack {
+                #[cfg(debug_assertions)]
+                test_mkdir_calls,
+                unlink_on_collision,
+                attributes: _,
+            } => {
+                #[cfg(debug_assertions)]
+                {
+                    create_leading_directory(
+                        is_last_component,
+                        stack,
+                        self.is_dir,
+                        test_mkdir_calls,
+                        *unlink_on_collision,
+                    )?
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    create_leading_directory(is_last_component, stack, self.is_dir, *unlink_on_collision)?
+                }
+            }
+            State::AttributesAndIgnoreStack { .. } | State::IgnoreStack(_) => {}
+        }
+        Ok(())
+    }
+
+    fn pop_directory(&mut self) {
+        match &mut self.state {
+            State::CreateDirectoryAndAttributesStack { attributes, .. } => {
+                attributes.pop_directory();
+            }
+            State::AttributesAndIgnoreStack { attributes, ignore } => {
+                attributes.pop_directory();
+                ignore.pop_directory();
+            }
+            State::IgnoreStack(ignore) => {
+                ignore.pop_directory();
+            }
+        }
+    }
+}
+
+fn create_leading_directory(
+    is_last_component: bool,
+    stack: &gix_fs::Stack,
+    is_dir: bool,
+    #[cfg(debug_assertions)] mkdir_calls: &mut usize,
+    unlink_on_collision: bool,
+) -> std::io::Result<()> {
+    if is_last_component && !is_dir {
+        return Ok(());
+    }
+    #[cfg(debug_assertions)]
+    {
+        *mkdir_calls += 1;
+    }
+    match std::fs::create_dir(stack.current()) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let meta = stack.current().symlink_metadata()?;
+            if meta.is_dir() {
+                Ok(())
+            } else if unlink_on_collision {
+                if meta.file_type().is_symlink() {
+                    gix_fs::symlink::remove(stack.current())?;
+                } else {
+                    std::fs::remove_file(stack.current())?;
+                }
+                #[cfg(debug_assertions)]
+                {
+                    *mkdir_calls += 1;
+                }
+                std::fs::create_dir(stack.current())
+            } else {
+                Err(err)
+            }
+        }
+        Err(err) => Err(err),
+    }
+}

--- a/gix-worktree/src/cache/mod.rs
+++ b/gix-worktree/src/cache/mod.rs
@@ -5,7 +5,7 @@ use bstr::{BStr, ByteSlice};
 use gix_hash::oid;
 
 use super::Cache;
-use crate::PathOidMapping;
+use crate::PathIdMapping;
 
 #[derive(Clone)]
 pub enum State {
@@ -32,6 +32,7 @@ pub enum State {
 }
 
 #[cfg(debug_assertions)]
+/// debug builds only for use in tests.
 impl Cache {
     pub fn set_case(&mut self, case: gix_glob::pattern::Case) {
         self.case = case;
@@ -65,16 +66,19 @@ pub struct Platform<'a> {
     is_dir: Option<bool>,
 }
 
+/// Initialization
 impl Cache {
-    /// Create a new instance with `worktree_root` being the base for all future paths we handle, assuming it to be valid which includes
-    /// symbolic links to be included in it as well.
-    /// The `case` configures attribute and exclusion query case sensitivity.
+    /// Create a new instance with `worktree_root` being the base for all future paths we match.
+    /// `state` defines the capabilities of the cache.
+    /// The `case` configures attribute and exclusion case sensitivity at *query time*, which should match the case that
+    /// `state` might be configured with.
+    /// `buf` is used when reading files, and `id_mappings` should have been created with [State::id_mappings_from_index()].
     pub fn new(
         worktree_root: impl Into<PathBuf>,
         state: State,
         case: gix_glob::pattern::Case,
         buf: Vec<u8>,
-        attribute_files_in_index: Vec<PathOidMapping>,
+        id_mappings: Vec<PathIdMapping>,
     ) -> Self {
         let root = worktree_root.into();
         Cache {
@@ -82,15 +86,20 @@ impl Cache {
             state,
             case,
             buf,
-            attribute_files_in_index,
+            id_mappings,
         }
     }
+}
 
-    /// Append the `relative` path to the root directory the cache contains and efficiently create leading directories
-    /// unless `is_dir` is known (`Some(…)`) then `relative` points to a directory itself in which case the entire resulting
+/// Mutable Access
+impl Cache {
+    /// Append the `relative` path to the root directory of the cache and efficiently create leading directories, while assuring that no
+    /// symlinks are in that path.
+    /// Unless `is_dir` is known with `Some(…)`, then `relative` points to a directory itself in which case the entire resulting
     /// path is created as directory. If it's not known it is assumed to be a file.
+    /// `find` maybe used to lookup objects from an [id mapping][crate::cache::State::id_mappings_from_index()], with mappnigs
     ///
-    /// Provide access to cached information for that `relative` entry via the platform returned.
+    /// Provide access to cached information for that `relative` path via the returned platform.
     pub fn at_path<Find, E>(
         &mut self,
         relative: impl AsRef<Path>,
@@ -101,19 +110,27 @@ impl Cache {
         Find: for<'a> FnMut(&oid, &'a mut Vec<u8>) -> Result<gix_object::BlobRef<'a>, E>,
         E: std::error::Error + Send + Sync + 'static,
     {
-        let mut delegate = platform::StackDelegate {
+        let mut delegate = StackDelegate {
             state: &mut self.state,
             buf: &mut self.buf,
             is_dir: is_dir.unwrap_or(false),
-            attribute_files_in_index: &self.attribute_files_in_index,
+            id_mappings: &self.id_mappings,
             find,
         };
         self.stack.make_relative_path_current(relative, &mut delegate)?;
         Ok(Platform { parent: self, is_dir })
     }
 
-    /// **Panics** on illformed UTF8 in `relative`
-    // TODO: more docs
+    /// Obtain a platform for lookups from a repo-`relative` path, typically obtained from an index entry. `is_dir` should reflect
+    /// whether it's a directory or not, or left at `None` if unknown.
+    /// `find` maybe used to lookup objects from an [id mapping][crate::cache::State::id_mappings_from_index()].
+    /// All effects are similar to [`at_path()`][Self::at_path()].
+    ///
+    /// If `relative` ends with `/` and `is_dir` is `None`, it is automatically assumed to be a directory.
+    ///
+    /// ### Panics
+    ///
+    /// on illformed UTF8 in `relative`
     pub fn at_entry<'r, Find, E>(
         &mut self,
         relative: impl Into<&'r BStr>,
@@ -130,9 +147,16 @@ impl Cache {
         self.at_path(
             relative_path,
             is_dir.or_else(|| relative.ends_with_str("/").then_some(true)),
-            // is_dir,
             find,
         )
+    }
+}
+
+/// Access
+impl Cache {
+    /// Return the state for introspection.
+    pub fn state(&self) -> &State {
+        &self.state
     }
 
     /// Return the base path against which all entries or paths should be relative to when querying.
@@ -142,6 +166,9 @@ impl Cache {
         self.stack.root()
     }
 }
+
+mod delegate;
+use delegate::StackDelegate;
 
 mod platform;
 ///

--- a/gix-worktree/src/cache/platform.rs
+++ b/gix-worktree/src/cache/platform.rs
@@ -1,13 +1,10 @@
 use std::path::Path;
 
 use bstr::ByteSlice;
-use gix_hash::oid;
 
-use crate::{
-    cache::{Platform, State},
-    PathOidMapping,
-};
+use crate::cache::Platform;
 
+/// Access
 impl<'a> Platform<'a> {
     /// The full path to `relative` will be returned for use on the file system.
     pub fn path(&self) -> &'a Path {
@@ -37,132 +34,22 @@ impl<'a> Platform<'a> {
             gix_path::to_unix_separators_on_windows(gix_path::into_bstr(self.parent.stack.current_relative()));
         ignore.matching_exclude_pattern(relative_path.as_bstr(), self.is_dir, self.parent.case)
     }
+
+    /// Match all attributes at the current path and store the result in `out`, returning `true` if at least one attribute was found.
+    ///
+    /// # Panics
+    ///
+    /// If the cache was configured without attributes.
+    pub fn matching_attributes(&self, out: &mut gix_attributes::search::Outcome) -> bool {
+        let attrs = self.parent.state.attributes_or_panic();
+        let relative_path =
+            gix_path::to_unix_separators_on_windows(gix_path::into_bstr(self.parent.stack.current_relative()));
+        attrs.matching_attributes(relative_path.as_bstr(), self.parent.case, out)
+    }
 }
 
 impl<'a> std::fmt::Debug for Platform<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.path(), f)
-    }
-}
-
-pub struct StackDelegate<'a, Find> {
-    pub state: &'a mut State,
-    pub buf: &'a mut Vec<u8>,
-    pub is_dir: bool,
-    pub attribute_files_in_index: &'a Vec<PathOidMapping>,
-    pub find: Find,
-}
-
-impl<'a, Find, E> gix_fs::stack::Delegate for StackDelegate<'a, Find>
-where
-    Find: for<'b> FnMut(&oid, &'b mut Vec<u8>) -> Result<gix_object::BlobRef<'b>, E>,
-    E: std::error::Error + Send + Sync + 'static,
-{
-    fn push_directory(&mut self, stack: &gix_fs::Stack) -> std::io::Result<()> {
-        match &mut self.state {
-            State::CreateDirectoryAndAttributesStack { attributes: _, .. } => {
-                // TODO: attributes
-            }
-            State::AttributesAndIgnoreStack { ignore, attributes: _ } => {
-                // TODO: attributes
-                ignore.push_directory(
-                    stack.root(),
-                    stack.current(),
-                    self.buf,
-                    self.attribute_files_in_index,
-                    &mut self.find,
-                )?
-            }
-            State::IgnoreStack(ignore) => ignore.push_directory(
-                stack.root(),
-                stack.current(),
-                self.buf,
-                self.attribute_files_in_index,
-                &mut self.find,
-            )?,
-        }
-        Ok(())
-    }
-
-    fn push(&mut self, is_last_component: bool, stack: &gix_fs::Stack) -> std::io::Result<()> {
-        match &mut self.state {
-            State::CreateDirectoryAndAttributesStack {
-                #[cfg(debug_assertions)]
-                test_mkdir_calls,
-                unlink_on_collision,
-                attributes: _,
-            } => {
-                #[cfg(debug_assertions)]
-                {
-                    create_leading_directory(
-                        is_last_component,
-                        stack,
-                        self.is_dir,
-                        test_mkdir_calls,
-                        *unlink_on_collision,
-                    )?
-                }
-                #[cfg(not(debug_assertions))]
-                {
-                    create_leading_directory(is_last_component, stack, self.is_dir, *unlink_on_collision)?
-                }
-            }
-            State::AttributesAndIgnoreStack { .. } | State::IgnoreStack(_) => {}
-        }
-        Ok(())
-    }
-
-    fn pop_directory(&mut self) {
-        match &mut self.state {
-            State::CreateDirectoryAndAttributesStack { attributes: _, .. } => {
-                // TODO: attributes
-            }
-            State::AttributesAndIgnoreStack { attributes: _, ignore } => {
-                // TODO: attributes
-                ignore.pop_directory();
-            }
-            State::IgnoreStack(ignore) => {
-                ignore.pop_directory();
-            }
-        }
-    }
-}
-
-fn create_leading_directory(
-    is_last_component: bool,
-    stack: &gix_fs::Stack,
-    is_dir: bool,
-    #[cfg(debug_assertions)] mkdir_calls: &mut usize,
-    unlink_on_collision: bool,
-) -> std::io::Result<()> {
-    if is_last_component && !is_dir {
-        return Ok(());
-    }
-    #[cfg(debug_assertions)]
-    {
-        *mkdir_calls += 1;
-    }
-    match std::fs::create_dir(stack.current()) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            let meta = stack.current().symlink_metadata()?;
-            if meta.is_dir() {
-                Ok(())
-            } else if unlink_on_collision {
-                if meta.file_type().is_symlink() {
-                    gix_fs::symlink::remove(stack.current())?;
-                } else {
-                    std::fs::remove_file(stack.current())?;
-                }
-                #[cfg(debug_assertions)]
-                {
-                    *mkdir_calls += 1;
-                }
-                std::fs::create_dir(stack.current())
-            } else {
-                Err(err)
-            }
-        }
-        Err(err) => Err(err),
     }
 }

--- a/gix-worktree/src/cache/state/ignore.rs
+++ b/gix-worktree/src/cache/state/ignore.rs
@@ -1,10 +1,8 @@
 use std::path::Path;
 
+use crate::{cache::state::IgnoreMatchGroup, PathIdMapping};
 use bstr::{BStr, BString, ByteSlice};
 use gix_glob::pattern::Case;
-use gix_hash::oid;
-
-use crate::{cache::state::IgnoreMatchGroup, PathOidMapping};
 
 /// State related to the exclusion of files.
 #[derive(Default, Clone)]
@@ -25,7 +23,7 @@ pub struct Ignore {
     pub(crate) exclude_file_name_for_directories: BString,
     /// The case to use when matching directories as they are pushed onto the stack. We run them against the exclude engine
     /// to know if an entire path can be ignored as a parent directory is ignored.
-    case: Case,
+    pub(crate) case: Case,
 }
 
 impl Ignore {
@@ -103,7 +101,7 @@ impl Ignore {
         groups
             .iter()
             .rev()
-            .find_map(|group| group.pattern_matching_relative_path(relative_path.as_bytes(), is_dir, case))
+            .find_map(|group| group.pattern_matching_relative_path(relative_path, is_dir, case))
             .or(dir_match)
     }
 
@@ -142,11 +140,11 @@ impl Ignore {
         root: &Path,
         dir: &Path,
         buf: &mut Vec<u8>,
-        attribute_files_in_index: &[PathOidMapping],
+        id_mappings: &[PathIdMapping],
         mut find: Find,
     ) -> std::io::Result<()>
     where
-        Find: for<'b> FnMut(&oid, &'b mut Vec<u8>) -> Result<gix_object::BlobRef<'b>, E>,
+        Find: for<'b> FnMut(&gix_hash::oid, &'b mut Vec<u8>) -> Result<gix_object::BlobRef<'b>, E>,
         E: std::error::Error + Send + Sync + 'static,
     {
         let dir_bstr = gix_path::into_bstr(dir);
@@ -166,8 +164,7 @@ impl Ignore {
 
         let ignore_path_relative =
             gix_path::to_unix_separators_on_windows(gix_path::join_bstr_unix_pathsep(rela_dir, ".gitignore"));
-        let ignore_file_in_index =
-            attribute_files_in_index.binary_search_by(|t| t.0.as_bstr().cmp(ignore_path_relative.as_ref()));
+        let ignore_file_in_index = id_mappings.binary_search_by(|t| t.0.as_bstr().cmp(ignore_path_relative.as_ref()));
         let follow_symlinks = ignore_file_in_index.is_err();
         if !gix_glob::search::add_patterns_file(
             &mut self.stack.patterns,
@@ -178,11 +175,11 @@ impl Ignore {
         )? {
             match ignore_file_in_index {
                 Ok(idx) => {
-                    let ignore_blob = find(&attribute_files_in_index[idx].1, buf)
+                    let ignore_blob = find(&id_mappings[idx].1, buf)
                         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
                     let ignore_path = gix_path::from_bstring(ignore_path_relative.into_owned());
                     self.stack
-                        .add_patterns_buffer(ignore_blob.data, ignore_path, Some(root));
+                        .add_patterns_buffer(ignore_blob.data, ignore_path, Some(Path::new("")));
                 }
                 Err(_) => {
                     // Need one stack level per component so push and pop matches.

--- a/gix-worktree/src/checkout/function.rs
+++ b/gix-worktree/src/checkout/function.rs
@@ -58,7 +58,7 @@ where
     );
 
     let state = cache::State::for_checkout(options.overwrite_existing, options.attributes.clone().with_case(case));
-    let attribute_files = state.attribute_list_from_index(index, paths, case);
+    let attribute_files = state.id_mappings_from_index(index, paths, case);
     let mut ctx = chunk::Context {
         buf: Vec::new(),
         path_cache: Cache::new(dir, state, case, Vec::with_capacity(512), attribute_files),

--- a/gix-worktree/src/lib.rs
+++ b/gix-worktree/src/lib.rs
@@ -44,10 +44,10 @@ pub struct Cache {
     /// If case folding should happen when looking up attributes or exclusions.
     case: gix_glob::pattern::Case,
     /// A lookup table for object ids to read from in some situations when looking up attributes or exclusions.
-    attribute_files_in_index: Vec<PathOidMapping>,
+    id_mappings: Vec<PathIdMapping>,
 }
 
-pub(crate) type PathOidMapping = (BString, gix_hash::ObjectId);
+pub(crate) type PathIdMapping = (BString, gix_hash::ObjectId);
 
 ///
 pub mod cache;

--- a/gix-worktree/tests/fixtures/generated-archives/.gitignore
+++ b/gix-worktree/tests/fixtures/generated-archives/.gitignore
@@ -1,0 +1,1 @@
+make_ignore_and_attributes_setup.tar.xz

--- a/gix-worktree/tests/fixtures/generated-archives/make_attributes_baseline.tar.xz
+++ b/gix-worktree/tests/fixtures/generated-archives/make_attributes_baseline.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2ebee1d749247762ab430489d42d5c52791a590f6672e289ebe8319d9e64417
+size 11872

--- a/gix-worktree/tests/fixtures/generated-archives/make_ignore_and_attributes_setup.tar.xz
+++ b/gix-worktree/tests/fixtures/generated-archives/make_ignore_and_attributes_setup.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae297f2c067e2cc7b0c8eabfff721ff775a7d8266ffef979bde2458de2ab03c9
-size 10944
+oid sha256:38df6900cdb0ad620e158a3cc19325053658b9cfcb8987779af634813d957f6c
+size 11088

--- a/gix-worktree/tests/fixtures/make_attributes_baseline.sh
+++ b/gix-worktree/tests/fixtures/make_attributes_baseline.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -eu -o pipefail
+
+mkdir basics;
+
+function baseline() {
+  {
+    echo "$1"
+    GIT_ATTR_NOSYSTEM=1 git -c core.attributesFile=$PWD/user.attributes check-attr -a "$1"
+    echo
+  } >> baseline
+
+  {
+    echo "$1"
+    GIT_ATTR_NOSYSTEM=1 git -c core.attributesFile=$PWD/user.attributes check-attr info test -- "$1"
+    echo
+  } >> baseline.selected
+}
+
+
+(cd basics
+  git init
+
+  # based on https://github.com/git/git/blob/140b9478dad5d19543c1cb4fd293ccec228f1240/t/t0003-attributes.sh#L45
+	mkdir -p a/b/d a/c b
+	(
+		echo "[attr]notest !test"
+		echo "\" d \"	test=d"
+		echo " e	test=e"
+		echo " e\"	test=e"
+		echo "f	test=f"
+		echo "a/i test=a/i"
+		echo "onoff test -test"
+		echo "offon -test test"
+		echo "no notest"
+		echo "A/e/F test=A/e/F"
+		echo "\!escaped test-escaped"
+		echo "**/recursive test-double-star-slash"
+		echo "a**f test-double-star-no-slash"
+		echo "dir-slash/ never"
+		echo "dir/** always"
+	) > .gitattributes
+	(
+		echo "g test=a/g"
+		echo "b/g test=a/b/g"
+	) > a/.gitattributes
+	(
+		echo "h test=a/b/h"
+		echo "d/* test=a/b/d/*"
+		echo "d/yes notest"
+	) > a/b/.gitattributes
+	(
+		echo "global test=global"
+		echo "z/x/a global-no-wildcard-case-test"
+		echo "z/x/* global-wildcard-case-test"
+	) > user.attributes
+
+	git add . && git commit -qm c1
+	(
+		echo "global test=global"
+		echo "* info=attributes"
+	) > .git/info/attributes
+
+
+  baseline z/x/a
+  baseline Z/x/a
+  baseline z/x/A
+  baseline Z/X/a
+  baseline Z/x/a
+  baseline " d "
+  baseline e
+  baseline f
+  baseline dir-slash
+  baseline dir-slash/a
+  baseline dir
+  baseline dir/a
+  baseline recursive
+  baseline a/recursive
+  baseline a/b/recursive
+  baseline a/b/c/recursive
+  baseline "!escaped"
+  baseline af
+  baseline axf
+  baseline a/b/d/no
+  baseline a/e/f
+  baseline a/f
+  baseline a/b/d/g
+  baseline a/B/D/g
+  baseline b/g
+  baseline a/c/f
+  baseline "e\""
+  baseline a/i
+  baseline A/b/h
+  baseline A/B/D/NO
+  baseline subdir/a/i
+  baseline onoff
+  baseline offon
+  baseline no
+  baseline A/e/F
+  baseline a/e/F
+  baseline a/e/f
+  baseline a/g
+  baseline a/b/g
+  baseline a/b/h
+  baseline a/b/d/ANY
+  baseline a/b/d/yes
+  baseline global
+)

--- a/gix-worktree/tests/fixtures/make_ignore_and_attributes_setup.sh
+++ b/gix-worktree/tests/fixtures/make_ignore_and_attributes_setup.sh
@@ -6,11 +6,13 @@ cat <<EOF >user.exclude
 user-file-anywhere
 /user-file-from-top
 
-user-dir-anywhere/
+user-Dir-anywhere/
 /user-dir-from-top
 
 user-subdir/file
 **/user-subdir-anywhere/file
+a/b/*
+z/x
 EOF
 
 mkdir repo;
@@ -33,13 +35,15 @@ EOF
   cat <<EOF >.gitignore
 # a sample .gitignore
 top-level-local-file-anywhere
+d/e/*
+e/f
 EOF
 
   mkdir dir-with-ignore
   cat <<EOF >dir-with-ignore/.gitignore
 # a sample .gitignore
 sub-level-local-file-anywhere
-sub-level-dir-anywhere/
+sub-Level-dir-anywhere/
 !/negated
 /negated-dir/
 !/negated-dir/
@@ -63,13 +67,13 @@ EOF
 
   git check-ignore -vn --stdin 2>&1 <<EOF >git-check-ignore.baseline || :
 dir-with-ignore/sub-level-dir-anywhere/
-dir-with-ignore/foo/sub-level-dir-anywhere/
-dir-with-ignore/sub-level-dir-anywhere
+dir-with-ignore/foo/Sub-level-dir-anywhere/
+dir-with-ignore/Sub-level-dir-anywhere
 user-file-anywhere
 dir/user-file-anywhere
 user-file-from-top
 no-match/user-file-from-top
-user-dir-anywhere
+USER-dir-anywhere
 user-dir-from-top
 no-match/user-dir-from-top
 user-subdir/file
@@ -107,6 +111,20 @@ other-dir-with-ignore/other-sub-level-dir-anywhere/hello
 other-dir-with-ignore/other-sub-level-dir-anywhere/
 dir-with-ignore/negated
 dir-with-ignore/negated-dir/hello
+a/b/C
+a/B/c
+A/B/C
+z/x
+Z/x
+z/X
+Z/X
+d/e/F
+d/e/f
+D/e/F
+D/E/F
+e/f
+e/F
+E/f
+E/F
 EOF
-
 )

--- a/gix-worktree/tests/worktree/cache/attributes.rs
+++ b/gix-worktree/tests/worktree/cache/attributes.rs
@@ -1,0 +1,143 @@
+use bstr::ByteSlice;
+use gix_attributes::search::Outcome;
+use gix_glob::pattern::Case;
+use gix_worktree::cache::state;
+
+#[test]
+fn baseline() -> crate::Result {
+    // Due to the way our setup differs from gits dynamic stack (which involves trying to read files from disk
+    // by path) we can only test one case baseline, so we require multiple platforms (or filesystems) to run this.
+    let case = if gix_fs::Capabilities::probe("../.git").ignore_case {
+        Case::Fold
+    } else {
+        Case::Sensitive
+    };
+
+    let dir = gix_testtools::scripted_fixture_read_only("make_attributes_baseline.sh")?;
+    let base = dir.join("basics");
+    let git_dir = base.join(".git");
+
+    let mut buf = Vec::new();
+    let mut collection = gix_attributes::search::MetadataCollection::default();
+    let state = gix_worktree::cache::State::for_checkout(
+        false,
+        state::Attributes::new(
+            gix_attributes::Search::new_globals([base.join("user.attributes")], &mut buf, &mut collection)?,
+            Some(git_dir.join("info").join("attributes")),
+            case,
+            gix_worktree::cache::state::attributes::Source::WorktreeThenIdMapping,
+            collection,
+        ),
+    );
+
+    let mut cache = gix_worktree::Cache::new(&base, state, case, buf, vec![]);
+
+    let mut actual = cache.attribute_matches();
+    let input = std::fs::read(base.join("baseline"))?;
+    for (rela_path, expected) in (baseline::Expectations { lines: input.lines() }) {
+        let entry = cache.at_entry(rela_path, None, |_, _| -> Result<_, std::convert::Infallible> {
+            unreachable!("we provide not id-mappings")
+        })?;
+        let has_match = entry.matching_attributes(&mut actual);
+
+        assert_eq!(
+            has_match,
+            !expected.is_empty(),
+            "matches are reported when git reports them, too"
+        );
+        assert_references(&actual);
+        assert_eq!(actual.iter_selected().count(), 0, "no selection made yet");
+        let actual: Vec<_> = actual
+            .iter()
+            .filter_map(|m| (!m.assignment.state.is_unspecified()).then_some(m.assignment))
+            .collect();
+        assert_eq!(actual, expected, "we have the same matches: {rela_path:?}");
+        assert_eq!(has_match, !actual.is_empty());
+    }
+
+    let mut actual = cache.selected_attribute_matches(["info", "test"]);
+    let input = std::fs::read(base.join("baseline.selected"))?;
+    for (rela_path, expected) in (baseline::Expectations { lines: input.lines() }) {
+        let entry = cache.at_entry(rela_path, None, |_, _| -> Result<_, std::convert::Infallible> {
+            unreachable!("we provide not id-mappings")
+        })?;
+        let has_match = entry.matching_attributes(&mut actual);
+
+        assert_eq!(
+            has_match,
+            !expected.is_empty(),
+            "matches are reported when git reports them, too"
+        );
+        assert_references(&actual);
+        let actual: Vec<_> = actual.iter_selected().map(|m| m.assignment).collect();
+        assert_eq!(actual, expected, "we have the same matches: {rela_path:?}");
+        assert_eq!(has_match, !actual.is_empty());
+    }
+
+    Ok(())
+}
+
+fn assert_references(out: &Outcome) {
+    for m in out.iter() {
+        if let Some(source) = m.kind.source_id() {
+            let sm = out
+                .match_by_id(source)
+                .expect("sources are always available in the outcome");
+            assert_ne!(
+                sm.assignment.name, m.assignment.name,
+                "it's impossible to resolve to ourselves"
+            );
+        }
+    }
+}
+
+mod baseline {
+    use bstr::{BStr, ByteSlice};
+    use gix_attributes::{AssignmentRef, StateRef};
+
+    pub struct Expectations<'a> {
+        pub lines: bstr::Lines<'a>,
+    }
+
+    impl<'a> Iterator for Expectations<'a> {
+        type Item = (
+            &'a BStr,
+            // Names might refer to attributes or macros
+            Vec<AssignmentRef<'a>>,
+        );
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let path = self.lines.next()?;
+            let mut assignments = Vec::new();
+            loop {
+                let line = self.lines.next()?;
+                if line.is_empty() {
+                    return Some((path.as_bstr(), assignments));
+                }
+
+                let mut prev = None;
+                let mut tokens = line.splitn(3, |b| {
+                    let is_match = *b == b' ' && prev.take() == Some(b':');
+                    prev = Some(*b);
+                    is_match
+                });
+
+                if let Some(((_path, attr), info)) = tokens.next().zip(tokens.next()).zip(tokens.next()) {
+                    let state = match info {
+                        b"set" => StateRef::Set,
+                        b"unset" => StateRef::Unset,
+                        b"unspecified" => StateRef::Unspecified,
+                        _ => StateRef::from_bytes(info),
+                    };
+                    let attr = attr.trim_end_with(|b| b == ':');
+                    assignments.push(AssignmentRef {
+                        name: gix_attributes::NameRef::try_from(attr.as_bstr()).expect("valid attributes"),
+                        state,
+                    });
+                } else {
+                    unreachable!("invalid line format: {line:?}", line = line.as_bstr())
+                }
+            }
+        }
+    }
+}

--- a/gix-worktree/tests/worktree/cache/ignore.rs
+++ b/gix-worktree/tests/worktree/cache/ignore.rs
@@ -108,7 +108,7 @@ fn check_against_baseline() -> crate::Result {
         ),
     );
     let paths_storage = index.take_path_backing();
-    let attribute_files_in_index = state.attribute_list_from_index(&index, &paths_storage, case);
+    let attribute_files_in_index = state.id_mappings_from_index(&index, &paths_storage, case);
     assert_eq!(
         attribute_files_in_index,
         vec![(

--- a/gix-worktree/tests/worktree/cache/mod.rs
+++ b/gix-worktree/tests/worktree/cache/mod.rs
@@ -1,4 +1,4 @@
 mod create_directory;
 
-#[allow(unused)]
+mod attributes;
 mod ignore;

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -176,7 +176,7 @@ impl Cache {
             attributes: self.assemble_attribute_globals(
                 git_dir,
                 case,
-                gix_worktree::cache::state::attributes::Source::AttributeListThenWorktree,
+                gix_worktree::cache::state::attributes::Source::IdMappingThenWorktree,
                 self.attributes,
             )?,
             fs: capabilities,

--- a/gix/src/worktree/mod.rs
+++ b/gix/src/worktree/mod.rs
@@ -151,7 +151,7 @@ pub mod excludes {
                 None,
                 case,
             ));
-            let attribute_list = state.attribute_list_from_index(index, index.path_backing(), case);
+            let attribute_list = state.id_mappings_from_index(index, index.path_backing(), case);
             Ok(gix_worktree::Cache::new(self.path, state, case, buf, attribute_list))
         }
     }

--- a/src/plumbing/options/free.rs
+++ b/src/plumbing/options/free.rs
@@ -287,13 +287,13 @@ pub mod pack {
 
         #[derive(Debug, clap::Subcommand)]
         pub enum Subcommands {
-            /// Display all entries of a multi-index: <oid> <pack-id> <pack-offset>
+            /// Display all entries of a multi-index as: *oid* *pack-id* *pack-offset*
             Entries,
             /// Print general information about a multi-index file
             Info,
             /// Verify a multi-index quickly without inspecting objects themselves
             Verify,
-            /// Create a multi-pack index from one or more pack index files, overwriting possibloy existing files.
+            /// Create a multi-pack index from one or more pack index files, overwriting possibly existing files.
             Create {
                 /// Paths to the pack index files to read (with .idx extension).
                 ///


### PR DESCRIPTION
Make attribute access possible with the attribute cache.

### Tasks

* [x] fix case-sensitivity handling for excludes (and validate for `path/` excludes)
* [x] basic attributes access with baseline tests
* [x] basic attributes with selection