### PR TITLE
Port to rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,8 +2073,8 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "gix-testtools",
- "nix",
  "parking_lot",
+ "rustix",
  "serial_test",
  "thiserror",
 ]
@@ -2931,9 +2931,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "litrs"
@@ -3628,9 +3628,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
 dependencies = [
  "bitflags 1.3.2",
  "errno",

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0.32"
 parking_lot = "0.12.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.26.1", default-features = false, features = ["term"] }
+rustix = { version = "0.37.13", features = ["termios"] }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools"}

--- a/gix-prompt/src/types.rs
+++ b/gix-prompt/src/types.rs
@@ -15,7 +15,7 @@ pub enum Error {
     TtyIo(#[from] std::io::Error),
     #[cfg(unix)]
     #[error("Failed to obtain or set terminal configuration")]
-    TerminalConfiguration(#[from] nix::errno::Errno),
+    TerminalConfiguration(#[from] rustix::io::Errno),
 }
 
 /// The way the user is prompted.

--- a/gix-prompt/src/unix.rs
+++ b/gix-prompt/src/unix.rs
@@ -4,12 +4,12 @@ pub const TTY_PATH: &str = "/dev/tty";
 #[cfg(unix)]
 pub(crate) mod imp {
     use std::{
-        io::{BufRead, Write},
-        os::unix::io::{AsRawFd, RawFd},
+        fs::File,
+        io::{self, BufRead, Read, Write},
     };
 
-    use nix::sys::{termios, termios::Termios};
     use parking_lot::{const_mutex, lock_api::MutexGuard, Mutex, RawMutex};
+    use rustix::termios::{self, Termios};
 
     use crate::{unix::TTY_PATH, Error, Mode, Options};
 
@@ -21,8 +21,10 @@ pub(crate) mod imp {
             Mode::Disable => Err(Error::Disabled),
             Mode::Hidden => {
                 let state = TERM_STATE.lock();
-                let mut in_out = std::fs::OpenOptions::new().write(true).read(true).open(TTY_PATH)?;
-                let restore = save_term_state_and_disable_echo(state, in_out.as_raw_fd())?;
+                let mut in_out = save_term_state_and_disable_echo(
+                    state,
+                    std::fs::OpenOptions::new().write(true).read(true).open(TTY_PATH)?,
+                )?;
                 in_out.write_all(prompt.as_bytes())?;
 
                 let mut buf_read = std::io::BufReader::with_capacity(64, in_out);
@@ -33,7 +35,7 @@ pub(crate) mod imp {
                 if out.ends_with('\r') {
                     out.pop();
                 }
-                restore.now()?;
+                buf_read.into_inner().now()?;
                 Ok(out)
             }
             Mode::Visible => {
@@ -52,13 +54,40 @@ pub(crate) mod imp {
 
     struct RestoreTerminalStateOnDrop<'a> {
         state: TermiosGuard<'a>,
-        fd: RawFd,
+        fd: File,
+    }
+
+    impl<'a> Read for RestoreTerminalStateOnDrop<'a> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.fd.read(buf)
+        }
+
+        fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+            self.fd.read_vectored(bufs)
+        }
+    }
+
+    impl<'a> Write for RestoreTerminalStateOnDrop<'a> {
+        #[inline(always)]
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.fd.write(buf)
+        }
+
+        #[inline(always)]
+        fn flush(&mut self) -> io::Result<()> {
+            self.fd.flush()
+        }
+
+        #[inline(always)]
+        fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+            self.fd.write_vectored(bufs)
+        }
     }
 
     impl<'a> RestoreTerminalStateOnDrop<'a> {
         fn now(mut self) -> Result<(), Error> {
             let state = self.state.take().expect("BUG: we exist only if something is saved");
-            termios::tcsetattr(self.fd, termios::SetArg::TCSAFLUSH, &state)?;
+            termios::tcsetattr(&self.fd, termios::OptionalActions::Flush, &state)?;
             Ok(())
         }
     }
@@ -66,27 +95,27 @@ pub(crate) mod imp {
     impl<'a> Drop for RestoreTerminalStateOnDrop<'a> {
         fn drop(&mut self) {
             if let Some(state) = self.state.take() {
-                termios::tcsetattr(self.fd, termios::SetArg::TCSAFLUSH, &state).ok();
+                termios::tcsetattr(&self.fd, termios::OptionalActions::Flush, &state).ok();
             }
         }
     }
 
     fn save_term_state_and_disable_echo(
         mut state: TermiosGuard<'_>,
-        fd: RawFd,
+        fd: File,
     ) -> Result<RestoreTerminalStateOnDrop<'_>, Error> {
         assert!(
             state.is_none(),
             "BUG: recursive calls are not possible and we restore afterwards"
         );
 
-        let prev = termios::tcgetattr(fd)?;
+        let prev = termios::tcgetattr(&fd)?;
         let mut new = prev.clone();
         *state = prev.into();
 
-        new.local_flags &= !termios::LocalFlags::ECHO;
-        new.local_flags |= termios::LocalFlags::ECHONL;
-        termios::tcsetattr(fd, termios::SetArg::TCSAFLUSH, &new)?;
+        new.c_lflag &= !termios::ECHO;
+        new.c_lflag |= termios::ECHONL;
+        termios::tcsetattr(&fd, termios::OptionalActions::Flush, &new)?;
 
         Ok(RestoreTerminalStateOnDrop { fd, state })
     }


### PR DESCRIPTION
Port the termios usage from nix to rustix.

Change `RestoreTerminalStateOnDrop` to a wrapper that owns the `File`.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
