### PR TITLE
fix: symbolic refs are now written with a newline. #(836)

### DIFF
--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -184,7 +184,7 @@ impl<'s, 'p> Transaction<'s, 'p> {
 
                     lock.with_mut(|file| match new {
                         Target::Peeled(oid) => write!(file, "{oid}"),
-                        Target::Symbolic(name) => write!(file, "ref: {}", name.0),
+                        Target::Symbolic(name) => writeln!(file, "ref: {}", name.0),
                     })?;
                     Some(lock.close()?)
                 } else {

--- a/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -481,6 +481,11 @@ fn symbolic_head_missing_referent_then_update_referent() -> crate::Result {
         assert_eq!(head.name.as_bstr(), "HEAD");
         assert_eq!(head.kind(), gix_ref::Kind::Symbolic);
         assert_eq!(
+            std::fs::read_to_string(store.git_dir().join("HEAD"))?,
+            "ref: refs/heads/alt-main\n",
+            "note the newline - symbolic refs really want a newline just like git does it, otherwise some tools may break"
+        );
+        assert_eq!(
             head.target.to_ref().try_name().map(|n| n.as_bstr()),
             Some(referent.as_bytes().as_bstr())
         );


### PR DESCRIPTION
This should help some tools to work correctly.
