### PR TITLE
chore: improve link to crate-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ like `fetch` and `clone`, and to validate the usability and control of the API o
 ## Development Status
 
 The command-line tools as well as the status of each crate is described in 
-[the crate status document](https://github.com/Byron/gitoxide/blob/main/crate-status.md#gix-mailmap).
+[the crate status document](https://github.com/Byron/gitoxide/blob/main/crate-status.md).
 
 For use in applications, look for the [`gix`](https://github.com/Byron/gitoxide/blob/main/crate-status.md#gix) crate, 
 which serves as entrypoint to the functionality provided by various lower-level plumbing crates like


### PR DESCRIPTION
The previous link had an anchor to the `gix-mailmap` heading. Remove the anchor so that it leads to the top of the document instead.

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.
