### PR TITLE
try `moonwalk` in `ein`

### DIFF
--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 
 #! ### Tools
 ## Discover all git repositories within a directory. Particularly useful with [skim](https://github.com/lotabout/skim).
-organize = ["dep:gix-url", "dep:jwalk"]
+organize = ["dep:gix-url", "dep:moonwalk"]
 ## Derive the amount of time invested into a git repository akin to [git-hours](https://github.com/kimmobrunfeldt/git-hours).
 estimate-hours = ["dep:itertools", "dep:fs-err", "dep:crossbeam-channel", "dep:smallvec"]
 ## Gather information about repositories and store it in a database for easy querying.
@@ -64,7 +64,7 @@ blocking = { version = "1.0.2", optional = true }
 
 # for 'organize' functionality
 gix-url = { version = "^0.21.1", path = "../gix-url", optional = true }
-jwalk = { version = "0.8.0", optional = true }
+moonwalk = { git = "https://github.com/pascalkuthe/moonwalk", optional = true }
 
 # for 'hours'
 itertools = { version = "0.11.0", optional = true }

--- a/gitoxide-core/src/corpus/engine.rs
+++ b/gitoxide-core/src/corpus/engine.rs
@@ -327,12 +327,8 @@ impl Engine {
                     Ok(out)
                 });
 
-                let repos = gix::interrupt::Iter::new(
-                    find_git_repository_workdirs(corpus_path, find_progress, false, Some(threads)),
-                    || anyhow::anyhow!("interrupted by user"),
-                );
-                for res in repos {
-                    let (repo_path, _kind) = res?;
+                let repos = find_git_repository_workdirs(corpus_path, find_progress, false, Some(threads))?;
+                for (repo_path, _kind) in repos {
                     path_tx.send(repo_path)?;
                 }
                 drop(path_tx);


### PR DESCRIPTION
`moonwalk` could speed up `ein tool find (and related) ` significantly,
and we give that an early shot here.

It turned out that `jwalk` was constrained from old times and unlocking it for all cores already makes a difference.
Can `moonwalk` be even faster? We will find out.

### Tasks

* [x] unleash `jwalk` for comparison
* [x] integrate `moonwalk`, loose sorting for now

### Problems

Without inspecting siblings its not easy to prevent it from, in parallel, descend into git repositories. Maybe synchronization on the user's side would work, but it seems hard.
If that would be solved, it would absolutely kill, for sure, as it perfectly saturates IO.