### PR TITLE
feat: add --capitalize-commit option to capitalize commit message in cargo-smart-release

### DIFF
--- a/cargo-smart-release/src/cli/main.rs
+++ b/cargo-smart-release/src/cli/main.rs
@@ -21,6 +21,7 @@ fn main() -> anyhow::Result<()> {
             no_links,
             without,
             allow_dirty,
+            capitalize_commit,
         } => {
             init_logging(false);
             command::changelog(
@@ -31,6 +32,7 @@ fn main() -> anyhow::Result<()> {
                     preview: !no_preview,
                     dependencies: !no_dependencies,
                     generator_segments: names_to_segment_selection(&without)?,
+                    capitalize_commit,
                 },
                 crates,
             )?
@@ -60,6 +62,7 @@ fn main() -> anyhow::Result<()> {
             allow_fully_generated_changelogs,
             no_dependencies,
             no_isolate_dependencies_from_breaking_changes,
+            capitalize_commit
         } => {
             let verbose = execute || verbose;
             init_logging(verbose);
@@ -86,6 +89,7 @@ fn main() -> anyhow::Result<()> {
                     allow_fully_generated_changelogs,
                     changelog_links: !no_changelog_links,
                     allow_changelog_github_release: !no_changelog_github_release,
+                    capitalize_commit,
                 },
                 crates,
                 to_bump_spec(bump.as_deref().unwrap_or(DEFAULT_BUMP_SPEC))?,

--- a/cargo-smart-release/src/cli/options.rs
+++ b/cargo-smart-release/src/cli/options.rs
@@ -157,6 +157,10 @@ pub enum SubCommands {
         /// depend on an unpublished version with "--no-validate".
         #[clap(long, help_heading = Some("EXPERT"))]
         ignore_instability: bool,
+
+        /// Automatically capitalize commit message
+        #[clap(long, help_heading = Some("CHANGELOG"))]
+        capitalize_commit: bool,
     },
     #[clap(name = "changelog", version = clap::crate_version!())]
     /// Generate changelogs from commit histories, non-destructively.
@@ -201,5 +205,9 @@ pub enum SubCommands {
         /// Do not generate links to commits and issues when writing the changelogs. This currently only works for GitHub.
         #[clap(long, help_heading = Some("CUSTOMIZATION"))]
         no_links: bool,
+
+        /// Automatically capitalize commit message
+        #[clap(long, help_heading = Some("CUSTOMIZATION"))]
+        capitalize_commit: bool,
     },
 }

--- a/cargo-smart-release/src/command/changelog.rs
+++ b/cargo-smart-release/src/command/changelog.rs
@@ -18,6 +18,7 @@ pub fn changelog(opts: Options, crates: Vec<String>) -> anyhow::Result<()> {
         dry_run,
         preview,
         no_links,
+        capitalize_commit,
         ..
     } = opts;
     let bump_spec = if dependencies { BumpSpec::Auto } else { BumpSpec::Keep };
@@ -97,6 +98,7 @@ pub fn changelog(opts: Options, crates: Vec<String>) -> anyhow::Result<()> {
                 } else {
                     Components::all()
                 },
+                capitalize_commit,
             )
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
             file.write_all(buf.as_bytes())

--- a/cargo-smart-release/src/command/mod.rs
+++ b/cargo-smart-release/src/command/mod.rs
@@ -25,6 +25,7 @@ pub mod release {
         pub allow_fully_generated_changelogs: bool,
         pub changelog_links: bool,
         pub allow_changelog_github_release: bool,
+        pub capitalize_commit: bool,
     }
 }
 #[path = "release/mod.rs"]
@@ -43,6 +44,7 @@ pub mod changelog {
         // All the segments to generate
         pub generator_segments: segment::Selection,
         pub no_links: bool,
+        pub capitalize_commit: bool,
     }
 }
 #[path = "changelog.rs"]

--- a/cargo-smart-release/src/command/release/manifest.rs
+++ b/cargo-smart-release/src/command/release/manifest.rs
@@ -377,6 +377,7 @@ fn gather_changelog_data<'meta>(
     Options {
         dry_run,
         generator_segments,
+        capitalize_commit,
         ..
     }: Options,
 ) -> anyhow::Result<GatherOutcome<'meta>> {
@@ -484,6 +485,7 @@ fn gather_changelog_data<'meta>(
                 } else {
                     changelog::write::Components::all()
                 },
+                capitalize_commit
             )?;
             lock.with_mut(|file| file.write_all(write_buf.as_bytes()))?;
             *made_change |= previous_content.map(|previous| write_buf != previous).unwrap_or(true);

--- a/cargo-smart-release/src/command/release/manifest.rs
+++ b/cargo-smart-release/src/command/release/manifest.rs
@@ -485,7 +485,7 @@ fn gather_changelog_data<'meta>(
                 } else {
                     changelog::write::Components::all()
                 },
-                capitalize_commit
+                capitalize_commit,
             )?;
             lock.with_mut(|file| file.write_all(write_buf.as_bytes()))?;
             *made_change |= previous_content.map(|previous| write_buf != previous).unwrap_or(true);

--- a/cargo-smart-release/src/command/release/mod.rs
+++ b/cargo-smart-release/src/command/release/mod.rs
@@ -437,7 +437,7 @@ fn perform_release(ctx: &Context, options: Options, crates: &[Dependency<'_>]) -
             commit_id,
             release_section_by_publishee
                 .get(&publishee.name.as_str())
-                .and_then(|s| section_to_string(s, WriteMode::Tag)),
+                .and_then(|s| section_to_string(s, WriteMode::Tag, options.capitalize_commit)),
             &ctx.base,
             options,
         )? {
@@ -449,7 +449,7 @@ fn perform_release(ctx: &Context, options: Options, crates: &[Dependency<'_>]) -
         for (publishee, new_version) in successful_publishees_and_version {
             release_section_by_publishee
                 .get(&publishee.name.as_str())
-                .and_then(|s| section_to_string(s, WriteMode::GitHubRelease))
+                .and_then(|s| section_to_string(s, WriteMode::GitHubRelease, options.capitalize_commit))
                 .map(|release_notes| github::create_release(publishee, new_version, &release_notes, options, &ctx.base))
                 .transpose()?;
         }
@@ -512,7 +512,7 @@ enum WriteMode {
     GitHubRelease,
 }
 
-fn section_to_string(section: &Section, mode: WriteMode) -> Option<String> {
+fn section_to_string(section: &Section, mode: WriteMode, capitalize_commit: bool) -> Option<String> {
     let mut b = String::new();
     section
         .write_to(
@@ -522,6 +522,7 @@ fn section_to_string(section: &Section, mode: WriteMode) -> Option<String> {
                 WriteMode::Tag => changelog::write::Components::empty(),
                 WriteMode::GitHubRelease => changelog::write::Components::DETAIL_TAGS,
             },
+            capitalize_commit,
         )
         .ok()
         .map(|_| b)

--- a/cargo-smart-release/tests/changelog/write_and_parse/mod.rs
+++ b/cargo-smart-release/tests/changelog/write_and_parse/mod.rs
@@ -59,7 +59,7 @@ fn conventional_write_empty_messages() -> Result {
         let log = log.clone();
         for _round in 1..=2 {
             let mut md = String::new();
-            log.write_to(&mut md, link_mode, changelog::write::Components::all())?;
+            log.write_to(&mut md, link_mode, changelog::write::Components::all(), false)?;
             insta::assert_snapshot!(md);
 
             let parsed_log = ChangeLog::from_markdown(&md);
@@ -72,7 +72,7 @@ fn conventional_write_empty_messages() -> Result {
     ] {
         for section in &log.sections {
             let mut buf = String::new();
-            section.write_to(&mut buf, &changelog::write::Linkables::AsText, *components)?;
+            section.write_to(&mut buf, &changelog::write::Linkables::AsText, *components, false)?;
             insta::assert_snapshot!(buf);
         }
     }
@@ -164,7 +164,7 @@ fn all_section_types_round_trips_lossy() -> Result {
     ] {
         // NOTE: we can't run this a second time as the statistical information will be gone (it was never parsed back)
         let mut md = String::new();
-        log.write_to(&mut md, link_mode, changelog::write::Components::all())?;
+        log.write_to(&mut md, link_mode, changelog::write::Components::all(), false)?;
         insta::assert_snapshot!(md);
 
         let parsed_log = ChangeLog::from_markdown(&md);
@@ -178,7 +178,7 @@ fn all_section_types_round_trips_lossy() -> Result {
     ] {
         for section in &log.sections {
             let mut buf = String::new();
-            section.write_to(&mut buf, &changelog::write::Linkables::AsText, *components)?;
+            section.write_to(&mut buf, &changelog::write::Linkables::AsText, *components, false)?;
             insta::assert_snapshot!(buf);
         }
     }


### PR DESCRIPTION
Added a --capitalize-commit option to capitalize the commit msg in changelog

[demo](https://asciinema.org/a/zmXAHdeBLoM15r9AFBx7fs0iC)

----

Ok for [Byron](https://github.com/Byron) review the PR on video?

- [x] I give my permission to record review and upload on YouTube publicly

If I think the review will be helpful for the community, then I might record and publish a video.

