### PR TITLE
fix(next_by_topology): Correct the commit iteration order

### DIFF
--- a/gix-traverse/src/commit.rs
+++ b/gix-traverse/src/commit.rs
@@ -343,7 +343,7 @@ pub mod ancestors {
                             Ok(gix_object::commit::ref_iter::Token::Parent { id }) => {
                                 let was_inserted = state.seen.insert(id);
                                 if was_inserted && (self.predicate)(&id) {
-                                    state.next.push_back((id, 0));
+                                    state.next.push_front((id, 0));
                                 }
                                 if matches!(self.parents, Parents::First) {
                                     break;


### PR DESCRIPTION
Iterating over `gix::revision::walk::Platform::all()` returns commits in
the wrong order.

The expected commit output order is the same as `git log --graph`

```
*   0a534f214a
|\
| * ebcd820b65
| * b56e33210a
| * 46ff9bbc93
| * 6db404e52d
|/
*   f79134e683
|\
| * 29daaad4ad
|/
* dbeb4b38c9
|\
| * 2398fb5d9f
| * c550167bec
| * 8d6c064c26
```

Similar iteration using `gix::traverse::Platform` without this patch

```
* 0a534f214a
* f79134e683
| * ebcd820b65
* dbeb4b38c9
| * 29daaad4ad
| * b56e33210a
* 163f943697
| * 2398fb5d9f
| * 46ff9bbc93
* 00f8b9701e
* cca06c8bd7
| * c550167bec
| * 6db404e52d
| * 8d6c064c26
```
