### PR TITLE
pack traverse memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,11 +182,9 @@ sha1_smol = { opt-level = 3 }
 
 [profile.release]
 overflow-checks = false
-lto = "fat"
 # this bloats files but assures destructors are called, important for tempfiles. One day I hope we
 # can wire up the 'abrt' signal handler so tempfiles will be removed in case of panics.
 panic = 'unwind'
-codegen-units = 1
 incremental = false
 build-override = { opt-level = 0 }
 

--- a/gix-pack/src/cache/delta/traverse/mod.rs
+++ b/gix-pack/src/cache/delta/traverse/mod.rs
@@ -114,7 +114,7 @@ where
         }: Options<'_, P1, P2>,
     ) -> Result<Outcome<T>, Error>
     where
-        F: for<'r> FnMut(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
+        F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
         R: Send + Sync,
         P1: Progress,
         P2: Progress,
@@ -148,7 +148,6 @@ where
                     move |thread_index| {
                         let _ = &child_items;
                         resolve::State {
-                            bytes_buf: Vec::<u8>::with_capacity(4096),
                             delta_bytes: Vec::<u8>::with_capacity(4096),
                             fully_resolved_delta_bytes: Vec::<u8>::with_capacity(4096),
                             progress: threading::lock(&object_progress).add_child(format!("thread {thread_index}")),

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 pub(crate) struct State<P, F, MBFN, T: Send> {
-    pub bytes_buf: Vec<u8>,
     pub delta_bytes: Vec<u8>,
     pub fully_resolved_delta_bytes: Vec<u8>,
     pub progress: P,
@@ -32,7 +31,6 @@ pub(crate) fn deltas<T, F, MBFN, E, R, P>(
     size_counter: Option<gix_features::progress::StepShared>,
     node: &mut Item<T>,
     State {
-        bytes_buf,
         delta_bytes,
         fully_resolved_delta_bytes,
         progress,
@@ -49,19 +47,20 @@ where
     T: Send,
     R: Send + Sync,
     P: Progress,
-    F: for<'r> FnMut(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
+    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
     MBFN: FnMut(&mut T, &P, Context<'_>) -> Result<(), E> + Send + Clone,
     E: std::error::Error + Send + Sync + 'static,
 {
     let mut decompressed_bytes_by_pack_offset = BTreeMap::new();
-    let mut decompress_from_resolver = |slice: EntryRange| -> Result<(data::Entry, u64, Vec<u8>), Error> {
+    let decompress_from_resolver = |slice: EntryRange, out: &mut Vec<u8>| -> Result<(data::Entry, u64), Error> {
         let bytes = resolve(slice.clone(), resolve_data).ok_or(Error::ResolveFailed {
             pack_offset: slice.start,
         })?;
         let entry = data::Entry::from_bytes(bytes, slice.start, hash_len);
         let compressed = &bytes[entry.header_size()..];
         let decompressed_len = entry.decompressed_size as usize;
-        Ok((entry, slice.end, decompress_all_at_once(compressed, decompressed_len)?))
+        decompress_all_at_once_with(compressed, decompressed_len, out)?;
+        Ok((entry, slice.end))
     };
 
     // each node is a base, and its children always start out as deltas which become a base after applying them.
@@ -79,11 +78,10 @@ where
             return Err(Error::Interrupted);
         }
         let (base_entry, entry_end, base_bytes) = if level == root_level {
-            decompress_from_resolver(base.entry_slice())?
+            let mut buf = Vec::new();
+            let (a, b) = decompress_from_resolver(base.entry_slice(), &mut buf)?;
+            (a, b, buf)
         } else {
-            if !bytes_buf.is_empty() {
-                *bytes_buf = Vec::new();
-            }
             decompressed_bytes_by_pack_offset
                 .remove(&base.offset())
                 .expect("we store the resolved delta buffer when done")
@@ -111,8 +109,8 @@ where
         }
 
         for mut child in base.into_child_iter() {
-            let (mut child_entry, entry_end, delta_bytes) = decompress_from_resolver(child.entry_slice())?;
-            let (base_size, consumed) = data::delta::decode_header_size(&delta_bytes);
+            let (mut child_entry, entry_end) = decompress_from_resolver(child.entry_slice(), delta_bytes)?;
+            let (base_size, consumed) = data::delta::decode_header_size(delta_bytes);
             let mut header_ofs = consumed;
             assert_eq!(
                 base_bytes.len(),
@@ -122,7 +120,7 @@ where
             let (result_size, consumed) = data::delta::decode_header_size(&delta_bytes[consumed..]);
             header_ofs += consumed;
 
-            resize_vec(fully_resolved_delta_bytes, result_size as usize);
+            set_len(fully_resolved_delta_bytes, result_size as usize);
             data::delta::apply(&base_bytes, fully_resolved_delta_bytes, &delta_bytes[header_ofs..]);
 
             // FIXME: this actually invalidates the "pack_offset()" computation, which is not obvious to consumers
@@ -164,7 +162,6 @@ where
                 })
             {
                 // Assure no memory is held here.
-                *bytes_buf = Vec::new();
                 *delta_bytes = Vec::new();
                 *fully_resolved_delta_bytes = Vec::new();
                 return deltas_mt(
@@ -210,7 +207,7 @@ where
     T: Send,
     R: Send + Sync,
     P: Progress,
-    F: for<'r> FnMut(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
+    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
     MBFN: FnMut(&mut T, &P, Context<'_>) -> Result<(), E> + Send + Clone,
     E: std::error::Error + Send + Sync + 'static,
 {
@@ -229,22 +226,24 @@ where
                     .spawn_scoped(s, {
                         let nodes = &nodes;
                         let decompressed_bytes_by_pack_offset = &decompressed_bytes_by_pack_offset;
-                        let mut resolve = resolve.clone();
+                        let resolve = resolve.clone();
                         let mut modify_base = modify_base.clone();
                         let object_counter = object_counter.as_ref();
                         let size_counter = size_counter.as_ref();
 
                         move || -> Result<(), Error> {
                             let mut fully_resolved_delta_bytes = Vec::new();
-                            let mut decompress_from_resolver =
-                                |slice: EntryRange| -> Result<(data::Entry, u64, Vec<u8>), Error> {
+                            let mut delta_bytes = Vec::new();
+                            let decompress_from_resolver =
+                                |slice: EntryRange, out: &mut Vec<u8>| -> Result<(data::Entry, u64), Error> {
                                     let bytes = resolve(slice.clone(), resolve_data).ok_or(Error::ResolveFailed {
                                         pack_offset: slice.start,
                                     })?;
                                     let entry = data::Entry::from_bytes(bytes, slice.start, hash_len);
                                     let compressed = &bytes[entry.header_size()..];
                                     let decompressed_len = entry.decompressed_size as usize;
-                                    Ok((entry, slice.end, decompress_all_at_once(compressed, decompressed_len)?))
+                                    decompress_all_at_once_with(compressed, decompressed_len, out)?;
+                                    Ok((entry, slice.end))
                                 };
 
                             loop {
@@ -256,7 +255,9 @@ where
                                     return Err(Error::Interrupted);
                                 }
                                 let (base_entry, entry_end, base_bytes) = if level == 0 {
-                                    decompress_from_resolver(base.entry_slice())?
+                                    let mut buf = Vec::new();
+                                    let (a, b) = decompress_from_resolver(base.entry_slice(), &mut buf)?;
+                                    (a, b, buf)
                                 } else {
                                     threading::lock(decompressed_bytes_by_pack_offset)
                                         .remove(&base.offset())
@@ -285,8 +286,8 @@ where
                                 }
 
                                 for mut child in base.into_child_iter() {
-                                    let (mut child_entry, entry_end, delta_bytes) =
-                                        decompress_from_resolver(child.entry_slice())?;
+                                    let (mut child_entry, entry_end) =
+                                        decompress_from_resolver(child.entry_slice(), &mut delta_bytes)?;
                                     let (base_size, consumed) = data::delta::decode_header_size(&delta_bytes);
                                     let mut header_ofs = consumed;
                                     assert_eq!(
@@ -387,7 +388,7 @@ where
     })
 }
 
-fn resize_vec(v: &mut Vec<u8>, new_len: usize) {
+fn set_len(v: &mut Vec<u8>, new_len: usize) {
     if new_len > v.len() {
         v.reserve_exact(new_len.saturating_sub(v.capacity()) + (v.capacity() - v.len()));
         // SAFETY:
@@ -402,14 +403,13 @@ fn resize_vec(v: &mut Vec<u8>, new_len: usize) {
     }
 }
 
-fn decompress_all_at_once(b: &[u8], decompressed_len: usize) -> Result<Vec<u8>, Error> {
-    let mut out = Vec::new();
-    resize_vec(&mut out, decompressed_len);
+fn decompress_all_at_once_with(b: &[u8], decompressed_len: usize, out: &mut Vec<u8>) -> Result<(), Error> {
+    set_len(out, decompressed_len);
     zlib::Inflate::default()
-        .once(b, &mut out)
+        .once(b, out)
         .map_err(|err| Error::ZlibInflate {
             source: err,
             message: "Failed to decompress entry",
         })?;
-    Ok(out)
+    Ok(())
 }


### PR DESCRIPTION
- further optimize buffer usage when traversing packs
- feat: Use `jemalloc` for consistent memory performance
