### PR TITLE
Include license files in all crates that are published to crates.io

### DIFF
--- a/gitoxide-core/LICENSE-APACHE
+++ b/gitoxide-core/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gitoxide-core/LICENSE-MIT
+++ b/gitoxide-core/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT/Apache-2.0"
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-actor/LICENSE-APACHE
+++ b/gix-actor/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-actor/LICENSE-MIT
+++ b/gix-actor/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-archive/LICENSE-APACHE
+++ b/gix-archive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-archive/LICENSE-MIT
+++ b/gix-archive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project dealing .gitattributes files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-attributes/LICENSE-APACHE
+++ b/gix-attributes/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-attributes/LICENSE-MIT
+++ b/gix-attributes/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-bitmap/LICENSE-APACHE
+++ b/gix-bitmap/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-bitmap/LICENSE-MIT
+++ b/gix-bitmap/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-chunk/Cargo.toml
+++ b/gix-chunk/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Byron/gitoxide"
 documentation = "https://github.com/git/git/blob/seen/Documentation/technical/chunk-format.txt"
 license = "MIT/Apache-2.0"
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-chunk/LICENSE-APACHE
+++ b/gix-chunk/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-chunk/LICENSE-MIT
+++ b/gix-chunk/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-command/LICENSE-APACHE
+++ b/gix-command/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-command/LICENSE-MIT
+++ b/gix-command/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 description = "Read-only access to the git commitgraph file format"
 authors = ["Conor Davis <gitoxide@conor.fastmail.fm>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-commitgraph/LICENSE-APACHE
+++ b/gix-commitgraph/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-commitgraph/LICENSE-MIT
+++ b/gix-commitgraph/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-config-value/LICENSE-APACHE
+++ b/gix-config-value/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-config-value/LICENSE-MIT
+++ b/gix-config-value/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-credentials/LICENSE-APACHE
+++ b/gix-credentials/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-credentials/LICENSE-MIT
+++ b/gix-credentials/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project parsing dates the way git does"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-date/LICENSE-APACHE
+++ b/gix-date/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-date/LICENSE-MIT
+++ b/gix-date/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "Calculate differences between various git objects"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 autotests = false
 

--- a/gix-diff/LICENSE-APACHE
+++ b/gix-diff/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-diff/LICENSE-MIT
+++ b/gix-diff/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "Discover git repositories and check if a directory is a git repository"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-discover/LICENSE-APACHE
+++ b/gix-discover/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-discover/LICENSE-MIT
+++ b/gix-discover/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-features/LICENSE-APACHE
+++ b/gix-features/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-features/LICENSE-MIT
+++ b/gix-features/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-fetchhead/LICENSE-APACHE
+++ b/gix-fetchhead/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-fetchhead/LICENSE-MIT
+++ b/gix-fetchhead/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-filter/LICENSE-APACHE
+++ b/gix-filter/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-filter/LICENSE-MIT
+++ b/gix-filter/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-fs/LICENSE-APACHE
+++ b/gix-fs/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-fs/LICENSE-MIT
+++ b/gix-fs/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-glob/LICENSE-APACHE
+++ b/gix-glob/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-glob/LICENSE-MIT
+++ b/gix-glob/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT/Apache-2.0"
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-hash/LICENSE-APACHE
+++ b/gix-hash/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-hash/LICENSE-MIT
+++ b/gix-hash/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-hashtable/Cargo.toml
+++ b/gix-hashtable/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A crate that provides hashtable based data structures optimized to utilize ObjectId keys"
 authors = ["Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-hashtable/LICENSE-APACHE
+++ b/gix-hashtable/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-hashtable/LICENSE-MIT
+++ b/gix-hashtable/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project dealing .gitignore files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-ignore/LICENSE-APACHE
+++ b/gix-ignore/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-ignore/LICENSE-MIT
+++ b/gix-ignore/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 rust-version = "1.64"
 autotests = false
 

--- a/gix-index/LICENSE-APACHE
+++ b/gix-index/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-index/LICENSE-MIT
+++ b/gix-index/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-lfs/LICENSE-APACHE
+++ b/gix-lfs/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-lfs/LICENSE-MIT
+++ b/gix-lfs/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-mailmap/LICENSE-APACHE
+++ b/gix-mailmap/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-mailmap/LICENSE-MIT
+++ b/gix-mailmap/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-negotiate/LICENSE-APACHE
+++ b/gix-negotiate/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-negotiate/LICENSE-MIT
+++ b/gix-negotiate/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-note/LICENSE-APACHE
+++ b/gix-note/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-note/LICENSE-MIT
+++ b/gix-note/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT/Apache-2.0"
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-object/LICENSE-APACHE
+++ b/gix-object/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-object/LICENSE-MIT
+++ b/gix-object/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT/Apache-2.0"
 description = "Implements various git object databases"
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-odb/LICENSE-APACHE
+++ b/gix-odb/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-odb/LICENSE-MIT
+++ b/gix-odb/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT/Apache-2.0"
 description = "Implements git packs and related data structures"
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 autotests = false
 

--- a/gix-pack/LICENSE-APACHE
+++ b/gix-pack/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-pack/LICENSE-MIT
+++ b/gix-pack/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project implementing the pkt-line serialization format"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-packetline/LICENSE-APACHE
+++ b/gix-packetline/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-packetline/LICENSE-MIT
+++ b/gix-packetline/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project dealing paths and their conversions"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-path/LICENSE-APACHE
+++ b/gix-path/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-path/LICENSE-MIT
+++ b/gix-path/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-pathspec/LICENSE-APACHE
+++ b/gix-pathspec/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-pathspec/LICENSE-MIT
+++ b/gix-pathspec/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A crate of the gitoxide project for handling prompts in the terminal"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-prompt/LICENSE-APACHE
+++ b/gix-prompt/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-prompt/LICENSE-MIT
+++ b/gix-prompt/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project for implementing git protocols"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md", "!**/tests/**/*"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md", "!**/tests/**/*"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-protocol/LICENSE-APACHE
+++ b/gix-protocol/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-protocol/LICENSE-MIT
+++ b/gix-protocol/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-quote/LICENSE-APACHE
+++ b/gix-quote/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-quote/LICENSE-MIT
+++ b/gix-quote/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-rebase/LICENSE-APACHE
+++ b/gix-rebase/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-rebase/LICENSE-MIT
+++ b/gix-rebase/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A crate to handle git references"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 autotests = false
 

--- a/gix-ref/LICENSE-APACHE
+++ b/gix-ref/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-ref/LICENSE-MIT
+++ b/gix-ref/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project for parsing and representing refspecs"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md", "README.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md", "README.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-refspec/LICENSE-APACHE
+++ b/gix-refspec/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-refspec/LICENSE-MIT
+++ b/gix-refspec/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project dealing with finding names for revisions and parsing specifications"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md", "README.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md", "README.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-revision/LICENSE-APACHE
+++ b/gix-revision/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-revision/LICENSE-MIT
+++ b/gix-revision/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project providing a shared trust model"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-sec/LICENSE-APACHE
+++ b/gix-sec/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-sec/LICENSE-MIT
+++ b/gix-sec/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-sequencer/LICENSE-APACHE
+++ b/gix-sequencer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-sequencer/LICENSE-MIT
+++ b/gix-sequencer/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-submodule/LICENSE-APACHE
+++ b/gix-submodule/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-submodule/LICENSE-MIT
+++ b/gix-submodule/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-tix/LICENSE-APACHE
+++ b/gix-tix/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-tix/LICENSE-MIT
+++ b/gix-tix/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project dedicated to implementing the git transport layer"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-transport/LICENSE-APACHE
+++ b/gix-transport/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-transport/LICENSE-MIT
+++ b/gix-transport/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 autotests = false
 

--- a/gix-traverse/LICENSE-APACHE
+++ b/gix-traverse/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-traverse/LICENSE-MIT
+++ b/gix-traverse/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-tui/LICENSE-APACHE
+++ b/gix-tui/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-tui/LICENSE-MIT
+++ b/gix-tui/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project implementing parsing and serialization of gix-url"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-url/LICENSE-APACHE
+++ b/gix-url/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-url/LICENSE-MIT
+++ b/gix-url/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-utils/LICENSE-APACHE
+++ b/gix-utils/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-utils/LICENSE-MIT
+++ b/gix-utils/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-validate/Cargo.toml
+++ b/gix-validate/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "Validation functions for various kinds of names in git"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE-*"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-validate/LICENSE-APACHE
+++ b/gix-validate/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-validate/LICENSE-MIT
+++ b/gix-validate/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A WIP crate of the gitoxide project dedicated implementing everything around working trees and git excludes"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix-worktree/LICENSE-APACHE
+++ b/gix-worktree/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix-worktree/LICENSE-MIT
+++ b/gix-worktree/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 version = "0.45.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
 rust-version = "1.64"
 
 [lib]

--- a/gix/LICENSE-APACHE
+++ b/gix/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/gix/LICENSE-MIT
+++ b/gix/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -162,7 +162,7 @@ title "gix attributes"
 (with "gix attributes"
   (with "the 'validate-baseline' sub-command"
     it "passes when operating on all of our files" && {
-      expect_run_sh $SUCCESSFULLY "find . -type f | sed 's|^./||' | $exe_plumbing --no-verbose attributes validate-baseline"
+      expect_run_sh_no_pipefail $SUCCESSFULLY "find . -type f | sed 's|^./||' | $exe_plumbing --no-verbose attributes validate-baseline"
     }
   )
 )

--- a/tests/utilities.sh
+++ b/tests/utilities.sh
@@ -16,6 +16,9 @@ function with_program () {
     function expect_run_sh () {
       echo 1>&2 "${WHITE} - skipped (missing program)"
     }
+    function expect_run_sh_no_pipefail () {
+      echo 1>&2 "${WHITE} - skipped (missing program)"
+    }
   }
 }
 
@@ -27,6 +30,9 @@ function on_ci () {
     function expect_run_sh () {
       echo 1>&2 "${WHITE} - skipped (runs only on CI)"
     }
+    function expect_run_sh_no_pipefail () {
+      echo 1>&2 "${WHITE} - skipped (runs only on CI)"
+    }
   }
 }
 
@@ -36,6 +42,9 @@ function not_on_ci () {
       echo 1>&2 "${WHITE} - skipped (runs only locally)"
     }
     function expect_run_sh () {
+      echo 1>&2 "${WHITE} - skipped (runs only locally)"
+    }
+    function expect_run_sh_no_pipefail () {
       echo 1>&2 "${WHITE} - skipped (runs only locally)"
     }
   }
@@ -125,6 +134,10 @@ function expect_exists () {
 
 function expect_run_sh () {
   expect_run "${1:?}" bash -c -eu -o pipefail "${2:?}"
+}
+
+function expect_run_sh_no_pipefail () {
+  expect_run "${1:?}" bash -c -eu "${2:?}"
 }
 
 function expect_snapshot () {


### PR DESCRIPTION
I want to package the `gix*` crates for fedora because [helix](https://github.com/helix-editor/helix/blob/master/helix-vcs/Cargo.toml#L20) depends on the `gix` crate and I would like to include `helix` to fedora. Looking at your crates I see that almost none of them contain license files. Is that on purpose? This PR tries to fix this by adding symlinks and including the files in `Cargo.toml` where necessary.