### PR TITLE
Apply -W clippy::cloned-instead-of-copied

### DIFF
--- a/gix-odb/src/store_impls/dynamic/access.rs
+++ b/gix-odb/src/store_impls/dynamic/access.rs
@@ -19,6 +19,6 @@ impl Store {
 
     /// An iterator over replacements from object-ids `X` to `X-replaced` as `(X, X-replaced)`, sorted by the original id `X`.
     pub fn replacements(&self) -> impl Iterator<Item = (gix_hash::ObjectId, gix_hash::ObjectId)> + '_ {
-        self.replacements.iter().cloned()
+        self.replacements.iter().copied()
     }
 }

--- a/gix-odb/src/store_impls/dynamic/prefix.rs
+++ b/gix-odb/src/store_impls/dynamic/prefix.rs
@@ -172,7 +172,7 @@ where
                     return match &candidates {
                         Some(candidates) => match candidates.len() {
                             0 => Ok(None),
-                            1 => Ok(candidates.iter().cloned().next().map(Ok)),
+                            1 => Ok(candidates.iter().copied().next().map(Ok)),
                             _ => Ok(Some(Err(()))),
                         },
                         None => Ok(candidate.map(Ok)),

--- a/gix-odb/src/store_impls/loose/find.rs
+++ b/gix-odb/src/store_impls/loose/find.rs
@@ -94,7 +94,7 @@ impl Store {
         match &mut candidates {
             Some(candidates) => match candidates.len() {
                 0 => Ok(None),
-                1 => Ok(candidates.iter().next().cloned().map(Ok)),
+                1 => Ok(candidates.iter().next().copied().map(Ok)),
                 _ => Ok(Some(Err(()))),
             },
             None => Ok(candidate.map(Ok)),

--- a/gix-packetline/src/read/async_io.rs
+++ b/gix-packetline/src/read/async_io.rs
@@ -51,7 +51,7 @@ where
             Some(match Self::read_line_inner(reader, buf).await {
                 Ok(Ok(line)) => {
                     if delimiters.contains(&line) {
-                        let stopped_at = delimiters.iter().find(|l| **l == line).cloned();
+                        let stopped_at = delimiters.iter().find(|l| **l == line).copied();
                         buf.clear();
                         return (true, stopped_at, None);
                     } else if fail_on_err_lines {

--- a/gix-packetline/src/read/blocking_io.rs
+++ b/gix-packetline/src/read/blocking_io.rs
@@ -45,7 +45,7 @@ where
             Some(match Self::read_line_inner(reader, buf) {
                 Ok(Ok(line)) => {
                     if delimiters.contains(&line) {
-                        let stopped_at = delimiters.iter().find(|l| **l == line).cloned();
+                        let stopped_at = delimiters.iter().find(|l| **l == line).copied();
                         buf.clear();
                         return (true, stopped_at, None);
                     } else if fail_on_err_lines {

--- a/gix-protocol/src/fetch/tests.rs
+++ b/gix-protocol/src/fetch/tests.rs
@@ -163,7 +163,7 @@ mod arguments {
         async fn include_tag() {
             let mut out = Vec::new();
             let mut t = transport(&mut out, true);
-            let mut arguments = arguments_v1(["include-tag", "feature-b"].iter().cloned());
+            let mut arguments = arguments_v1(["include-tag", "feature-b"].iter().copied());
             assert!(arguments.can_use_include_tag());
 
             arguments.use_include_tag();
@@ -183,7 +183,7 @@ mod arguments {
         async fn haves_and_wants_for_clone() {
             let mut out = Vec::new();
             let mut t = transport(&mut out, true);
-            let mut arguments = arguments_v1(["feature-a", "feature-b"].iter().cloned());
+            let mut arguments = arguments_v1(["feature-a", "feature-b"].iter().copied());
             assert!(
                 !arguments.can_use_include_tag(),
                 "needs to be enabled by features in V1"

--- a/gix-transport/tests/client/blocking_io/http/mod.rs
+++ b/gix-transport/tests/client/blocking_io/http/mod.rs
@@ -566,7 +566,7 @@ Git-Protocol: version=2:value-only:key=value
     drop(refs);
     let res = c.invoke(
         "ls-refs",
-        [("without-value", None), ("with-value", Some("value"))].iter().cloned(),
+        [("without-value", None), ("with-value", Some("value"))].iter().copied(),
         Some(vec!["arg1".as_bytes().as_bstr().to_owned()].into_iter()),
     )?;
     assert_eq!(

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -325,7 +325,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
             "ls-refs",
             [("agent", Some("git/2.28.0")), ("object-format", Some("sha1"))]
                 .iter()
-                .cloned(),
+                .copied(),
             Some(
                 [
                     "peel",
@@ -364,7 +364,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
                 ("object-format", Some("sha1")),
             ]
             .iter()
-            .cloned(),
+            .copied(),
             Some(
                 [
                     "thin-pack",

--- a/justfile
+++ b/justfile
@@ -19,10 +19,11 @@ ci-test: check doc unit-tests journey-tests-pure journey-tests-small journey-tes
 #   -D clippy::range-plus-one - useful, but caused too many false positives as we use range types directly quite a lot
 
 clippy-flags := """
-  -D clippy::uninlined_format_args \
-  -D clippy::unnested-or-patterns \
+  -D clippy::cloned-instead-of-copied \
   -D clippy::explicit-iter-loop \
   -D clippy::map-unwrap-or \
+  -D clippy::uninlined_format_args \
+  -D clippy::unnested-or-patterns \
 """
 
 # Run cargo clippy on all crates
@@ -32,12 +33,13 @@ clippy:
     cargo clippy --all --no-default-features --features max-pure -- {{ clippy-flags }}
     cargo clippy --all --no-default-features --features lean-async --tests -- {{ clippy-flags }}
 
-# Run cargo clippy on all crates, fixing what can be fixed
+# Run cargo clippy on all crates, fixing what can be fixed, and format all code
 clippy-fix:
     cargo clippy --fix --all --tests --examples -- {{ clippy-flags }}
     cargo clippy --fix --allow-dirty --all --no-default-features --features small -- {{ clippy-flags }}
     cargo clippy --fix --allow-dirty --all --no-default-features --features max-pure -- {{ clippy-flags }}
     cargo clippy --fix --allow-dirty --all --no-default-features --features lean-async --tests -- {{ clippy-flags }}
+    cargo fmt --all
 
 # Build all code in suitable configurations
 check:


### PR DESCRIPTION
Ran `just 'clippy-flags=-W clippy::cloned-instead-of-copied' clippy-fix`

Also sorted clippy-flags

