### PR TITLE
Cleaning up documentation

### DIFF
--- a/gitoxide-core/src/hours/mod.rs
+++ b/gitoxide-core/src/hours/mod.rs
@@ -31,9 +31,9 @@ pub struct Context<W> {
 /// Estimate the hours it takes to produce the content of the repository in `_working_dir_`, with `_refname_` for
 /// the start of the commit graph traversal.
 ///
-/// * _working_dir_ - The directory containing a '.git/' folder.
-/// * _refname_ - The name of the ref like 'main' or 'master' at which to start iterating the commit graph.
-/// * _progress_ - A way to provide progress and performance information
+/// * `_working_dir_` - The directory containing a '.git/' folder.
+/// * `_refname_` - The name of the ref like 'main' or 'master' at which to start iterating the commit graph.
+/// * `_progress_` - A way to provide progress and performance information
 pub fn estimate<W, P>(
     working_dir: &Path,
     rev_spec: &BStr,

--- a/gix-chunk/src/file/decode.rs
+++ b/gix-chunk/src/file/decode.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryInto, ops::Range};
 
 mod error {
-    /// The value returned by [crate::FileRef::from_bytes()
+    /// The value returned by [`crate::file::Index::from_bytes()`]
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-chunk/src/file/index.rs
+++ b/gix-chunk/src/file/index.rs
@@ -6,7 +6,7 @@ use crate::file::Index;
 pub mod offset_by_kind {
     use std::fmt::{Display, Formatter};
 
-    /// The error returned by [`Index::offset_by_kind()`][super::Index::offset_by_id()].
+    /// The error returned by [`Index::offset_by_id()`][super::Index::offset_by_id()].
     #[allow(missing_docs)]
     #[derive(Debug)]
     pub struct Error {
@@ -28,7 +28,7 @@ pub mod offset_by_kind {
 
 ///
 pub mod data_by_kind {
-    /// The error returned by [`Index::data_by_kind()`][super::Index::data_by_id()].
+    /// The error returned by [`Index::data_by_id()`][super::Index::data_by_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-chunk/src/file/index.rs
+++ b/gix-chunk/src/file/index.rs
@@ -6,7 +6,7 @@ use crate::file::Index;
 pub mod offset_by_kind {
     use std::fmt::{Display, Formatter};
 
-    /// The error returned by [Index::offset_by_kind()][super::Index::offset_by_id()].
+    /// The error returned by [`Index::offset_by_kind()`][super::Index::offset_by_id()].
     #[allow(missing_docs)]
     #[derive(Debug)]
     pub struct Error {
@@ -28,7 +28,7 @@ pub mod offset_by_kind {
 
 ///
 pub mod data_by_kind {
-    /// The error returned by [Index::data_by_kind()][super::Index::data_by_id()].
+    /// The error returned by [`Index::data_by_kind()`][super::Index::data_by_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-commitgraph/src/file/access.rs
+++ b/gix-commitgraph/src/file/access.rs
@@ -18,7 +18,7 @@ impl File {
 
     /// Returns the commit data for the commit located at the given lexigraphical position.
     ///
-    /// `pos` must range from 0 to self.num_commits().
+    /// `pos` must range from 0 to `self.num_commits()`.
     ///
     /// # Panics
     ///
@@ -35,7 +35,7 @@ impl File {
     }
 
     /// Returns an object id at the given index in our list of (sorted) hashes.
-    /// The position ranges from 0 to self.num_commits()
+    /// The position ranges from 0 to `self.num_commits()`
     // copied from gix-odb/src/pack/index/ext
     pub fn id_at(&self, pos: file::Position) -> &gix_hash::oid {
         assert!(

--- a/gix-config-value/src/types.rs
+++ b/gix-config-value/src/types.rs
@@ -24,7 +24,7 @@ pub struct Color {
 /// wish to obtain the true value of the integer, you must account for the
 /// suffix after fetching the value. [`integer::Suffix`] provides
 /// [`bitwise_offset()`][integer::Suffix::bitwise_offset] to help with the
-/// math, or [to_decimal()][Integer::to_decimal()] for obtaining a usable value in one step.
+/// math, or [`to_decimal()`][Integer::to_decimal()] for obtaining a usable value in one step.
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Integer {
     /// The value, without any suffix modification

--- a/gix-config/src/file/init/from_paths.rs
+++ b/gix-config/src/file/init/from_paths.rs
@@ -63,7 +63,7 @@ impl File<'static> {
         Self::from_paths_metadata_buf(path_meta, &mut buf, err_on_nonexisting_paths, options)
     }
 
-    /// Like [from_paths_metadata()][Self::from_paths_metadata()], but will use `buf` to temporarily store the config file
+    /// Like [`from_paths_metadata()`][Self::from_paths_metadata()], but will use `buf` to temporarily store the config file
     /// contents for parsing instead of allocating an own buffer.
     ///
     /// If `err_on_nonexisting_paths` is false, instead of aborting with error, we will continue to the next path instead.

--- a/gix-config/src/file/section/mod.rs
+++ b/gix-config/src/file/section/mod.rs
@@ -52,7 +52,7 @@ impl<'a> Section<'a> {
     }
 
     /// Return the unique `id` of the section, for use with the `*_by_id()` family of methods
-    /// in [gix_config::File][crate::File].
+    /// in [`gix_config::File`][crate::File].
     pub fn id(&self) -> SectionId {
         self.id
     }

--- a/gix-diff/src/tree/changes.rs
+++ b/gix-diff/src/tree/changes.rs
@@ -8,7 +8,7 @@ use crate::{
     tree::{visit::Change, TreeInfoPair},
 };
 
-/// The error returned by [tree::Changes::needed_to_obtain()].
+/// The error returned by [`tree::Changes::needed_to_obtain()`].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
@@ -42,7 +42,7 @@ impl<'a> tree::Changes<'a> {
     ///   by the delegate implementation which should be as specific as possible. Rename tracking can be computed on top of the changes
     ///   received by the `delegate`.
     /// * cycle checking is not performed, but can be performed in the delegate which can return [`tree::visit::Action::Cancel`] to stop the traversal.
-    /// * [std::mem::ManuallyDrop] is used because `Peekable` is needed. When using it as wrapper around our no-drop iterators, all of the sudden
+    /// * [`std::mem::ManuallyDrop`] is used because `Peekable` is needed. When using it as wrapper around our no-drop iterators, all of the sudden
     ///   borrowcheck complains as Drop is present (even though it's not)
     ///
     /// [git_cmp_c]: https://github.com/git/git/blob/311531c9de557d25ac087c1637818bd2aad6eb3a/tree-diff.c#L49:L65

--- a/gix-diff/src/tree/recorder.rs
+++ b/gix-diff/src/tree/recorder.rs
@@ -18,7 +18,7 @@ pub enum Location {
 }
 
 /// A Change as observed by a call to [`visit(…)`][visit::Visit::visit()], enhanced with the path affected by the change.
-/// Its similar to [visit::Change] but includes the path that changed.
+/// Its similar to [`visit::Change`] but includes the path that changed.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum Change {

--- a/gix-discover/src/upwards/types.rs
+++ b/gix-discover/src/upwards/types.rs
@@ -1,6 +1,6 @@
 use std::{env, ffi::OsStr, path::PathBuf};
 
-/// The error returned by [gix_discover::upwards()][crate::upwards()].
+/// The error returned by [`gix_discover::upwards()`][crate::upwards()].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {

--- a/gix-features/src/parallel/mod.rs
+++ b/gix-features/src/parallel/mod.rs
@@ -1,12 +1,12 @@
 //! Run computations in parallel, or not based the `parallel` feature toggle.
 //!
-//! ### in_parallel(…)
+//! ### `in_parallel`(…)
 //!
 //! The [`in_parallel(…)`][in_parallel()] is the typical fan-out-fan-in mode of parallelism, with thread local storage
 //! made available to a `consume(…)` function to process input. The result is sent to the [`Reduce`] running in the calling
 //! thread to aggregate the results into a single output, which is returned by [`in_parallel()`].
 //!
-//! Interruptions can be achieved by letting the reducers [`feed(…)`][Reduce::feed()]` method fail.
+//! Interruptions can be achieved by letting the reducers [`feed(…)`][Reduce::feed()] method fail.
 //!
 //! It gets a boost in usability as it allows threads to borrow variables from the stack, most commonly the repository itself
 //! or the data to work on.

--- a/gix-features/src/threading.rs
+++ b/gix-features/src/threading.rs
@@ -17,7 +17,7 @@ mod _impl {
     pub type Mutable<T> = parking_lot::Mutex<T>;
     /// A guarded reference suitable for safekeeping in a struct.
     pub type RefGuard<'a, T> = parking_lot::RwLockReadGuard<'a, T>;
-    /// A mapped reference created from a RefGuard
+    /// A mapped reference created from a `RefGuard`
     pub type MappedRefGuard<'a, U> = parking_lot::MappedRwLockReadGuard<'a, U>;
 
     /// Get a shared reference through a [`MutableOnDemand`] for read-only access.

--- a/gix-fs/src/stack.rs
+++ b/gix-fs/src/stack.rs
@@ -56,7 +56,7 @@ impl Stack {
     /// Set the current stack to point to the `relative` path and call `push_comp()` each time a new path component is popped
     /// along with the stacks state for inspection to perform an operation that produces some data.
     ///
-    /// The full path to `relative` will be returned along with the data returned by push_comp.
+    /// The full path to `relative` will be returned along with the data returned by `push_comp`.
     /// Note that this only works correctly for the delegate's `push_directory()` and `pop_directory()` methods if
     /// `relative` paths are terminal, so point to their designated file or directory.
     pub fn make_relative_path_current(

--- a/gix-glob/src/pattern.rs
+++ b/gix-glob/src/pattern.rs
@@ -30,7 +30,7 @@ bitflags! {
 
 /// Describes whether to match a path case sensitively or not.
 ///
-/// Used in [Pattern::matches_repo_relative_path()].
+/// Used in [`Pattern::matches_repo_relative_path()`].
 #[derive(Default, Debug, PartialOrd, PartialEq, Copy, Clone, Hash, Ord, Eq)]
 pub enum Case {
     /// The case affects the match

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -206,7 +206,7 @@ impl PartialEq<crate::ObjectId> for &oid {
 
 /// Manually created from a version that uses a slice, and we forcefully try to convert it into a borrowed array of the desired size
 /// Could be improved by fitting this into serde.
-/// Unfortunately the serde::Deserialize derive wouldn't work for borrowed arrays.
+/// Unfortunately the `serde::Deserialize` derive wouldn't work for borrowed arrays.
 #[cfg(feature = "serde")]
 impl<'de: 'a, 'a> serde::Deserialize<'de> for &'a oid {
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>

--- a/gix-hash/src/prefix.rs
+++ b/gix-hash/src/prefix.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, convert::TryFrom};
 
 use crate::{oid, ObjectId, Prefix};
 
-/// The error returned by [Prefix::new()].
+/// The error returned by [`Prefix::new()`].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
@@ -17,7 +17,7 @@ pub enum Error {
 
 ///
 pub mod from_hex {
-    /// The error returned by [Prefix::from_hex][super::Prefix::from_hex()].
+    /// The error returned by [`Prefix::from_hex`][super::Prefix::from_hex()].
     #[derive(Debug, Eq, PartialEq, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-hashtable/src/lib.rs
+++ b/gix-hashtable/src/lib.rs
@@ -1,4 +1,4 @@
-//! Customized HashMap and Hasher implementation optimized for using `ObjectId`s as keys.
+//! Customized `HashMap` and Hasher implementation optimized for using `ObjectId`s as keys.
 //!
 //! The crate mirrors `std::collections` in layout for familiarity.
 #![deny(missing_docs, rust_2018_idioms)]
@@ -35,7 +35,7 @@ pub mod sync {
 
 ///
 pub mod hash {
-    /// A Hasher for usage with HashMap keys that are already robust hashes (like an `ObjectId`).
+    /// A Hasher for usage with `HashMap` keys that are already robust hashes (like an `ObjectId`).
     /// The first `8` bytes of the hash are used as the `HashMap` hash
     #[derive(Default, Clone, Copy)]
     pub struct Hasher(u64);
@@ -75,7 +75,7 @@ pub mod hash {
         panic_other_writers!(write_isize, isize);
     }
 
-    /// A Hasher for usage with HashMap keys that are already robust hashes (like an `ObjectId`).
+    /// A Hasher for usage with `HashMap` keys that are already robust hashes (like an `ObjectId`).
     /// The first `8` bytes of the hash are used as the `HashMap` hash
     #[derive(Default, Clone, Copy)]
     pub struct Builder;
@@ -88,9 +88,9 @@ pub mod hash {
     }
 }
 
-/// A HashMap for usage with keys that are already robust hashes (like an `ObjectId`).
+/// A `HashMap` for usage with keys that are already robust hashes (like an `ObjectId`).
 /// The first `8` bytes of the hash are used as the `HashMap` hash
 pub type HashMap<K, V> = hashbrown::HashMap<K, V, hash::Builder>;
-/// A HashSet for usage with keys that are already robust hashes (like an `ObjectId`).
+/// A `HashSet` for usage with keys that are already robust hashes (like an `ObjectId`).
 /// The first `8` bytes of the hash are used as the `HashMap` hash
 pub type HashSet<T = ObjectId> = hashbrown::HashSet<T, hash::Builder>;

--- a/gix-index/src/access/mod.rs
+++ b/gix-index/src/access/mod.rs
@@ -103,14 +103,14 @@ impl State {
 
     /// Return the entry at `idx` or _panic_ if the index is out of bounds.
     ///
-    /// The `idx` is typically returned by [entry_by_path_and_stage()][State::entry_by_path_and_stage()].
+    /// The `idx` is typically returned by [`entry_by_path_and_stage()`][State::entry_by_path_and_stage()].
     pub fn entry(&self, idx: usize) -> &Entry {
         &self.entries[idx]
     }
 
     /// Returns a boolean value indicating whether the index is sparse or not.
     ///
-    /// An index is sparse if it contains at least one [Mode::DIR][entry::Mode::DIR] entry.
+    /// An index is sparse if it contains at least one [`Mode::DIR`][entry::Mode::DIR] entry.
     pub fn is_sparse(&self) -> bool {
         self.is_sparse
     }
@@ -180,7 +180,7 @@ impl State {
     /// [`entry_index_by_path_and_stage_bounded()`][State::entry_index_by_path_and_stage_bounded()] is used with
     /// the `upper_bound` being the amount of entries before the first call to this method.
     ///
-    /// Alternatively, make sure to call [sort_entries()][State::sort_entries()] before entry lookup by path to restore
+    /// Alternatively, make sure to call [`sort_entries()`][State::sort_entries()] before entry lookup by path to restore
     /// the invariant.
     pub fn dangerously_push_entry(
         &mut self,

--- a/gix-index/src/decode/mod.rs
+++ b/gix-index/src/decode/mod.rs
@@ -10,7 +10,7 @@ mod error {
 
     use crate::{decode, extension};
 
-    /// The error returned by [State::from_bytes()][crate::State::from_bytes()].
+    /// The error returned by [`State::from_bytes()`][crate::State::from_bytes()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-index/src/entry/stat.rs
+++ b/gix-index/src/entry/stat.rs
@@ -75,7 +75,7 @@ impl Stat {
         }
     }
 
-    /// Creates stat information from the result of symlink_metadata.
+    /// Creates stat information from the result of `symlink_metadata`.
     pub fn from_fs(fstat: &std::fs::Metadata) -> Result<Stat, SystemTimeError> {
         let mtime = fstat.modified().unwrap_or(std::time::UNIX_EPOCH);
         let ctime = fstat.created().unwrap_or(std::time::UNIX_EPOCH);

--- a/gix-index/src/extension/tree/verify.rs
+++ b/gix-index/src/extension/tree/verify.rs
@@ -4,7 +4,7 @@ use bstr::{BString, ByteSlice};
 
 use crate::extension::Tree;
 
-/// The error returned by [Tree::verify()][crate::extension::Tree::verify()].
+/// The error returned by [`Tree::verify()`][crate::extension::Tree::verify()].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {

--- a/gix-index/src/verify.rs
+++ b/gix-index/src/verify.rs
@@ -6,7 +6,7 @@ use crate::State;
 pub mod entries {
     use bstr::BString;
 
-    /// The error returned by [State::verify_entries()][crate::State::verify_entries()].
+    /// The error returned by [`State::verify_entries()`][crate::State::verify_entries()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -30,7 +30,7 @@ pub mod extensions {
         None
     }
 
-    /// The error returned by [State::verify_extensions()][crate::State::verify_extensions()].
+    /// The error returned by [`State::verify_extensions()`][crate::State::verify_extensions()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-lock/src/file.rs
+++ b/gix-lock/src/file.rs
@@ -17,7 +17,7 @@ impl File {
         self.inner.with_mut(|tf| f(tf.as_file_mut())).and_then(|res| res)
     }
     /// Close the lock file to prevent further writes and to save system resources.
-    /// A call to [Marker::commit()] is allowed on the [`Marker`] to write changes back to the resource.
+    /// A call to [`Marker::commit()`] is allowed on the [`Marker`] to write changes back to the resource.
     pub fn close(self) -> std::io::Result<Marker> {
         Ok(Marker {
             inner: self.inner.close()?,

--- a/gix-mailmap/src/snapshot/mod.rs
+++ b/gix-mailmap/src/snapshot/mod.rs
@@ -22,7 +22,7 @@ impl Snapshot {
 
     /// Create a new instance from `entries`.
     ///
-    /// These can be obtained using [crate::parse()].
+    /// These can be obtained using [`crate::parse()`].
     pub fn new<'a>(entries: impl IntoIterator<Item = crate::Entry<'a>>) -> Self {
         let mut snapshot = Self::default();
         snapshot.merge(entries);
@@ -54,7 +54,7 @@ impl Snapshot {
     /// Transform our acceleration structure into a list of entries.
     ///
     /// Note that the order is different from how they were obtained initially, and are explicitly ordered by
-    /// (old_email, old_name).
+    /// (`old_email`, `old_name`).
     pub fn entries(&self) -> Vec<crate::Entry<'_>> {
         let mut out = Vec::with_capacity(self.entries_by_old_email.len());
         for entry in &self.entries_by_old_email {

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -51,7 +51,7 @@ impl<'a> CommitRefIter<'a> {
         Token::try_into_id(tree_id).ok_or_else(missing_field)
     }
 
-    /// Return all parent_ids as iterator.
+    /// Return all `parent_ids` as iterator.
     ///
     /// Parsing errors are ignored quietly.
     pub fn parent_ids(self) -> impl Iterator<Item = gix_hash::ObjectId> + 'a {

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod parse;
 ///
 pub mod kind;
 
-/// The four types of objects that git differentiates. #[derive(PartialEq, Eq, Debug, Hash, Ord, `PartialOrd`, Clone, Copy)]
+/// The four types of objects that git differentiates.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[allow(missing_docs)]

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod parse;
 ///
 pub mod kind;
 
-/// The four types of objects that git differentiates. #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
+/// The four types of objects that git differentiates. #[derive(PartialEq, Eq, Debug, Hash, Ord, `PartialOrd`, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[allow(missing_docs)]

--- a/gix-object/src/tree/mod.rs
+++ b/gix-object/src/tree/mod.rs
@@ -11,7 +11,7 @@ pub mod write;
 
 /// The mode of items storable in a tree, similar to the file mode on a unix file system.
 ///
-/// Used in [mutable::Entry][crate::tree::Entry] and [EntryRef].
+/// Used in [`mutable::Entry`][crate::tree::Entry] and [`EntryRef`].
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash)]
 #[repr(u16)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/gix-object/tests/encode/mod.rs
+++ b/gix-object/tests/encode/mod.rs
@@ -1,4 +1,4 @@
-/// Because the TryFrom implementations don't return proper errors
+/// Because the `TryFrom` implementations don't return proper errors
 /// on failure
 #[derive(Debug, thiserror::Error)]
 enum Error {

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -101,7 +101,7 @@ impl super::Store {
         }
     }
 
-    /// load a new index (if not yet loaded), and return true if one was indeed loaded (leading to a state_id() change) of the current index.
+    /// load a new index (if not yet loaded), and return true if one was indeed loaded (leading to a `state_id()` change) of the current index.
     /// Note that interacting with the slot-map is inherently racy and we have to deal with it, being conservative in what we even try to load
     /// as our index might already be out-of-date as we try to use it to learn what's next.
     fn load_next_index(&self, mut index: arc_swap::Guard<Arc<SlotMapIndex>>) -> bool {

--- a/gix-pack/src/bundle/find.rs
+++ b/gix-pack/src/bundle/find.rs
@@ -19,7 +19,7 @@ impl crate::Bundle {
     }
 
     /// Special-use function to get an object given an index previously returned from
-    /// internal_find_pack_index.
+    /// `internal_find_pack_index`.
     ///
     /// # Panics
     ///

--- a/gix-pack/src/bundle/write/mod.rs
+++ b/gix-pack/src/bundle/write/mod.rs
@@ -168,7 +168,7 @@ impl crate::Bundle {
     /// # Note
     ///
     /// As it sends portions of the input to a thread it requires the 'static lifetime for the interrupt flags. This can only
-    /// be satisfied by a static AtomicBool which is only suitable for programs that only run one of these operations at a time
+    /// be satisfied by a static `AtomicBool` which is only suitable for programs that only run one of these operations at a time
     /// or don't mind that all of them abort when the flag is set.
     pub fn write_to_directory_eagerly<P>(
         pack: impl io::Read + Send + 'static,

--- a/gix-pack/src/bundle/write/types.rs
+++ b/gix-pack/src/bundle/write/types.rs
@@ -2,8 +2,8 @@ use std::{hash::Hash, io, io::SeekFrom, path::PathBuf, sync::Arc};
 
 use gix_tempfile::handle::Writable;
 
-/// Configuration for [write_to_directory][crate::Bundle::write_to_directory()] or
-/// [write_to_directory_eagerly][crate::Bundle::write_to_directory_eagerly()]
+/// Configuration for [`write_to_directory`][crate::Bundle::write_to_directory()] or
+/// [`write_to_directory_eagerly`][crate::Bundle::write_to_directory_eagerly()]
 #[derive(Debug, Clone)]
 pub struct Options {
     /// The amount of threads to use at most when resolving the pack. If `None`, all logical cores are used.
@@ -28,8 +28,8 @@ impl Default for Options {
     }
 }
 
-/// Returned by [write_to_directory][crate::Bundle::write_to_directory()] or
-/// [write_to_directory_eagerly][crate::Bundle::write_to_directory_eagerly()]
+/// Returned by [`write_to_directory`][crate::Bundle::write_to_directory()] or
+/// [`write_to_directory_eagerly`][crate::Bundle::write_to_directory_eagerly()]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outcome {

--- a/gix-pack/src/cache/delta/from_offsets.rs
+++ b/gix-pack/src/cache/delta/from_offsets.rs
@@ -31,7 +31,7 @@ const PACK_HEADER_LEN: usize = 12;
 /// Generate tree from certain input
 impl<T> Tree<T> {
     /// Create a new `Tree` from any data sorted by offset, ascending as returned by the `data_sorted_by_offsets` iterator.
-    /// * `get_pack_offset(item: &T`) -> data::Offset` is a function returning the pack offset of the given item, which can be used
+    /// * `get_pack_offset(item: &T) -> data::Offset` is a function returning the pack offset of the given item, which can be used
     /// for obtaining the objects entry within the pack.
     /// * `pack_path` is the path to the pack file itself and from which to read the entry data, which is a pack file matching the offsets
     /// returned by `get_pack_offset(…)`.

--- a/gix-pack/src/cache/object.rs
+++ b/gix-pack/src/cache/object.rs
@@ -1,4 +1,4 @@
-//! This module is a bit 'misplaced' if spelled out like 'gix_pack::cache::object::*' but is best placed here for code re-use and
+//! This module is a bit 'misplaced' if spelled out like '`gix_pack::cache::object::`*' but is best placed here for code re-use and
 //! general usefulness.
 use crate::cache;
 

--- a/gix-pack/src/data/input/bytes_to_entries.rs
+++ b/gix-pack/src/data/input/bytes_to_entries.rs
@@ -11,7 +11,7 @@ use crate::data::input;
 
 /// An iterator over [`Entries`][input::Entry] in a byte stream.
 ///
-/// The iterator used as part of [Bundle::write_to_directory(…)][crate::Bundle::write_to_directory()].
+/// The iterator used as part of [`Bundle::write_to_directory`(…)][crate::Bundle::write_to_directory()].
 pub struct BytesToEntriesIter<BR> {
     read: BR,
     decompressor: Option<Box<Decompress>>,

--- a/gix-pack/src/data/input/bytes_to_entries.rs
+++ b/gix-pack/src/data/input/bytes_to_entries.rs
@@ -11,7 +11,7 @@ use crate::data::input;
 
 /// An iterator over [`Entries`][input::Entry] in a byte stream.
 ///
-/// The iterator used as part of [`Bundle::write_to_directory`(…)][crate::Bundle::write_to_directory()].
+/// The iterator used as part of [`Bundle::write_to_directory(…)`][crate::Bundle::write_to_directory()].
 pub struct BytesToEntriesIter<BR> {
     read: BR,
     decompressor: Option<Box<Decompress>>,

--- a/gix-pack/src/data/output/bytes.rs
+++ b/gix-pack/src/data/output/bytes.rs
@@ -51,7 +51,7 @@ where
     /// `output` writer, resembling a pack of `version` with exactly `num_entries` amount of objects contained in it.
     /// `object_hash` is the kind of hash to use for the pack checksum and maybe other places, depending on the version.
     ///
-    /// The input chunks are expected to be sorted already. You can use the [InOrderIter][gix_features::parallel::InOrderIter] to assure
+    /// The input chunks are expected to be sorted already. You can use the [`InOrderIter`][gix_features::parallel::InOrderIter] to assure
     /// this happens on the fly holding entire chunks in memory as long as needed for them to be dispensed in order.
     ///
     /// # Panics

--- a/gix-pack/src/data/output/count/mod.rs
+++ b/gix-pack/src/data/output/count/mod.rs
@@ -13,14 +13,14 @@ pub enum PackLocation {
 }
 
 impl PackLocation {
-    /// Directly go through to LookedUp variant, panic otherwise
+    /// Directly go through to `LookedUp` variant, panic otherwise
     pub fn is_none(&self) -> bool {
         match self {
             PackLocation::LookedUp(opt) => opt.is_none(),
             PackLocation::NotLookedUp => unreachable!("must have been resolved"),
         }
     }
-    /// Directly go through to LookedUp variant, panic otherwise
+    /// Directly go through to `LookedUp` variant, panic otherwise
     pub fn as_ref(&self) -> Option<&crate::data::entry::Location> {
         match self {
             PackLocation::LookedUp(opt) => opt.as_ref(),

--- a/gix-pack/src/data/output/count/objects/types.rs
+++ b/gix-pack/src/data/output/count/objects/types.rs
@@ -77,7 +77,7 @@ impl Default for Options {
     }
 }
 
-/// The error returned by the pack generation iterator [bytes::FromEntriesIter][crate::data::output::bytes::FromEntriesIter].
+/// The error returned by the pack generation iterator [`bytes::FromEntriesIter`][crate::data::output::bytes::FromEntriesIter].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error<FindErr, IterErr>

--- a/gix-pack/src/index/access.rs
+++ b/gix-pack/src/index/access.rs
@@ -64,7 +64,7 @@ impl index::File {
     }
 
     /// Returns the object hash at the given index in our list of (sorted) sha1 hashes.
-    /// The index ranges from 0 to self.num_objects()
+    /// The index ranges from 0 to `self.num_objects()`
     ///
     /// # Panics
     ///

--- a/gix-pack/src/multi_index/chunk.rs
+++ b/gix-pack/src/multi_index/chunk.rs
@@ -11,7 +11,7 @@ pub mod index_names {
     pub mod decode {
         use gix_object::bstr::BString;
 
-        /// The error returned by [from_bytes()][super::from_bytes()].
+        /// The error returned by [`from_bytes()`][super::from_bytes()].
         #[derive(Debug, thiserror::Error)]
         #[allow(missing_docs)]
         pub enum Error {

--- a/gix-pack/src/multi_index/write.rs
+++ b/gix-pack/src/multi_index/write.rs
@@ -10,7 +10,7 @@ use gix_features::progress::Progress;
 use crate::multi_index;
 
 mod error {
-    /// The error returned by [multi_index::File::write_from_index_paths()][super::multi_index::File::write_from_index_paths()]..
+    /// The error returned by [`multi_index::File::write_from_index_paths()`][super::multi_index::File::write_from_index_paths()]..
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-packetline/src/read/async_io.rs
+++ b/gix-packetline/src/read/async_io.rs
@@ -37,7 +37,7 @@ where
     }
 
     /// This function is needed to help the borrow checker allow us to return references all the time
-    /// It contains a bunch of logic shared between peek and read_line invocations.
+    /// It contains a bunch of logic shared between peek and `read_line` invocations.
     async fn read_line_inner_exhaustive<'a>(
         reader: &mut T,
         buf: &'a mut Vec<u8>,

--- a/gix-packetline/src/read/blocking_io.rs
+++ b/gix-packetline/src/read/blocking_io.rs
@@ -31,7 +31,7 @@ where
     }
 
     /// This function is needed to help the borrow checker allow us to return references all the time
-    /// It contains a bunch of logic shared between peek and read_line invocations.
+    /// It contains a bunch of logic shared between peek and `read_line` invocations.
     fn read_line_inner_exhaustive<'a>(
         reader: &mut T,
         buf: &'a mut Vec<u8>,

--- a/gix-packetline/src/read/mod.rs
+++ b/gix-packetline/src/read/mod.rs
@@ -95,7 +95,7 @@ impl<T> StreamingPeekableIter<T> {
 
     /// If `value` is `true` the provider will check for special `ERR` packet lines and stop iteration when one is encountered.
     ///
-    /// Use [`stopped_at()]`[StreamingPeekableIter::stopped_at()] to inspect the cause of the end of the iteration.
+    /// Use [`stopped_at()]`[`StreamingPeekableIter::stopped_at()`] to inspect the cause of the end of the iteration.
     /// ne
     pub fn fail_on_err_lines(&mut self, value: bool) {
         self.fail_on_err_lines = value;

--- a/gix-packetline/src/read/sidebands/async_io.rs
+++ b/gix-packetline/src/read/sidebands/async_io.rs
@@ -77,7 +77,7 @@ mod tests {
     use super::*;
     fn receiver<T: Send>(_i: T) {}
 
-    /// We want to declare items containing pointers of StreamingPeekableIter `Send` as well, so it must be `Send` itself.
+    /// We want to declare items containing pointers of `StreamingPeekableIter` `Send` as well, so it must be `Send` itself.
     #[test]
     fn streaming_peekable_iter_is_send() {
         receiver(StreamingPeekableIter::new(Vec::<u8>::new(), &[]));
@@ -118,7 +118,7 @@ where
         }
     }
 
-    /// Forwards to the parent [StreamingPeekableIter::reset_with()]
+    /// Forwards to the parent [`StreamingPeekableIter::reset_with()`]
     pub fn reset_with(&mut self, delimiters: &'static [PacketLineRef<'static>]) {
         if let State::Idle { ref mut parent } = self.state {
             parent
@@ -128,7 +128,7 @@ where
         }
     }
 
-    /// Forwards to the parent [StreamingPeekableIter::stopped_at()]
+    /// Forwards to the parent [`StreamingPeekableIter::stopped_at()`]
     pub fn stopped_at(&self) -> Option<PacketLineRef<'static>> {
         match self.state {
             State::Idle { ref parent } => {
@@ -146,7 +146,7 @@ where
         self.handle_progress = handle_progress;
     }
 
-    /// Effectively forwards to the parent [StreamingPeekableIter::peek_line()], allowing to see what would be returned
+    /// Effectively forwards to the parent [`StreamingPeekableIter::peek_line()`], allowing to see what would be returned
     /// next on a call to [`read_line()`][io::BufRead::read_line()].
     ///
     /// # Warning

--- a/gix-packetline/src/read/sidebands/blocking_io.rs
+++ b/gix-packetline/src/read/sidebands/blocking_io.rs
@@ -67,12 +67,12 @@ where
         }
     }
 
-    /// Forwards to the parent [StreamingPeekableIter::reset_with()]
+    /// Forwards to the parent [`StreamingPeekableIter::reset_with()`]
     pub fn reset_with(&mut self, delimiters: &'static [PacketLineRef<'static>]) {
         self.parent.reset_with(delimiters)
     }
 
-    /// Forwards to the parent [StreamingPeekableIter::stopped_at()]
+    /// Forwards to the parent [`StreamingPeekableIter::stopped_at()`]
     pub fn stopped_at(&self) -> Option<PacketLineRef<'static>> {
         self.parent.stopped_at
     }
@@ -82,7 +82,7 @@ where
         self.handle_progress = handle_progress;
     }
 
-    /// Effectively forwards to the parent [StreamingPeekableIter::peek_line()], allowing to see what would be returned
+    /// Effectively forwards to the parent [`StreamingPeekableIter::peek_line()`], allowing to see what would be returned
     /// next on a call to [`read_line()`][io::BufRead::read_line()].
     ///
     /// # Warning

--- a/gix-prompt/src/lib.rs
+++ b/gix-prompt/src/lib.rs
@@ -49,7 +49,7 @@ pub fn ask(prompt: &str, opts: &Options<'_>) -> Result<String, Error> {
     imp::ask(prompt, opts)
 }
 
-/// Ask for information typed by the user into the terminal after showing the prompt`, like `"Username: `.
+/// Ask for information typed by the user into the terminal after showing the prompt, like `"Username: `.
 ///
 /// Use [`ask()`] for more control.
 pub fn openly(prompt: impl AsRef<str>) -> Result<String, Error> {

--- a/gix-protocol/src/fetch/arguments/mod.rs
+++ b/gix-protocol/src/fetch/arguments/mod.rs
@@ -49,20 +49,20 @@ impl Arguments {
     pub fn can_use_deepen(&self) -> bool {
         self.shallow
     }
-    /// Return true if the 'deepen_since' capability is supported.
+    /// Return true if the '`deepen_since`' capability is supported.
     ///
     /// This is relevant for partial clones when using `--depth X` and retrieving additional history
     /// based on a date beyond which all history should be present.
     pub fn can_use_deepen_since(&self) -> bool {
         self.deepen_since
     }
-    /// Return true if the 'deepen_not' capability is supported.
+    /// Return true if the '`deepen_not`' capability is supported.
     ///
     /// This is relevant for partial clones when using `--depth X`.
     pub fn can_use_deepen_not(&self) -> bool {
         self.deepen_not
     }
-    /// Return true if the 'deepen_relative' capability is supported.
+    /// Return true if the '`deepen_relative`' capability is supported.
     ///
     /// This is relevant for partial clones when using `--depth X`.
     pub fn can_use_deepen_relative(&self) -> bool {

--- a/gix-protocol/src/fetch/delegate.rs
+++ b/gix-protocol/src/fetch/delegate.rs
@@ -40,7 +40,7 @@ pub trait DelegateBlocking {
     /// Note that some arguments are preset based on typical use, and `features` are preset to maximize options.
     /// The `server` capabilities can be used to see which additional capabilities the server supports as per the handshake which happened prior.
     ///
-    /// If the delegate returns [`ls_refs::Action::Skip`], no 'ls-refs` command is sent to the server.
+    /// If the delegate returns [`ls_refs::Action::Skip`], no `ls-refs` command is sent to the server.
     ///
     /// Note that this is called only if we are using protocol version 2.
     fn prepare_ls_refs(
@@ -55,7 +55,7 @@ pub trait DelegateBlocking {
     /// Called before invoking the 'fetch' interaction with `features` pre-filled for typical use
     /// and to maximize capabilities to allow aborting an interaction early.
     ///
-    /// `refs` is a list of known references on the remote based on the handshake or a prior call to ls_refs.
+    /// `refs` is a list of known references on the remote based on the handshake or a prior call to `ls_refs`.
     /// These can be used to abort early in case the refs are already known here.
     ///
     /// As there will be another call allowing to post arguments conveniently in the correct format, i.e. `want hex-oid`,

--- a/gix-protocol/src/ls_refs.rs
+++ b/gix-protocol/src/ls_refs.rs
@@ -1,7 +1,7 @@
 mod error {
     use crate::handshake::refs::parse;
 
-    /// The error returned by [ls_refs()][crate::ls_refs()].
+    /// The error returned by [`ls_refs()`][crate::ls_refs()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -25,7 +25,7 @@ mod error {
 }
 pub use error::Error;
 
-/// What to do after preparing ls-refs in [ls_refs()][crate::ls_refs()].
+/// What to do after preparing ls-refs in [`ls_refs()`][crate::ls_refs()].
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 pub enum Action {
     /// Continue by sending a 'ls-refs' command.

--- a/gix-quote/src/ansi_c.rs
+++ b/gix-quote/src/ansi_c.rs
@@ -2,7 +2,7 @@
 pub mod undo {
     use bstr::{BStr, BString};
 
-    /// The error returned by [ansi_c][crate::ansi_c::undo()].
+    /// The error returned by [`ansi_c`][crate::ansi_c::undo()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-ref/src/lib.rs
+++ b/gix-ref/src/lib.rs
@@ -5,7 +5,7 @@
 //! Refs are the way to keep track of objects and come in two flavors.
 //!
 //! * symbolic refs are pointing to another reference
-//! * peeled refs point to the an object by its [ObjectId][gix_hash::ObjectId]
+//! * peeled refs point to the an object by its [`ObjectId`][gix_hash::ObjectId]
 //!
 //! They can be identified by a relative path and stored in various flavors.
 //!

--- a/gix-ref/src/name.rs
+++ b/gix-ref/src/name.rs
@@ -4,7 +4,7 @@ use gix_object::bstr::{BStr, BString, ByteSlice, ByteVec};
 
 use crate::{Category, FullName, FullNameRef, PartialName, PartialNameRef};
 
-/// The error used in the [`PartialNameRef`][super::PartialNameRef]::try_from(…) implementations.
+/// The error used in the [`PartialNameRef`][super::PartialNameRef]`::try_from`(…) implementations.
 pub type Error = gix_validate::reference::name::Error;
 
 impl<'a> Category<'a> {
@@ -260,7 +260,7 @@ impl convert::TryFrom<BString> for PartialName {
     }
 }
 
-/// Note that this method is disagreeing with gix_validate as it allows dashes '-' for some reason.
+/// Note that this method is disagreeing with `gix_validate` as it allows dashes '-' for some reason.
 /// Since partial names cannot be created with dashes inside we adjusted this as it's probably unintended or git creates pseudo-refs
 /// which wouldn't pass its safety checks.
 pub(crate) fn is_pseudo_ref<'a>(name: impl Into<&'a BStr>) -> bool {

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -88,7 +88,7 @@ pub mod decode {
     mod error {
         use gix_object::bstr::{BString, ByteSlice};
 
-        /// The error returned by [from_bytes(…)][super::Line::from_bytes()]
+        /// The error returned by [`from_bytes`(…)][super::Line::from_bytes()]
         #[derive(Debug)]
         pub struct Error {
             pub input: BString,

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -88,7 +88,7 @@ pub mod decode {
     mod error {
         use gix_object::bstr::{BString, ByteSlice};
 
-        /// The error returned by [`from_bytes`(…)][super::Line::from_bytes()]
+        /// The error returned by [`from_bytes(…)`][super::Line::from_bytes()]
         #[derive(Debug)]
         pub struct Error {
             pub input: BString,

--- a/gix-ref/src/store/file/loose/reflog.rs
+++ b/gix-ref/src/store/file/loose/reflog.rs
@@ -231,7 +231,7 @@ pub mod create_or_update {
 }
 
 mod error {
-    /// The error returned by [crate::file::Store::reflog_iter()].
+    /// The error returned by [`crate::file::Store::reflog_iter()`].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -197,7 +197,7 @@ impl<'s> Platform<'s> {
 
     /// As [`iter(…)`][file::Store::iter()], but filters by `prefix`, i.e. "refs/heads".
     ///
-    /// Please note that "refs/heads` or "refs\\heads" is equivalent to "refs/heads/"
+    /// Please note that "refs/heads" or "refs\\heads" is equivalent to "refs/heads/"
     pub fn prefixed(&self, prefix: impl AsRef<Path>) -> std::io::Result<LooseThenPacked<'_, '_>> {
         self.store
             .iter_prefixed_packed(prefix, self.packed.as_ref().map(|b| &***b))
@@ -349,7 +349,7 @@ impl file::Store {
 
     /// As [`iter(…)`][file::Store::iter()], but filters by `prefix`, i.e. "refs/heads".
     ///
-    /// Please note that "refs/heads` or "refs\\heads" is equivalent to "refs/heads/"
+    /// Please note that "refs/heads" or "refs\\heads" is equivalent to "refs/heads/"
     pub fn iter_prefixed_packed<'s, 'p>(
         &'s self,
         prefix: impl AsRef<Path>,

--- a/gix-ref/src/store/file/raw_ext.rs
+++ b/gix-ref/src/store/file/raw_ext.rs
@@ -17,17 +17,17 @@ pub trait ReferenceExt: Sealed {
     /// A step towards obtaining forward or reverse iterators on reference logs.
     fn log_iter<'a, 's>(&'a self, store: &'s file::Store) -> log::iter::Platform<'a, 's>;
 
-    /// For details, see [Reference::log_exists()].
+    /// For details, see [`Reference::log_exists()`].
     fn log_exists(&self, store: &file::Store) -> bool;
 
-    /// For details, see [Reference::peel_to_id_in_place()].
+    /// For details, see [`Reference::peel_to_id_in_place()`].
     fn peel_to_id_in_place<E: std::error::Error + Send + Sync + 'static>(
         &mut self,
         store: &file::Store,
         find: impl FnMut(gix_hash::ObjectId, &mut Vec<u8>) -> Result<Option<(gix_object::Kind, &[u8])>, E>,
     ) -> Result<ObjectId, peel::to_id::Error>;
 
-    /// For details, see [Reference::peel_to_id_in_place()], with support for a known stable packed buffer.
+    /// For details, see [`Reference::peel_to_id_in_place()`], with support for a known stable packed buffer.
     fn peel_to_id_in_place_packed<E: std::error::Error + Send + Sync + 'static>(
         &mut self,
         store: &file::Store,

--- a/gix-ref/src/store/general/handle/find.rs
+++ b/gix-ref/src/store/general/handle/find.rs
@@ -5,7 +5,7 @@ use crate::{store, PartialNameRef, Reference};
 mod error {
     use std::convert::Infallible;
 
-    /// The error returned by [crate::file::Store::find_loose()].
+    /// The error returned by [`crate::file::Store::find_loose()`].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-ref/src/store/general/init.rs
+++ b/gix-ref/src/store/general/init.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::store::WriteReflog;
 
 mod error {
-    /// The error returned by [crate::Store::at()].
+    /// The error returned by [`crate::Store::at()`].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-refspec/src/spec.rs
+++ b/gix-refspec/src/spec.rs
@@ -7,7 +7,7 @@ use crate::{
     Instruction, RefSpec, RefSpecRef,
 };
 
-/// Conversion. Use the [RefSpecRef][RefSpec::to_ref()] type for more usage options.
+/// Conversion. Use the [`RefSpecRef`][RefSpec::to_ref()] type for more usage options.
 impl RefSpec {
     /// Return ourselves as reference type.
     pub fn to_ref(&self) -> RefSpecRef<'_> {

--- a/gix-tempfile/src/lib.rs
+++ b/gix-tempfile/src/lib.rs
@@ -13,7 +13,7 @@
 //! This also allows to control how `git-tempfiles` integrates with other handlers under application control.
 //!
 //! As a general rule of thumb, use `Default::default()` as argument to emulate the default behaviour and
-//! abort the process after cleaning temporary files. Read more about options in [signal::handler::Mode].
+//! abort the process after cleaning temporary files. Read more about options in [`signal::handler::Mode`].
 //!
 //! # Limitations
 //!

--- a/gix-tempfile/src/signal.rs
+++ b/gix-tempfile/src/signal.rs
@@ -8,7 +8,7 @@ use crate::REGISTRY;
 /// Only has an effect the first time it is called.
 ///
 /// Note that it is possible to not call this function and instead call
-/// [registry::cleanup_tempfiles_signal_safe()][crate::registry::cleanup_tempfiles_signal_safe()]
+/// [`registry::cleanup_tempfiles_signal_safe()`][crate::registry::cleanup_tempfiles_signal_safe()]
 /// from a signal handler under the application's control.
 pub fn setup(mode: handler::Mode) {
     handler::MODE.store(mode as usize, std::sync::atomic::Ordering::SeqCst);

--- a/gix-transport/src/client/async_io/request.rs
+++ b/gix-transport/src/client/async_io/request.rs
@@ -87,7 +87,7 @@ impl<'a> RequestWriter<'a> {
         Ok(self.reader)
     }
 
-    /// Dissolve this instance into its write and read handles without any message-writing side-effect as in [RequestWriter::into_read()].
+    /// Dissolve this instance into its write and read handles without any message-writing side-effect as in [`RequestWriter::into_read()`].
     ///
     /// Furthermore, the writer will not encode everything it writes as packetlines, but write everything verbatim into the
     /// underlying channel.

--- a/gix-transport/src/client/blocking_io/http/traits.rs
+++ b/gix-transport/src/client/blocking_io/http/traits.rs
@@ -35,7 +35,7 @@ impl crate::IsSpuriousError for Error {
     }
 }
 
-/// The return value of [Http::get()].
+/// The return value of [`Http::get()`].
 pub struct GetResponse<H, B> {
     /// The response headers.
     pub headers: H,
@@ -43,7 +43,7 @@ pub struct GetResponse<H, B> {
     pub body: B,
 }
 
-/// The return value of [Http::post()].
+/// The return value of [`Http::post()`].
 pub struct PostResponse<H, B, PB> {
     /// The body to post to the server as part of the request.
     ///

--- a/gix-transport/src/client/blocking_io/request.rs
+++ b/gix-transport/src/client/blocking_io/request.rs
@@ -63,7 +63,7 @@ impl<'a> RequestWriter<'a> {
         Ok(self.reader)
     }
 
-    /// Dissolve this instance into its write and read handles without any message-writing side-effect as in [RequestWriter::into_read()].
+    /// Dissolve this instance into its write and read handles without any message-writing side-effect as in [`RequestWriter::into_read()`].
     ///
     /// Furthermore, the writer will not encode everything it writes as packetlines, but write everything verbatim into the
     /// underlying channel.

--- a/gix-transport/src/client/blocking_io/traits.rs
+++ b/gix-transport/src/client/blocking_io/traits.rs
@@ -31,8 +31,8 @@ pub trait Transport: TransportWithoutIO {
     /// Returns the service capabilities according according to the actual [Protocol] it supports,
     /// and possibly a list of refs to be obtained.
     /// This means that asking for an unsupported protocol might result in a protocol downgrade to the given one
-    /// if [TransportWithoutIO::supported_protocol_versions()] includes it.
-    /// Exhaust the returned [BufReader][SetServiceResponse::refs] for a list of references in case of protocol V1
+    /// if [`TransportWithoutIO::supported_protocol_versions()`] includes it.
+    /// Exhaust the returned [`BufReader`][SetServiceResponse::refs] for a list of references in case of protocol V1
     /// before making another request.
     fn handshake<'a>(
         &mut self,

--- a/gix-transport/src/client/traits.rs
+++ b/gix-transport/src/client/traits.rs
@@ -13,7 +13,7 @@ use crate::{client::Error, Protocol};
 /// This trait represents all transport related functions that don't require any input/output to be done which helps
 /// implementation to share more code across blocking and async programs.
 pub trait TransportWithoutIO {
-    /// If the handshake or subsequent reads failed with [std::io::ErrorKind::PermissionDenied], use this method to
+    /// If the handshake or subsequent reads failed with [`std::io::ErrorKind::PermissionDenied`], use this method to
     /// inform the transport layer about the identity to use for subsequent calls.
     /// If authentication continues to fail even with an identity set, consider communicating this to the provider
     /// of the identity in order to mark it as invalid. Otherwise the user might have difficulty updating obsolete

--- a/gix-traverse/src/commit.rs
+++ b/gix-traverse/src/commit.rs
@@ -144,7 +144,7 @@ pub mod ancestors {
     {
         /// Create a new instance.
         ///
-        /// * `find` - a way to lookup new object data during traversal by their ObjectId, writing their data into buffer and returning
+        /// * `find` - a way to lookup new object data during traversal by their `ObjectId`, writing their data into buffer and returning
         ///    an iterator over commit tokens if the object is present and is a commit. Caching should be implemented within this function
         ///    as needed.
         /// * `state` - all state used for the traversal. If multiple traversals are performed, allocations can be minimized by reusing
@@ -167,7 +167,7 @@ pub mod ancestors {
     {
         /// Create a new instance with commit filtering enabled.
         ///
-        /// * `find` - a way to lookup new object data during traversal by their ObjectId, writing their data into buffer and returning
+        /// * `find` - a way to lookup new object data during traversal by their `ObjectId`, writing their data into buffer and returning
         ///    an iterator over commit tokens if the object is present and is a commit. Caching should be implemented within this function
         ///    as needed.
         /// * `state` - all state used for the traversal. If multiple traversals are performed, allocations can be minimized by reusing

--- a/gix-traverse/src/tree/breadthfirst.rs
+++ b/gix-traverse/src/tree/breadthfirst.rs
@@ -43,7 +43,7 @@ pub(crate) mod impl_ {
     ///   * the tree to iterate in a nested fashion.
     /// * `state` - all state used for the iteration. If multiple iterations are performed, allocations can be minimized by reusing
     ///   this state.
-    /// * `find` - a way to lookup new object data during traversal by their ObjectId, writing their data into buffer and returning
+    /// * `find` - a way to lookup new object data during traversal by their `ObjectId`, writing their data into buffer and returning
     ///    an iterator over entries if the object is present and is a tree. Caching should be implemented within this function
     ///    as needed. The return value is `Option<TreeIter>` which degenerates all error information. Not finding a commit should also
     ///    be considered an errors as all objects in the tree DAG should be present in the database. Hence [`Error::NotFound`] should

--- a/gix-validate/src/reference.rs
+++ b/gix-validate/src/reference.rs
@@ -2,7 +2,7 @@
 pub mod name {
     use std::convert::Infallible;
 
-    /// The error used in [name()][super::name()] and [name_partial()][super::name_partial()]
+    /// The error used in [name()][super::name()] and [`name_partial()`][super::name_partial()]
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix-worktree/src/cache/mod.rs
+++ b/gix-worktree/src/cache/mod.rs
@@ -53,7 +53,7 @@ impl Cache {
     /// `state` defines the capabilities of the cache.
     /// The `case` configures attribute and exclusion case sensitivity at *query time*, which should match the case that
     /// `state` might be configured with.
-    /// `buf` is used when reading files, and `id_mappings` should have been created with [State::id_mappings_from_index()].
+    /// `buf` is used when reading files, and `id_mappings` should have been created with [`State::id_mappings_from_index()`].
     pub fn new(
         worktree_root: impl Into<PathBuf>,
         state: State,

--- a/gix-worktree/src/cache/state/attributes.rs
+++ b/gix-worktree/src/cache/state/attributes.rs
@@ -45,7 +45,7 @@ pub enum Source {
 /// Initialization
 impl Attributes {
     /// Create a new instance from an attribute match group that represents `globals`. It can more easily be created with
-    /// [AttributeMatchGroup::new_globals()].
+    /// [`AttributeMatchGroup::new_globals()`].
     ///
     /// * `globals` contribute first and consist of all globally available, static files.
     /// * `info_attributes` is a path that should refer to `.git/info/attributes`, and it's not an error if the file doesn't exist.

--- a/gix/src/clone/access.rs
+++ b/gix/src/clone/access.rs
@@ -12,7 +12,7 @@ impl PrepareFetch {
     /// _all changes done in `f()` will be persisted_.
     ///
     /// It can also be used to configure additional options, like those for fetching tags. Note that
-    /// [with_fetch_tags()][crate::Remote::with_fetch_tags()] should be called here to configure the clone as desired.
+    /// [`with_fetch_tags()`][crate::Remote::with_fetch_tags()] should be called here to configure the clone as desired.
     /// Otherwise a clone is configured to be complete and fetches all tags, not only those reachable from all branches.
     pub fn configure_remote(
         mut self,

--- a/gix/src/clone/fetch/util.rs
+++ b/gix/src/clone/fetch/util.rs
@@ -185,7 +185,7 @@ pub fn update_head(
 
 /// Setup the remote configuration for `branch` so that it points to itself, but on the remote, if and only if currently
 /// saved refspecs are able to match it.
-/// For that we reload the remote of `remote_name` and use its ref_specs for match.
+/// For that we reload the remote of `remote_name` and use its `ref_specs` for match.
 fn setup_branch_config(
     repo: &mut Repository,
     branch: &FullNameRef,

--- a/gix/src/commit.rs
+++ b/gix/src/commit.rs
@@ -31,7 +31,7 @@ pub mod describe {
 
     use crate::{bstr::BStr, ext::ObjectIdExt, Repository};
 
-    /// The result of [try_resolve()][Platform::try_resolve()].
+    /// The result of [`try_resolve()`][Platform::try_resolve()].
     pub struct Resolution<'repo> {
         /// The outcome of the describe operation.
         pub outcome: gix_revision::describe::Outcome<'static>,
@@ -47,7 +47,7 @@ pub mod describe {
         }
     }
 
-    /// The error returned by [try_format()][Platform::try_format()].
+    /// The error returned by [`try_format()`][Platform::try_format()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -438,7 +438,7 @@ pub mod transport {
 /// Utility type to keep pre-obtained configuration values, only for those required during initial setup
 /// and other basic operations that are common enough to warrant a permanent cache.
 ///
-/// All other values are obtained lazily using OnceCell.
+/// All other values are obtained lazily using `OnceCell`.
 #[derive(Clone)]
 pub(crate) struct Cache {
     pub resolved: crate::Config,

--- a/gix/src/config/overrides.rs
+++ b/gix/src/config/overrides.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use crate::bstr::{BStr, BString, ByteSlice};
 
-/// The error returned by [SnapshotMut::apply_cli_overrides()][crate::config::SnapshotMut::append_config()].
+/// The error returned by [`SnapshotMut::apply_cli_overrides()`][crate::config::SnapshotMut::append_config()].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {

--- a/gix/src/config/snapshot/credential_helpers.rs
+++ b/gix/src/config/snapshot/credential_helpers.rs
@@ -13,7 +13,7 @@ use crate::{
 mod error {
     use crate::bstr::BString;
 
-    /// The error returned by [Snapshot::credential_helpers()][super::Snapshot::credential_helpers()].
+    /// The error returned by [`Snapshot::credential_helpers()`][super::Snapshot::credential_helpers()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix/src/config/tree/keys.rs
+++ b/gix/src/config/tree/keys.rs
@@ -179,10 +179,10 @@ pub type Url = Any<validate::Url>;
 /// A key that represents a UTF-8 string.
 pub type String = Any<validate::String>;
 
-/// A key that represents a RefSpec for pushing.
+/// A key that represents a `RefSpec` for pushing.
 pub type PushRefSpec = Any<validate::PushRefSpec>;
 
-/// A key that represents a RefSpec for fetching.
+/// A key that represents a `RefSpec` for fetching.
 pub type FetchRefSpec = Any<validate::FetchRefSpec>;
 
 mod duration {

--- a/gix/src/config/tree/mod.rs
+++ b/gix/src/config/tree/mod.rs
@@ -102,7 +102,7 @@ pub mod keys;
 pub mod key {
     ///
     pub mod validate {
-        /// The error returned by [Key::validate()][crate::config::tree::Key::validate()].
+        /// The error returned by [`Key::validate()`][crate::config::tree::Key::validate()].
         #[derive(Debug, thiserror::Error)]
         #[error(transparent)]
         #[allow(missing_docs)]
@@ -113,7 +113,7 @@ pub mod key {
     }
     ///
     pub mod validate_assignment {
-        /// The error returned by [Key::validated_assignment*()][crate::config::tree::Key::validated_assignment_fmt()].
+        /// The error returned by [`Key::validated_assignment`*()][crate::config::tree::Key::validated_assignment_fmt()].
         #[derive(Debug, thiserror::Error)]
         #[allow(missing_docs)]
         pub enum Error {

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -36,7 +36,7 @@ impl Core {
         LogAllRefUpdates::new_with_validate("logAllRefUpdates", &config::Tree::CORE, validate::LogAllRefUpdates);
     /// The `core.precomposeUnicode` key.
     ///
-    /// Needs application to use [env::args_os][crate::env::args_os()] to conform all input paths before they are used.
+    /// Needs application to use [`env::args_os`][crate::env::args_os()] to conform all input paths before they are used.
     pub const PRECOMPOSE_UNICODE: keys::Boolean = keys::Boolean::new_boolean("precomposeUnicode", &config::Tree::CORE)
         .with_note("application needs to conform all program input by using gix::env::args_os()");
     /// The `core.repositoryFormatVersion` key.

--- a/gix/src/env.rs
+++ b/gix/src/env.rs
@@ -12,7 +12,7 @@ pub fn agent() -> &'static str {
     concat!("oxide-", env!("CARGO_PKG_VERSION"))
 }
 
-/// Equivalent to `std::env::args_os()`, but with precomposed unicode on MacOS and other apple platforms.
+/// Equivalent to `std::env::args_os()`, but with precomposed unicode on `MacOS` and other apple platforms.
 #[cfg(not(target_vendor = "apple"))]
 pub fn args_os() -> impl Iterator<Item = OsString> {
     std::env::args_os()

--- a/gix/src/head/peel.rs
+++ b/gix/src/head/peel.rs
@@ -6,7 +6,7 @@ use crate::{
 mod error {
     use crate::{object, reference};
 
-    /// The error returned by [Head::peel_to_id_in_place()][super::Head::peel_to_id_in_place()] and [Head::into_fully_peeled_id()][super::Head::into_fully_peeled_id()].
+    /// The error returned by [`Head::peel_to_id_in_place()`][super::Head::peel_to_id_in_place()] and [`Head::into_fully_peeled_id()`][super::Head::into_fully_peeled_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -25,7 +25,7 @@ use crate::head::Kind;
 pub mod to_commit {
     use crate::object;
 
-    /// The error returned by [Head::peel_to_commit_in_place()][super::Head::peel_to_commit_in_place()].
+    /// The error returned by [`Head::peel_to_commit_in_place()`][super::Head::peel_to_commit_in_place()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix/src/id.rs
+++ b/gix/src/id.rs
@@ -81,7 +81,7 @@ impl<'repo> Id<'repo> {
         Id { inner: id.into(), repo }
     }
 
-    /// Turn this instance into its bare [ObjectId].
+    /// Turn this instance into its bare [`ObjectId`].
     pub fn detach(self) -> ObjectId {
         self.inner
     }

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -14,7 +14,7 @@
 //! Most extensions to existing objects provide an `obj_with_extension.attach(&repo).an_easier_version_of_a_method()` for simpler
 //! call signatures.
 //!
-//! ## ThreadSafe Mode
+//! ## `ThreadSafe` Mode
 //!
 //! By default, the [`Repository`] isn't `Sync` and thus can't be used in certain contexts which require the `Sync` trait.
 //!
@@ -37,7 +37,7 @@
 //!
 //! ### Terminology
 //!
-//! #### WorkingTree and WorkTree
+//! #### `WorkingTree` and `WorkTree`
 //!
 //! When reading the documentation of the canonical gix-worktree program one gets the impression work tree and working tree are used
 //! interchangeably. We use the term _work tree_ only and try to do so consistently as its shorter and assumed to be the same.
@@ -139,7 +139,7 @@ pub mod progress;
 ///
 pub mod diff;
 
-/// See [ThreadSafeRepository::discover()], but returns a [`Repository`] instead.
+/// See [`ThreadSafeRepository::discover()`], but returns a [`Repository`] instead.
 ///
 /// # Note
 ///
@@ -154,13 +154,13 @@ pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, di
     ThreadSafeRepository::discover(directory).map(Into::into)
 }
 
-/// See [ThreadSafeRepository::init()], but returns a [`Repository`] instead.
+/// See [`ThreadSafeRepository::init()`], but returns a [`Repository`] instead.
 #[allow(clippy::result_large_err)]
 pub fn init(directory: impl AsRef<std::path::Path>) -> Result<Repository, init::Error> {
     ThreadSafeRepository::init(directory, create::Kind::WithWorktree, create::Options::default()).map(Into::into)
 }
 
-/// See [ThreadSafeRepository::init()], but returns a [`Repository`] instead.
+/// See [`ThreadSafeRepository::init()`], but returns a [`Repository`] instead.
 #[allow(clippy::result_large_err)]
 pub fn init_bare(directory: impl AsRef<std::path::Path>) -> Result<Repository, init::Error> {
     ThreadSafeRepository::init(directory, create::Kind::Bare, create::Options::default()).map(Into::into)
@@ -169,7 +169,7 @@ pub fn init_bare(directory: impl AsRef<std::path::Path>) -> Result<Repository, i
 /// Create a platform for configuring a bare clone from `url` to the local `path`, using default options for opening it (but
 /// amended with using configuration from the git installation to ensure all authentication options are honored).
 ///
-/// See [`clone::PrepareFetch::new()] for a function to take full control over all options.
+/// See [`clone::PrepareFetch::new()`] for a function to take full control over all options.
 #[allow(clippy::result_large_err)]
 pub fn prepare_clone_bare<Url, E>(
     url: Url,
@@ -191,7 +191,7 @@ where
 /// Create a platform for configuring a clone with main working tree from `url` to the local `path`, using default options for opening it
 /// (but amended with using configuration from the git installation to ensure all authentication options are honored).
 ///
-/// See [`clone::PrepareFetch::new()] for a function to take full control over all options.
+/// See [`clone::PrepareFetch::new()`] for a function to take full control over all options.
 #[allow(clippy::result_large_err)]
 pub fn prepare_clone<Url, E>(url: Url, path: impl AsRef<std::path::Path>) -> Result<clone::PrepareFetch, clone::Error>
 where
@@ -214,13 +214,13 @@ fn open_opts_with_git_binary_config() -> open::Options {
     opts
 }
 
-/// See [ThreadSafeRepository::open()], but returns a [`Repository`] instead.
+/// See [`ThreadSafeRepository::open()`], but returns a [`Repository`] instead.
 #[allow(clippy::result_large_err)]
 pub fn open(directory: impl Into<std::path::PathBuf>) -> Result<Repository, open::Error> {
     ThreadSafeRepository::open(directory).map(Into::into)
 }
 
-/// See [ThreadSafeRepository::open_opts()], but returns a [`Repository`] instead.
+/// See [`ThreadSafeRepository::open_opts()`], but returns a [`Repository`] instead.
 #[allow(clippy::result_large_err)]
 pub fn open_opts(directory: impl Into<std::path::PathBuf>, options: open::Options) -> Result<Repository, open::Error> {
     ThreadSafeRepository::open_opts(directory, options).map(Into::into)

--- a/gix/src/object/tree/diff/rewrites.rs
+++ b/gix/src/object/tree/diff/rewrites.rs
@@ -49,7 +49,7 @@ pub struct Outcome {
     pub num_similarity_checks_skipped_for_copy_tracking_due_to_limit: usize,
 }
 
-/// The error returned by [`Rewrites::try_from_config()].
+/// The error returned by [`Rewrites::try_from_config()`].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {

--- a/gix/src/object/tree/diff/tracked.rs
+++ b/gix/src/object/tree/diff/tracked.rs
@@ -311,7 +311,7 @@ fn needs_exact_match(percentage: Option<f32>) -> bool {
     percentage.map_or(true, |p| p >= 1.0)
 }
 
-/// <src_idx, src, possibly diff stat>
+/// <`src_idx`, src, possibly diff stat>
 type SourceTuple<'a> = (usize, &'a Item, Option<DiffLineStats>);
 
 /// Find `item` in our set of items ignoring `item_idx` to avoid finding ourselves, by similarity indicated by `percentage`.

--- a/gix/src/reference/edits.rs
+++ b/gix/src/reference/edits.rs
@@ -25,7 +25,7 @@ pub mod set_target_id {
         /// Note that the operation will fail on symbolic references, to change their type use the lower level reference database,
         /// or if the reference was deleted or changed in the mean time.
         /// Furthermore, refrain from using this method for more than a one-off change as it creates a transaction for each invocation.
-        /// If multiple reference should be changed, use [Repository::edit_references()][crate::Repository::edit_references()]
+        /// If multiple reference should be changed, use [`Repository::edit_references()`][crate::Repository::edit_references()]
         /// or the lower level reference database instead.
         #[allow(clippy::result_large_err)]
         pub fn set_target_id(

--- a/gix/src/reference/errors.rs
+++ b/gix/src/reference/errors.rs
@@ -2,7 +2,7 @@
 pub mod edit {
     use crate::config;
 
-    /// The error returned by [`edit_references`(…)][crate::Repository::edit_references()], and others
+    /// The error returned by [`edit_references(…)`][crate::Repository::edit_references()], and others
     /// which ultimately create a reference.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
@@ -22,8 +22,8 @@ pub mod edit {
 
 ///
 pub mod peel {
-    /// The error returned by [`Reference::peel_to_id_in_place`(…)][crate::Reference::peel_to_id_in_place()] and
-    /// [`Reference::into_fully_peeled_id`(…)][crate::Reference::into_fully_peeled_id()].
+    /// The error returned by [`Reference::peel_to_id_in_place(…)`][crate::Reference::peel_to_id_in_place()] and
+    /// [`Reference::into_fully_peeled_id(…)`][crate::Reference::into_fully_peeled_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -36,7 +36,7 @@ pub mod peel {
 
 ///
 pub mod head_id {
-    /// The error returned by [`Repository::head_id`(…)][crate::Repository::head_id()].
+    /// The error returned by [`Repository::head_id(…)`][crate::Repository::head_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -66,7 +66,7 @@ pub mod head_commit {
 pub mod find {
     ///
     pub mod existing {
-        /// The error returned by [`find_reference`(…)][crate::Repository::find_reference()], and others.
+        /// The error returned by [`find_reference(…)`][crate::Repository::find_reference()], and others.
         #[derive(Debug, thiserror::Error)]
         #[allow(missing_docs)]
         pub enum Error {
@@ -77,7 +77,7 @@ pub mod find {
         }
     }
 
-    /// The error returned by [`try_find_reference`(…)][crate::Repository::try_find_reference()].
+    /// The error returned by [`try_find_reference(…)`][crate::Repository::try_find_reference()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix/src/reference/errors.rs
+++ b/gix/src/reference/errors.rs
@@ -2,7 +2,7 @@
 pub mod edit {
     use crate::config;
 
-    /// The error returned by [edit_references(…)][crate::Repository::edit_references()], and others
+    /// The error returned by [`edit_references`(…)][crate::Repository::edit_references()], and others
     /// which ultimately create a reference.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
@@ -22,8 +22,8 @@ pub mod edit {
 
 ///
 pub mod peel {
-    /// The error returned by [Reference::peel_to_id_in_place(…)][crate::Reference::peel_to_id_in_place()] and
-    /// [Reference::into_fully_peeled_id(…)][crate::Reference::into_fully_peeled_id()].
+    /// The error returned by [`Reference::peel_to_id_in_place`(…)][crate::Reference::peel_to_id_in_place()] and
+    /// [`Reference::into_fully_peeled_id`(…)][crate::Reference::into_fully_peeled_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -36,7 +36,7 @@ pub mod peel {
 
 ///
 pub mod head_id {
-    /// The error returned by [Repository::head_id(…)][crate::Repository::head_id()].
+    /// The error returned by [`Repository::head_id`(…)][crate::Repository::head_id()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -51,7 +51,7 @@ pub mod head_id {
 
 ///
 pub mod head_commit {
-    /// The error returned by [Repository::head_commit(…)][crate::Repository::head_commit()].
+    /// The error returned by [`Repository::head_commit`(…)][crate::Repository::head_commit()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
@@ -66,7 +66,7 @@ pub mod head_commit {
 pub mod find {
     ///
     pub mod existing {
-        /// The error returned by [find_reference(…)][crate::Repository::find_reference()], and others.
+        /// The error returned by [`find_reference`(…)][crate::Repository::find_reference()], and others.
         #[derive(Debug, thiserror::Error)]
         #[allow(missing_docs)]
         pub enum Error {
@@ -77,7 +77,7 @@ pub mod find {
         }
     }
 
-    /// The error returned by [try_find_reference(…)][crate::Repository::try_find_reference()].
+    /// The error returned by [`try_find_reference`(…)][crate::Repository::try_find_reference()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {

--- a/gix/src/reference/remote.rs
+++ b/gix/src/reference/remote.rs
@@ -4,7 +4,7 @@ use crate::{config, config::tree::Branch, remote, Reference};
 impl<'repo> Reference<'repo> {
     /// Find the unvalidated name of our remote for `direction` as configured in `branch.<name>.remote|pushRemote` respectively.
     /// If `Some(<name>)` it can be used in [`Repository::find_remote(…)`][crate::Repository::find_remote()], or if `None` then
-    /// [Repository::remote_default_name()][crate::Repository::remote_default_name()] could be used in its place.
+    /// [`Repository::remote_default_name()`][crate::Repository::remote_default_name()] could be used in its place.
     ///
     /// Return `None` if no remote is configured.
     ///

--- a/gix/src/remote/connection/access.rs
+++ b/gix/src/remote/connection/access.rs
@@ -13,7 +13,7 @@ impl<'a, 'repo, T> Connection<'a, 'repo, T> {
     ///
     /// A custom function may also be used to prevent accessing resources with authentication.
     ///
-    /// Use the [configured_credentials()][Connection::configured_credentials()] method to obtain the implementation
+    /// Use the [`configured_credentials()`][Connection::configured_credentials()] method to obtain the implementation
     /// that would otherwise be used, which can be useful to proxy the default configuration and obtain information about the
     /// URLs to authenticate with.
     pub fn with_credentials(

--- a/gix/src/remote/connection/fetch/mod.rs
+++ b/gix/src/remote/connection/fetch/mod.rs
@@ -157,7 +157,7 @@ impl<'remote, 'repo, T> Prepare<'remote, 'repo, T>
 where
     T: Transport,
 {
-    /// Return the ref_map (that includes the server handshake) which was part of listing refs prior to fetching a pack.
+    /// Return the `ref_map` (that includes the server handshake) which was part of listing refs prior to fetching a pack.
     pub fn ref_map(&self) -> &RefMap {
         &self.ref_map
     }

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -155,7 +155,7 @@ mod branch {
         /// In some cases, the returned name will be an URL.
         /// Returns `None` if the remote was not found or if the name contained illformed UTF-8.
         ///
-        /// See also [Reference::remote_name()][crate::Reference::remote_name()] for a more typesafe version
+        /// See also [`Reference::remote_name()`][crate::Reference::remote_name()] for a more typesafe version
         /// to be used when a `Reference` is available.
         pub fn branch_remote_name<'a>(
             &self,

--- a/gix/src/repository/remote.rs
+++ b/gix/src/repository/remote.rs
@@ -42,7 +42,7 @@ impl crate::Repository {
 
     /// Find the default remote as configured, or `None` if no such configuration could be found.
     ///
-    /// See [remote_default_name()][Self::remote_default_name()] for more information on the `direction` parameter.
+    /// See [`remote_default_name()`][Self::remote_default_name()] for more information on the `direction` parameter.
     pub fn find_default_remote(
         &self,
         direction: remote::Direction,
@@ -65,7 +65,7 @@ impl crate::Repository {
         self.try_find_remote_inner(name_or_url, true)
     }
 
-    /// Similar to [try_find_remote()][Self::try_find_remote()], but removes a failure mode if rewritten URLs turn out to be invalid
+    /// Similar to [`try_find_remote()`][Self::try_find_remote()], but removes a failure mode if rewritten URLs turn out to be invalid
     /// as it skips rewriting them.
     /// Use this in conjunction with [`Remote::rewrite_urls()`] to non-destructively apply the rules and keep the failed urls unchanged.
     pub fn try_find_remote_without_url_rewrite<'a>(

--- a/gix/src/types.rs
+++ b/gix/src/types.rs
@@ -21,7 +21,7 @@ pub struct Head<'repo> {
     pub(crate) repo: &'repo Repository,
 }
 
-/// An [ObjectId] with access to a repository.
+/// An [`ObjectId`] with access to a repository.
 #[derive(Clone, Copy)]
 pub struct Id<'r> {
     /// The actual object id

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -83,7 +83,7 @@ static EXCLUDE_LUT: Lazy<Mutex<Option<gix_worktree::Cache>>> = Lazy::new(|| {
 /// The major, minor and patch level of the git version on the system.
 pub static GIT_VERSION: Lazy<(u8, u8, u8)> = Lazy::new(|| parse_gix_version().expect("git version to be parsable"));
 
-/// Define how [scripted_fixture_writable_with_args()] uses produces the writable copy.
+/// Define how [`scripted_fixture_writable_with_args()`] uses produces the writable copy.
 pub enum Creation {
     /// Run the script once and copy the data from its output to the writable location.
     /// This is fast but won't work if absolute paths are produced by the script.


### PR DESCRIPTION
Applied this lint:

```
just 'clippy-flags=-W clippy::doc-markdown' clippy-fix
```

I also had to search/replace:

```
[`to_decimal`()]  ->  [`to_decimal()`]
```

I have never seen parenthesis used as part of the link, so this is perhaps why clippy handles it like that.

There are still a few warnings being produced, but they have to do with how some of the links are constructed, e.g. this link

```
[File::index_names().len()][File::index_names()]
```

shows a warning

> you should put bare URLs between `<`/`>` or make a proper Markdown link

Not certain how these should be fixed, but there are 10-20 of such warnings.  What are you linking to here?

