### PR TITLE
fix negotiation

### DIFF
--- a/gix-protocol/src/fetch/response/async_io.rs
+++ b/gix-protocol/src/fetch/response/async_io.rs
@@ -47,6 +47,7 @@ impl Response {
                 let mut line = String::new();
                 let mut acks = Vec::<Acknowledgement>::new();
                 let mut shallows = Vec::<ShallowUpdate>::new();
+                let mut saw_ready = false;
                 let has_pack = 'lines: loop {
                     line.clear();
                     let peeked_line = match reader.peek_data_line().await {
@@ -81,14 +82,16 @@ impl Response {
                     if Response::parse_v1_ack_or_shallow_or_assume_pack(&mut acks, &mut shallows, &peeked_line) {
                         break 'lines true;
                     }
-                    if let Some(Acknowledgement::Nak) = acks.last().filter(|_| !client_expects_pack) {
-                        break 'lines false;
-                    }
                     assert_ne!(
                         reader.readline_str(&mut line).await?,
                         0,
                         "consuming a peeked line works"
                     );
+                    // When the server sends ready, we know there is going to be a pack so no need to stop early.
+                    saw_ready |= matches!(acks.last(), Some(Acknowledgement::Ready));
+                    if let Some(Acknowledgement::Nak) = acks.last().filter(|_| !client_expects_pack && !saw_ready) {
+                        break 'lines false;
+                    }
                 };
                 Ok(Response {
                     acks,


### PR DESCRIPTION
Seeing READY means a pack will follow, which is exactly the kind of knowledge we want.
Thus we now either listen to the client OR to what the server says.

This remedy relies on multi-ack-detailed though, so let's hope nobody with a very old server
comes along.
