### PR TITLE
improve tests related to the handling of shallow repos

### DIFF
--- a/gix/tests/fixtures/generated-archives/make_repo_with_fork_and_dates.tar.xz
+++ b/gix/tests/fixtures/generated-archives/make_repo_with_fork_and_dates.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2898513038dbd39a50856789cea432ddc48e8bf545e33dc5af394f7834cdb857
-size 10520
+oid sha256:1edbe089c9931dc56e9089683324a73b03fb51d10b3405f2d61487ddb22f4da8
+size 10588

--- a/gix/tests/fixtures/generated-archives/make_shallow_repo.tar.xz
+++ b/gix/tests/fixtures/generated-archives/make_shallow_repo.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c56c269562ef67b1f8bd46640e6ad9d196cbc9c7c609300ffd6a8da3bc501852
-size 12632
+oid sha256:89bc9094b1e483b928fd734b4d39a3e4f25e9c6ed35aa4d900a4198d209948dc
+size 12636

--- a/gix/tests/fixtures/make_repo_with_fork_and_dates.sh
+++ b/gix/tests/fixtures/make_repo_with_fork_and_dates.sh
@@ -16,8 +16,9 @@ GIT_COMMITTER_DATE="2001-01-02 00:00:00 +0000" git commit -q --allow-empty -m b1
 git checkout -q main
 GIT_COMMITTER_DATE="2000-01-02 00:00:00 +0000" git commit -q --allow-empty -m c2 #9902e3c3e8f0c569b4ab295ddf473e6de763e1e7-
 
-# Commit from branch1 made in 2001 merged in 2002
-GIT_COMMITTER_DATE="2002-01-02 00:00:00 +0000" git merge branch1 -m m1b1 #288e509293165cb5630d08f4185bdf2445bf6170-
 
 git commit-graph write --no-progress --reachable
 git repack -adq
+
+# Commit from branch1 made in 2001 merged in 2002
+GIT_COMMITTER_DATE="2002-01-02 00:00:00 +0000" git merge branch1 -m m1b1 #288e509293165cb5630d08f4185bdf2445bf6170-

--- a/gix/tests/fixtures/make_shallow_repo.sh
+++ b/gix/tests/fixtures/make_shallow_repo.sh
@@ -25,4 +25,7 @@ mkdir empty
 )
 
 git clone --depth 1 --bare file://$PWD/base shallow.git
+git -C  shallow.git commit-graph write --no-progress --reachable
+
 git clone --depth 1 file://$PWD/base shallow
+git -C  shallow commit-graph write --no-progress --reachable

--- a/gix/tests/repository/shallow.rs
+++ b/gix/tests/repository/shallow.rs
@@ -52,15 +52,18 @@ mod traverse {
     #[test]
     #[parallel]
     fn boundary_is_detected_triggering_no_error() -> crate::Result {
-        for name in ["shallow.git", "shallow"] {
-            let repo = named_subrepo_opts("make_shallow_repo.sh", name, crate::restricted())?;
-            let commits: Vec<_> = repo
-                .head_id()?
-                .ancestors()
-                .all()?
-                .map(|c| c.map(|c| c.id))
-                .collect::<Result<_, _>>()?;
-            assert_eq!(commits, [hex_to_id("30887839de28edf7ab66c860e5c58b4d445f6b12")]);
+        for toggle in [false, true] {
+            for name in ["shallow.git", "shallow"] {
+                let repo = named_subrepo_opts("make_shallow_repo.sh", name, crate::restricted())?;
+                let commits: Vec<_> = repo
+                    .head_id()?
+                    .ancestors()
+                    .use_commit_graph(toggle)
+                    .all()?
+                    .map(|c| c.map(|c| c.id))
+                    .collect::<Result<_, _>>()?;
+                assert_eq!(commits, [hex_to_id("30887839de28edf7ab66c860e5c58b4d445f6b12")]);
+            }
         }
         Ok(())
     }
@@ -73,45 +76,48 @@ mod traverse {
             "make_complex_shallow_repo.sh",
             Some(base.to_string_lossy()),
         )?;
-        for name in ["shallow.git", "shallow"] {
-            let repo = gix::open_opts(shallow_base.join(name), crate::restricted())?;
-            assert_eq!(
-                repo.shallow_commits()?.expect("present").as_slice(),
-                [
-                    hex_to_id("27e71576a6335294aa6073ab767f8b36bdba81d0"),
-                    hex_to_id("82024b2ef7858273337471cbd1ca1cedbdfd5616"),
-                    hex_to_id("b5152869aedeb21e55696bb81de71ea1bb880c85"),
-                ]
-            );
-            let commits: Vec<_> = repo
-                .head_id()?
-                .ancestors()
-                .sorting(Sorting::ByCommitTimeNewestFirst)
-                .all()?
-                .map(|c| c.map(|c| c.id))
-                .collect::<Result<_, _>>()?;
-            assert_eq!(
-                commits,
-                [
-                    "f99771fe6a1b535783af3163eba95a927aae21d5",
-                    "2d9d136fb0765f2e24c44a0f91984318d580d03b",
-                    "dfd0954dabef3b64f458321ef15571cc1a46d552",
-                    "b5152869aedeb21e55696bb81de71ea1bb880c85",
-                    "27e71576a6335294aa6073ab767f8b36bdba81d0",
-                    "82024b2ef7858273337471cbd1ca1cedbdfd5616",
-                ]
-                .into_iter()
-                .map(hex_to_id)
-                .collect::<Vec<_>>()
-            );
+        for toggle in [false, true] {
+            for name in ["shallow.git", "shallow"] {
+                let repo = gix::open_opts(shallow_base.join(name), crate::restricted())?;
+                assert_eq!(
+                    repo.shallow_commits()?.expect("present").as_slice(),
+                    [
+                        hex_to_id("27e71576a6335294aa6073ab767f8b36bdba81d0"),
+                        hex_to_id("82024b2ef7858273337471cbd1ca1cedbdfd5616"),
+                        hex_to_id("b5152869aedeb21e55696bb81de71ea1bb880c85"),
+                    ]
+                );
+                let commits: Vec<_> = repo
+                    .head_id()?
+                    .ancestors()
+                    .use_commit_graph(toggle)
+                    .sorting(Sorting::ByCommitTimeNewestFirst)
+                    .all()?
+                    .map(|c| c.map(|c| c.id))
+                    .collect::<Result<_, _>>()?;
+                assert_eq!(
+                    commits,
+                    [
+                        "f99771fe6a1b535783af3163eba95a927aae21d5",
+                        "2d9d136fb0765f2e24c44a0f91984318d580d03b",
+                        "dfd0954dabef3b64f458321ef15571cc1a46d552",
+                        "b5152869aedeb21e55696bb81de71ea1bb880c85",
+                        "27e71576a6335294aa6073ab767f8b36bdba81d0",
+                        "82024b2ef7858273337471cbd1ca1cedbdfd5616",
+                    ]
+                    .into_iter()
+                    .map(hex_to_id)
+                    .collect::<Vec<_>>()
+                );
 
-            // should be
-            // *   f99771f - (HEAD -> main, origin/main, origin/HEAD) A (18 years ago) <A U Thor>
-            // | * 2d9d136 - C (18 years ago) <A U Thor>
-            // *-. | dfd0954 - (tag: b-tag) B (18 years ago) <A U Thor>
-            // | | * 27e7157 - (grafted) F (18 years ago) <A U Thor>
-            //     | * b515286 - (grafted) E (18 years ago) <A U Thor>
-            //     * 82024b2 - (grafted) D (18 years ago) <A U Thor>
+                // should be
+                // *   f99771f - (HEAD -> main, origin/main, origin/HEAD) A (18 years ago) <A U Thor>
+                // | * 2d9d136 - C (18 years ago) <A U Thor>
+                // *-. | dfd0954 - (tag: b-tag) B (18 years ago) <A U Thor>
+                // | | * 27e7157 - (grafted) F (18 years ago) <A U Thor>
+                //     | * b515286 - (grafted) E (18 years ago) <A U Thor>
+                //     * 82024b2 - (grafted) D (18 years ago) <A U Thor>
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
When commit-graphs are used, it's easily possible for it to point to commits that don't exist anymore
as the repo has been shallowed after generating it. Also we should be sure that we can deal with mixed
commit-graph present/not-present situations.
