### PR TITLE
visualize commit-graphs as SVG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,7 +1876,7 @@ dependencies = [
  "gix-object 0.30.0",
  "gix-odb",
  "gix-ref 0.30.0",
- "gix-revision",
+ "gix-revwalk",
  "gix-testtools",
  "smallvec",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,8 @@ dependencies = [
  "gix-url",
  "itertools",
  "jwalk",
+ "layout-rs",
+ "open",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2790,6 +2792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2810,16 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2868,6 +2889,12 @@ checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "layout-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1164ef87cb9607c2d887216eca79f0fc92895affe1789bba805dd38d829584e0"
 
 [[package]]
 name = "lazy_static"
@@ -3164,6 +3191,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "open"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16814a067484415fda653868c9be0ac5f2abd2ef5d951082a5f2fe1b3662944"
+dependencies = [
+ "is-wsl",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,6 +3314,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ sha1_smol = { opt-level = 3 }
 
 [profile.release]
 overflow-checks = false
-lto = "fat"
+#lto = "fat"
 # this bloats files but assures destructors are called, important for tempfiles. One day I hope we
 # can wire up the 'abrt' signal handler so tempfiles will be removed in case of panics.
 panic = 'unwind'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 
 [[bin]]
 name = "ein"
+doc = false
 path = "src/ein.rs"
 test = false
 doctest = false
@@ -19,6 +20,7 @@ doctest = false
 [[bin]]
 name = "gix"
 path = "src/gix.rs"
+doc = false
 test = false
 doctest = false
 

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -69,6 +69,10 @@ smallvec = { version = "1.10.0", optional = true }
 # for 'query'
 rusqlite = { version = "0.29.0", optional = true, features = ["bundled"] }
 
+# for svg graph output
+layout-rs = "0.1.1"
+open = "4.1.0"
+
 document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/gitoxide-core/src/repository/clone.rs
+++ b/gitoxide-core/src/repository/clone.rs
@@ -88,14 +88,12 @@ pub(crate) mod function {
         }
 
         match fetch_outcome.status {
-            Status::NoPackReceived { .. } => {
+            Status::NoPackReceived { dry_run, .. } => {
+                assert!(!dry_run, "dry-run unsupported");
                 writeln!(err, "The cloned repository appears to be empty")?;
             }
-            Status::DryRun { .. } => unreachable!("dry-run unsupported"),
             Status::Change {
-                update_refs,
-                negotiation_rounds,
-                ..
+                update_refs, negotiate, ..
             } => {
                 let remote = repo
                     .find_default_remote(gix::remote::Direction::Fetch)
@@ -103,7 +101,7 @@ pub(crate) mod function {
                 let ref_specs = remote.refspecs(gix::remote::Direction::Fetch);
                 print_updates(
                     &repo,
-                    negotiation_rounds,
+                    negotiate,
                     update_refs,
                     ref_specs,
                     fetch_outcome.ref_map,

--- a/gitoxide-core/src/repository/clone.rs
+++ b/gitoxide-core/src/repository/clone.rs
@@ -101,7 +101,7 @@ pub(crate) mod function {
                 let ref_specs = remote.refspecs(gix::remote::Direction::Fetch);
                 print_updates(
                     &repo,
-                    negotiate,
+                    &negotiate,
                     update_refs,
                     ref_specs,
                     fetch_outcome.ref_map,

--- a/gitoxide-core/src/repository/revision/list.rs
+++ b/gitoxide-core/src/repository/revision/list.rs
@@ -1,42 +1,140 @@
-use std::ffi::OsString;
-
-use anyhow::{bail, Context};
-use gix::traverse::commit::Sorting;
-
 use crate::OutputFormat;
+use std::ffi::OsString;
+use std::path::PathBuf;
 
-pub fn list(
-    mut repo: gix::Repository,
-    spec: OsString,
-    mut out: impl std::io::Write,
-    format: OutputFormat,
-) -> anyhow::Result<()> {
-    if format != OutputFormat::Human {
-        bail!("Only human output is currently supported");
-    }
-    repo.object_cache_size_if_unset(4 * 1024 * 1024);
+pub struct Context {
+    pub limit: Option<usize>,
+    pub spec: OsString,
+    pub format: OutputFormat,
+    pub text: Format,
+}
 
-    let spec = gix::path::os_str_into_bstr(&spec)?;
-    let id = repo
-        .rev_parse_single(spec)
-        .context("Only single revisions are currently supported")?;
-    let commits = id
-        .object()?
-        .peel_to_kind(gix::object::Kind::Commit)
-        .context("Need commitish as starting point")?
-        .id()
-        .ancestors()
-        .sorting(Sorting::ByCommitTimeNewestFirst)
-        .all()?;
-    for commit in commits {
-        let commit = commit?;
-        writeln!(
-            out,
-            "{} {} {}",
-            commit.id().shorten_or_id(),
-            commit.commit_time.expect("traversal with date"),
-            commit.parent_ids.len()
-        )?;
+pub enum Format {
+    Text,
+    Svg { path: PathBuf },
+}
+pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 0..=2;
+
+pub(crate) mod function {
+    use anyhow::{bail, Context};
+    use gix::traverse::commit::Sorting;
+    use std::collections::HashMap;
+
+    use gix::Progress;
+    use layout::backends::svg::SVGWriter;
+    use layout::core::base::Orientation;
+    use layout::core::geometry::Point;
+    use layout::core::style::StyleAttr;
+    use layout::std_shapes::shapes::{Arrow, Element, ShapeKind};
+
+    use crate::repository::revision::list::Format;
+    use crate::OutputFormat;
+
+    pub fn list(
+        mut repo: gix::Repository,
+        mut progress: impl Progress,
+        mut out: impl std::io::Write,
+        super::Context {
+            spec,
+            format,
+            text,
+            limit,
+        }: super::Context,
+    ) -> anyhow::Result<()> {
+        if format != OutputFormat::Human {
+            bail!("Only human output is currently supported");
+        }
+        repo.object_cache_size_if_unset(4 * 1024 * 1024);
+
+        let spec = gix::path::os_str_into_bstr(&spec)?;
+        let id = repo
+            .rev_parse_single(spec)
+            .context("Only single revisions are currently supported")?;
+        let commits = id
+            .object()?
+            .peel_to_kind(gix::object::Kind::Commit)
+            .context("Need commitish as starting point")?
+            .id()
+            .ancestors()
+            .sorting(Sorting::ByCommitTimeNewestFirst)
+            .all()?;
+
+        let mut vg = match text {
+            Format::Svg { path } => (
+                layout::topo::layout::VisualGraph::new(Orientation::TopToBottom),
+                path,
+                HashMap::new(),
+            )
+                .into(),
+            Format::Text => None,
+        };
+        progress.init(None, gix::progress::count("commits"));
+        progress.set_name("traverse");
+
+        let start = std::time::Instant::now();
+        for commit in commits {
+            if gix::interrupt::is_triggered() {
+                bail!("interrupted by user");
+            }
+            let commit = commit?;
+            match vg.as_mut() {
+                Some((vg, _path, map)) => {
+                    let pt = Point::new(100., 30.);
+                    let source = match map.get(&commit.id) {
+                        Some(handle) => *handle,
+                        None => {
+                            let name = commit.id().shorten_or_id().to_string();
+                            let shape = ShapeKind::new_box(name.as_str());
+                            let style = StyleAttr::simple();
+                            let handle = vg.add_node(Element::create(shape, style, Orientation::LeftToRight, pt));
+                            map.insert(commit.id, handle);
+                            handle
+                        }
+                    };
+
+                    for parent_id in commit.parent_ids() {
+                        let dest = match map.get(parent_id.as_ref()) {
+                            Some(handle) => *handle,
+                            None => {
+                                let name = parent_id.shorten_or_id().to_string();
+                                let shape = ShapeKind::new_box(name.as_str());
+                                let style = StyleAttr::simple();
+                                let dest = vg.add_node(Element::create(shape, style, Orientation::LeftToRight, pt));
+                                map.insert(parent_id.detach(), dest);
+                                dest
+                            }
+                        };
+                        let arrow = Arrow::simple("");
+                        vg.add_edge(arrow, source, dest);
+                    }
+                }
+                None => {
+                    writeln!(
+                        out,
+                        "{} {} {}",
+                        commit.id().shorten_or_id(),
+                        commit.commit_time.expect("traversal with date"),
+                        commit.parent_ids.len()
+                    )?;
+                }
+            }
+            progress.inc();
+            if limit.map_or(false, |limit| limit == progress.step()) {
+                break;
+            }
+        }
+
+        progress.show_throughput(start);
+        if let Some((mut vg, path, _)) = vg {
+            let start = std::time::Instant::now();
+            progress.set_name("computing graph");
+            progress.info(format!("writing {path:?}…"));
+            let mut svg = SVGWriter::new();
+            vg.do_it(false, false, false, &mut svg);
+            std::fs::write(&path, svg.finalize().as_bytes())?;
+            open::that(path)?;
+            progress.show_throughput(start);
+        }
+        Ok(())
     }
-    Ok(())
 }

--- a/gitoxide-core/src/repository/revision/mod.rs
+++ b/gitoxide-core/src/repository/revision/mod.rs
@@ -1,5 +1,5 @@
-mod list;
-pub use list::list;
+pub mod list;
+pub use list::function::list;
 mod explain;
 pub use explain::explain;
 

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -17,7 +17,7 @@ gix-hash = { version = "^0.11.2", path = "../gix-hash" }
 gix-object = { version = "^0.30.0", path = "../gix-object" }
 gix-date = { version = "^0.5.1", path = "../gix-date" }
 gix-commitgraph = { version = "^0.16.0", path = "../gix-commitgraph" }
-gix-revision = { version = "^0.15.2", path = "../gix-revision" }
+gix-revwalk = { version = "^0.1.0", path = "../gix-revwalk" }
 thiserror = "1.0.40"
 smallvec = "1.10.0"
 bitflags = "2"

--- a/gix-negotiate/src/consecutive.rs
+++ b/gix-negotiate/src/consecutive.rs
@@ -4,14 +4,14 @@ use gix_hash::ObjectId;
 use crate::{Error, Flags, Negotiator};
 
 pub(crate) struct Algorithm {
-    revs: gix_revision::PriorityQueue<SecondsSinceUnixEpoch, ObjectId>,
+    revs: gix_revwalk::PriorityQueue<SecondsSinceUnixEpoch, ObjectId>,
     non_common_revs: usize,
 }
 
 impl Default for Algorithm {
     fn default() -> Self {
         Self {
-            revs: gix_revision::PriorityQueue::new(),
+            revs: gix_revwalk::PriorityQueue::new(),
             non_common_revs: 0,
         }
     }
@@ -50,7 +50,7 @@ impl Algorithm {
             .try_lookup_or_insert_commit(id, |data| is_common = data.flags.contains(Flags::COMMON))?
             .filter(|_| !is_common)
         {
-            let mut queue = gix_revision::PriorityQueue::from_iter(Some((commit.commit_time, (id, 0_usize))));
+            let mut queue = gix_revwalk::PriorityQueue::from_iter(Some((commit.commit_time, (id, 0_usize))));
             if let Mark::ThisCommitAndAncestors = mode {
                 commit.data.flags |= Flags::COMMON;
                 if commit.data.flags.contains(Flags::SEEN) && !commit.data.flags.contains(Flags::POPPED) {

--- a/gix-negotiate/src/lib.rs
+++ b/gix-negotiate/src/lib.rs
@@ -58,7 +58,10 @@ pub struct Metadata {
 }
 
 /// The graph our callers use to store traversal information, for (re-)use in the negotiation implementation.
-pub type Graph<'find> = gix_revision::Graph<'find, gix_revision::graph::Commit<Metadata>>;
+pub type Graph<'find> = gix_revwalk::Graph<'find, gix_revwalk::graph::Commit<Metadata>>;
+
+/// A map associating an object id with its commit-metadata.
+pub type IdMap = gix_revwalk::graph::IdMap<gix_revwalk::graph::Commit<Metadata>>;
 
 /// The way the negotiation is performed.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
@@ -141,4 +144,4 @@ pub trait Negotiator {
 }
 
 /// An error that happened during any of the methods on a [`Negotiator`].
-pub type Error = gix_revision::graph::lookup::commit::Error;
+pub type Error = gix_revwalk::graph::lookup::commit::Error;

--- a/gix-negotiate/src/lib.rs
+++ b/gix-negotiate/src/lib.rs
@@ -46,7 +46,7 @@ bitflags::bitflags! {
 /// Additional data to store with each commit when used by any of our algorithms.
 ///
 /// It's shared among those who use the [`Negotiator`] trait, and all implementations of it.
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct Metadata {
     /// Used by `skipping`.
     /// Only used if commit is not COMMON

--- a/gix-negotiate/src/skipping.rs
+++ b/gix-negotiate/src/skipping.rs
@@ -4,14 +4,14 @@ use gix_hash::ObjectId;
 use crate::{Error, Flags, Metadata, Negotiator};
 
 pub(crate) struct Algorithm {
-    revs: gix_revision::PriorityQueue<SecondsSinceUnixEpoch, ObjectId>,
+    revs: gix_revwalk::PriorityQueue<SecondsSinceUnixEpoch, ObjectId>,
     non_common_revs: usize,
 }
 
 impl Default for Algorithm {
     fn default() -> Self {
         Self {
-            revs: gix_revision::PriorityQueue::new(),
+            revs: gix_revwalk::PriorityQueue::new(),
             non_common_revs: 0,
         }
     }
@@ -41,7 +41,7 @@ impl Algorithm {
             })?
             .filter(|_| !is_common)
         {
-            let mut queue = gix_revision::PriorityQueue::from_iter(Some((commit.commit_time, id)));
+            let mut queue = gix_revwalk::PriorityQueue::from_iter(Some((commit.commit_time, id)));
             while let Some(id) = queue.pop_value() {
                 if let Some(commit) = graph.try_lookup_or_insert_commit(id, |entry| {
                     if !entry.flags.contains(Flags::POPPED) {

--- a/gix-negotiate/tests/baseline/mod.rs
+++ b/gix-negotiate/tests/baseline/mod.rs
@@ -59,7 +59,7 @@ fn run() -> crate::Result {
                 let cache = use_cache
                     .then(|| gix_commitgraph::at(store.store_ref().path().join("info")).ok())
                     .flatten();
-                let mut graph = gix_revision::Graph::new(
+                let mut graph = gix_revwalk::Graph::new(
                     |id, buf| {
                         store
                             .try_find(id, buf)

--- a/gix-negotiate/tests/negotiate.rs
+++ b/gix-negotiate/tests/negotiate.rs
@@ -39,7 +39,7 @@ mod baseline;
 #[test]
 fn size_of_entry() {
     assert_eq!(
-        std::mem::size_of::<gix_revision::graph::Commit<gix_negotiate::Metadata>>(),
+        std::mem::size_of::<gix_revwalk::graph::Commit<gix_negotiate::Metadata>>(),
         56,
         "we may keep a lot of these, so let's not let them grow unnoticed"
     );

--- a/gix-revwalk/src/lib.rs
+++ b/gix-revwalk/src/lib.rs
@@ -31,12 +31,13 @@ pub struct Graph<'find, T> {
     /// A way to speedup commit access, essentially a multi-file commit database.
     cache: Option<gix_commitgraph::Graph>,
     /// The set of cached commits that we have seen once, along with data associated with them.
-    set: gix_hashtable::HashMap<gix_hash::ObjectId, T>,
+    map: graph::IdMap<T>,
     /// A buffer for writing commit data into.
     buf: Vec<u8>,
     /// Another buffer we typically use to store parents.
     parent_buf: Vec<u8>,
 }
+
 ///
 pub mod graph;
 

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -77,6 +77,7 @@ pub use gix_features::{parallel, progress::Progress, threading};
 pub use gix_fs as fs;
 pub use gix_glob as glob;
 pub use gix_hash as hash;
+pub use gix_hashtable as hashtable;
 pub use gix_ignore as ignore;
 #[doc(inline)]
 pub use gix_index as index;

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -19,7 +19,8 @@ use crate::{
         connection::fetch::config,
         fetch,
         fetch::{
-            negotiate, negotiate::Algorithm, refs, Error, Outcome, Prepare, ProgressId, RefLogMessage, Shallow, Status,
+            negotiate, negotiate::Algorithm, outcome, refs, Error, Outcome, Prepare, ProgressId, RefLogMessage,
+            Shallow, Status,
         },
     },
     Progress, Repository,
@@ -141,11 +142,10 @@ where
             negotiate::make_refmapping_ignore_predicate(con.remote.fetch_tags, &self.ref_map),
         )?;
         let mut previous_response = None::<gix_protocol::fetch::Response>;
-        let mut round = 1;
-        let mut write_pack_bundle = match &action {
+        let (mut write_pack_bundle, negotiate) = match &action {
             negotiate::Action::NoChange | negotiate::Action::SkipToRefUpdate => {
                 gix_protocol::indicate_end_of_interaction(&mut con.transport).await.ok();
-                None
+                (None, None)
             }
             negotiate::Action::MustNegotiate {
                 remote_ref_target_known,
@@ -158,6 +158,7 @@ where
                     &self.shallow,
                     negotiate::make_refmapping_ignore_predicate(con.remote.fetch_tags, &self.ref_map),
                 );
+                let mut rounds = Vec::new();
                 let is_stateless =
                     arguments.is_stateless(!con.transport.connection_persists_across_multiple_requests());
                 let mut haves_to_send = gix_negotiate::window_size(is_stateless, None);
@@ -166,7 +167,7 @@ where
                 let mut common = is_stateless.then(Vec::new);
                 let reader = 'negotiation: loop {
                     progress.step();
-                    progress.set_name(format!("negotiate (round {round})"));
+                    progress.set_name(format!("negotiate (round {})", rounds.len() + 1));
 
                     let is_done = match negotiate::one_round(
                         negotiator.deref_mut(),
@@ -182,6 +183,12 @@ where
                             }
                             seen_ack |= ack_seen;
                             in_vain += haves_sent;
+                            rounds.push(outcome::negotiate::Round {
+                                haves_sent,
+                                in_vain,
+                                haves_to_send,
+                                previous_response_had_at_least_one_in_common: ack_seen,
+                            });
                             let is_done = haves_sent != haves_to_send || (seen_ack && in_vain >= 256);
                             haves_to_send = gix_negotiate::window_size(is_stateless, haves_to_send);
                             is_done
@@ -206,11 +213,9 @@ where
                             setup_remote_progress(progress, &mut reader, should_interrupt);
                         }
                         break 'negotiation reader;
-                    } else {
-                        round += 1;
                     }
                 };
-                drop(graph);
+                let graph = graph.detach();
                 drop(graph_repo);
                 let previous_response = previous_response.expect("knowledge of a pack means a response was received");
                 if !previous_response.shallow_updates().is_empty() && shallow_lock.is_none() {
@@ -267,7 +272,7 @@ where
                         crate::shallow::write(shallow_lock, shallow_commits, previous_response.shallow_updates())?;
                     }
                 }
-                write_pack_bundle
+                (write_pack_bundle, Some(outcome::Negotiate { graph, rounds }))
             }
         };
 
@@ -294,21 +299,17 @@ where
 
         let out = Outcome {
             ref_map: std::mem::take(&mut self.ref_map),
-            status: if matches!(self.dry_run, fetch::DryRun::Yes) {
-                assert!(write_pack_bundle.is_none(), "in dry run we never read a bundle");
-                Status::DryRun {
+            status: match write_pack_bundle {
+                Some(write_pack_bundle) => Status::Change {
+                    write_pack_bundle,
                     update_refs,
-                    negotiation_rounds: round,
-                }
-            } else {
-                match write_pack_bundle {
-                    Some(write_pack_bundle) => Status::Change {
-                        write_pack_bundle,
-                        update_refs,
-                        negotiation_rounds: round,
-                    },
-                    None => Status::NoPackReceived { update_refs },
-                }
+                    negotiate: negotiate.expect("if we have a pack, we always negotiated it"),
+                },
+                None => Status::NoPackReceived {
+                    dry_run: matches!(self.dry_run, fetch::DryRun::Yes),
+                    negotiate,
+                    update_refs,
+                },
             },
         };
         Ok(out)

--- a/gix/src/remote/fetch.rs
+++ b/gix/src/remote/fetch.rs
@@ -11,7 +11,9 @@ pub mod negotiate {
 }
 
 #[cfg(any(feature = "blocking-network-client", feature = "async-network-client"))]
-pub use super::connection::fetch::{prepare, refs, Error, Outcome, Prepare, ProgressId, RefLogMessage, Status};
+pub use super::connection::fetch::{
+    outcome, prepare, refs, Error, Outcome, Prepare, ProgressId, RefLogMessage, Status,
+};
 
 /// If `Yes`, don't really make changes but do as much as possible to get an idea of what would be done.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/ein.rs
+++ b/src/ein.rs
@@ -1,9 +1,3 @@
-//! ## Feature Flags
-#![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
-)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms, unsafe_code)]
 
 mod porcelain;

--- a/src/gix.rs
+++ b/src/gix.rs
@@ -1,10 +1,3 @@
-//! The `gitoxide` plumbing.
-//! ## Feature Flags
-#![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
-)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(unsafe_code, rust_2018_idioms)]
 
 mod plumbing;

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -693,14 +693,26 @@ pub fn main() -> Result<()> {
             },
         ),
         Subcommands::Revision(cmd) => match cmd {
-            revision::Subcommands::List { spec } => prepare_and_run(
+            revision::Subcommands::List { spec, svg, limit } => prepare_and_run(
                 "revision-list",
-                verbose,
+                auto_verbose,
                 progress,
                 progress_keep_open,
-                None,
-                move |_progress, out, _err| {
-                    core::repository::revision::list(repository(Mode::Lenient)?, spec, out, format)
+                core::repository::revision::list::PROGRESS_RANGE,
+                move |progress, out, _err| {
+                    core::repository::revision::list(
+                        repository(Mode::Lenient)?,
+                        progress,
+                        out,
+                        core::repository::revision::list::Context {
+                            limit,
+                            spec,
+                            format,
+                            text: svg.map_or(core::repository::revision::list::Format::Text, |path| {
+                                core::repository::revision::list::Format::Svg { path }
+                            }),
+                        },
+                    )
                 },
             ),
             revision::Subcommands::PreviousBranches => prepare_and_run(

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -190,6 +190,7 @@ pub fn main() -> Result<()> {
             dry_run,
             handshake_info,
             negotiation_info,
+            open_negotiation_graph,
             remote,
             shallow,
             ref_spec,
@@ -200,6 +201,7 @@ pub fn main() -> Result<()> {
                 remote,
                 handshake_info,
                 negotiation_info,
+                open_negotiation_graph,
                 shallow: shallow.into(),
                 ref_specs: ref_spec,
             };

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -189,6 +189,7 @@ pub fn main() -> Result<()> {
         Subcommands::Fetch(crate::plumbing::options::fetch::Platform {
             dry_run,
             handshake_info,
+            negotiation_info,
             remote,
             shallow,
             ref_spec,
@@ -198,6 +199,7 @@ pub fn main() -> Result<()> {
                 dry_run,
                 remote,
                 handshake_info,
+                negotiation_info,
                 shallow: shallow.into(),
                 ref_specs: ref_spec,
             };

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -155,6 +155,10 @@ pub mod fetch {
         #[clap(long, short = 'H')]
         pub handshake_info: bool,
 
+        /// Print statistics about negotiation phase.
+        #[clap(long, short = 's')]
+        pub negotiation_info: bool,
+
         #[clap(flatten)]
         pub shallow: ShallowOptions,
 

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -159,6 +159,10 @@ pub mod fetch {
         #[clap(long, short = 's')]
         pub negotiation_info: bool,
 
+        /// Open the commit graph used for negotiation and write an SVG file to PATH.
+        #[clap(long, value_name = "PATH", short = 'g')]
+        pub open_negotiation_graph: Option<std::path::PathBuf>,
+
         #[clap(flatten)]
         pub shallow: ShallowOptions,
 

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -441,6 +441,12 @@ pub mod revision {
         /// List all commits reachable from the given rev-spec.
         #[clap(visible_alias = "l")]
         List {
+            /// How many commits to list at most.
+            #[clap(long, short = 'l')]
+            limit: Option<usize>,
+            /// Write the graph as SVG file to the given path.
+            #[clap(long, short = 's')]
+            svg: Option<std::path::PathBuf>,
             /// The rev-spec to list reachable commits from.
             #[clap(default_value = "@")]
             spec: std::ffi::OsString,


### PR DESCRIPTION
It's mainly a test of how well `layout-rs` performs.

### Tasks

* [x] `bit revision list --svg`
* [x] `gix fetch --stats` for negotiation statistics 
* [x] a way to write an SVG of negotiation graphs
