### PR TITLE
use [build] instead of [target.<...>]

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.'cfg(any(test, not(test)))']
+[build]
 rustflags = [
     # Rustc lints
     # "-W", "warning_name"


### PR DESCRIPTION
Ref https://github.com/Byron/gitoxide/pull/898

I checked it still works by commenting out an `#[allow(clippy::manual_map)]` and running `just clippy`