### PR TITLE
i64 times

### DIFF
--- a/cargo-smart-release/src/utils.rs
+++ b/cargo-smart-release/src/utils.rs
@@ -300,7 +300,7 @@ mod tests {
 }
 
 pub fn time_to_offset_date_time(time: gix::date::Time) -> OffsetDateTime {
-    time::OffsetDateTime::from_unix_timestamp(time.seconds as i64)
+    time::OffsetDateTime::from_unix_timestamp(time.seconds)
         .expect("always valid unix time")
         .replace_offset(time::UtcOffset::from_whole_seconds(time.offset).expect("valid offset"))
 }

--- a/gix-actor/tests/signature/mod.rs
+++ b/gix-actor/tests/signature/mod.rs
@@ -67,6 +67,7 @@ fn trim() {
 fn round_trip() -> Result<(), Box<dyn std::error::Error>> {
     static DEFAULTS: &[&[u8]] =     &[
         b"Sebastian Thiel <byronimo@gmail.com> 1 -0030",
+        b"Sebastian Thiel <byronimo@gmail.com> -1500 -0030",
         ".. ☺️Sebastian 王知明 Thiel🙌 .. <byronimo@gmail.com> 1528473343 +0230".as_bytes(),
         b".. whitespace  \t  is explicitly allowed    - unicode aware trimming must be done elsewhere  <byronimo@gmail.com> 1528473343 +0230"
     ];

--- a/gix-commitgraph/tests/access/mod.rs
+++ b/gix-commitgraph/tests/access/mod.rs
@@ -46,7 +46,7 @@ fn single_commit_future_64bit_dates_work() {
     let actual = cg.commit_by_id(info.id).expect("present");
     assert_eq!(
         actual.committer_timestamp(),
-        info.time.seconds,
+        info.time.seconds.try_into().expect("timestamps in bound"),
         "this is close the the highest representable value in the graph, like year 2500, so we are good for longer than I should care about"
     );
     assert_eq!(actual.generation(), 1);

--- a/gix-commitgraph/tests/commitgraph.rs
+++ b/gix-commitgraph/tests/commitgraph.rs
@@ -40,7 +40,10 @@ pub fn check_common(cg: &Graph, expected: &HashMap<String, RefInfo, impl BuildHa
 
         let commit = cg.commit_at(ref_info.pos());
         assert_eq!(commit.id(), ref_info.id());
-        assert_eq!(commit.committer_timestamp(), ref_info.time.seconds);
+        assert_eq!(
+            commit.committer_timestamp(),
+            ref_info.time.seconds.try_into().expect("timestamp in bounds")
+        );
         assert_eq!(commit.root_tree_id(), ref_info.root_tree_id());
         assert_eq!(
             commit.parent1().expect("failed to access commit's parent1"),

--- a/gix-date/src/lib.rs
+++ b/gix-date/src/lib.rs
@@ -30,6 +30,13 @@ pub struct Time {
 }
 
 /// The amount of seconds since unix epoch.
-pub type SecondsSinceUnixEpoch = u64;
+///
+/// Note that negative dates represent times before the unix epoch.
+///
+/// ### Deviation
+///
+/// `git` only supports dates *from* the UNIX epoch, whereas we chose to be more flexible at the expense of stopping time
+/// a few million years before the heat-death of the universe.
+pub type SecondsSinceUnixEpoch = i64;
 /// time offset in seconds.
 pub type OffsetInSeconds = i32;

--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -1,8 +1,6 @@
 #[derive(thiserror::Error, Debug, Clone)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error("Cannot represent times before UNIX epoch at timestamp {timestamp}")]
-    TooEarly { timestamp: i64 },
     #[error("Could not convert a duration into a date")]
     RelativeTimeConversion,
     #[error("Date string can not be parsed")]
@@ -14,7 +12,7 @@ pub enum Error {
 }
 
 pub(crate) mod function {
-    use std::{convert::TryInto, str::FromStr, time::SystemTime};
+    use std::{str::FromStr, time::SystemTime};
 
     use time::{format_description::well_known, Date, OffsetDateTime};
 
@@ -36,17 +34,17 @@ pub(crate) mod function {
 
         Ok(if let Ok(val) = Date::parse(input, SHORT) {
             let val = val.with_hms(0, 0, 0).expect("date is in range").assume_utc();
-            Time::new(val.unix_timestamp().try_into()?, val.offset().whole_seconds())
+            Time::new(val.unix_timestamp(), val.offset().whole_seconds())
         } else if let Ok(val) = OffsetDateTime::parse(input, &well_known::Rfc2822) {
-            Time::new(val.unix_timestamp().try_into()?, val.offset().whole_seconds())
+            Time::new(val.unix_timestamp(), val.offset().whole_seconds())
         } else if let Ok(val) = OffsetDateTime::parse(input, ISO8601) {
-            Time::new(val.unix_timestamp().try_into()?, val.offset().whole_seconds())
+            Time::new(val.unix_timestamp(), val.offset().whole_seconds())
         } else if let Ok(val) = OffsetDateTime::parse(input, ISO8601_STRICT) {
-            Time::new(val.unix_timestamp().try_into()?, val.offset().whole_seconds())
+            Time::new(val.unix_timestamp(), val.offset().whole_seconds())
         } else if let Ok(val) = OffsetDateTime::parse(input, GITOXIDE) {
-            Time::new(val.unix_timestamp().try_into()?, val.offset().whole_seconds())
+            Time::new(val.unix_timestamp(), val.offset().whole_seconds())
         } else if let Ok(val) = OffsetDateTime::parse(input, DEFAULT) {
-            Time::new(val.unix_timestamp().try_into()?, val.offset().whole_seconds())
+            Time::new(val.unix_timestamp(), val.offset().whole_seconds())
         } else if let Ok(val) = SecondsSinceUnixEpoch::from_str(input) {
             // Format::Unix
             Time::new(val, 0)
@@ -54,19 +52,10 @@ pub(crate) mod function {
             // Format::Raw
             val
         } else if let Some(time) = relative::parse(input, now).transpose()? {
-            Time::new(timestamp(time)?, time.offset().whole_seconds())
+            Time::new(time.unix_timestamp(), time.offset().whole_seconds())
         } else {
             return Err(Error::InvalidDateString { input: input.into() });
         })
-    }
-
-    fn timestamp(date: OffsetDateTime) -> Result<SecondsSinceUnixEpoch, Error> {
-        let timestamp = date.unix_timestamp();
-        if timestamp < 0 {
-            Err(Error::TooEarly { timestamp })
-        } else {
-            Ok(timestamp.try_into()?)
-        }
     }
 
     fn parse_raw(input: &str) -> Option<Time> {

--- a/gix-date/src/time/format.rs
+++ b/gix-date/src/time/format.rs
@@ -81,7 +81,7 @@ impl Time {
 
 impl Time {
     fn to_time(self) -> time::OffsetDateTime {
-        time::OffsetDateTime::from_unix_timestamp(self.seconds as i64)
+        time::OffsetDateTime::from_unix_timestamp(self.seconds)
             .expect("always valid unix time")
             .to_offset(time::UtcOffset::from_whole_seconds(self.offset).expect("valid offset"))
     }

--- a/gix-date/src/time/init.rs
+++ b/gix-date/src/time/init.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, ops::Sub};
+use std::ops::Sub;
 
 use crate::{time::Sign, OffsetInSeconds, SecondsSinceUnixEpoch, Time};
 
@@ -17,9 +17,7 @@ impl Time {
     pub fn now_utc() -> Self {
         let seconds = time::OffsetDateTime::now_utc()
             .sub(std::time::SystemTime::UNIX_EPOCH)
-            .whole_seconds()
-            .try_into()
-            .expect("this is not the end of the universe");
+            .whole_seconds();
         Self {
             seconds,
             offset: 0,
@@ -30,11 +28,7 @@ impl Time {
     /// Return the current local time, or `None` if the local time wasn't available.
     pub fn now_local() -> Option<Self> {
         let now = time::OffsetDateTime::now_utc();
-        let seconds = now
-            .sub(std::time::SystemTime::UNIX_EPOCH)
-            .whole_seconds()
-            .try_into()
-            .expect("this is not the end of the universe");
+        let seconds = now.sub(std::time::SystemTime::UNIX_EPOCH).whole_seconds();
         // TODO: make this work without cfg(unsound_local_offset), see
         //       https://github.com/time-rs/time/issues/293#issuecomment-909158529
         let offset = time::UtcOffset::local_offset_at(now).ok()?.whole_seconds();
@@ -49,11 +43,7 @@ impl Time {
     /// Return the current local time, or the one at UTC if the local time wasn't available.
     pub fn now_local_or_utc() -> Self {
         let now = time::OffsetDateTime::now_utc();
-        let seconds = now
-            .sub(std::time::SystemTime::UNIX_EPOCH)
-            .whole_seconds()
-            .try_into()
-            .expect("this is not the end of the universe");
+        let seconds = now.sub(std::time::SystemTime::UNIX_EPOCH).whole_seconds();
         // TODO: make this work without cfg(unsound_local_offset), see
         //       https://github.com/time-rs/time/issues/293#issuecomment-909158529
         let offset = time::UtcOffset::local_offset_at(now)

--- a/gix-date/src/time/write.rs
+++ b/gix-date/src/time/write.rs
@@ -42,9 +42,7 @@ impl Time {
 
     /// Computes the number of bytes necessary to write it using [`Time::write_to()`].
     pub fn size(&self) -> usize {
-        (if self.seconds >= 10_000_000_000_000_000_000 {
-            20
-        } else if self.seconds >= 1_000_000_000_000_000_000 {
+        (if self.seconds >= 1_000_000_000_000_000_000 {
             19
         } else if self.seconds >= 100_000_000_000_000_000 {
             18
@@ -80,8 +78,47 @@ impl Time {
             3
         } else if self.seconds >= 10 {
             2
-        } else {
+        } else if self.seconds >= 0 {
             1
+            // from here, it's sign + num-digits characters
+        } else if self.seconds >= -10 {
+            2
+        } else if self.seconds >= -100 {
+            3
+        } else if self.seconds >= -1_000 {
+            4
+        } else if self.seconds >= -10_000 {
+            5
+        } else if self.seconds >= -100_000 {
+            6
+        } else if self.seconds >= -1_000_000 {
+            7
+        } else if self.seconds >= -10_000_000 {
+            8
+        } else if self.seconds >= -100_000_000 {
+            9
+        } else if self.seconds >= -1_000_000_000 {
+            10
+        } else if self.seconds >= -10_000_000_000 {
+            11
+        } else if self.seconds >= -100_000_000_000 {
+            12
+        } else if self.seconds >= -1_000_000_000_000 {
+            13
+        } else if self.seconds >= -10_000_000_000_000 {
+            14
+        } else if self.seconds >= -100_000_000_000_000 {
+            15
+        } else if self.seconds >= -1_000_000_000_000_000 {
+            16
+        } else if self.seconds >= -10_000_000_000_000_000 {
+            17
+        } else if self.seconds >= -100_000_000_000_000_000 {
+            18
+        } else if self.seconds >= -1_000_000_000_000_000_000 {
+            19
+        } else {
+            20
         }) + 2 /*space + offset sign*/ + 2 /*offset hours*/ + 2 /*offset minutes*/
     }
 }

--- a/gix-date/tests/time/mod.rs
+++ b/gix-date/tests/time/mod.rs
@@ -41,7 +41,15 @@ fn write_to() -> Result<(), Box<dyn std::error::Error>> {
                 offset: 0,
                 sign: Sign::Minus,
             },
-            "18446744073709551615 -0000",
+            "9223372036854775807 -0000",
+        ),
+        (
+            Time {
+                seconds: SecondsSinceUnixEpoch::MIN,
+                offset: 0,
+                sign: Sign::Minus,
+            },
+            "-9223372036854775808 -0000",
         ),
         (
             Time {

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -94,7 +94,6 @@ fn bad_raw() {
         "123456 06000",
         "123456  0600",
         "123456 +0600 extra",
-        "-123456 +0600",
         "123456+0600",
         "123456 + 600",
     ] {
@@ -125,7 +124,7 @@ fn invalid_dates_can_be_produced_without_current_time() {
 mod relative {
     use std::time::SystemTime;
 
-    use gix_date::{parse::Error, time::Sign};
+    use gix_date::time::Sign;
     use time::{Duration, OffsetDateTime};
 
     #[test]
@@ -142,9 +141,9 @@ mod relative {
     }
 
     #[test]
-    fn offset_leading_to_before_unix_epoch_cannot_be_represented() {
-        let err = gix_date::parse("1 second ago", Some(std::time::UNIX_EPOCH)).unwrap_err();
-        assert!(matches!(err, Error::TooEarly{timestamp} if timestamp == -1));
+    fn offset_leading_to_before_unix_epoch_can_be_represented() {
+        let date = gix_date::parse("1 second ago", Some(std::time::UNIX_EPOCH)).unwrap();
+        assert_eq!(date.seconds, -1);
     }
 
     #[test]

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -156,7 +156,7 @@ mod relative {
         // account for the loss of precision when creating `Time` with seconds
         let expected = expected.replace_nanosecond(0).unwrap();
         assert_eq!(
-            OffsetDateTime::from_unix_timestamp(two_weeks_ago.seconds as i64).unwrap(),
+            OffsetDateTime::from_unix_timestamp(two_weeks_ago.seconds).unwrap(),
             expected,
             "relative times differ"
         );

--- a/gix-object/tests/commit/from_bytes.rs
+++ b/gix-object/tests/commit/from_bytes.rs
@@ -135,6 +135,32 @@ fn with_encoding() -> crate::Result {
 }
 
 #[test]
+fn pre_epoch() -> crate::Result {
+    let signature = || SignatureRef {
+        name: "Législateur".into(),
+        email: "".into(),
+        time: Time {
+            seconds: -5263834140,
+            offset: 540,
+            sign: Sign::Plus,
+        },
+    };
+    assert_eq!(
+        CommitRef::from_bytes(&fixture_name("commit", "pre-epoch.txt"))?,
+        CommitRef {
+            tree: b"71cdd4015386b764b178005cad4c88966bc9d61a".as_bstr(),
+            parents: SmallVec::default(),
+            author: signature(),
+            committer: signature(),
+            encoding: None,
+            message: "Version consolidée au 14 mars 1803\n".into(),
+            extra_headers: vec![]
+        }
+    );
+    Ok(())
+}
+
+#[test]
 fn with_trailer() -> crate::Result {
     let kim = SignatureRef {
         name: "Kim Altintop".into(),

--- a/gix-object/tests/fixtures/commit/pre-epoch.txt
+++ b/gix-object/tests/fixtures/commit/pre-epoch.txt
@@ -1,0 +1,5 @@
+tree 71cdd4015386b764b178005cad4c88966bc9d61a
+author Législateur <> -5263834140 +0009
+committer Législateur <> -5263834140 +0009
+
+Version consolidée au 14 mars 1803

--- a/gix-traverse/src/commit.rs
+++ b/gix-traverse/src/commit.rs
@@ -82,7 +82,7 @@ pub struct Info {
     pub parent_ids: ParentIds,
     /// The time at which the commit was created. It's only `Some(_)` if sorting is not [`Sorting::BreadthFirst`], as the walk
     /// needs to require the commit-date.
-    pub commit_time: Option<u64>,
+    pub commit_time: Option<gix_date::SecondsSinceUnixEpoch>,
 }
 
 ///
@@ -121,7 +121,7 @@ pub mod ancestors {
         buf: Vec<u8>,
         seen: HashSet<ObjectId>,
         parents_buf: Vec<u8>,
-        parent_ids: SmallVec<[(ObjectId, u64); 2]>,
+        parent_ids: SmallVec<[(ObjectId, gix_date::SecondsSinceUnixEpoch); 2]>,
     }
 
     impl Default for State {
@@ -482,7 +482,7 @@ enum Either<'buf, 'cache> {
 }
 
 fn collect_parents(
-    dest: &mut SmallVec<[(gix_hash::ObjectId, u64); 2]>,
+    dest: &mut SmallVec<[(gix_hash::ObjectId, gix_date::SecondsSinceUnixEpoch); 2]>,
     cache: Option<&gix_commitgraph::Graph>,
     parents: gix_commitgraph::file::commit::Parents<'_>,
 ) -> bool {

--- a/gix-traverse/src/commit.rs
+++ b/gix-traverse/src/commit.rs
@@ -121,7 +121,7 @@ pub mod ancestors {
         buf: Vec<u8>,
         seen: HashSet<ObjectId>,
         parents_buf: Vec<u8>,
-        parent_ids: SmallVec<[(ObjectId, gix_date::SecondsSinceUnixEpoch); 2]>,
+        parent_ids: SmallVec<[(ObjectId, SecondsSinceUnixEpoch); 2]>,
     }
 
     impl Default for State {
@@ -325,7 +325,7 @@ pub mod ancestors {
 
     impl Sorting {
         /// If not topo sort, provide the cutoff date if present.
-        fn cutoff_time(&self) -> Option<gix_date::SecondsSinceUnixEpoch> {
+        fn cutoff_time(&self) -> Option<SecondsSinceUnixEpoch> {
             match self {
                 Sorting::ByCommitTimeNewestFirstCutoffOlderThan { seconds } => Some(*seconds),
                 _ => None,
@@ -492,7 +492,10 @@ fn collect_parents(
         match parent_id {
             Ok(pos) => dest.push({
                 let parent = cache.commit_at(pos);
-                (parent.id().to_owned(), parent.committer_timestamp())
+                (
+                    parent.id().to_owned(),
+                    parent.committer_timestamp() as gix_date::SecondsSinceUnixEpoch, // we can't handle errors here and trying seems overkill
+                )
             }),
             Err(_err) => return false,
         }

--- a/gix/src/revision/walk.rs
+++ b/gix/src/revision/walk.rs
@@ -24,7 +24,7 @@ pub struct Info<'repo> {
     pub parent_ids: gix_traverse::commit::ParentIds,
     /// The time at which the commit was created. It's only `Some(_)` if sorting is not [`Sorting::BreadthFirst`][gix_traverse::commit::Sorting::BreadthFirst],
     /// as the walk needs to require the commit-date.
-    pub commit_time: Option<u64>,
+    pub commit_time: Option<gix_date::SecondsSinceUnixEpoch>,
 
     repo: &'repo Repository,
 }
@@ -54,7 +54,7 @@ impl<'repo> Info<'repo> {
     /// ### Panics
     ///
     /// If the iteration wasn't ordered by date.
-    pub fn commit_time(&self) -> u64 {
+    pub fn commit_time(&self) -> gix_date::SecondsSinceUnixEpoch {
         self.commit_time.expect("traversal involving date caused it to be set")
     }
 }

--- a/gix/tests/fixtures/generated-archives/make_pre_epoch_repo.tar.xz
+++ b/gix/tests/fixtures/generated-archives/make_pre_epoch_repo.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8aff9b7f7d17a890e2153a3fc378d5b3123534bb33b7e220351bd2225b046cf
+oid sha256:9c5dbba1a3fbd85057252d942b63611ce3459ee8261c79b203e9047bddc5fbe6
 size 10280

--- a/gix/tests/fixtures/generated-archives/make_pre_epoch_repo.tar.xz
+++ b/gix/tests/fixtures/generated-archives/make_pre_epoch_repo.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8aff9b7f7d17a890e2153a3fc378d5b3123534bb33b7e220351bd2225b046cf
+size 10280

--- a/gix/tests/fixtures/make_pre_epoch_repo.sh
+++ b/gix/tests/fixtures/make_pre_epoch_repo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -eu -o pipefail
+
+git init -q
+git checkout -b main
+
+echo "hello\nworld" >> code.rs
+git add code.rs
+GIT_AUTHOR_DATE="@0 +0000" GIT_COMMITTER_DATE="@0 +0000" git commit -q -m c1
+git cat-file -p @ > to-be-patched.txt
+
+patch -p1 <<EOF
+diff --git a/to-be-patched.txt b/to-be-patched.txt
+index 95ad1b1..3ea89af 100644
+--- a/to-be-patched.txt
++++ b/to-be-patched.txt
+@@ -1,5 +1,5 @@
+ tree 00d3a67028ba1004a04bd720eee966811102f0c3
+-author author <author@example.com> 0 +0000
+-committer committer <committer@example.com> 0 +0000
++author author <author@example.com> -5263747740 +0009
++committer committer <committer@example.com> -5263747740 +0009
+
+ c1
+EOF
+
+new_commit=$(git hash-object -w -t commit to-be-patched.txt || git hash-object --literally -w -t commit to-be-patched.txt)
+git update-ref refs/heads/main $new_commit
+
+git commit-graph write --no-progress --reachable

--- a/gix/tests/id/mod.rs
+++ b/gix/tests/id/mod.rs
@@ -74,11 +74,11 @@ mod ancestors {
     #[test]
     fn all() -> crate::Result {
         let repo = crate::repo("make_repo_with_fork_and_dates.sh")?.to_thread_local();
-        for toggle in [false, true] {
+        for use_commit_graph in [false, true] {
             let head = repo.head()?.into_fully_peeled_id().expect("born")?;
             let commits_graph_order = head
                 .ancestors()
-                .use_commit_graph(toggle)
+                .use_commit_graph(use_commit_graph)
                 .all()?
                 .map(|c| c.map(gix::revision::walk::Info::detach))
                 .collect::<Result<Vec<_>, _>>()?;
@@ -86,7 +86,7 @@ mod ancestors {
 
             let commits_by_commit_date = head
                 .ancestors()
-                .use_commit_graph(!toggle)
+                .use_commit_graph(!use_commit_graph)
                 .sorting(commit::Sorting::ByCommitTimeNewestFirst)
                 .all()?
                 .map(|c| c.map(gix::revision::walk::Info::detach))
@@ -104,11 +104,34 @@ mod ancestors {
             assert_eq!(
                 head.ancestors()
                     .first_parent_only()
-                    .use_commit_graph(toggle)
+                    .use_commit_graph(use_commit_graph)
                     .all()?
                     .count(),
                 3,
                 "It skips merges this way."
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn pre_epoch() -> crate::Result {
+        let repo = crate::repo("make_pre_epoch_repo.sh")?.to_thread_local();
+        for use_commit_graph in [false, true] {
+            let head = repo.head()?.into_fully_peeled_id().expect("born")?;
+            let commits = head
+                .ancestors()
+                .sorting(commit::Sorting::ByCommitTimeNewestFirst) // assure we have time set
+                .use_commit_graph(use_commit_graph)
+                .all()?
+                .collect::<Result<Vec<_>, _>>()?;
+            assert_eq!(commits.len(), 1, "only one commit");
+
+            let commit = &commits[0];
+            assert_eq!(commit.id, hex_to_id("9902e3c3e8f0c569b4ab295ddf473e6de763e1e7"));
+            assert_eq!(
+                commit.commit_time(),
+                0 // TODO: actual time
             );
         }
         Ok(())

--- a/gix/tests/id/mod.rs
+++ b/gix/tests/id/mod.rs
@@ -128,11 +128,8 @@ mod ancestors {
             assert_eq!(commits.len(), 1, "only one commit");
 
             let commit = &commits[0];
-            assert_eq!(commit.id, hex_to_id("9902e3c3e8f0c569b4ab295ddf473e6de763e1e7"));
-            assert_eq!(
-                commit.commit_time(),
-                0 // TODO: actual time
-            );
+            assert_eq!(commit.id, hex_to_id("cfa5e6f7872c2f4fed7bd8c3f2732a37536d6912"));
+            assert_eq!(commit.commit_time(), -5263747740);
         }
         Ok(())
     }


### PR DESCRIPTION
Support the past as well as the future.

This makes `gitoxide` more versatile as `git` as well and is a real improvement.
`libgit2`, however, already supports this, so in a way it's just being en-par.

### Tasks

* [x] i64 time support
* [x] a `git2` to `gitoxide` API mapping