### PR TITLE
Couple fixes to the refactor done to #932

### DIFF
--- a/examples/log.rs
+++ b/examples/log.rs
@@ -141,7 +141,7 @@ fn run(args: Args) -> anyhow::Result<()> {
                     parents: info.parent_ids().map(|id| id.shorten_or_id().to_string()).collect(),
                     author: {
                         let mut buf = Vec::new();
-                        commit_ref.author.write_to(&mut buf)?;
+                        commit_ref.author.actor().write_to(&mut buf)?;
                         buf.into()
                     },
                     time: commit_ref.author.time.format(format::DEFAULT),


### PR DESCRIPTION
Adjusted to ensure the output of `git log` example omit the timestamp details like the real thing (had I remember `.actor()` earlier we would have avoided this one).

As for `git ls-tree` example, I would have liked to refactor to something like this instead of just reverting to what I had originally:

```rust
let tree = match repo
    .rev_parse_single(&*args.treeish)?
    .object()?
    .try_into_commit()
{
    Ok(commit) => commit.tree()?,
    Err(e) => e.try_into_tree()?,
};
```

Except of course `try_into_commit()` doesn't doesn't return itself in the event of `Error`, in spite of what the [current documentation might imply](https://github.com/Byron/gitoxide/blob/c6bfee0d483/gix/src/object/mod.rs#L101) (Having lifetime attached to an `thiserror::Error` derived type is possibly trouble? That said, that documentation line is definitely better applied to [`gix-object::Object`](https://github.com/Byron/gitoxide/blob/c6bfee0d483/gix-object/src/object/mod.rs#L112)). I supposed it's possible to use the resulting id to fetch the object again, but just inserting this check back in would just do the job quicker.

Also imho, separating each of the return values out separately per let binding can potentially serve as better examples, especially if the variable names being used reflect what each of the return types are (despite it being less idiomatic - it's a trade off I supposed).

As for why this needs to come back in, check using this example command:

```console
$ ./target/debug/examples/ls-tree HEAD:src/
100644 blob bfb4ba4716dd6a0fc76dbca19bd698c3b42828cf    ein.rs
100644 blob 7e78175060b92090776965e17d913cc707353d14    gix.rs
100644 blob 3f4780123918e6a771e40c8f855c7fc679489de2    lib.rs
040000 tree 726614a5c7962f1222afe3c3694b25a1edea1d43    plumbing
040000 tree 3f6581bb19fbc838c70783c0e40171596e5c83a7    porcelain
100644 blob 9b775d9b66d2bd836fc9eb35ef3e5dc844ce0578    shared.rs
```

At the point of the refactor:

```console
$ ./target/debug/examples/ls-tree HEAD:src/
error: Could not find path "src/^{tree}" in tree 491736762 of parent object c6bfee0d4
```

Note the goal of this implementation is to mirror `git log` directly as closely as possible.