### PR TITLE
Fix build on  by disabling sha1-asm

### DIFF
--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -150,9 +150,9 @@ libc = { version = "0.2.119" }
 bstr = { version = "1.3.0", default-features = false }
 
 
-# Assembly doesn't yet compile on MSVC on windows, but does on GNU, see https://github.com/RustCrypto/asm-hashes/issues/17
+# Assembly doesn't yet compile on MSVC and x86 GNU on windows, but does on x86_64 GNU, see https://github.com/RustCrypto/asm-hashes/issues/17
 # At this time, only aarch64, x86 and x86_64 are supported.
-[target.'cfg(all(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"), not(target_env = "msvc")))'.dependencies]
+[target.'cfg(all(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"), not(any(target_env = "msvc", all(target_arch = "x86", target_env = "gnu")))))'.dependencies]
 sha1 = { version = "0.10.0", optional = true, features = ["asm"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Hello,
We have found `sha1-asm` to break build on i686-pc-windows-gnu and i686-pc-windows-gnullvm targets. Unfortunately `sha1-asm` crates are in maintenance mode so they are unlikely to be fixed: https://github.com/RustCrypto/asm-hashes/issues/60

EDIT: I'll hold back to see if upstream bug gets fixed.