### PR TITLE
refactor(release): Switch from nom to winnow

### DIFF
--- a/cargo-smart-release/Cargo.lock
+++ b/cargo-smart-release/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "semver",
  "time",
  "toml_edit",
- "winnow 0.4.9",
+ "winnow",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ checksum = "4b3db1aca6f1a2607dd99beed5d99df831ac73eae5994ff301dae712928e2dac"
 dependencies = [
  "doc-comment",
  "unicase",
- "winnow 0.5.0",
+ "winnow",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.5.0",
+ "winnow",
 ]
 
 [[package]]
@@ -2710,18 +2710,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
 dependencies = [
  "memchr",
 ]

--- a/cargo-smart-release/Cargo.lock
+++ b/cargo-smart-release/Cargo.lock
@@ -181,11 +181,11 @@ dependencies = [
  "home",
  "insta",
  "log",
- "nom",
  "pulldown-cmark",
  "semver",
  "time",
  "toml_edit",
+ "winnow 0.3.6",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ checksum = "4b3db1aca6f1a2607dd99beed5d99df831ac73eae5994ff301dae712928e2dac"
 dependencies = [
  "doc-comment",
  "unicase",
- "winnow",
+ "winnow 0.5.0",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.0",
 ]
 
 [[package]]
@@ -2707,6 +2707,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/cargo-smart-release/Cargo.lock
+++ b/cargo-smart-release/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "semver",
  "time",
  "toml_edit",
- "winnow 0.3.6",
+ "winnow 0.4.9",
 ]
 
 [[package]]
@@ -2710,9 +2710,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]

--- a/cargo-smart-release/Cargo.toml
+++ b/cargo-smart-release/Cargo.toml
@@ -34,7 +34,7 @@ toml_edit = "0.19.1"
 semver = "1.0.4"
 crates-index = { version = "1.0.0", git = "https://github.com/Byron/rust-crates-index", branch = "replace-git2-with-gitoxide" }
 cargo_toml = "0.15.1"
-winnow = "0.4.0"
+winnow = "0.5.1"
 git-conventional = "0.12.0"
 time = "0.3.19"
 pulldown-cmark = "0.9.0"

--- a/cargo-smart-release/Cargo.toml
+++ b/cargo-smart-release/Cargo.toml
@@ -34,7 +34,7 @@ toml_edit = "0.19.1"
 semver = "1.0.4"
 crates-index = { version = "1.0.0", git = "https://github.com/Byron/rust-crates-index", branch = "replace-git2-with-gitoxide" }
 cargo_toml = "0.15.1"
-winnow = "0.3.0"
+winnow = "0.4.0"
 git-conventional = "0.12.0"
 time = "0.3.19"
 pulldown-cmark = "0.9.0"

--- a/cargo-smart-release/Cargo.toml
+++ b/cargo-smart-release/Cargo.toml
@@ -34,7 +34,7 @@ toml_edit = "0.19.1"
 semver = "1.0.4"
 crates-index = { version = "1.0.0", git = "https://github.com/Byron/rust-crates-index", branch = "replace-git2-with-gitoxide" }
 cargo_toml = "0.15.1"
-nom = { version = "7", default-features = false, features = ["std"]}
+winnow = "0.3.0"
 git-conventional = "0.12.0"
 time = "0.3.19"
 pulldown-cmark = "0.9.0"

--- a/cargo-smart-release/src/changelog/parse.rs
+++ b/cargo-smart-release/src/changelog/parse.rs
@@ -8,12 +8,12 @@ use std::{
 use gix::bstr::ByteSlice;
 use pulldown_cmark::{CowStr, Event, HeadingLevel, OffsetIter, Tag};
 use winnow::{
-    branch::alt,
-    bytes::{tag_no_case, take_till0, take_while},
+    combinator::alt,
     combinator::opt,
-    error::{FromExternalError, ParseError},
+    combinator::{delimited, preceded, separated_pair, terminated},
+    error::{FromExternalError, ParserError},
     prelude::*,
-    sequence::{delimited, preceded, separated_pair, terminated},
+    token::{tag_no_case, take_till0, take_while},
 };
 
 use crate::{
@@ -471,7 +471,7 @@ impl<'a> TryFrom<&'a str> for Headline {
     }
 }
 
-fn headline<'a, E: ParseError<&'a str> + FromExternalError<&'a str, ()>>(i: &'a str) -> IResult<&'a str, Headline, E> {
+fn headline<'a, E: ParserError<&'a str> + FromExternalError<&'a str, ()>>(i: &'a str) -> IResult<&'a str, Headline, E> {
     let hashes = take_while(0.., |c: char| c == '#');
     let greedy_whitespace = |i| take_while(0.., char::is_whitespace).parse_next(i);
     let take_n_digits =

--- a/cargo-smart-release/src/changelog/parse.rs
+++ b/cargo-smart-release/src/changelog/parse.rs
@@ -468,13 +468,13 @@ impl<'a> TryFrom<&'a str> for Headline {
     type Error = ();
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        headline::<()>(value).finish()
+        headline::<()>.parse_next(value).finish()
     }
 }
 
 fn headline<'a, E: ParseError<&'a str> + FromExternalError<&'a str, ()>>(i: &'a str) -> IResult<&'a str, Headline, E> {
     let hashes = take_while0(|c: char| c == '#');
-    let greedy_whitespace = |i| take_while0(char::is_whitespace)(i);
+    let greedy_whitespace = |i| take_while0(char::is_whitespace).parse_next(i);
     let take_n_digits =
         |n: usize| take_while_m_n(n, n, |c: char| c.is_ascii_digit()).map_res(|num| u32::from_str(num).map_err(|_| ()));
 

--- a/cargo-smart-release/src/changelog/parse.rs
+++ b/cargo-smart-release/src/changelog/parse.rs
@@ -10,7 +10,7 @@ use pulldown_cmark::{CowStr, Event, HeadingLevel, OffsetIter, Tag};
 use winnow::{
     branch::alt,
     bytes::complete::{tag_no_case, take_till, take_while, take_while_m_n},
-    combinator::{all_consuming, opt},
+    combinator::opt,
     error::{FromExternalError, ParseError},
     prelude::*,
     sequence::{delimited, preceded, separated_pair, terminated},
@@ -468,7 +468,7 @@ impl<'a> TryFrom<&'a str> for Headline {
     type Error = ();
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        all_consuming(headline::<()>)(value).finish_err().map(|(_, h)| h)
+        headline::<()>(value).finish()
     }
 }
 

--- a/cargo-smart-release/src/changelog/parse.rs
+++ b/cargo-smart-release/src/changelog/parse.rs
@@ -9,7 +9,7 @@ use gix::bstr::ByteSlice;
 use pulldown_cmark::{CowStr, Event, HeadingLevel, OffsetIter, Tag};
 use winnow::{
     branch::alt,
-    bytes::{tag_no_case, take_till0, take_while0, take_while_m_n},
+    bytes::{tag_no_case, take_till0, take_while},
     combinator::opt,
     error::{FromExternalError, ParseError},
     prelude::*,
@@ -473,10 +473,10 @@ impl<'a> TryFrom<&'a str> for Headline {
 }
 
 fn headline<'a, E: ParseError<&'a str> + FromExternalError<&'a str, ()>>(i: &'a str) -> IResult<&'a str, Headline, E> {
-    let hashes = take_while0(|c: char| c == '#');
-    let greedy_whitespace = |i| take_while0(char::is_whitespace).parse_next(i);
+    let hashes = take_while(0.., |c: char| c == '#');
+    let greedy_whitespace = |i| take_while(0.., char::is_whitespace).parse_next(i);
     let take_n_digits =
-        |n: usize| take_while_m_n(n, n, |c: char| c.is_ascii_digit()).map_res(|num| u32::from_str(num).map_err(|_| ()));
+        |n: usize| take_while(n, |c: char| c.is_ascii_digit()).map_res(|num| u32::from_str(num).map_err(|_| ()));
 
     terminated(
         (

--- a/cargo-smart-release/src/changelog/parse.rs
+++ b/cargo-smart-release/src/changelog/parse.rs
@@ -9,7 +9,7 @@ use gix::bstr::ByteSlice;
 use pulldown_cmark::{CowStr, Event, HeadingLevel, OffsetIter, Tag};
 use winnow::{
     branch::alt,
-    bytes::complete::{tag_no_case, take_till, take_while, take_while_m_n},
+    bytes::{tag_no_case, take_till0, take_while0, take_while_m_n},
     combinator::opt,
     error::{FromExternalError, ParseError},
     prelude::*,
@@ -473,8 +473,8 @@ impl<'a> TryFrom<&'a str> for Headline {
 }
 
 fn headline<'a, E: ParseError<&'a str> + FromExternalError<&'a str, ()>>(i: &'a str) -> IResult<&'a str, Headline, E> {
-    let hashes = take_while(|c: char| c == '#');
-    let greedy_whitespace = |i| take_while(char::is_whitespace)(i);
+    let hashes = take_while0(|c: char| c == '#');
+    let greedy_whitespace = |i| take_while0(char::is_whitespace)(i);
     let take_n_digits =
         |n: usize| take_while_m_n(n, n, |c: char| c.is_ascii_digit()).map_res(|num| u32::from_str(num).map_err(|_| ()));
 
@@ -486,7 +486,8 @@ fn headline<'a, E: ParseError<&'a str> + FromExternalError<&'a str, ()>>(i: &'a 
                 alt((
                     (
                         opt("v"),
-                        take_till(char::is_whitespace).map_res(|v| semver::Version::parse(v).map_err(|_| ()).map(Some)),
+                        take_till0(char::is_whitespace)
+                            .map_res(|v| semver::Version::parse(v).map_err(|_| ()).map(Some)),
                     ),
                     tag_no_case("unreleased").map(|_| (None, None)),
                 )),


### PR DESCRIPTION
@Byron has mentioned interest in `winnow` but priorities lie elsewhere, so I'm porting the `gitoxide` repo over, starting with `cargo-smart-release`.

My expectation is that I will help with upgrades across breaking changes though I try to make that path as smooth as possible by providing both implementations of an API and deprecating the old one, rather than making hard cut offs, allowing the compiler to guide people through upgrades.

I started here because I assumed this was a smaller, less critical parser to test the waters with.

I did this the "easy path" which was to port to winnow 0.3 which has almost the exact same API as nom and then used the deprecation messages to help me through the process.  I split this up into a lot of commits so that it would be easier to see what changed as rustfmt did its thing.