### PR TITLE
Fixes and Improvements

### DIFF
--- a/cargo-smart-release/Cargo.lock
+++ b/cargo-smart-release/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3feb29cc02fb72a5999ea88eaf38e82fb9ef453a746925d3bf74ebc25940c34c"
+checksum = "a2d899e96f67edf44af465951d34f354c7bc04d10a42b813537cd70d62dfbb50"
 dependencies = [
  "gix",
  "hex",

--- a/cargo-smart-release/Cargo.toml
+++ b/cargo-smart-release/Cargo.toml
@@ -28,11 +28,11 @@ gix = { version = "^0.50.0", default-features = false, features = ["max-performa
 anyhow = "1.0.42"
 clap = { version = "4.1.0", features = ["derive", "cargo"] }
 env_logger = { version = "0.10.0", default-features = false, features = ["humantime", "auto-color"] }
-cargo_metadata = "0.15.0"
+cargo_metadata = "0.17.0"
 log = "0.4.14"
 toml_edit = "0.19.1"
 semver = "1.0.4"
-crates-index = { version = "2.0.0", default-features = false, features = ["git-performance", "git-https"] }
+crates-index = { version = "2.1.0", default-features = false, features = ["git-performance", "git-https"] }
 cargo_toml = "0.15.1"
 winnow = "0.5.1"
 git-conventional = "0.12.0"

--- a/cargo-smart-release/src/crates_index.rs
+++ b/cargo-smart-release/src/crates_index.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 pub struct Index {
     inner: Option<crates_index::GitIndex>,
 }
@@ -7,13 +5,8 @@ pub struct Index {
 impl Index {
     /// Like the original one, but doesn't create it if it doesn't exist
     pub fn new_cargo_default() -> Result<Index, crates_index::Error> {
-        let path = default_path();
         Ok(Index {
-            inner: if path.is_dir() {
-                crates_index::GitIndex::new_cargo_default()?.into()
-            } else {
-                None
-            },
+            inner: crates_index::GitIndex::try_new_cargo_default()?,
         })
     }
 
@@ -28,10 +21,4 @@ impl Index {
     pub fn crate_(&self, name: &str) -> Option<crates_index::Crate> {
         self.inner.as_ref().and_then(|idx| idx.crate_(name))
     }
-}
-
-fn default_path() -> PathBuf {
-    crates_index::local_path_and_canonical_url(crates_index::git::URL, None)
-        .expect("defaults are well-known")
-        .0
 }

--- a/gix-object/tests/commit/from_bytes.rs
+++ b/gix-object/tests/commit/from_bytes.rs
@@ -161,6 +161,32 @@ fn pre_epoch() -> crate::Result {
 }
 
 #[test]
+fn double_dash_special_time_offset() -> crate::Result {
+    let signature = || SignatureRef {
+        name: "name".into(),
+        email: "name@example.com".into(),
+        time: Time {
+            seconds: 1288373970,
+            offset: -252000,
+            sign: Sign::Minus,
+        },
+    };
+    assert_eq!(
+        CommitRef::from_bytes(&fixture_name("commit", "double-dash-date-offset.txt"))?,
+        CommitRef {
+            tree: b"0a851d7a2a66084ab10516c406a405d147e974ad".as_bstr(),
+            parents: SmallVec::from(vec![b"31350f4f0f459485eff2131517e3450cf251f6fa".as_bstr()]),
+            author: signature(),
+            committer: signature(),
+            encoding: None,
+            message: "msg\n".into(),
+            extra_headers: vec![]
+        }
+    );
+    Ok(())
+}
+
+#[test]
 fn with_trailer() -> crate::Result {
     let kim = SignatureRef {
         name: "Kim Altintop".into(),

--- a/gix-object/tests/fixtures/commit/double-dash-date-offset.txt
+++ b/gix-object/tests/fixtures/commit/double-dash-date-offset.txt
@@ -1,0 +1,6 @@
+tree 0a851d7a2a66084ab10516c406a405d147e974ad
+parent 31350f4f0f459485eff2131517e3450cf251f6fa
+author name <name@example.com> 1288373970 --700
+committer name <name@example.com> 1288373970 --700
+
+msg

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -493,6 +493,11 @@ impl super::Store {
         // Unlike libgit2, do not sort by modification date, but by size and put the biggest indices first. That way
         // the chance to hit an object should be higher. We leave it to the handle to sort by LRU.
         // Git itself doesn't change the order which may safe time, but we want it to be stable which also helps some tests.
+        // NOTE: this will work well for well-packed repos or those using geometric repacking, but force us to open a lot
+        //       of files when dealing with new objects, as there is no notion of recency here as would be with unmaintained
+        //       repositories. Different algorithms should be provided, like newest packs first, and possibly a mix of both
+        //       with big packs first, then sorting by recency for smaller packs.
+        //       We also want to implement `fetch.unpackLimit` to alleviate this issue a little.
         indices_by_modification_time.sort_by(|l, r| l.2.cmp(&r.2).reverse());
         Ok(indices_by_modification_time)
     }

--- a/gix-protocol/src/fetch/arguments/blocking_io.rs
+++ b/gix-protocol/src/fetch/arguments/blocking_io.rs
@@ -45,9 +45,7 @@ impl Arguments {
                 }
                 transport.invoke(
                     Command::Fetch.as_str(),
-                    self.features
-                        .iter()
-                        .filter_map(|(k, v)| v.as_ref().map(|v| (*k, Some(v.as_ref())))),
+                    self.features.iter().filter(|(_, v)| v.is_some()).cloned(),
                     Some(std::mem::replace(&mut self.args, retained_state).into_iter()),
                 )
             }

--- a/gix-protocol/src/fetch/arguments/mod.rs
+++ b/gix-protocol/src/fetch/arguments/mod.rs
@@ -165,20 +165,30 @@ impl Arguments {
     pub fn use_include_tag(&mut self) {
         debug_assert!(self.supports_include_tag, "'include-tag' feature required");
         if self.supports_include_tag {
-            match self.version {
-                gix_transport::Protocol::V0 | gix_transport::Protocol::V1 => {
-                    let features = self
-                        .features_for_first_want
-                        .as_mut()
-                        .expect("call use_include_tag before want()");
-                    features.push("include-tag".into())
-                }
-                gix_transport::Protocol::V2 => {
-                    self.args.push("include-tag".into());
-                }
+            self.add_feature("include-tag");
+        }
+    }
+
+    /// Add the given `feature`, unconditionally.
+    ///
+    /// Note that sending an unknown or unsupported feature may cause the remote to terminate
+    /// the connection. Use this method if you know what you are doing *and* there is no specialized
+    /// method for this, e.g. [`Self::use_include_tag()`].
+    pub fn add_feature(&mut self, feature: &str) {
+        match self.version {
+            gix_transport::Protocol::V0 | gix_transport::Protocol::V1 => {
+                let features = self
+                    .features_for_first_want
+                    .as_mut()
+                    .expect("call add_feature before first want()");
+                features.push(feature.into())
+            }
+            gix_transport::Protocol::V2 => {
+                self.args.push(feature.into());
             }
         }
     }
+
     fn prefixed(&mut self, prefix: &str, value: impl fmt::Display) {
         self.args.push(format!("{prefix}{value}").into());
     }

--- a/gix-protocol/src/fetch/tests.rs
+++ b/gix-protocol/src/fetch/tests.rs
@@ -319,6 +319,7 @@ mod arguments {
             assert!(arguments.is_stateless(true), "V2 is stateless…");
             assert!(arguments.is_stateless(false), "…in all cases");
 
+            arguments.add_feature("no-progress");
             arguments.deepen(1);
             arguments.deepen_relative();
             arguments.want(id("7b333369de1221f9bfbbe03a3a13e9a09bc1c907"));
@@ -329,6 +330,7 @@ mod arguments {
                 b"0012command=fetch
 0001000ethin-pack
 000eofs-delta
+0010no-progress
 000ddeepen 1
 0014deepen-relative
 0032want 7b333369de1221f9bfbbe03a3a13e9a09bc1c907
@@ -347,6 +349,7 @@ mod arguments {
                 let mut t = transport(&mut out, *is_stateful);
                 let mut arguments = arguments_v2(Some("shallow"));
 
+                arguments.add_feature("no-progress");
                 arguments.deepen(1);
                 arguments.deepen_since(12345);
                 arguments.shallow(id("7b333369de1221f9bfbbe03a3a13e9a09bc1c9ff"));
@@ -362,6 +365,7 @@ mod arguments {
                     b"0012command=fetch
 0001000ethin-pack
 000eofs-delta
+0010no-progress
 000ddeepen 1
 0017deepen-since 12345
 0035shallow 7b333369de1221f9bfbbe03a3a13e9a09bc1c9ff
@@ -371,6 +375,7 @@ mod arguments {
 00000012command=fetch
 0001000ethin-pack
 000eofs-delta
+0010no-progress
 000ddeepen 1
 0017deepen-since 12345
 0035shallow 7b333369de1221f9bfbbe03a3a13e9a09bc1c9ff

--- a/gix-protocol/src/handshake/mod.rs
+++ b/gix-protocol/src/handshake/mod.rs
@@ -21,7 +21,7 @@ pub enum Ref {
         /// The hash of the object the ref points to.
         object: gix_hash::ObjectId,
     },
-    /// A symbolic ref pointing to `target` ref, which in turn points to an `object`
+    /// A symbolic ref pointing to `target` ref, which in turn, ultimately after possibly following `tag`, points to an `object`
     Symbolic {
         /// The name at which the symbolic ref is located, like `HEAD`.
         full_ref_name: BString,
@@ -31,7 +31,11 @@ pub enum Ref {
         ///
         /// [#205]: https://github.com/Byron/gitoxide/issues/205
         target: BString,
-        /// The hash of the object the `target` ref points to.
+        /// The hash of the annotated tag the ref points to, if present.
+        ///
+        /// Note that this field is also `None` if `full_ref_name` is a lightweight tag.
+        tag: Option<gix_hash::ObjectId>,
+        /// The hash of the object the `target` ref ultimately points to.
         object: gix_hash::ObjectId,
     },
     /// A ref is unborn on the remote and just points to the initial, unborn branch, as is the case in a newly initialized repository

--- a/gix-protocol/src/handshake/refs/mod.rs
+++ b/gix-protocol/src/handshake/refs/mod.rs
@@ -38,10 +38,17 @@ impl Ref {
     /// If `unborn`, the first object id will be the null oid.
     pub fn unpack(&self) -> (&BStr, Option<&gix_hash::oid>, Option<&gix_hash::oid>) {
         match self {
-            Ref::Direct { full_ref_name, object }
-            | Ref::Symbolic {
-                full_ref_name, object, ..
-            } => (full_ref_name.as_ref(), Some(object), None),
+            Ref::Direct { full_ref_name, object } => (full_ref_name.as_ref(), Some(object), None),
+            Ref::Symbolic {
+                full_ref_name,
+                tag,
+                object,
+                ..
+            } => (
+                full_ref_name.as_ref(),
+                Some(tag.as_deref().unwrap_or(object)),
+                tag.as_deref().map(|_| object.as_ref()),
+            ),
             Ref::Peeled {
                 full_ref_name,
                 tag: object,

--- a/gix-protocol/src/handshake/refs/tests.rs
+++ b/gix-protocol/src/handshake/refs/tests.rs
@@ -17,6 +17,7 @@ unborn refs/heads/symbolic symref-target:refs/heads/target
 808e50d724f604f69ab93c6da2919c014667bedb refs/heads/main
 7fe1b98b39423b71e14217aa299a03b7c937d656 refs/tags/foo peeled:808e50d724f604f69ab93c6da2919c014667bedb
 7fe1b98b39423b71e14217aa299a03b7c937d6ff refs/tags/blaz
+978f927e6397113757dfec6332e7d9c7e356ac25 refs/heads/symbolic symref-target:refs/tags/v1.0 peeled:4d979abcde5cea47b079c38850828956c9382a56
 "
         .as_bytes(),
     );
@@ -29,6 +30,7 @@ unborn refs/heads/symbolic symref-target:refs/heads/target
             Ref::Symbolic {
                 full_ref_name: "HEAD".into(),
                 target: "refs/heads/main".into(),
+                tag: None,
                 object: oid("808e50d724f604f69ab93c6da2919c014667bedb")
             },
             Ref::Direct {
@@ -56,8 +58,14 @@ unborn refs/heads/symbolic symref-target:refs/heads/target
                 full_ref_name: "refs/tags/blaz".into(),
                 object: oid("7fe1b98b39423b71e14217aa299a03b7c937d6ff")
             },
+            Ref::Symbolic {
+                full_ref_name: "refs/heads/symbolic".into(),
+                target: "refs/tags/v1.0".into(),
+                tag: Some(oid("978f927e6397113757dfec6332e7d9c7e356ac25")),
+                object: oid("4d979abcde5cea47b079c38850828956c9382a56")
+            },
         ]
-    )
+    );
 }
 
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
@@ -86,6 +94,7 @@ dce0ea858eef7ff61ad345cc5cdac62203fb3c10 refs/tags/gix-commitgraph-v0.0.0
             Ref::Symbolic {
                 full_ref_name: "HEAD".into(),
                 target: "refs/heads/main".into(),
+                tag: None,
                 object: oid("73a6868963993a3328e7d8fe94e5a6ac5078a944")
             },
             Ref::Direct {

--- a/gix-protocol/tests/fetch/v1.rs
+++ b/gix-protocol/tests/fetch/v1.rs
@@ -81,6 +81,7 @@ async fn ls_remote() -> crate::Result {
             handshake::Ref::Symbolic {
                 full_ref_name: "HEAD".into(),
                 object: oid("808e50d724f604f69ab93c6da2919c014667bedb"),
+                tag: None,
                 target: "refs/heads/master".into()
             },
             handshake::Ref::Direct {

--- a/gix-protocol/tests/fetch/v2.rs
+++ b/gix-protocol/tests/fetch/v2.rs
@@ -81,6 +81,7 @@ async fn ls_remote() -> crate::Result {
             handshake::Ref::Symbolic {
                 full_ref_name: "HEAD".into(),
                 object: oid("808e50d724f604f69ab93c6da2919c014667bedb"),
+                tag: None,
                 target: "refs/heads/master".into()
             },
             handshake::Ref::Direct {

--- a/gix-ref/src/store/file/transaction/commit.rs
+++ b/gix-ref/src/store/file/transaction/commit.rs
@@ -50,7 +50,8 @@ impl<'s, 'p> Transaction<'s, 'p> {
                     if update_reflog {
                         let log_update = match new {
                             Target::Symbolic(_) => {
-                                // no reflog for symref changes, unless the ref is new and we can obtain a peeled id
+                                // Special HACK: no reflog for symref changes as there is no OID involved which the reflog needs.
+                                // Unless, the ref is new and we can obtain a peeled id
                                 // identified by the expectation of what could be there, as is the case when cloning.
                                 match expected {
                                     PreviousValue::ExistingMustMatch(Target::Peeled(oid)) => {
@@ -61,6 +62,8 @@ impl<'s, 'p> Transaction<'s, 'p> {
                             }
                             Target::Peeled(new_oid) => {
                                 let previous = match expected {
+                                    // Here, this means that the ref already existed, and that it will receive (even transitively)
+                                    // the given value
                                     PreviousValue::MustExistAndMatch(Target::Peeled(oid)) => Some(oid.to_owned()),
                                     _ => None,
                                 }

--- a/gix-ref/src/transaction/mod.rs
+++ b/gix-ref/src/transaction/mod.rs
@@ -64,7 +64,7 @@ pub enum Change {
         /// The desired change to the reference log.
         log: LogChange,
         /// The expected value already present in the reference.
-        /// If a ref was existing previously it will be overwritten at `MustExistAndMatch(actual_value)` for use after
+        /// If a ref was existing previously this field will be overwritten with `MustExistAndMatch(actual_value)` for use after
         /// the transaction was committed successfully.
         expected: PreviousValue,
         /// The new state of the reference, either for updating an existing one or creating a new one.
@@ -94,7 +94,6 @@ impl Change {
     /// Return references to values that are in common between all variants and denote the previous observed value.
     pub fn previous_value(&self) -> Option<crate::TargetRef<'_>> {
         match self {
-            // TODO: use or-patterns once MRV is larger than 1.52 (and this is supported)
             Change::Update {
                 expected: PreviousValue::MustExistAndMatch(previous) | PreviousValue::ExistingMustMatch(previous),
                 ..

--- a/gix/src/clone/fetch/util.rs
+++ b/gix/src/clone/fetch/util.rs
@@ -76,6 +76,7 @@ pub fn update_head(
             gix_protocol::handshake::Ref::Symbolic {
                 full_ref_name,
                 target,
+                tag: _,
                 object,
             } if full_ref_name == "HEAD" => (Some(object.as_ref()), Some(target)),
             gix_protocol::handshake::Ref::Direct { full_ref_name, object } if full_ref_name == "HEAD" => {

--- a/gix/src/reference/log.rs
+++ b/gix/src/reference/log.rs
@@ -12,6 +12,11 @@ impl<'repo> Reference<'repo> {
     pub fn log_iter(&self) -> gix_ref::file::log::iter::Platform<'_, '_> {
         self.inner.log_iter(&self.repo.refs)
     }
+
+    /// Return true if a reflog is present for this reference.
+    pub fn log_exists(&self) -> bool {
+        self.inner.log_exists(&self.repo.refs)
+    }
 }
 
 /// Generate a message typical for git commit logs based on the given `operation`, commit `message` and `num_parents` of the commit.

--- a/gix/src/reference/mod.rs
+++ b/gix/src/reference/mod.rs
@@ -62,6 +62,7 @@ impl<'repo> Reference<'repo> {
     }
 }
 
+/// Peeling
 impl<'repo> Reference<'repo> {
     /// Follow all symbolic targets this reference might point to and peel the underlying object
     /// to the end of the chain, and return it.
@@ -80,6 +81,18 @@ impl<'repo> Reference<'repo> {
     /// Similar to [`peel_to_id_in_place()`][Reference::peel_to_id_in_place()], but consumes this instance.
     pub fn into_fully_peeled_id(mut self) -> Result<Id<'repo>, peel::Error> {
         self.peel_to_id_in_place()
+    }
+
+    /// Follow this symbolic reference one level and return the ref it refers to.
+    ///
+    /// Returns `None` if this is not a symbolic reference, hence the leaf of the chain.
+    pub fn follow(&self) -> Option<Result<Reference<'repo>, gix_ref::file::find::existing::Error>> {
+        self.inner.follow(&self.repo.refs).map(|res| {
+            res.map(|r| Reference {
+                inner: r,
+                repo: self.repo,
+            })
+        })
     }
 }
 

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -582,11 +582,14 @@ mod update {
             },
             TargetRef::Symbolic(name) => {
                 let target = name.as_bstr().into();
-                let id = r.peel_to_id_in_place().unwrap();
-                gix_protocol::handshake::Ref::Symbolic {
-                    full_ref_name,
-                    target,
-                    object: id.detach(),
+                match r.peel_to_id_in_place() {
+                    Ok(id) => gix_protocol::handshake::Ref::Symbolic {
+                        full_ref_name,
+                        target,
+                        tag: None,
+                        object: id.detach(),
+                    },
+                    Err(_) => gix_protocol::handshake::Ref::Unborn { full_ref_name, target },
                 }
             }
         }

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -31,6 +31,10 @@ mod update {
             gix_testtools::scripted_fixture_read_only_with_args("make_fetch_repos.sh", [base_repo_path()]).unwrap();
         gix::open_opts(dir.join(name), restricted()).unwrap()
     }
+    fn named_repo(name: &str) -> gix::Repository {
+        let dir = gix_testtools::scripted_fixture_read_only("make_remote_repos.sh").unwrap();
+        gix::open_opts(dir.join(name), restricted()).unwrap()
+    }
     fn repo_rw(name: &str) -> (gix::Repository, gix_testtools::tempfile::TempDir) {
         let dir = gix_testtools::scripted_fixture_writable_with_args(
             "make_fetch_repos.sh",
@@ -41,8 +45,10 @@ mod update {
         let repo = gix::open_opts(dir.path().join(name), restricted()).unwrap();
         (repo, dir)
     }
-    use gix_ref::{transaction::Change, TargetRef};
+    use gix_ref::transaction::{LogChange, PreviousValue, RefEdit, RefLog};
+    use gix_ref::{transaction::Change, Target, TargetRef};
 
+    use crate::remote::fetch::refs::update::TypeChange;
     use crate::{
         bstr::BString,
         remote::{
@@ -112,7 +118,7 @@ mod update {
             (
                 "+refs/remotes/origin/g:refs/heads/main",
                 fetch::refs::update::Mode::RejectedCurrentlyCheckedOut {
-                    worktree_dir: repo.work_dir().expect("present").to_owned(),
+                    worktree_dirs: vec![repo.work_dir().expect("present").to_owned()],
                 },
                 None,
                 "checked out branches cannot be written, as it requires a merge of sorts which isn't done here",
@@ -148,6 +154,7 @@ mod update {
             assert_eq!(
                 out.updates,
                 vec![fetch::refs::Update {
+                    type_change: None,
                     mode: expected_mode.clone(),
                     edit_index: reflog_message.map(|_| 0),
                 }],
@@ -211,8 +218,9 @@ mod update {
                 out.updates,
                 vec![fetch::refs::Update {
                     mode: fetch::refs::update::Mode::RejectedCurrentlyCheckedOut {
-                        worktree_dir: root.join(path_from_root),
+                        worktree_dirs: vec![root.join(path_from_root)],
                     },
+                    type_change: None,
                     edit_index: None,
                 }],
                 "{spec}: checked-out checks are done before checking if a change would actually be required (here it isn't)"
@@ -223,10 +231,370 @@ mod update {
     }
 
     #[test]
-    fn local_symbolic_refs_are_never_written() {
+    fn unborn_remote_branches_can_be_created_locally_if_they_are_new() -> Result {
+        let repo = named_repo("unborn");
+        let (mappings, specs) = mapping_from_spec("HEAD:refs/remotes/origin/HEAD", &repo);
+        assert_eq!(mappings.len(), 1);
+        let out = fetch::refs::update(
+            &repo,
+            prefixed("action"),
+            &mappings,
+            &specs,
+            &[],
+            fetch::Tags::None,
+            fetch::DryRun::Yes,
+            fetch::WritePackedRefs::Never,
+        )?;
+        assert_eq!(
+            out.updates,
+            vec![fetch::refs::Update {
+                mode: fetch::refs::update::Mode::New,
+                type_change: None,
+                edit_index: Some(0)
+            }]
+        );
+        assert_eq!(out.edits.len(), 1, "we are OK with creating unborn refs");
+        Ok(())
+    }
+
+    #[test]
+    fn unborn_remote_branches_can_update_local_unborn_branches() -> Result {
+        let repo = named_repo("unborn");
+        let (mappings, specs) = mapping_from_spec("HEAD:refs/heads/existing-unborn-symbolic", &repo);
+        assert_eq!(mappings.len(), 1);
+        let out = fetch::refs::update(
+            &repo,
+            prefixed("action"),
+            &mappings,
+            &specs,
+            &[],
+            fetch::Tags::None,
+            fetch::DryRun::Yes,
+            fetch::WritePackedRefs::Never,
+        )?;
+        assert_eq!(
+            out.updates,
+            vec![fetch::refs::Update {
+                mode: fetch::refs::update::Mode::NoChangeNeeded,
+                type_change: None,
+                edit_index: Some(0)
+            }]
+        );
+        assert_eq!(out.edits.len(), 1, "we are OK with updating unborn refs");
+        assert_eq!(
+            out.edits[0],
+            RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "action: change unborn ref".into(),
+                    },
+                    expected: PreviousValue::MustExistAndMatch(Target::Symbolic(
+                        "refs/heads/main".try_into().expect("valid"),
+                    )),
+                    new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                },
+                name: "refs/heads/existing-unborn-symbolic".try_into().expect("valid"),
+                deref: false,
+            }
+        );
+
+        let (mappings, specs) = mapping_from_spec("HEAD:refs/heads/existing-unborn-symbolic-other", &repo);
+        assert_eq!(mappings.len(), 1);
+        let out = fetch::refs::update(
+            &repo,
+            prefixed("action"),
+            &mappings,
+            &specs,
+            &[],
+            fetch::Tags::None,
+            fetch::DryRun::Yes,
+            fetch::WritePackedRefs::Never,
+        )?;
+        assert_eq!(
+            out.updates,
+            vec![fetch::refs::Update {
+                mode: fetch::refs::update::Mode::Forced,
+                type_change: None,
+                edit_index: Some(0)
+            }]
+        );
+        assert_eq!(
+            out.edits.len(),
+            1,
+            "we are OK with creating unborn refs even without actually forcing it"
+        );
+        assert_eq!(
+            out.edits[0],
+            RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "action: change unborn ref".into(),
+                    },
+                    expected: PreviousValue::MustExistAndMatch(Target::Symbolic(
+                        "refs/heads/other".try_into().expect("valid"),
+                    )),
+                    new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                },
+                name: "refs/heads/existing-unborn-symbolic-other".try_into().expect("valid"),
+                deref: false,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn remote_symbolic_refs_with_locally_unavailable_target_result_in_inborn_branches() -> Result {
+        let remote_repo = named_repo("one-commit-with-symref");
+        let local_repo = named_repo("unborn");
+        let (mappings, specs) = mapping_from_spec("refs/heads/symbolic:refs/heads/new", &remote_repo);
+        assert_eq!(mappings.len(), 1);
+
+        let out = fetch::refs::update(
+            &local_repo,
+            prefixed("action"),
+            &mappings,
+            &specs,
+            &[],
+            fetch::Tags::None,
+            fetch::DryRun::Yes,
+            fetch::WritePackedRefs::Never,
+        )?;
+        assert_eq!(
+            out.updates,
+            vec![fetch::refs::Update {
+                mode: fetch::refs::update::Mode::New,
+                type_change: None,
+                edit_index: Some(0)
+            }]
+        );
+        assert_eq!(out.edits.len(), 1);
+        assert_eq!(
+            out.edits[0],
+            RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "action: storing head".into(),
+                    },
+                    expected: PreviousValue::ExistingMustMatch(Target::Symbolic(
+                        "refs/heads/branch".try_into().expect("valid"),
+                    )),
+                    new: Target::Symbolic("refs/heads/branch".try_into().expect("valid")),
+                },
+                name: "refs/heads/new".try_into().expect("valid"),
+                deref: false,
+            },
+            "we create local-refs whose targets aren't present yet, even though the remote knows them.\
+             This leaves the caller with assuring all refs are mentioned in mappings."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn remote_symbolic_refs_with_locally_unavailable_target_dont_overwrite_valid_local_branches() -> Result {
+        let remote_repo = named_repo("one-commit-with-symref");
+        let local_repo = named_repo("one-commit-with-symref-missing-branch");
+        let (mappings, specs) = mapping_from_spec("refs/heads/symbolic:refs/heads/valid-locally", &remote_repo);
+        assert_eq!(mappings.len(), 1);
+
+        let out = fetch::refs::update(
+            &local_repo,
+            prefixed("action"),
+            &mappings,
+            &specs,
+            &[],
+            fetch::Tags::None,
+            fetch::DryRun::Yes,
+            fetch::WritePackedRefs::Never,
+        )?;
+        assert_eq!(
+            out.updates,
+            vec![fetch::refs::Update {
+                mode: fetch::refs::update::Mode::RejectedToReplaceWithUnborn,
+                type_change: None,
+                edit_index: Some(0)
+            }]
+        );
+        assert_eq!(out.edits.len(), 1);
+        assert_eq!(
+            out.edits[0],
+            RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "no-op".into(),
+                    },
+                    expected: PreviousValue::MustExistAndMatch(Target::Peeled(hex_to_id(
+                        "66f16e4e8baf5c77bb6d0484495bebea80e916ce"
+                    ))),
+                    new: Target::Peeled(hex_to_id("66f16e4e8baf5c77bb6d0484495bebea80e916ce")),
+                },
+                name: "refs/heads/valid-locally".try_into().expect("valid"),
+                deref: false,
+            },
+            "edits are created for logistical reasons (we don't currently update edit-indices) so have to create a no-op"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unborn_remote_refs_dont_overwrite_valid_local_refs() -> Result {
+        let remote_repo = named_repo("unborn");
+        let local_repo = named_repo("one-commit-with-symref");
+        let (mappings, specs) =
+            mapping_from_spec("refs/heads/existing-unborn-symbolic:refs/heads/branch", &remote_repo);
+        assert_eq!(mappings.len(), 1);
+
+        let out = fetch::refs::update(
+            &local_repo,
+            prefixed("action"),
+            &mappings,
+            &specs,
+            &[],
+            fetch::Tags::None,
+            fetch::DryRun::Yes,
+            fetch::WritePackedRefs::Never,
+        )?;
+        assert_eq!(
+            out.updates,
+            vec![fetch::refs::Update {
+                mode: fetch::refs::update::Mode::RejectedToReplaceWithUnborn,
+                type_change: None,
+                edit_index: None
+            }],
+            "we don't overwrite locally present refs with unborn ones for safety"
+        );
+        assert_eq!(out.edits.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn local_symbolic_refs_can_be_overwritten() {
         let repo = repo("two-origins");
-        for source in ["refs/heads/main", "refs/heads/symbolic", "HEAD"] {
-            let (mappings, specs) = mapping_from_spec(&format!("{source}:refs/heads/symbolic"), &repo);
+        for (source, destination, expected_update, expected_edit) in [
+            (
+                // attempt to overwrite HEAD isn't possible as the matching engine will normalize the path. That way, `HEAD`
+                // can never be set. This is by design (of git) and we follow it.
+                "refs/heads/symbolic",
+                "HEAD",
+                fetch::refs::Update {
+                    mode: fetch::refs::update::Mode::New,
+                    type_change: None,
+                    edit_index: Some(0),
+                },
+                Some(RefEdit {
+                    change: Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: "action: storing head".into(),
+                        },
+                        expected: PreviousValue::ExistingMustMatch(Target::Symbolic(
+                            "refs/heads/main".try_into().expect("valid"),
+                        )),
+                        new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                    },
+                    name: "refs/heads/HEAD".try_into().expect("valid"),
+                    deref: false,
+                }),
+            ),
+            (
+                // attempt to overwrite checked out branch fails
+                "refs/remotes/origin/b", // strange, but the remote-refs are simulated and based on local refs
+                "refs/heads/main",
+                fetch::refs::Update {
+                    mode: fetch::refs::update::Mode::RejectedCurrentlyCheckedOut {
+                        worktree_dirs: vec![repo.work_dir().expect("present").to_owned()],
+                    },
+                    type_change: None,
+                    edit_index: None,
+                },
+                None,
+            ),
+            (
+                // symbolic becomes direct
+                "refs/heads/main",
+                "refs/heads/symbolic",
+                fetch::refs::Update {
+                    mode: fetch::refs::update::Mode::NoChangeNeeded,
+                    type_change: Some(TypeChange::SymbolicToDirect),
+                    edit_index: Some(0),
+                },
+                Some(RefEdit {
+                    change: Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: "action: no update will be performed".into(),
+                        },
+                        expected: PreviousValue::MustExistAndMatch(Target::Symbolic(
+                            "refs/heads/main".try_into().expect("valid"),
+                        )),
+                        new: Target::Peeled(hex_to_id("f99771fe6a1b535783af3163eba95a927aae21d5")),
+                    },
+                    name: "refs/heads/symbolic".try_into().expect("valid"),
+                    deref: false,
+                }),
+            ),
+            (
+                // direct becomes symbolic
+                "refs/heads/symbolic",
+                "refs/remotes/origin/a",
+                fetch::refs::Update {
+                    mode: fetch::refs::update::Mode::NoChangeNeeded,
+                    type_change: Some(TypeChange::DirectToSymbolic),
+                    edit_index: Some(0),
+                },
+                Some(RefEdit {
+                    change: Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: "action: no update will be performed".into(),
+                        },
+                        expected: PreviousValue::MustExistAndMatch(Target::Peeled(hex_to_id(
+                            "f99771fe6a1b535783af3163eba95a927aae21d5",
+                        ))),
+                        new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                    },
+                    name: "refs/remotes/origin/a".try_into().expect("valid"),
+                    deref: false,
+                }),
+            ),
+            (
+                // symbolic to symbolic (same)
+                "refs/heads/symbolic",
+                "refs/heads/symbolic",
+                fetch::refs::Update {
+                    mode: fetch::refs::update::Mode::NoChangeNeeded,
+                    type_change: None,
+                    edit_index: Some(0),
+                },
+                Some(RefEdit {
+                    change: Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: "action: no update will be performed".into(),
+                        },
+                        expected: PreviousValue::MustExistAndMatch(Target::Symbolic(
+                            "refs/heads/main".try_into().expect("valid"),
+                        )),
+                        new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                    },
+                    name: "refs/heads/symbolic".try_into().expect("valid"),
+                    deref: false,
+                }),
+            ),
+        ] {
+            let (mappings, specs) = mapping_from_spec(&format!("{source}:{destination}"), &repo);
+            assert_eq!(mappings.len(), 1);
             let out = fetch::refs::update(
                 &repo,
                 prefixed("action"),
@@ -239,15 +607,11 @@ mod update {
             )
             .unwrap();
 
-            assert_eq!(out.edits.len(), 0);
-            assert_eq!(
-                out.updates,
-                vec![fetch::refs::Update {
-                    mode: fetch::refs::update::Mode::RejectedSymbolic,
-                    edit_index: None
-                }],
-                "we don't overwrite these as the checked-out check needs to consider much more than it currently does, we are playing it safe"
-            );
+            assert_eq!(out.edits.len(), usize::from(expected_edit.is_some()));
+            assert_eq!(out.updates, vec![expected_update]);
+            if let Some(expected) = expected_edit {
+                assert_eq!(out.edits, vec![expected]);
+            }
         }
     }
 
@@ -275,17 +639,19 @@ mod update {
         )
         .unwrap();
 
-        assert_eq!(out.edits.len(), 1);
+        assert_eq!(out.edits.len(), 2, "symbolic refs are handled just like any other ref");
         assert_eq!(
             out.updates,
             vec![
                 fetch::refs::Update {
                     mode: fetch::refs::update::Mode::New,
+                    type_change: None,
                     edit_index: Some(0)
                 },
                 fetch::refs::Update {
-                    mode: fetch::refs::update::Mode::RejectedSymbolic,
-                    edit_index: None
+                    mode: fetch::refs::update::Mode::NoChangeNeeded,
+                    type_change: Some(TypeChange::SymbolicToDirect),
+                    edit_index: Some(1)
                 }
             ],
         );
@@ -303,7 +669,7 @@ mod update {
     }
 
     #[test]
-    fn local_direct_refs_are_never_written_with_symbolic_ones_but_see_only_the_destination() {
+    fn local_direct_refs_are_written_with_symbolic_ones() {
         let repo = repo("two-origins");
         let (mappings, specs) = mapping_from_spec("refs/heads/symbolic:refs/heads/not-currently-checked-out", &repo);
         let out = fetch::refs::update(
@@ -323,6 +689,7 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::NoChangeNeeded,
+                type_change: Some(fetch::refs::update::TypeChange::DirectToSymbolic),
                 edit_index: Some(0)
             }],
         );
@@ -349,6 +716,7 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::New,
+                type_change: None,
                 edit_index: Some(0),
             }],
         );
@@ -399,10 +767,12 @@ mod update {
             vec![
                 fetch::refs::Update {
                     mode: fetch::refs::update::Mode::New,
+                    type_change: None,
                     edit_index: Some(0),
                 },
                 fetch::refs::Update {
                     mode: fetch::refs::update::Mode::NoChangeNeeded,
+                    type_change: None,
                     edit_index: Some(1),
                 }
             ],
@@ -446,6 +816,7 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::FastForward,
+                type_change: None,
                 edit_index: Some(0),
             }],
             "The caller has to be aware and note that dry-runs can't know about fast-forwards as they don't have remote objects"
@@ -480,6 +851,7 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::RejectedNonFastForward,
+                type_change: None,
                 edit_index: None,
             }]
         );
@@ -502,6 +874,7 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::FastForward,
+                type_change: None,
                 edit_index: Some(0),
             }]
         );
@@ -535,6 +908,7 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::FastForward,
+                type_change: None,
                 edit_index: Some(0),
             }]
         );
@@ -548,12 +922,15 @@ mod update {
         }
     }
 
-    fn mapping_from_spec(spec: &str, repo: &gix::Repository) -> (Vec<fetch::Mapping>, Vec<gix::refspec::RefSpec>) {
+    fn mapping_from_spec(
+        spec: &str,
+        remote_repo: &gix::Repository,
+    ) -> (Vec<fetch::Mapping>, Vec<gix::refspec::RefSpec>) {
         let spec = gix_refspec::parse(spec.into(), gix_refspec::parse::Operation::Fetch).unwrap();
         let group = gix_refspec::MatchGroup::from_fetch_specs(Some(spec));
-        let references = repo.references().unwrap();
+        let references = remote_repo.references().unwrap();
         let mut references: Vec<_> = references.all().unwrap().map(|r| into_remote_ref(r.unwrap())).collect();
-        references.push(into_remote_ref(repo.find_reference("HEAD").unwrap()));
+        references.push(into_remote_ref(remote_repo.find_reference("HEAD").unwrap()));
         let mappings = group
             .match_remotes(references.iter().map(remote_ref_to_item))
             .mappings
@@ -597,9 +974,10 @@ mod update {
 
     fn remote_ref_to_item(r: &gix_protocol::handshake::Ref) -> gix_refspec::match_group::Item<'_> {
         let (full_ref_name, target, object) = r.unpack();
+        static NULL: gix_hash::ObjectId = gix_hash::Kind::Sha1.null();
         gix_refspec::match_group::Item {
             full_ref_name,
-            target: target.expect("no unborn HEAD"),
+            target: target.unwrap_or(NULL.as_ref()),
             object,
         }
     }

--- a/gix/src/remote/fetch.rs
+++ b/gix/src/remote/fetch.rs
@@ -154,6 +154,18 @@ impl Source {
         }
     }
 
+    /// Return the target that this symbolic ref is pointing to, or `None` if it is no symbolic ref.
+    pub fn as_target(&self) -> Option<&crate::bstr::BStr> {
+        match self {
+            Source::ObjectId(_) => None,
+            Source::Ref(r) => match r {
+                gix_protocol::handshake::Ref::Peeled { .. } | gix_protocol::handshake::Ref::Direct { .. } => None,
+                gix_protocol::handshake::Ref::Symbolic { target, .. }
+                | gix_protocol::handshake::Ref::Unborn { target, .. } => Some(target.as_ref()),
+            },
+        }
+    }
+
     /// Returns the peeled id of this instance, that is the object that can't be de-referenced anymore.
     pub fn peeled_id(&self) -> Option<&gix_hash::oid> {
         match self {

--- a/gix/tests/clone/mod.rs
+++ b/gix/tests/clone/mod.rs
@@ -348,8 +348,22 @@ mod blocking_io {
                             .expect("computable")
                             .1
                             .starts_with_str(remote_name));
-                        let mut logs = r.log_iter();
-                        assert_reflog(logs.all());
+                        match r.target() {
+                            TargetRef::Peeled(_) => {
+                                let mut logs = r.log_iter();
+                                assert_reflog(logs.all());
+                            }
+                            TargetRef::Symbolic(_) => {
+                                // TODO: it *should* be possible to set the reflog here based on the referent if deref = true
+                                //       when setting up the edits. But it doesn't seem to work. Also, some tests are
+                                //       missing for `leaf_referent_previous_oid`.
+                                assert!(
+                                    !r.log_exists(),
+                                    "symbolic refs don't have object ids, so they can't get \
+                                      into the reflog as these need previous and new oid"
+                                )
+                            }
+                        }
                     }
                 }
                 let mut out_of_graph_tags = Vec::new();

--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -350,3 +350,22 @@ function optimize_repo() {
     optimize_repo
   )
 )
+
+git init unborn
+(cd unborn
+  git symbolic-ref refs/heads/existing-unborn-symbolic refs/heads/main
+  git symbolic-ref refs/heads/existing-unborn-symbolic-other refs/heads/other
+)
+
+git init one-commit-with-symref
+(cd one-commit-with-symref
+  touch content && git add content && git commit -m "init"
+  git checkout -b branch
+  git symbolic-ref refs/heads/symbolic refs/heads/branch
+  git checkout main
+)
+
+git clone one-commit-with-symref one-commit-with-symref-missing-branch
+(cd one-commit-with-symref-missing-branch
+  git branch valid-locally
+)


### PR DESCRIPTION
### Tasks

* [x] #923
* [x] assure we can deal with symrefs which are included in refspecs - this probably works naturally
* [x] assure we can't overwrite a local `HEAD` with a remote refspec if there is a worktree - actually it doesn't allow to write into any other place than `refs/`.
* [x] assure we deal with symrefs that have the target ref not included in refspecs - ~~the intermediate ref should then be created, too, as the peeled value is known~~ let's leave it as 'unborn' then but document that beahviour
* [x] `gitoxide-core`: visualize ref type change as well
* [x] #926
* [x]  #950
* [x] #928 