### PR TITLE
Migrate config from nom 7 to winnow 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,9 +4752,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,12 +1392,12 @@ dependencies = [
  "gix-sec 0.8.4",
  "log",
  "memchr",
- "nom",
  "once_cell",
  "serde",
  "smallvec",
  "thiserror",
  "unicode-bom",
+ "winnow",
 ]
 
 [[package]]
@@ -4749,6 +4749,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,9 +4752,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
 dependencies = [
  "memchr",
 ]

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -25,7 +25,7 @@ gix-ref = { version = "^0.33.1", path = "../gix-ref" }
 gix-glob = { version = "^0.10.1", path = "../gix-glob" }
 
 log = "0.4.17"
-winnow = "0.4"
+winnow = "0.5"
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -25,7 +25,7 @@ gix-ref = { version = "^0.33.1", path = "../gix-ref" }
 gix-glob = { version = "^0.10.1", path = "../gix-glob" }
 
 log = "0.4.17"
-winnow = "0.3"
+winnow = "0.4"
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -25,7 +25,7 @@ gix-ref = { version = "^0.33.1", path = "../gix-ref" }
 gix-glob = { version = "^0.10.1", path = "../gix-glob" }
 
 log = "0.4.17"
-nom = { version = "7", default_features = false, features = [ "std" ] }
+winnow = "0.3"
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-config/src/parse/nom/mod.rs
+++ b/gix-config/src/parse/nom/mod.rs
@@ -2,14 +2,14 @@ use std::borrow::Cow;
 
 use bstr::{BStr, BString, ByteSlice, ByteVec};
 use winnow::{
-    branch::alt,
-    bytes::{one_of, take_till0, take_while},
+    combinator::alt,
+    combinator::delimited,
     combinator::fold_repeat,
     combinator::opt,
-    error::{Error as NomError, ErrorKind},
+    error::{ErrorKind, InputError as NomError},
     prelude::*,
-    sequence::delimited,
     stream::AsChar,
+    token::{one_of, take_till0, take_while},
 };
 
 use crate::parse::{error::ParseNode, section, Comment, Error, Event};
@@ -76,7 +76,7 @@ pub fn from_bytes<'a>(input: &'a [u8], mut dispatch: impl FnMut(Event<'a>)) -> R
 }
 
 fn comment(i: &[u8]) -> IResult<&[u8], Comment<'_>> {
-    let (i, comment_tag) = one_of(";#").parse_next(i)?;
+    let (i, comment_tag) = one_of([';', '#']).parse_next(i)?;
     let (i, comment) = take_till0(|c| c == b'\n').parse_next(i)?;
     Ok((
         i,

--- a/gix-config/src/parse/nom/tests.rs
+++ b/gix-config/src/parse/nom/tests.rs
@@ -134,7 +134,7 @@ mod sub_section {
 }
 
 mod config_name {
-    use winnow::combinator::all_consuming;
+    use winnow::prelude::*;
 
     use super::config_name;
     use crate::parse::tests::util::fully_consumed;
@@ -152,8 +152,8 @@ mod config_name {
 
     #[test]
     fn only_a_subset_of_characters_is_allowed() {
-        assert!(all_consuming(config_name)(b"Name$_").is_err());
-        assert!(all_consuming(config_name)(b"other#").is_err());
+        assert!(config_name.parse_next(b"Name$_").finish().is_err());
+        assert!(config_name.parse_next(b"other#").finish().is_err());
     }
 
     #[test]

--- a/gix-config/src/parse/nom/tests.rs
+++ b/gix-config/src/parse/nom/tests.rs
@@ -152,8 +152,8 @@ mod config_name {
 
     #[test]
     fn only_a_subset_of_characters_is_allowed() {
-        assert!(config_name.parse_next(b"Name$_").finish().is_err());
-        assert!(config_name.parse_next(b"other#").finish().is_err());
+        assert!(config_name.parse(b"Name$_").is_err());
+        assert!(config_name.parse(b"other#").is_err());
     }
 
     #[test]

--- a/gix-config/src/parse/nom/tests.rs
+++ b/gix-config/src/parse/nom/tests.rs
@@ -134,7 +134,7 @@ mod sub_section {
 }
 
 mod config_name {
-    use nom::combinator::all_consuming;
+    use winnow::combinator::all_consuming;
 
     use super::config_name;
     use crate::parse::tests::util::fully_consumed;
@@ -174,7 +174,7 @@ mod section {
         Event, Section,
     };
 
-    fn section<'a>(i: &'a [u8], node: &mut ParseNode) -> nom::IResult<&'a [u8], (Section<'a>, usize)> {
+    fn section<'a>(i: &'a [u8], node: &mut ParseNode) -> winnow::IResult<&'a [u8], (Section<'a>, usize)> {
         let mut header = None;
         let mut events = section::Events::default();
         super::section(i, node, &mut |e| match &header {
@@ -567,7 +567,7 @@ mod value_continuation {
         tests::util::{into_events, newline_custom_event, newline_event, value_done_event, value_not_done_event},
     };
 
-    pub fn value_impl<'a>(i: &'a [u8], events: &mut section::Events<'a>) -> nom::IResult<&'a [u8], ()> {
+    pub fn value_impl<'a>(i: &'a [u8], events: &mut section::Events<'a>) -> winnow::IResult<&'a [u8], ()> {
         super::value_impl(i, &mut |e| events.push(e)).map(|t| (t.0, ()))
     }
 
@@ -843,7 +843,7 @@ mod key_value_pair {
         i: &'a [u8],
         node: &mut ParseNode,
         events: &mut section::Events<'a>,
-    ) -> nom::IResult<&'a [u8], ()> {
+    ) -> winnow::IResult<&'a [u8], ()> {
         super::key_value_pair(i, node, &mut |e| events.push(e)).map(|t| (t.0, ()))
     }
 

--- a/gix-config/src/parse/nom/tests.rs
+++ b/gix-config/src/parse/nom/tests.rs
@@ -176,7 +176,7 @@ mod section {
         Event, Section,
     };
 
-    fn section<'a>(mut i: &'a [u8], node: &mut ParseNode) -> winnow::IResult<&'a [u8], (Section<'a>, usize)> {
+    fn section<'a>(mut i: &'a [u8], node: &mut ParseNode) -> winnow::IResult<&'a [u8], Section<'a>> {
         let mut header = None;
         let mut events = section::Events::default();
         super::section(&mut i, node, &mut |e| match &header {
@@ -185,19 +185,16 @@ mod section {
             }
             Some(_) => events.push(e),
         })
-        .map(|o| {
+        .map(|_| {
             (
                 i,
-                (
-                    Section {
-                        header: match header.expect("header set") {
-                            Event::SectionHeader(header) => header,
-                            _ => unreachable!("unexpected"),
-                        },
-                        events,
+                Section {
+                    header: match header.expect("header set") {
+                        Event::SectionHeader(header) => header,
+                        _ => unreachable!("unexpected"),
                     },
-                    o,
-                ),
+                    events,
+                },
             )
         })
     }
@@ -207,22 +204,19 @@ mod section {
         let mut node = ParseNode::SectionHeader;
         assert_eq!(
             section(b"[a] k = \r\n", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("a", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("k"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event(""),
-                        newline_custom_event("\r\n")
-                    ]
-                    .into(),
-                },
-                1
-            )),
+            fully_consumed(Section {
+                header: parsed_section_header("a", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("k"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event(""),
+                    newline_custom_event("\r\n")
+                ]
+                .into(),
+            }),
         );
     }
 
@@ -231,41 +225,35 @@ mod section {
         let mut node = ParseNode::SectionHeader;
         assert_eq!(
             section(b"[a] k = v\r\n", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("a", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("k"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("v"),
-                        newline_custom_event("\r\n")
-                    ]
-                    .into(),
-                },
-                1
-            )),
+            fully_consumed(Section {
+                header: parsed_section_header("a", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("k"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("v"),
+                    newline_custom_event("\r\n")
+                ]
+                .into(),
+            }),
         );
         assert_eq!(
             section(b"[a] k = \r\n", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("a", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("k"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event(""),
-                        newline_custom_event("\r\n")
-                    ]
-                    .into(),
-                },
-                1
-            )),
+            fully_consumed(Section {
+                header: parsed_section_header("a", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("k"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event(""),
+                    newline_custom_event("\r\n")
+                ]
+                .into(),
+            }),
         );
     }
 
@@ -274,13 +262,10 @@ mod section {
         let mut node = ParseNode::SectionHeader;
         assert_eq!(
             section(b"[test]", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("test", None),
-                    events: Default::default()
-                },
-                0
-            )),
+            fully_consumed(Section {
+                header: parsed_section_header("test", None),
+                events: Default::default()
+            }),
         );
     }
 
@@ -293,33 +278,30 @@ mod section {
             d = "lol""#;
         assert_eq!(
             section(section_data, &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("hello", None),
-                    events: vec![
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("a"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("b"),
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("c"),
-                        value_event(""),
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("d"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("\"lol\"")
-                    ]
-                    .into()
-                },
-                3
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("hello", None),
+                events: vec![
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("a"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("b"),
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("c"),
+                    value_event(""),
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("d"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("\"lol\"")
+                ]
+                .into()
+            })
         );
     }
 
@@ -329,38 +311,32 @@ mod section {
         let section_data = b"[a] k=";
         assert_eq!(
             section(section_data, &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("a", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("k"),
-                        Event::KeyValueSeparator,
-                        value_event(""),
-                    ]
-                    .into()
-                },
-                0
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("a", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("k"),
+                    Event::KeyValueSeparator,
+                    value_event(""),
+                ]
+                .into()
+            })
         );
 
         let section_data = b"[a] k=\n";
         assert_eq!(
             section(section_data, &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("a", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("k"),
-                        Event::KeyValueSeparator,
-                        value_event(""),
-                        newline_event(),
-                    ]
-                    .into()
-                },
-                1
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("a", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("k"),
+                    Event::KeyValueSeparator,
+                    value_event(""),
+                    newline_event(),
+                ]
+                .into()
+            })
         );
     }
 
@@ -373,34 +349,31 @@ mod section {
             d = "lol""#;
         assert_eq!(
             section(section_data, &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("hello", None),
-                    events: vec![
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("a"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("b"),
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("c"),
-                        Event::KeyValueSeparator,
-                        value_event(""),
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("d"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("\"lol\"")
-                    ]
-                    .into()
-                },
-                3
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("hello", None),
+                events: vec![
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("a"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("b"),
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("c"),
+                    Event::KeyValueSeparator,
+                    value_event(""),
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("d"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("\"lol\"")
+                ]
+                .into()
+            })
         );
     }
 
@@ -409,32 +382,26 @@ mod section {
         let mut node = ParseNode::SectionHeader;
         assert_eq!(
             section(b"[hello] c", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("hello", None),
-                    events: vec![whitespace_event(" "), name_event("c"), value_event("")].into()
-                },
-                0
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("hello", None),
+                events: vec![whitespace_event(" "), name_event("c"), value_event("")].into()
+            })
         );
 
         assert_eq!(
             section(b"[hello] c\nd", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("hello", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("c"),
-                        value_event(""),
-                        newline_event(),
-                        name_event("d"),
-                        value_event("")
-                    ]
-                    .into()
-                },
-                1
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("hello", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("c"),
+                    value_event(""),
+                    newline_event(),
+                    name_event("d"),
+                    value_event("")
+                ]
+                .into()
+            })
         );
     }
 
@@ -448,39 +415,36 @@ mod section {
             c = d"#;
         assert_eq!(
             section(section_data, &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("hello", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        comment_event(';', " commentA"),
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("a"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("b"),
-                        whitespace_event(" "),
-                        comment_event('#', " commentB"),
-                        newline_event(),
-                        whitespace_event("            "),
-                        comment_event(';', " commentC"),
-                        newline_event(),
-                        whitespace_event("            "),
-                        comment_event(';', " commentD"),
-                        newline_event(),
-                        whitespace_event("            "),
-                        name_event("c"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_event("d"),
-                    ]
-                    .into()
-                },
-                4
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("hello", None),
+                events: vec![
+                    whitespace_event(" "),
+                    comment_event(';', " commentA"),
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("a"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("b"),
+                    whitespace_event(" "),
+                    comment_event('#', " commentB"),
+                    newline_event(),
+                    whitespace_event("            "),
+                    comment_event(';', " commentC"),
+                    newline_event(),
+                    whitespace_event("            "),
+                    comment_event(';', " commentD"),
+                    newline_event(),
+                    whitespace_event("            "),
+                    name_event("c"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_event("d"),
+                ]
+                .into()
+            })
         );
     }
 
@@ -490,27 +454,24 @@ mod section {
         // This test is absolute hell. Good luck if this fails.
         assert_eq!(
             section(b"[section] a = 1    \"\\\"\\\na ; e \"\\\"\\\nd # \"b\t ; c", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("section", None),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("a"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        whitespace_event(" "),
-                        value_not_done_event(r#"1    "\""#),
-                        newline_event(),
-                        value_not_done_event(r#"a ; e "\""#),
-                        newline_event(),
-                        value_done_event("d"),
-                        whitespace_event(" "),
-                        comment_event('#', " \"b\t ; c"),
-                    ]
-                    .into()
-                },
-                2
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("section", None),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("a"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    whitespace_event(" "),
+                    value_not_done_event(r#"1    "\""#),
+                    newline_event(),
+                    value_not_done_event(r#"a ; e "\""#),
+                    newline_event(),
+                    value_done_event("d"),
+                    whitespace_event(" "),
+                    comment_event('#', " \"b\t ; c"),
+                ]
+                .into()
+            })
         );
     }
 
@@ -519,23 +480,20 @@ mod section {
         let mut node = ParseNode::SectionHeader;
         assert_eq!(
             section(b"[section \"a\"] b =\"\\\n;\";a", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("section", (" ", "a")),
-                    events: vec![
-                        whitespace_event(" "),
-                        name_event("b"),
-                        whitespace_event(" "),
-                        Event::KeyValueSeparator,
-                        value_not_done_event("\""),
-                        newline_event(),
-                        value_done_event(";\""),
-                        comment_event(';', "a"),
-                    ]
-                    .into()
-                },
-                1
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("section", (" ", "a")),
+                events: vec![
+                    whitespace_event(" "),
+                    name_event("b"),
+                    whitespace_event(" "),
+                    Event::KeyValueSeparator,
+                    value_not_done_event("\""),
+                    newline_event(),
+                    value_done_event(";\""),
+                    comment_event(';', "a"),
+                ]
+                .into()
+            })
         );
     }
 
@@ -544,19 +502,16 @@ mod section {
         let mut node = ParseNode::SectionHeader;
         assert_eq!(
             section(b"[s]hello             #world", &mut node).unwrap(),
-            fully_consumed((
-                Section {
-                    header: parsed_section_header("s", None),
-                    events: vec![
-                        name_event("hello"),
-                        whitespace_event("             "),
-                        value_event(""),
-                        comment_event('#', "world"),
-                    ]
-                    .into()
-                },
-                0
-            ))
+            fully_consumed(Section {
+                header: parsed_section_header("s", None),
+                events: vec![
+                    name_event("hello"),
+                    whitespace_event("             "),
+                    value_event(""),
+                    comment_event('#', "world"),
+                ]
+                .into()
+            })
         );
     }
 }


### PR DESCRIPTION
Inspired by the talk of improvement in #948, between winnow 0.4 and 0.5, I refactored the code to make the migration easier.  After that upgrade, I went and did what felt like further improvements to me.

While I didn't benchmark, a couple of potential performance improvements in those changes include
- Moving the counting of newlines from the "hot loop" to only in  the error path.
- Removing the counting of indexes in `value_impl`, making it so we just do math when we need it

Further improvements that I held off on for time
- Switching the input type while parsing internals to `winnow::BStr` which makes debug output a lot nicer (especially when running with `cargo test -F winnow/debug`)
- Track the `ParseNode` in the context of a custom error type
- Move `dispatch` from being an explicit parameter to a part of the input type

By adjusting how those two other `&mut` parameters are handled, all of the functions would follow the normal parser structure / impl `Parser` which would make them easier to work with.