### PR TITLE
build: rust-cache should happen after rustup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
     container: debian:buster
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
       - name: Prerequisites
         run: apt-get update && apt-get install --no-install-recommends -y ca-certificates curl gcc libc-dev # gcc is required as OS abstraction
       - name: install Rust via Rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal;
+      - uses: Swatinem/rust-cache@v2
       - run: /github/home/.cargo/bin/cargo build --no-default-features --features max-pure
 
   test:


### PR DESCRIPTION
As described on https://github.com/Swatinem/rust-cache, the Swatinem/rust-cache@v2 GitHub action should happen after installing Rust with rustup to use the current rustc version as the cache key.