### PR TITLE
tests: Evaluate Cargo's target directory dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ debug-small: always ## minimal dependencies, at cost of performance
 
 ##@ Development
 
-target/release/gix: always
+gix := $(shell cargo metadata --format-version 1 | jq -r .target_directory)/release/gix
+$(gix): always
 	cargo build --release --no-default-features --features small
 
 ##@ Testing
@@ -95,20 +96,20 @@ commit_graphs = \
 
 stress: ## Run various algorithms on big repositories
 	$(MAKE) -j3 $(linux_repo) $(rust_repo) release-lean
-	time ./target/release/gix --verbose no-repo pack verify --re-encode $(linux_repo)/objects/pack/*.idx
-	time ./target/release/gix --verbose no-repo pack multi-index -i $(linux_repo)/objects/pack/multi-pack-index create $(linux_repo)/objects/pack/*.idx
-	time ./target/release/gix --verbose no-repo pack verify $(linux_repo)/objects/pack/multi-pack-index
-	rm -Rf out; mkdir out && time ./target/release/gix --verbose no-repo pack index create -p $(linux_repo)/objects/pack/*.pack out/
-	time ./target/release/gix --verbose no-repo pack verify out/*.idx
+	time $(gix) --verbose no-repo pack verify --re-encode $(linux_repo)/objects/pack/*.idx
+	time $(gix) --verbose no-repo pack multi-index -i $(linux_repo)/objects/pack/multi-pack-index create $(linux_repo)/objects/pack/*.idx
+	time $(gix) --verbose no-repo pack verify $(linux_repo)/objects/pack/multi-pack-index
+	rm -Rf out; mkdir out && time $(gix) --verbose no-repo pack index create -p $(linux_repo)/objects/pack/*.pack out/
+	time $(gix) --verbose no-repo pack verify out/*.idx
 
-	time ./target/release/gix --verbose no-repo pack verify --statistics $(rust_repo)/objects/pack/*.idx
-	time ./target/release/gix --verbose no-repo pack verify --algorithm less-memory $(rust_repo)/objects/pack/*.idx
-	time ./target/release/gix --verbose no-repo pack verify --re-encode $(rust_repo)/objects/pack/*.idx
+	time $(gix) --verbose no-repo pack verify --statistics $(rust_repo)/objects/pack/*.idx
+	time $(gix) --verbose no-repo pack verify --algorithm less-memory $(rust_repo)/objects/pack/*.idx
+	time $(gix) --verbose no-repo pack verify --re-encode $(rust_repo)/objects/pack/*.idx
 	# We must ensure there is exactly one pack file for the pack-explode *.idx globs to work.
 	git repack -Ad
-	time ./target/release/gix --verbose no-repo pack explode .git/objects/pack/*.idx
+	time $(gix) --verbose no-repo pack explode .git/objects/pack/*.idx
 
-	rm -Rf delme; mkdir delme && time ./target/release/gix --verbose no-repo pack explode .git/objects/pack/*.idx delme/
+	rm -Rf delme; mkdir delme && time $(gix) --verbose no-repo pack explode .git/objects/pack/*.idx delme/
 
 	$(MAKE) stress-commitgraph
 	$(MAKE) bench-gix-config
@@ -116,7 +117,7 @@ stress: ## Run various algorithms on big repositories
 .PHONY: stress-commitgraph
 stress-commitgraph: release-lean $(commit_graphs)
 	set -x; for path in $(wordlist 2, 999, $^); do \
-		time ./target/release/gix --verbose no-repo commit-graph verify $$path; \
+		time $(gix) --verbose no-repo commit-graph verify $$path; \
 	done
 
 .PHONY: bench-gix-config
@@ -158,5 +159,9 @@ force-update-assets: ## As update-assets, but will run git to update the baselin
 
 ##@ Publishing & Versioning
 
-try-publish-all: ## Dry-run publish all crates in the currently set version if they are not published yet.
-	(cd cargo-smart-release && cargo build --bin cargo-smart-release) && cargo-smart-release/target/debug/cargo-smart-release smart-release gitoxide
+cargo-smart-release := $(shell cargo metadata --manifest-path ./cargo-smart-release/Cargo.toml --format-version 1 | jq -r .target_directory)/debug/cargo-smart-release
+$(cargo-smart-release): always
+	cargo build --manifest-path ./cargo-smart-release/Cargo.toml --bin cargo-smart-release
+
+try-publish-all: $(cargo-smart-release) ## Dry-run publish all crates in the currently set version if they are not published yet.
+	$(cargo-smart-release) smart-release gitoxide

--- a/cargo-smart-release/tests/journey.sh
+++ b/cargo-smart-release/tests/journey.sh
@@ -4,7 +4,11 @@ set -eu
 exe=${1:?First argument must be the executable to test}
 
 root="$(cd "${0%/*}" && pwd)"
-exe="${root}/../$exe"
+
+# if exe path is relative eval it from the parent of this script's location
+if [[ $exe != /* ]]; then
+  exe="${root}/../$exe"
+fi
 
 # shellcheck disable=1090
 source "$root/utilities.sh"

--- a/gix-prompt/tests/prompt.rs
+++ b/gix-prompt/tests/prompt.rs
@@ -1,6 +1,37 @@
 mod options;
 
 mod ask {
+    use gix_testtools::bstr::ByteSlice;
+
+    /// Evaluates Cargo's target directory for this project at runtime to adjust for the concrete
+    /// execution environment. This is necessary because certain environment variables and
+    /// configuration options can change its location (e.g. CARGO_TARGET_DIR).
+    fn evaluate_target_dir() -> String {
+        let manifest_proc = std::process::Command::new(env!("CARGO"))
+            .args(["metadata", "--format-version", "1"])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let jq_proc = std::process::Command::new("jq")
+            .args(["-r", ".target_directory"]) // -r makes it output raw strings
+            .stdin(manifest_proc.stdout.unwrap())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("jq utility is available in PATH");
+
+        let output = jq_proc
+            .wait_with_output()
+            .expect(".target_directory is a valid search path for manifest format version 1");
+
+        output
+            .stdout
+            .trim()
+            .to_str()
+            .expect("value of target_directory is valid UTF8")
+            .to_owned()
+    }
+
     #[test]
     #[cfg(unix)]
     fn askpass_only() {
@@ -8,7 +39,7 @@ mod ask {
         cmd.args(["build", "--example", "use-askpass", "--example", "askpass"]);
         cmd.spawn().unwrap().wait().expect("example builds OK");
 
-        let mut p = expectrl::spawn("../target/debug/examples/use-askpass").unwrap();
+        let mut p = expectrl::spawn(evaluate_target_dir() + "/debug/examples/use-askpass").unwrap();
         p.expect("Password: ").unwrap();
         p.send_line(" password with space ").unwrap();
         p.expect("\" password with space \"").unwrap();
@@ -22,7 +53,7 @@ mod ask {
         cmd.args(["build", "--example", "credentials"]);
         cmd.spawn().unwrap().wait().expect("example builds OK");
 
-        let mut p = expectrl::spawn("../target/debug/examples/credentials").unwrap();
+        let mut p = expectrl::spawn(evaluate_target_dir() + "/debug/examples/credentials").unwrap();
         p.expect("Username: ").unwrap();
         p.send_line(" user with space ").unwrap();
         p.expect("\" user with space\"").unwrap();

--- a/justfile
+++ b/justfile
@@ -174,36 +174,41 @@ unit-tests:
 unit-tests-flaky:
     cargo test -p gix --features async-network-client-async-std
 
-jtt := "target/debug/jtt"
+target_dir := `cargo metadata --format-version 1 | jq -r .target_directory`
+ein := target_dir / "debug/ein"
+gix := target_dir / "debug/gix"
+jtt := target_dir / "debug/jtt"
 
 # run journey tests (max)
 journey-tests:
     cargo build
     cargo build -p gix-testtools --bin jtt
-    ./tests/journey.sh target/debug/ein target/debug/gix {{ jtt }} max
+    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} max
 
 # run journey tests (max-pure)
 journey-tests-pure:
     cargo build --no-default-features --features max-pure
     cargo build -p gix-testtools --bin jtt
-    ./tests/journey.sh target/debug/ein target/debug/gix {{ jtt }} max-pure
+    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} max-pure
 
 # run journey tests (small)
 journey-tests-small:
     cargo build --no-default-features --features small
     cargo build -p gix-testtools
-    ./tests/journey.sh target/debug/ein target/debug/gix {{ jtt }} small
+    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} small
 
 # run journey tests (lean-async)
 journey-tests-async:
     cargo build --no-default-features --features lean-async
     cargo build -p gix-testtools
-    ./tests/journey.sh target/debug/ein target/debug/gix {{ jtt }} async
+    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} async
+
+cargo-smart-release := `cargo metadata --manifest-path ./cargo-smart-release/Cargo.toml --format-version 1 | jq -r .target_directory` / "debug/cargo-smart-release"
 
 # run journey tests (cargo-smart-release)
 journey-tests-smart-release:
     cd cargo-smart-release && cargo build --bin cargo-smart-release
-    cd cargo-smart-release && ./tests/journey.sh ../cargo-smart-release/target/debug/cargo-smart-release
+    cd cargo-smart-release && ./tests/journey.sh {{ cargo-smart-release }}
 
 # Run cargo-diet on all crates to see that they are still in bound
 check-size:

--- a/tests/journey.sh
+++ b/tests/journey.sh
@@ -7,9 +7,17 @@ jtt=${3:?Third argument the journey test tool}
 kind=${4:?Fourth argument must an indicator of the kind of binary under test}
 
 root="$(cd "${0%/*}" && pwd)"
-exe="${root}/../$exe"
-exe_plumbing="${root}/../$exe_plumbing"
-jtt="${root}/../$jtt"
+
+# if relative paths are given eval them from the parent of this script's location 
+if [[ $exe != /* ]]; then
+  exe="${root}/../$exe"
+fi
+if [[ $exe_plumbing != /* ]]; then
+  exe_plumbing="${root}/../$exe_plumbing"
+fi
+if [[ $jtt != /* ]]; then
+  jtt="${root}/../$jtt"
+fi
 
 # shellcheck disable=1090
 source "$root/utilities.sh"


### PR DESCRIPTION
There are a few tests in Gitoxide that need to directly invoke the built binaries and previously this was achieved by hardcoding the path to those binaries to be in the local `target` directory. 

This PR changes ~~all~~ most (see below) cases to instead extract the target directory from the output of `cargo metadata`. This has the concrete advantage that the binaries can be found even if a developer (such as me) uses Cargo features like `CARGO_TARGET_DIR` to change the target directory to be somewhere else.

I realize that this might be kind of an edge case because not many people will just unconditionally set `CARGO_TARGET_DIR` to a central directory (like I do), but apart from the new dev dependency on `jq` (which is installed on all CI machines and probably most developer machines anyways) this change has no (to me obvious) disadvantages, so I went ahead and fixed the problem for everyone. Also, in the future this _might_ become more relevant gets https://github.com/rust-lang/rfcs/pull/3371 is accepted.

This change impacts
 - `make stress` (location of `gix`)
 - `make try-publish-all` (location of `cargo-smart-release`)
 - `just journey-tests-*` (location of `gix`, `ein`, `jtt` and `cargo-smart-release`)
 - `cargo test -p gix-prompt` (location of `use-askpass` and `credentials` examples)

The last two are commonly invoked via `just test`. I tested all those commands both with `CARGO_TARGET_DIR` set and unset and all worked (apart from `make stress` but that fails in both cases because it can't find `time` :shrug:).

There is one journey test for `cargo-smart-release` which interacts with the local target directory. I did not change that because I honestly don't quite understand what it does. It seems to be testing something with `.gitignore` which suggests to me that the test may depend on the assumption that there will always be a local target directory, even if their might be none?