### PR TITLE
Finish migrating gitoxide from nom 7 to winnow 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "thiserror",
- "winnow 0.3.8",
+ "winnow 0.4.11",
 ]
 
 [[package]]
@@ -1877,7 +1877,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "winnow 0.3.8",
+ "winnow 0.4.11",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "winnow 0.3.8",
+ "winnow 0.4.11",
 ]
 
 [[package]]
@@ -2278,7 +2278,7 @@ dependencies = [
  "parking_lot",
  "tar",
  "tempfile",
- "winnow 0.3.8",
+ "winnow 0.4.11",
  "xz2",
 ]
 
@@ -4771,9 +4771,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "thiserror",
- "winnow 0.4.11",
+ "winnow",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.5.1",
+ "winnow",
 ]
 
 [[package]]
@@ -1877,7 +1877,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "winnow 0.4.11",
+ "winnow",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "winnow 0.4.11",
+ "winnow",
 ]
 
 [[package]]
@@ -2278,7 +2278,7 @@ dependencies = [
  "parking_lot",
  "tar",
  "tempfile",
- "winnow 0.4.11",
+ "winnow",
  "xz2",
 ]
 
@@ -4771,18 +4771,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.11"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,10 +1283,10 @@ dependencies = [
  "gix-hash 0.11.4",
  "gix-testtools",
  "itoa",
- "nom",
  "pretty_assertions",
  "serde",
  "thiserror",
+ "winnow 0.3.8",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow",
+ "winnow 0.5.1",
 ]
 
 [[package]]
@@ -1873,11 +1873,11 @@ dependencies = [
  "gix-testtools",
  "gix-validate 0.8.0",
  "itoa",
- "nom",
  "pretty_assertions",
  "serde",
  "smallvec",
  "thiserror",
+ "winnow 0.3.8",
 ]
 
 [[package]]
@@ -2116,10 +2116,10 @@ dependencies = [
  "gix-utils 0.1.5",
  "gix-validate 0.8.0",
  "memmap2 0.7.1",
- "nom",
  "serde",
  "tempfile",
  "thiserror",
+ "winnow 0.3.8",
 ]
 
 [[package]]
@@ -2274,11 +2274,11 @@ dependencies = [
  "gix-worktree 0.17.1",
  "io-close",
  "is_ci",
- "nom",
  "once_cell",
  "parking_lot",
  "tar",
  "tempfile",
+ "winnow 0.3.8",
  "xz2",
 ]
 
@@ -4768,6 +4768,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/cargo-smart-release/Cargo.lock
+++ b/cargo-smart-release/Cargo.lock
@@ -2667,9 +2667,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.1"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
+checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
 dependencies = [
  "memchr",
 ]

--- a/cargo-smart-release/Cargo.toml
+++ b/cargo-smart-release/Cargo.toml
@@ -34,7 +34,7 @@ toml_edit = "0.19.1"
 semver = "1.0.4"
 crates-index = { version = "2.1.0", default-features = false, features = ["git-performance", "git-https"] }
 cargo_toml = "0.15.1"
-winnow = "0.5.1"
+winnow = "0.5.12"
 git-conventional = "0.12.0"
 time = "0.3.23"
 pulldown-cmark = "0.9.0"

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.7.1", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-winnow = { version = "0.5.12", features = ["simd"] }
+winnow = { version = "0.5.14", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.7.1", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-winnow = { version = "0.3", features = ["simd"] }
+winnow = { version = "0.4", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.7.1", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-nom = { version = "7", default-features = false, features = ["std"]}
+winnow = { version = "0.3", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.7.1", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-winnow = { version = "0.4", features = ["simd"] }
+winnow = { version = "0.5.12", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/src/identity.rs
+++ b/gix-actor/src/identity.rs
@@ -1,14 +1,15 @@
 use bstr::ByteSlice;
+use winnow::prelude::*;
 
 use crate::{signature::decode, Identity, IdentityRef};
 
 impl<'a> IdentityRef<'a> {
     /// Deserialize an identity from the given `data`.
-    pub fn from_bytes<E>(data: &'a [u8]) -> Result<Self, winnow::error::ErrMode<E>>
+    pub fn from_bytes<E>(mut data: &'a [u8]) -> Result<Self, winnow::error::ErrMode<E>>
     where
         E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8]>,
     {
-        decode::identity(data).map(|(_, t)| t)
+        decode::identity.parse_next(&mut data)
     }
 
     /// Create an owned instance from this shared one.

--- a/gix-actor/src/identity.rs
+++ b/gix-actor/src/identity.rs
@@ -6,7 +6,7 @@ impl<'a> IdentityRef<'a> {
     /// Deserialize an identity from the given `data`.
     pub fn from_bytes<E>(data: &'a [u8]) -> Result<Self, winnow::error::ErrMode<E>>
     where
-        E: winnow::error::ParseError<&'a [u8]> + winnow::error::ContextError<&'a [u8]>,
+        E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8]>,
     {
         decode::identity(data).map(|(_, t)| t)
     }

--- a/gix-actor/src/identity.rs
+++ b/gix-actor/src/identity.rs
@@ -4,9 +4,9 @@ use crate::{signature::decode, Identity, IdentityRef};
 
 impl<'a> IdentityRef<'a> {
     /// Deserialize an identity from the given `data`.
-    pub fn from_bytes<E>(data: &'a [u8]) -> Result<Self, nom::Err<E>>
+    pub fn from_bytes<E>(data: &'a [u8]) -> Result<Self, winnow::Err<E>>
     where
-        E: nom::error::ParseError<&'a [u8]> + nom::error::ContextError<&'a [u8]>,
+        E: winnow::error::ParseError<&'a [u8]> + winnow::error::ContextError<&'a [u8]>,
     {
         decode::identity(data).map(|(_, t)| t)
     }

--- a/gix-actor/src/identity.rs
+++ b/gix-actor/src/identity.rs
@@ -4,7 +4,7 @@ use crate::{signature::decode, Identity, IdentityRef};
 
 impl<'a> IdentityRef<'a> {
     /// Deserialize an identity from the given `data`.
-    pub fn from_bytes<E>(data: &'a [u8]) -> Result<Self, winnow::Err<E>>
+    pub fn from_bytes<E>(data: &'a [u8]) -> Result<Self, winnow::error::ErrMode<E>>
     where
         E: winnow::error::ParseError<&'a [u8]> + winnow::error::ContextError<&'a [u8]>,
     {

--- a/gix-actor/src/identity.rs
+++ b/gix-actor/src/identity.rs
@@ -1,4 +1,5 @@
 use bstr::ByteSlice;
+use winnow::error::StrContext;
 use winnow::prelude::*;
 
 use crate::{signature::decode, Identity, IdentityRef};
@@ -7,7 +8,7 @@ impl<'a> IdentityRef<'a> {
     /// Deserialize an identity from the given `data`.
     pub fn from_bytes<E>(mut data: &'a [u8]) -> Result<Self, winnow::error::ErrMode<E>>
     where
-        E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8]>,
+        E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8], StrContext>,
     {
         decode::identity.parse_next(&mut data)
     }

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -29,9 +29,9 @@ pub(crate) mod function {
                 tag(b" "),
                 context("<timestamp>", |i| {
                     terminated(take_until(SPACE), take(1usize))(i).and_then(|(i, v)| {
-                        btoi::<SecondsSinceUnixEpoch>(v).map(|v| (i, v)).map_err(|_| {
-                            winnow::Err::Backtrack(E::from_error_kind(i, winnow::error::ErrorKind::MapRes))
-                        })
+                        btoi::<SecondsSinceUnixEpoch>(v)
+                            .map(|v| (i, v))
+                            .map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))
                     })
                 }),
                 context(
@@ -43,16 +43,16 @@ pub(crate) mod function {
                 ),
                 context("HH", |i| {
                     take_while_m_n(2usize, 2, is_digit)(i).and_then(|(i, v)| {
-                        btoi::<OffsetInSeconds>(v).map(|v| (i, v)).map_err(|_| {
-                            winnow::Err::Backtrack(E::from_error_kind(i, winnow::error::ErrorKind::MapRes))
-                        })
+                        btoi::<OffsetInSeconds>(v)
+                            .map(|v| (i, v))
+                            .map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))
                     })
                 }),
                 context("MM", |i| {
                     take_while_m_n(1usize, 2, is_digit)(i).and_then(|(i, v)| {
-                        btoi::<OffsetInSeconds>(v).map(|v| (i, v)).map_err(|_| {
-                            winnow::Err::Backtrack(E::from_error_kind(i, winnow::error::ErrorKind::MapRes))
-                        })
+                        btoi::<OffsetInSeconds>(v)
+                            .map(|v| (i, v))
+                            .map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))
                     })
                 }),
             )),

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -5,7 +5,7 @@ pub(crate) mod function {
     use std::cell::RefCell;
     use winnow::{
         branch::alt,
-        bytes::complete::{tag, take, take_until, take_while_m_n},
+        bytes::complete::{take, take_until, take_while_m_n},
         character::is_digit,
         error::{context, ContextError, ParseError},
         multi::many1_count,
@@ -24,9 +24,9 @@ pub(crate) mod function {
         let tzsign = RefCell::new(b'-'); // TODO: there should be no need for this.
         let (i, (identity, _, time, _tzsign_count, hours, minutes)) = context(
             "<name> <<email>> <timestamp> <+|-><HHMM>",
-            tuple((
+            (
                 identity,
-                tag(b" "),
+                b" ",
                 context("<timestamp>", |i| {
                     terminated(take_until(SPACE), take(1usize))(i).and_then(|(i, v)| {
                         btoi::<SecondsSinceUnixEpoch>(v)
@@ -37,8 +37,8 @@ pub(crate) mod function {
                 context(
                     "+|-",
                     alt((
-                        many1_count(tag(b"-")).map(|_| *tzsign.borrow_mut() = b'-'), // TODO: this should be a non-allocating consumer of consecutive tags
-                        many1_count(tag(b"+")).map(|_| *tzsign.borrow_mut() = b'+'),
+                        many1_count(b"-").map(|_| *tzsign.borrow_mut() = b'-'), // TODO: this should be a non-allocating consumer of consecutive tags
+                        many1_count(b"+").map(|_| *tzsign.borrow_mut() = b'+'),
                     )),
                 ),
                 context("HH", |i| {
@@ -55,7 +55,7 @@ pub(crate) mod function {
                             .map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))
                     })
                 }),
-            )),
+            ),
         )(i)?;
 
         let tzsign = tzsign.into_inner();
@@ -83,10 +83,10 @@ pub(crate) mod function {
     ) -> IResult<&'a [u8], IdentityRef<'a>, E> {
         let (i, (name, email)) = context(
             "<name> <<email>>",
-            tuple((
+            (
                 context("<name>", terminated(take_until(&b" <"[..]), take(2usize))),
                 context("<email>", terminated(take_until(&b">"[..]), take(1usize))),
-            )),
+            ),
         )(i)?;
 
         Ok((

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -4,13 +4,13 @@ pub(crate) mod function {
     use gix_date::{time::Sign, OffsetInSeconds, SecondsSinceUnixEpoch, Time};
     use std::cell::RefCell;
     use winnow::{
-        branch::alt,
-        bytes::{take, take_until0, take_while},
+        combinator::alt,
         combinator::repeat,
-        error::{ContextError, ParseError},
+        combinator::terminated,
+        error::{AddContext, ParserError},
         prelude::*,
-        sequence::terminated,
         stream::AsChar,
+        token::{take, take_until0, take_while},
     };
 
     use crate::{IdentityRef, SignatureRef};
@@ -18,7 +18,7 @@ pub(crate) mod function {
     const SPACE: &[u8] = b" ";
 
     /// Parse a signature from the bytes input `i` using `nom`.
-    pub fn decode<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+    pub fn decode<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(
         i: &'a [u8],
     ) -> IResult<&'a [u8], SignatureRef<'a>, E> {
         let tzsign = RefCell::new(b'-'); // TODO: there should be no need for this.
@@ -82,7 +82,7 @@ pub(crate) mod function {
     }
 
     /// Parse an identity from the bytes input `i` (like `name <email>`) using `nom`.
-    pub fn identity<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+    pub fn identity<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(
         i: &'a [u8],
     ) -> IResult<&'a [u8], IdentityRef<'a>, E> {
         let (i, (name, email)) = (

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -31,7 +31,7 @@ pub(crate) mod function {
                     .and_then(|(i, v)| {
                         btoi::<SecondsSinceUnixEpoch>(v)
                             .map(|v| (i, v))
-                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
+                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify))
                     })
             })
             .context("<timestamp>"),
@@ -46,7 +46,7 @@ pub(crate) mod function {
                     .and_then(|(i, v)| {
                         btoi::<OffsetInSeconds>(v)
                             .map(|v| (i, v))
-                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
+                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify))
                     })
             })
             .context("HH"),
@@ -56,7 +56,7 @@ pub(crate) mod function {
                     .and_then(|(i, v)| {
                         btoi::<OffsetInSeconds>(v)
                             .map(|v| (i, v))
-                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
+                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify))
                     })
             })
             .context("MM"),
@@ -188,7 +188,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "Parse error:\nTakeUntil at:  12345 -1215\nin section '<email>', at:  12345 -1215\nin section '<name> <<email>>', at: hello < 12345 -1215\nin section '<name> <<email>> <timestamp> <+|-><HHMM>', at: hello < 12345 -1215\n"
+                        "Parse error:\nSlice at:  12345 -1215\nin section '<email>', at:  12345 -1215\nin section '<name> <<email>>', at: hello < 12345 -1215\nin section '<name> <<email>> <timestamp> <+|-><HHMM>', at: hello < 12345 -1215\n"
                     );
         }
 
@@ -199,7 +199,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "Parse error:\nMapRes at: -1215\nin section '<timestamp>', at: abc -1215\nin section '<name> <<email>> <timestamp> <+|-><HHMM>', at: hello <> abc -1215\n"
+                        "Parse error:\nVerify at: -1215\nin section '<timestamp>', at: abc -1215\nin section '<name> <<email>> <timestamp> <+|-><HHMM>', at: hello <> abc -1215\n"
                     );
         }
     }

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -26,11 +26,13 @@ pub(crate) mod function {
             identity,
             b" ",
             (|i| {
-                terminated(take_until0(SPACE), take(1usize))(i).and_then(|(i, v)| {
-                    btoi::<SecondsSinceUnixEpoch>(v)
-                        .map(|v| (i, v))
-                        .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
-                })
+                terminated(take_until0(SPACE), take(1usize))
+                    .parse_next(i)
+                    .and_then(|(i, v)| {
+                        btoi::<SecondsSinceUnixEpoch>(v)
+                            .map(|v| (i, v))
+                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
+                    })
             })
             .context("<timestamp>"),
             alt((
@@ -39,19 +41,23 @@ pub(crate) mod function {
             ))
             .context("+|-"),
             (|i| {
-                take_while_m_n(2usize, 2, AsChar::is_dec_digit)(i).and_then(|(i, v)| {
-                    btoi::<OffsetInSeconds>(v)
-                        .map(|v| (i, v))
-                        .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
-                })
+                take_while_m_n(2usize, 2, AsChar::is_dec_digit)
+                    .parse_next(i)
+                    .and_then(|(i, v)| {
+                        btoi::<OffsetInSeconds>(v)
+                            .map(|v| (i, v))
+                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
+                    })
             })
             .context("HH"),
             (|i| {
-                take_while_m_n(1usize, 2, AsChar::is_dec_digit)(i).and_then(|(i, v)| {
-                    btoi::<OffsetInSeconds>(v)
-                        .map(|v| (i, v))
-                        .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
-                })
+                take_while_m_n(1usize, 2, AsChar::is_dec_digit)
+                    .parse_next(i)
+                    .and_then(|(i, v)| {
+                        btoi::<OffsetInSeconds>(v)
+                            .map(|v| (i, v))
+                            .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))
+                    })
             })
             .context("MM"),
         )

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -4,7 +4,6 @@ pub(crate) mod function {
     use gix_date::{time::Sign, OffsetInSeconds, SecondsSinceUnixEpoch, Time};
     use winnow::{
         combinator::alt,
-        combinator::repeat,
         combinator::separated_pair,
         combinator::terminated,
         error::{AddContext, ParserError, StrContext},
@@ -29,8 +28,8 @@ pub(crate) mod function {
                     .verify_map(|v| btoi::<SecondsSinceUnixEpoch>(v).ok())
                     .context(StrContext::Expected("<timestamp>".into())),
                 alt((
-                    repeat(1.., b"-").map(|_: ()| Sign::Minus),
-                    repeat(1.., b"+").map(|_: ()| Sign::Plus),
+                    take_while(1.., b'-').map(|_| Sign::Minus),
+                    take_while(1.., b'+').map(|_| Sign::Plus),
                 ))
                 .context(StrContext::Expected("+|-".into())),
                 take_while(2, AsChar::is_dec_digit)

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -86,9 +86,7 @@ mod tests {
 
         use crate::{signature, SignatureRef, Time};
 
-        fn decode<'i>(
-            i: &mut &'i [u8],
-        ) -> PResult<SignatureRef<'i>, winnow::error::VerboseError<&'i [u8], &'static str>> {
+        fn decode<'i>(i: &mut &'i [u8]) -> PResult<SignatureRef<'i>, winnow::error::TreeError<&'i [u8], &'static str>> {
             signature::decode.parse_next(i)
         }
 
@@ -165,7 +163,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "Parse error:\nslice at:  12345 -1215\nin section '<email>', at:  12345 -1215\nin section '<name> <<email>>', at:  12345 -1215\nin section '<name> <<email>> <timestamp> <+|-><HHMM>', at:  12345 -1215\n"
+                        "in slice at ' 12345 -1215'\n  0: <email> at ' 12345 -1215'\n  1: <name> <<email>> at ' 12345 -1215'\n  2: <name> <<email>> <timestamp> <+|-><HHMM> at ' 12345 -1215'\n"
                     );
         }
 
@@ -176,7 +174,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "Parse error:\npredicate verification at: abc -1215\nin section '<timestamp>', at: abc -1215\nin section '<name> <<email>> <timestamp> <+|-><HHMM>', at: abc -1215\n"
+                        "in predicate verification at 'abc -1215'\n  0: <timestamp> at 'abc -1215'\n  1: <name> <<email>> <timestamp> <+|-><HHMM> at 'abc -1215'\n"
                     );
         }
     }

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -5,9 +5,9 @@ mod _ref {
 
     impl<'a> SignatureRef<'a> {
         /// Deserialize a signature from the given `data`.
-        pub fn from_bytes<E>(data: &'a [u8]) -> Result<SignatureRef<'a>, nom::Err<E>>
+        pub fn from_bytes<E>(data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::Err<E>>
         where
-            E: nom::error::ParseError<&'a [u8]> + nom::error::ContextError<&'a [u8]>,
+            E: winnow::error::ParseError<&'a [u8]> + winnow::error::ContextError<&'a [u8]>,
         {
             decode(data).map(|(_, t)| t)
         }

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -1,15 +1,16 @@
 mod _ref {
     use bstr::ByteSlice;
+    use winnow::prelude::*;
 
     use crate::{signature::decode, IdentityRef, Signature, SignatureRef};
 
     impl<'a> SignatureRef<'a> {
         /// Deserialize a signature from the given `data`.
-        pub fn from_bytes<E>(data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::error::ErrMode<E>>
+        pub fn from_bytes<E>(mut data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::error::ErrMode<E>>
         where
             E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8]>,
         {
-            decode(data).map(|(_, t)| t)
+            decode.parse_next(&mut data)
         }
 
         /// Create an owned instance from this shared one.

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -5,7 +5,7 @@ mod _ref {
 
     impl<'a> SignatureRef<'a> {
         /// Deserialize a signature from the given `data`.
-        pub fn from_bytes<E>(data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::Err<E>>
+        pub fn from_bytes<E>(data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::error::ErrMode<E>>
         where
             E: winnow::error::ParseError<&'a [u8]> + winnow::error::ContextError<&'a [u8]>,
         {

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -7,7 +7,7 @@ mod _ref {
         /// Deserialize a signature from the given `data`.
         pub fn from_bytes<E>(data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::error::ErrMode<E>>
         where
-            E: winnow::error::ParseError<&'a [u8]> + winnow::error::ContextError<&'a [u8]>,
+            E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8]>,
         {
             decode(data).map(|(_, t)| t)
         }

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -1,5 +1,6 @@
 mod _ref {
     use bstr::ByteSlice;
+    use winnow::error::StrContext;
     use winnow::prelude::*;
 
     use crate::{signature::decode, IdentityRef, Signature, SignatureRef};
@@ -8,7 +9,7 @@ mod _ref {
         /// Deserialize a signature from the given `data`.
         pub fn from_bytes<E>(mut data: &'a [u8]) -> Result<SignatureRef<'a>, winnow::error::ErrMode<E>>
         where
-            E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8]>,
+            E: winnow::error::ParserError<&'a [u8]> + winnow::error::AddContext<&'a [u8], StrContext>,
         {
             decode.parse_next(&mut data)
         }

--- a/gix-actor/tests/identity/mod.rs
+++ b/gix-actor/tests/identity/mod.rs
@@ -9,7 +9,7 @@ fn round_trip() -> gix_testtools::Result {
         b".. whitespace  \t  is explicitly allowed    - unicode aware trimming must be done elsewhere  <byronimo@gmail.com>"
     ];
     for input in DEFAULTS {
-        let signature: Identity = gix_actor::IdentityRef::from_bytes::<()>(input)?.into();
+        let signature: Identity = gix_actor::IdentityRef::from_bytes::<()>(input).unwrap().into();
         let mut output = Vec::new();
         signature.write_to(&mut output)?;
         assert_eq!(output.as_bstr(), input.as_bstr());

--- a/gix-actor/tests/signature/mod.rs
+++ b/gix-actor/tests/signature/mod.rs
@@ -73,7 +73,7 @@ fn round_trip() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for input in DEFAULTS {
-        let signature: Signature = gix_actor::SignatureRef::from_bytes::<()>(input)?.into();
+        let signature: Signature = gix_actor::SignatureRef::from_bytes::<()>(input).unwrap().into();
         let mut output = Vec::new();
         signature.write_to(&mut output)?;
         assert_eq!(output.as_bstr(), input.as_bstr());

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -25,7 +25,7 @@ gix-ref = { version = "^0.34.0", path = "../gix-ref" }
 gix-glob = { version = "^0.10.2", path = "../gix-glob" }
 
 log = "0.4.17"
-winnow = { version = "0.5.12", features = ["simd"] }
+winnow = { version = "0.5.14", features = ["simd"] }
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -25,7 +25,7 @@ gix-ref = { version = "^0.34.0", path = "../gix-ref" }
 gix-glob = { version = "^0.10.2", path = "../gix-glob" }
 
 log = "0.4.17"
-winnow = { version = "0.5", features = ["simd"] }
+winnow = { version = "0.5.12", features = ["simd"] }
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -25,7 +25,7 @@ gix-ref = { version = "^0.34.0", path = "../gix-ref" }
 gix-glob = { version = "^0.10.2", path = "../gix-glob" }
 
 log = "0.4.17"
-winnow = "0.5"
+winnow = { version = "0.5", features = ["simd"] }
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.12", features = ["simd"] }
+winnow = { version = "0.5.14", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "bstr/serde", "smallvec/serde", "gix-hash/serde", "gix-act
 ## details information about the error location will be collected.
 ## Use it in applications which expect broken or invalid objects or for debugging purposes. Incorrectly formatted objects aren't at all
 ## common otherwise.
-verbose-object-parsing-errors = ["nom/std"]
+verbose-object-parsing-errors = []
 
 [dependencies]
 gix-features = { version = "^0.32.1", path = "../gix-features", features = ["rustsha1"] }
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-nom = { version = "7", default-features = false, features = ["std"]}
+winnow = { version = "0.3", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.3", features = ["simd"] }
+winnow = { version = "0.4", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.4", features = ["simd"] }
+winnow = { version = "0.5.12", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -15,11 +15,8 @@ use crate::{parse, parse::NL, BStr, ByteSlice, CommitRef};
 pub fn message<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
     if i.is_empty() {
         // newline + [message]
-        return Err(winnow::Err::Backtrack(E::add_context(
-            E::from_error_kind(i, winnow::error::ErrorKind::Eof),
-            i,
-            "newline + <message>",
-        )));
+        return Err(winnow::Err::from_error_kind(i, winnow::error::ErrorKind::Eof)
+            .map(|err: E| err.add_context(i, "newline + <message>")));
     }
     let (i, _) = context("a newline separates headers from the message", tag(NL))(i)?;
     Ok((&[], i.as_bstr()))

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use smallvec::SmallVec;
 use winnow::{
     branch::alt,
-    bytes::complete::{is_not, tag},
+    bytes::complete::is_not,
     combinator::{all_consuming, opt},
     error::{context, ContextError, ParseError},
     multi::many0,
@@ -18,7 +18,7 @@ pub fn message<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]
         return Err(winnow::Err::from_error_kind(i, winnow::error::ErrorKind::Eof)
             .map(|err: E| err.add_context(i, "newline + <message>")));
     }
-    let (i, _) = context("a newline separates headers from the message", tag(NL))(i)?;
+    let (i, _) = context("a newline separates headers from the message", NL)(i)?;
     Ok((&[], i.as_bstr()))
 }
 

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -3,11 +3,11 @@ use std::borrow::Cow;
 use smallvec::SmallVec;
 use winnow::{
     branch::alt,
-    bytes::complete::is_not,
+    bytes::complete::{is_not, tag},
     combinator::{all_consuming, opt},
-    error::{context, ContextError, ParseError},
+    error::{ContextError, ParseError},
     multi::many0,
-    IResult, Parser,
+    prelude::*,
 };
 
 use crate::{parse, parse::NL, BStr, ByteSlice, CommitRef};
@@ -18,39 +18,36 @@ pub fn message<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]
         return Err(winnow::Err::from_error_kind(i, winnow::error::ErrorKind::Eof)
             .map(|err: E| err.add_context(i, "newline + <message>")));
     }
-    let (i, _) = context("a newline separates headers from the message", NL)(i)?;
+    let (i, _) = tag(NL)
+        .context("a newline separates headers from the message")
+        .parse_next(i)?;
     Ok((&[], i.as_bstr()))
 }
 
 pub fn commit<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
     i: &'a [u8],
 ) -> IResult<&'a [u8], CommitRef<'_>, E> {
-    let (i, tree) = context("tree <40 lowercase hex char>", |i| {
-        parse::header_field(i, b"tree", parse::hex_hash)
-    })(i)?;
-    let (i, parents): (_, Vec<_>) = context(
-        "zero or more 'parent <40 lowercase hex char>'",
-        many0(|i| parse::header_field(i, b"parent", parse::hex_hash)),
-    )(i)?;
-    let (i, author) = context("author <signature>", |i| {
-        parse::header_field(i, b"author", parse::signature)
-    })(i)?;
-    let (i, committer) = context("committer <signature>", |i| {
-        parse::header_field(i, b"committer", parse::signature)
-    })(i)?;
-    let (i, encoding) = context(
-        "encoding <encoding>",
-        opt(|i| parse::header_field(i, b"encoding", is_not(NL))),
-    )(i)?;
-    let (i, extra_headers) = context(
-        "<field> <single-line|multi-line>",
-        many0(alt((
-            parse::any_header_field_multi_line.map(|(k, o)| (k.as_bstr(), Cow::Owned(o))),
-            |i| {
-                parse::any_header_field(i, is_not(NL)).map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr()))))
-            },
-        ))),
-    )(i)?;
+    let (i, tree) = (|i| parse::header_field(i, b"tree", parse::hex_hash))
+        .context("tree <40 lowercase hex char>")
+        .parse_next(i)?;
+    let (i, parents): (_, Vec<_>) = many0(|i| parse::header_field(i, b"parent", parse::hex_hash))
+        .context("zero or more 'parent <40 lowercase hex char>'")
+        .parse_next(i)?;
+    let (i, author) = (|i| parse::header_field(i, b"author", parse::signature))
+        .context("author <signature>")
+        .parse_next(i)?;
+    let (i, committer) = (|i| parse::header_field(i, b"committer", parse::signature))
+        .context("committer <signature>")
+        .parse_next(i)?;
+    let (i, encoding) = opt(|i| parse::header_field(i, b"encoding", is_not(NL)))
+        .context("encoding <encoding>")
+        .parse_next(i)?;
+    let (i, extra_headers) = many0(alt((
+        parse::any_header_field_multi_line.map(|(k, o)| (k.as_bstr(), Cow::Owned(o))),
+        |i| parse::any_header_field(i, is_not(NL)).map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr())))),
+    )))
+    .context("<field> <single-line|multi-line>")
+    .parse_next(i)?;
     let (i, message) = all_consuming(message)(i)?;
 
     Ok((

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -53,7 +53,7 @@ pub fn commit<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
     )))
     .context("<field> <single-line|multi-line>")
     .parse_next(i)?;
-    let (i, message) = terminated(message, eof)(i)?;
+    let (i, message) = terminated(message, eof).parse_next(i)?;
 
     Ok((
         i,

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -19,7 +19,7 @@ pub fn message<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(i: &mut &'a 
         // newline + [message]
         return Err(
             winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Eof)
-                .map(|err: E| err.add_context(i, "newline + <message>")),
+                .add_context(i, "newline + <message>"),
         );
     }
     preceded(NL, rest.map(ByteSlice::as_bstr))

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -3,12 +3,13 @@ use std::borrow::Cow;
 use smallvec::SmallVec;
 use winnow::{
     combinator::alt,
+    combinator::preceded,
     combinator::repeat,
     combinator::terminated,
-    combinator::{eof, opt},
+    combinator::{eof, opt, rest},
     error::{AddContext, ParserError},
     prelude::*,
-    token::{tag, take_till1},
+    token::take_till1,
 };
 
 use crate::{parse, parse::NL, BStr, ByteSlice, CommitRef};
@@ -21,52 +22,43 @@ pub fn message<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(i: &'a [u8])
                 .map(|err: E| err.add_context(i, "newline + <message>")),
         );
     }
-    let (i, _) = tag(NL)
+    preceded(NL, rest.map(ByteSlice::as_bstr))
         .context("a newline separates headers from the message")
-        .parse_next(i)?;
-    Ok((&[], i.as_bstr()))
+        .parse_next(i)
 }
 
-pub fn commit<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], CommitRef<'_>, E> {
-    let (i, tree) = (|i| parse::header_field(i, b"tree", parse::hex_hash))
-        .context("tree <40 lowercase hex char>")
-        .parse_next(i)?;
-    let (i, parents): (_, Vec<_>) = repeat(0.., |i| parse::header_field(i, b"parent", parse::hex_hash))
-        .context("zero or more 'parent <40 lowercase hex char>'")
-        .parse_next(i)?;
-    let (i, author) = (|i| parse::header_field(i, b"author", parse::signature))
-        .context("author <signature>")
-        .parse_next(i)?;
-    let (i, committer) = (|i| parse::header_field(i, b"committer", parse::signature))
-        .context("committer <signature>")
-        .parse_next(i)?;
-    let (i, encoding) = opt(|i| parse::header_field(i, b"encoding", take_till1(NL)))
-        .context("encoding <encoding>")
-        .parse_next(i)?;
-    let (i, extra_headers) = repeat(
-        0..,
-        alt((
-            parse::any_header_field_multi_line.map(|(k, o)| (k.as_bstr(), Cow::Owned(o))),
-            |i| {
-                parse::any_header_field(i, take_till1(NL))
-                    .map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr()))))
-            },
-        )),
+pub fn commit<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], CommitRef<'a>, E> {
+    (
+        (|i| parse::header_field(i, b"tree", parse::hex_hash)).context("tree <40 lowercase hex char>"),
+        repeat(0.., |i| parse::header_field(i, b"parent", parse::hex_hash))
+            .map(|p: Vec<_>| p)
+            .context("zero or more 'parent <40 lowercase hex char>'"),
+        (|i| parse::header_field(i, b"author", parse::signature)).context("author <signature>"),
+        (|i| parse::header_field(i, b"committer", parse::signature)).context("committer <signature>"),
+        opt(|i| parse::header_field(i, b"encoding", take_till1(NL))).context("encoding <encoding>"),
+        repeat(
+            0..,
+            alt((
+                parse::any_header_field_multi_line.map(|(k, o)| (k.as_bstr(), Cow::Owned(o))),
+                |i| {
+                    parse::any_header_field(i, take_till1(NL))
+                        .map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr()))))
+                },
+            )),
+        )
+        .context("<field> <single-line|multi-line>"),
+        terminated(message, eof),
     )
-    .context("<field> <single-line|multi-line>")
-    .parse_next(i)?;
-    let (i, message) = terminated(message, eof).parse_next(i)?;
-
-    Ok((
-        i,
-        CommitRef {
-            tree,
-            parents: SmallVec::from(parents),
-            author,
-            committer,
-            encoding: encoding.map(ByteSlice::as_bstr),
-            message,
-            extra_headers,
-        },
-    ))
+        .map(
+            |(tree, parents, author, committer, encoding, extra_headers, message)| CommitRef {
+                tree,
+                parents: SmallVec::from(parents),
+                author,
+                committer,
+                encoding: encoding.map(ByteSlice::as_bstr),
+                message,
+                extra_headers,
+            },
+        )
+        .parse_next(i)
 }

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use winnow::{
-    bytes::complete::{tag, take_until1},
+    bytes::complete::take_until1,
     combinator::all_consuming,
     error::{ErrorKind, ParseError},
     sequence::terminated,
@@ -33,7 +33,7 @@ pub struct TrailerRef<'a> {
 }
 
 fn parse_single_line_trailer<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, &'a BStr), E> {
-    let (value, token) = terminated(take_until1(b":".as_ref()), tag(b": "))(i.trim_end())?;
+    let (value, token) = terminated(take_until1(b":".as_ref()), b": ")(i.trim_end())?;
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
         Err(winnow::Err::from_error_kind(i, ErrorKind::Fail).cut())
     } else {

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -1,11 +1,11 @@
 use std::ops::Deref;
 
 use winnow::{
-    bytes::take_until1,
     combinator::eof,
-    error::{ErrorKind, ParseError},
+    combinator::terminated,
+    error::{ErrorKind, ParserError},
     prelude::*,
-    sequence::terminated,
+    token::take_until1,
 };
 
 use crate::{
@@ -32,7 +32,7 @@ pub struct TrailerRef<'a> {
     pub value: &'a BStr,
 }
 
-fn parse_single_line_trailer<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, &'a BStr), E> {
+fn parse_single_line_trailer<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, &'a BStr), E> {
     let (value, token) = terminated(take_until1(b":".as_ref()), b": ").parse_next(i.trim_end())?;
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
         Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Fail).cut())

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -35,7 +35,7 @@ pub struct TrailerRef<'a> {
 fn parse_single_line_trailer<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, &'a BStr), E> {
     let (value, token) = terminated(take_until1(b":".as_ref()), tag(b": "))(i.trim_end())?;
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
-        Err(winnow::Err::Cut(E::from_error_kind(i, ErrorKind::Fail)))
+        Err(winnow::Err::from_error_kind(i, ErrorKind::Fail).cut())
     } else {
         Ok((&[], (token.as_bstr(), value.as_bstr())))
     }

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use nom::{
+use winnow::{
     bytes::complete::{tag, take_until1},
     combinator::all_consuming,
     error::{ErrorKind, ParseError},
@@ -35,7 +35,7 @@ pub struct TrailerRef<'a> {
 fn parse_single_line_trailer<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, &'a BStr), E> {
     let (value, token) = terminated(take_until1(b":".as_ref()), tag(b": "))(i.trim_end())?;
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
-        Err(nom::Err::Failure(E::from_error_kind(i, ErrorKind::Fail)))
+        Err(winnow::Err::Cut(E::from_error_kind(i, ErrorKind::Fail)))
     } else {
         Ok((&[], (token.as_bstr(), value.as_bstr())))
     }

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -1,8 +1,8 @@
 use std::ops::Deref;
 
 use winnow::{
-    bytes::complete::take_until1,
-    combinator::all_consuming,
+    bytes::take_until1,
+    combinator::eof,
     error::{ErrorKind, ParseError},
     sequence::terminated,
     IResult,
@@ -35,7 +35,7 @@ pub struct TrailerRef<'a> {
 fn parse_single_line_trailer<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, &'a BStr), E> {
     let (value, token) = terminated(take_until1(b":".as_ref()), b": ")(i.trim_end())?;
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
-        Err(winnow::Err::from_error_kind(i, ErrorKind::Fail).cut())
+        Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Fail).cut())
     } else {
         Ok((&[], (token.as_bstr(), value.as_bstr())))
     }
@@ -51,7 +51,7 @@ impl<'a> Iterator for Trailers<'a> {
         for line in self.cursor.lines_with_terminator() {
             self.cursor = &self.cursor[line.len()..];
             if let Some(trailer) =
-                all_consuming(parse_single_line_trailer::<()>)(line)
+                terminated(parse_single_line_trailer::<()>, eof)(line)
                     .ok()
                     .map(|(_, (token, value))| TrailerRef {
                         token: token.trim().as_bstr(),

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -3,14 +3,14 @@ use winnow::{branch::alt, bytes::take_till1, combinator::eof, error::ParseError,
 use crate::bstr::{BStr, ByteSlice};
 
 pub(crate) fn newline<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
-    alt((b"\r\n", b"\n"))(i)
+    alt((b"\r\n", b"\n")).parse_next(i)
 }
 
 fn subject_and_body<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, Option<&'a BStr>), E> {
     let mut c = i;
     let mut consumed_bytes = 0;
     while !c.is_empty() {
-        c = match take_till1::<_, _, E>(|c| c == b'\n' || c == b'\r')(c) {
+        c = match take_till1::<_, _, E>(|c| c == b'\n' || c == b'\r').parse_next(c) {
             Ok((i1, segment)) => {
                 consumed_bytes += segment.len();
                 match (newline::<E>, newline::<E>).parse_next(i1) {
@@ -46,5 +46,8 @@ fn subject_and_body<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8
 
 /// Returns title and body, without separator
 pub fn message(input: &[u8]) -> (&BStr, Option<&BStr>) {
-    terminated(subject_and_body::<()>, eof)(input).expect("cannot fail").1
+    terminated(subject_and_body::<()>, eof)
+        .parse_next(input)
+        .expect("cannot fail")
+        .1
 }

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -1,4 +1,4 @@
-use nom::{
+use winnow::{
     branch::alt,
     bytes::complete::{tag, take_till1},
     combinator::all_consuming,

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -1,16 +1,9 @@
-use winnow::{
-    branch::alt,
-    bytes::complete::{tag, take_till1},
-    combinator::all_consuming,
-    error::ParseError,
-    sequence::pair,
-    IResult,
-};
+use winnow::{branch::alt, bytes::complete::take_till1, combinator::all_consuming, error::ParseError, prelude::*};
 
 use crate::bstr::{BStr, ByteSlice};
 
 pub(crate) fn newline<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
-    alt((tag(b"\r\n"), tag(b"\n")))(i)
+    alt((b"\r\n", b"\n"))(i)
 }
 
 fn subject_and_body<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, Option<&'a BStr>), E> {
@@ -20,7 +13,7 @@ fn subject_and_body<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8
         c = match take_till1::<_, _, E>(|c| c == b'\n' || c == b'\r')(c) {
             Ok((i1, segment)) => {
                 consumed_bytes += segment.len();
-                match pair::<_, _, _, E, _, _>(newline, newline)(i1) {
+                match (newline::<E>, newline::<E>).parse_next(i1) {
                     Ok((body, _)) => {
                         return Ok((
                             &[],

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -1,12 +1,14 @@
-use winnow::{branch::alt, bytes::take_till1, combinator::eof, error::ParseError, prelude::*, sequence::terminated};
+use winnow::{
+    combinator::alt, combinator::eof, combinator::terminated, error::ParserError, prelude::*, token::take_till1,
+};
 
 use crate::bstr::{BStr, ByteSlice};
 
-pub(crate) fn newline<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
+pub(crate) fn newline<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
     alt((b"\r\n", b"\n")).parse_next(i)
 }
 
-fn subject_and_body<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, Option<&'a BStr>), E> {
+fn subject_and_body<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a BStr, Option<&'a BStr>), E> {
     let mut c = i;
     let mut consumed_bytes = 0;
     while !c.is_empty() {

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -1,4 +1,4 @@
-use winnow::{branch::alt, bytes::complete::take_till1, combinator::all_consuming, error::ParseError, prelude::*};
+use winnow::{branch::alt, bytes::take_till1, combinator::eof, error::ParseError, prelude::*, sequence::terminated};
 
 use crate::bstr::{BStr, ByteSlice};
 
@@ -46,5 +46,5 @@ fn subject_and_body<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8
 
 /// Returns title and body, without separator
 pub fn message(input: &[u8]) -> (&BStr, Option<&BStr>) {
-    all_consuming(subject_and_body::<()>)(input).expect("cannot fail").1
+    terminated(subject_and_body::<()>, eof)(input).expect("cannot fail").1
 }

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -1,52 +1,46 @@
 use winnow::{
     combinator::alt, combinator::eof, combinator::preceded, combinator::rest, combinator::terminated,
-    error::ParserError, prelude::*, stream::Offset, token::take_till1,
+    error::ParserError, prelude::*, stream::Offset, stream::Stream, token::take_till1,
 };
 
 use crate::bstr::{BStr, ByteSlice};
 
-pub(crate) fn newline<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
+pub(crate) fn newline<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a [u8], E> {
     alt((b"\n", b"\r\n")).parse_next(i)
 }
 
-fn subject_and_body<'a, E: ParserError<&'a [u8]>>(
-    mut i: &'a [u8],
-) -> IResult<&'a [u8], (&'a BStr, Option<&'a BStr>), E> {
-    let start = i;
+fn subject_and_body<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(&'a BStr, Option<&'a BStr>), E> {
+    let start_i = *i;
+    let start = i.checkpoint();
     while !i.is_empty() {
         match take_till1::<_, _, E>(|c| c == b'\n' || c == b'\r').parse_next(i) {
-            Ok((next, _)) => {
-                let consumed_bytes = next.offset_from(start);
-                match preceded((newline::<E>, newline::<E>), rest).parse_next(next) {
-                    Ok((next, body)) => {
+            Ok(_) => {
+                let consumed_bytes = i.offset_from(&start);
+                match preceded((newline::<E>, newline::<E>), rest).parse_next(i) {
+                    Ok(body) => {
                         let body = (!body.is_empty()).then(|| body.as_bstr());
-                        return Ok((next, (start[0usize..consumed_bytes].as_bstr(), body)));
+                        return Ok((start_i[0usize..consumed_bytes].as_bstr(), body));
                     }
-                    Err(_) => match next.get(1..) {
-                        Some(next) => {
-                            i = next;
-                        }
+                    Err(_) => match i.next_token() {
+                        Some(_) => {}
                         None => break,
                     },
                 }
             }
-            Err(_) => match i.get(1..) {
-                Some(next) => {
-                    i = next;
-                }
+            Err(_) => match i.next_token() {
+                Some(_) => {}
                 None => break,
             },
         }
     }
 
-    i = start;
+    i.reset(start);
     rest.map(|r: &[u8]| (r.as_bstr(), None)).parse_next(i)
 }
 
 /// Returns title and body, without separator
-pub fn message(input: &[u8]) -> (&BStr, Option<&BStr>) {
+pub fn message(mut input: &[u8]) -> (&BStr, Option<&BStr>) {
     terminated(subject_and_body::<()>, eof)
-        .parse_next(input)
+        .parse_next(&mut input)
         .expect("cannot fail")
-        .1
 }

--- a/gix-object/src/commit/mod.rs
+++ b/gix-object/src/commit/mod.rs
@@ -58,8 +58,8 @@ mod write;
 /// Lifecycle
 impl<'a> CommitRef<'a> {
     /// Deserialize a commit from the given `data` bytes while avoiding most allocations.
-    pub fn from_bytes(data: &'a [u8]) -> Result<CommitRef<'a>, crate::decode::Error> {
-        decode::commit(data).map(|(_, t)| t).map_err(crate::decode::Error::from)
+    pub fn from_bytes(mut data: &'a [u8]) -> Result<CommitRef<'a>, crate::decode::Error> {
+        decode::commit(&mut data).map_err(crate::decode::Error::from)
     }
 }
 

--- a/gix-object/src/commit/mod.rs
+++ b/gix-object/src/commit/mod.rs
@@ -59,7 +59,7 @@ mod write;
 impl<'a> CommitRef<'a> {
     /// Deserialize a commit from the given `data` bytes while avoiding most allocations.
     pub fn from_bytes(mut data: &'a [u8]) -> Result<CommitRef<'a>, crate::decode::Error> {
-        decode::commit(&mut data).map_err(crate::decode::Error::from)
+        decode::commit(&mut data).map_err(crate::decode::Error::with_err)
     }
 }
 

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -7,7 +7,7 @@ use winnow::{
     branch::alt,
     bytes::complete::is_not,
     combinator::{all_consuming, opt},
-    error::context,
+    prelude::*,
 };
 
 use crate::commit::SignedData;
@@ -153,9 +153,9 @@ impl<'a> CommitRefIter<'a> {
         use State::*;
         Ok(match state {
             Tree => {
-                let (i, tree) = context("tree <40 lowercase hex char>", |i| {
-                    parse::header_field(i, b"tree", parse::hex_hash)
-                })(i)?;
+                let (i, tree) = (|i| parse::header_field(i, b"tree", parse::hex_hash))
+                    .context("tree <40 lowercase hex char>")
+                    .parse_next(i)?;
                 *state = State::Parents;
                 (
                     i,
@@ -165,10 +165,9 @@ impl<'a> CommitRefIter<'a> {
                 )
             }
             Parents => {
-                let (i, parent) = context(
-                    "commit <40 lowercase hex char>",
-                    opt(|i| parse::header_field(i, b"parent", parse::hex_hash)),
-                )(i)?;
+                let (i, parent) = opt(|i| parse::header_field(i, b"parent", parse::hex_hash))
+                    .context("commit <40 lowercase hex char>")
+                    .parse_next(i)?;
                 match parent {
                     Some(parent) => (
                         i,
@@ -196,7 +195,9 @@ impl<'a> CommitRefIter<'a> {
                         (&b"committer"[..], "committer <signature>")
                     }
                 };
-                let (i, signature) = context(err_msg, |i| parse::header_field(i, field_name, parse::signature))(i)?;
+                let (i, signature) = (|i| parse::header_field(i, field_name, parse::signature))
+                    .context(err_msg)
+                    .parse_next(i)?;
                 (
                     i,
                     match who {
@@ -206,10 +207,9 @@ impl<'a> CommitRefIter<'a> {
                 )
             }
             Encoding => {
-                let (i, encoding) = context(
-                    "encoding <encoding>",
-                    opt(|i| parse::header_field(i, b"encoding", is_not(NL))),
-                )(i)?;
+                let (i, encoding) = opt(|i| parse::header_field(i, b"encoding", is_not(NL)))
+                    .context("encoding <encoding>")
+                    .parse_next(i)?;
                 *state = State::ExtraHeaders;
                 match encoding {
                     Some(encoding) => (i, Token::Encoding(encoding.as_bstr())),
@@ -217,16 +217,15 @@ impl<'a> CommitRefIter<'a> {
                 }
             }
             ExtraHeaders => {
-                let (i, extra_header) = context(
-                    "<field> <single-line|multi-line>",
-                    opt(alt((
-                        |i| parse::any_header_field_multi_line(i).map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Owned(o)))),
-                        |i| {
-                            parse::any_header_field(i, is_not(NL))
-                                .map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr()))))
-                        },
-                    ))),
-                )(i)?;
+                let (i, extra_header) = opt(alt((
+                    |i| parse::any_header_field_multi_line(i).map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Owned(o)))),
+                    |i| {
+                        parse::any_header_field(i, is_not(NL))
+                            .map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr()))))
+                    },
+                )))
+                .context("<field> <single-line|multi-line>")
+                .parse_next(i)?;
                 match extra_header {
                     Some(extra_header) => (i, Token::ExtraHeader(extra_header)),
                     None => {

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -5,9 +5,10 @@ use bstr::BStr;
 use gix_hash::{oid, ObjectId};
 use winnow::{
     branch::alt,
-    bytes::complete::is_not,
-    combinator::{all_consuming, opt},
+    bytes::take_till1,
+    combinator::{eof, opt},
     prelude::*,
+    sequence::terminated,
 };
 
 use crate::commit::SignedData;
@@ -207,7 +208,7 @@ impl<'a> CommitRefIter<'a> {
                 )
             }
             Encoding => {
-                let (i, encoding) = opt(|i| parse::header_field(i, b"encoding", is_not(NL)))
+                let (i, encoding) = opt(|i| parse::header_field(i, b"encoding", take_till1(NL)))
                     .context("encoding <encoding>")
                     .parse_next(i)?;
                 *state = State::ExtraHeaders;
@@ -220,7 +221,7 @@ impl<'a> CommitRefIter<'a> {
                 let (i, extra_header) = opt(alt((
                     |i| parse::any_header_field_multi_line(i).map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Owned(o)))),
                     |i| {
-                        parse::any_header_field(i, is_not(NL))
+                        parse::any_header_field(i, take_till1(NL))
                             .map(|(i, (k, o))| (i, (k.as_bstr(), Cow::Borrowed(o.as_bstr()))))
                     },
                 )))
@@ -235,7 +236,7 @@ impl<'a> CommitRefIter<'a> {
                 }
             }
             Message => {
-                let (i, message) = all_consuming(decode::message)(i)?;
+                let (i, message) = terminated(decode::message, eof)(i)?;
                 debug_assert!(
                     i.is_empty(),
                     "we should have consumed all data - otherwise iter may go forever"

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -236,7 +236,7 @@ impl<'a> CommitRefIter<'a> {
                 }
             }
             Message => {
-                let (i, message) = terminated(decode::message, eof)(i)?;
+                let (i, message) = terminated(decode::message, eof).parse_next(i)?;
                 debug_assert!(
                     i.is_empty(),
                     "we should have consumed all data - otherwise iter may go forever"

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use bstr::BStr;
 use gix_hash::{oid, ObjectId};
-use nom::{
+use winnow::{
     branch::alt,
     bytes::complete::is_not,
     combinator::{all_consuming, opt},

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -4,11 +4,11 @@ use std::ops::Range;
 use bstr::BStr;
 use gix_hash::{oid, ObjectId};
 use winnow::{
-    branch::alt,
-    bytes::take_till1,
+    combinator::alt,
+    combinator::terminated,
     combinator::{eof, opt},
     prelude::*,
-    sequence::terminated,
+    token::take_till1,
 };
 
 use crate::commit::SignedData;

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -261,13 +261,13 @@ pub mod decode {
         use crate::bstr::{BString, ByteSlice};
 
         /// The type to be used for parse errors.
-        pub type ParseError<'a> = nom::error::VerboseError<&'a [u8]>;
+        pub type ParseError<'a> = winnow::error::VerboseError<&'a [u8]>;
         /// The owned type to be used for parse errors.
-        pub type ParseErrorOwned = nom::error::VerboseError<BString>;
+        pub type ParseErrorOwned = winnow::error::VerboseError<BString>;
 
         pub(crate) fn empty_error() -> Error {
             Error {
-                inner: nom::error::VerboseError::<BString> { errors: Vec::new() },
+                inner: winnow::error::VerboseError::<BString> { errors: Vec::new() },
             }
         }
 
@@ -278,18 +278,18 @@ pub mod decode {
             pub inner: ParseErrorOwned,
         }
 
-        impl<'a> From<nom::Err<ParseError<'a>>> for Error {
-            fn from(v: nom::Err<ParseError<'a>>) -> Self {
+        impl<'a> From<winnow::Err<ParseError<'a>>> for Error {
+            fn from(v: winnow::Err<ParseError<'a>>) -> Self {
                 Error {
                     inner: match v {
-                        nom::Err::Error(err) | nom::Err::Failure(err) => nom::error::VerboseError {
+                        winnow::Err::Backtrack(err) | winnow::Err::Cut(err) => winnow::error::VerboseError {
                             errors: err
                                 .errors
                                 .into_iter()
                                 .map(|(i, v)| (i.as_bstr().to_owned(), v))
                                 .collect(),
                         },
-                        nom::Err::Incomplete(_) => unreachable!("we don't have streaming parsers"),
+                        winnow::Err::Incomplete(_) => unreachable!("we don't have streaming parsers"),
                     },
                 }
             }
@@ -321,12 +321,12 @@ pub mod decode {
             pub inner: ParseErrorOwned,
         }
 
-        impl<'a> From<nom::Err<ParseError<'a>>> for Error {
-            fn from(v: nom::Err<ParseError<'a>>) -> Self {
+        impl<'a> From<winnow::Err<ParseError<'a>>> for Error {
+            fn from(v: winnow::Err<ParseError<'a>>) -> Self {
                 Error {
                     inner: match v {
-                        nom::Err::Error(err) | nom::Err::Failure(err) => err,
-                        nom::Err::Incomplete(_) => unreachable!("we don't have streaming parsers"),
+                        winnow::Err::Backtrack(err) | winnow::Err::Cut(err) => err,
+                        winnow::Err::Incomplete(_) => unreachable!("we don't have streaming parsers"),
                     },
                 }
             }

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -278,18 +278,20 @@ pub mod decode {
             pub inner: ParseErrorOwned,
         }
 
-        impl<'a> From<winnow::Err<ParseError<'a>>> for Error {
-            fn from(v: winnow::Err<ParseError<'a>>) -> Self {
+        impl<'a> From<winnow::error::ErrMode<ParseError<'a>>> for Error {
+            fn from(v: winnow::error::ErrMode<ParseError<'a>>) -> Self {
                 Error {
                     inner: match v {
-                        winnow::Err::Backtrack(err) | winnow::Err::Cut(err) => winnow::error::VerboseError {
-                            errors: err
-                                .errors
-                                .into_iter()
-                                .map(|(i, v)| (i.as_bstr().to_owned(), v))
-                                .collect(),
-                        },
-                        winnow::Err::Incomplete(_) => unreachable!("we don't have streaming parsers"),
+                        winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => {
+                            winnow::error::VerboseError {
+                                errors: err
+                                    .errors
+                                    .into_iter()
+                                    .map(|(i, v)| (i.as_bstr().to_owned(), v))
+                                    .collect(),
+                            }
+                        }
+                        winnow::error::ErrMode::Incomplete(_) => unreachable!("we don't have streaming parsers"),
                     },
                 }
             }
@@ -321,12 +323,12 @@ pub mod decode {
             pub inner: ParseErrorOwned,
         }
 
-        impl<'a> From<winnow::Err<ParseError<'a>>> for Error {
-            fn from(v: winnow::Err<ParseError<'a>>) -> Self {
+        impl<'a> From<winnow::error::ErrMode<ParseError<'a>>> for Error {
+            fn from(v: winnow::error::ErrMode<ParseError<'a>>) -> Self {
                 Error {
                     inner: match v {
-                        winnow::Err::Backtrack(err) | winnow::Err::Cut(err) => err,
-                        winnow::Err::Incomplete(_) => unreachable!("we don't have streaming parsers"),
+                        winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => err,
+                        winnow::error::ErrMode::Incomplete(_) => unreachable!("we don't have streaming parsers"),
                     },
                 }
             }

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -261,13 +261,13 @@ pub mod decode {
         use crate::bstr::{BString, ByteSlice};
 
         /// The type to be used for parse errors.
-        pub type ParseError<'a> = winnow::error::VerboseError<&'a [u8]>;
+        pub type ParseError<'a> = winnow::error::VerboseError<&'a [u8], winnow::error::StrContext>;
         /// The owned type to be used for parse errors.
-        pub type ParseErrorOwned = winnow::error::VerboseError<BString>;
+        pub type ParseErrorOwned = winnow::error::VerboseError<BString, winnow::error::StrContext>;
 
         pub(crate) fn empty_error() -> Error {
             Error {
-                inner: winnow::error::VerboseError::<BString> { errors: Vec::new() },
+                inner: winnow::error::VerboseError::<_, _> { errors: Vec::new() },
             }
         }
 

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -276,8 +276,9 @@ pub mod decode {
 
         impl From<winnow::error::ErrMode<ParseError>> for Error {
             fn from(v: winnow::error::ErrMode<ParseError>) -> Self {
-                let err = v.into_inner().expect("we don't have streaming parsers");
-                Error { inner: err }
+                Error {
+                    inner: v.into_inner().expect("we don't have streaming parsers"),
+                }
             }
         }
 
@@ -307,8 +308,9 @@ pub mod decode {
 
         impl From<winnow::error::ErrMode<ParseError>> for Error {
             fn from(v: winnow::error::ErrMode<ParseError>) -> Self {
-                let err = v.into_inner().expect("we don't have streaming parsers");
-                Error { inner: err }
+                Error {
+                    inner: v.into_inner().expect("we don't have streaming parsers"),
+                }
             }
         }
 

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -280,18 +280,14 @@ pub mod decode {
 
         impl<'a> From<winnow::error::ErrMode<ParseError<'a>>> for Error {
             fn from(v: winnow::error::ErrMode<ParseError<'a>>) -> Self {
+                let err = v.into_inner().expect("we don't have streaming parsers");
                 Error {
-                    inner: match v {
-                        winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => {
-                            winnow::error::VerboseError {
-                                errors: err
-                                    .errors
-                                    .into_iter()
-                                    .map(|(i, v)| (i.as_bstr().to_owned(), v))
-                                    .collect(),
-                            }
-                        }
-                        winnow::error::ErrMode::Incomplete(_) => unreachable!("we don't have streaming parsers"),
+                    inner: winnow::error::VerboseError {
+                        errors: err
+                            .errors
+                            .into_iter()
+                            .map(|(i, v)| (i.as_bstr().to_owned(), v))
+                            .collect(),
                     },
                 }
             }
@@ -325,12 +321,8 @@ pub mod decode {
 
         impl<'a> From<winnow::error::ErrMode<ParseError<'a>>> for Error {
             fn from(v: winnow::error::ErrMode<ParseError<'a>>) -> Self {
-                Error {
-                    inner: match v {
-                        winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => err,
-                        winnow::error::ErrMode::Incomplete(_) => unreachable!("we don't have streaming parsers"),
-                    },
-                }
+                let err = v.into_inner().expect("we don't have streaming parsers");
+                Error { inner: err }
             }
         }
 

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -274,10 +274,10 @@ pub mod decode {
             pub inner: ParseError,
         }
 
-        impl From<winnow::error::ErrMode<ParseError>> for Error {
-            fn from(v: winnow::error::ErrMode<ParseError>) -> Self {
-                Error {
-                    inner: v.into_inner().expect("we don't have streaming parsers"),
+        impl Error {
+            pub(crate) fn with_err(err: winnow::error::ErrMode<ParseError>) -> Self {
+                Self {
+                    inner: err.into_inner().expect("we don't have streaming parsers"),
                 }
             }
         }
@@ -306,10 +306,10 @@ pub mod decode {
             pub inner: ParseError,
         }
 
-        impl From<winnow::error::ErrMode<ParseError>> for Error {
-            fn from(v: winnow::error::ErrMode<ParseError>) -> Self {
-                Error {
-                    inner: v.into_inner().expect("we don't have streaming parsers"),
+        impl Error {
+            pub(crate) fn with_err(err: winnow::error::ErrMode<ParseError>) -> Self {
+                Self {
+                    inner: err.into_inner().expect("we don't have streaming parsers"),
                 }
             }
         }

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -1,5 +1,5 @@
 use bstr::{BStr, BString, ByteVec};
-use nom::{
+use winnow::{
     bytes::complete::{is_not, tag, take_until, take_while_m_n},
     combinator::{peek, recognize},
     error::{context, ContextError, ParseError},

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -2,7 +2,7 @@ use bstr::{BStr, BString, ByteVec};
 use winnow::{
     combinator::repeat,
     combinator::{preceded, terminated},
-    error::{AddContext, ParserError},
+    error::{AddContext, ParserError, StrContext},
     prelude::*,
     token::{take_till1, take_until0, take_while},
     Parser,
@@ -14,7 +14,7 @@ pub(crate) const NL: &[u8] = b"\n";
 pub(crate) const SPACE: &[u8] = b" ";
 const SPACE_OR_NL: &[u8] = b" \n";
 
-pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(
+pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
 ) -> PResult<(&'a [u8], BString), E> {
     (
@@ -37,7 +37,7 @@ pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddCont
                 out
             }),
     )
-        .context("name <multi-line-value>")
+        .context(StrContext::Expected("name <multi-line-value>".into()))
         .parse_next(i)
 }
 
@@ -69,7 +69,7 @@ pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a B
     .parse_next(i)
 }
 
-pub(crate) fn signature<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(
+pub(crate) fn signature<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
 ) -> PResult<gix_actor::SignatureRef<'a>, E> {
     gix_actor::signature::decode(i)

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -15,8 +15,8 @@ pub(crate) const SPACE: &[u8] = b" ";
 const SPACE_OR_NL: &[u8] = b" \n";
 
 pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(
-    i: &'a [u8],
-) -> IResult<&'a [u8], (&'a [u8], BString), E> {
+    i: &mut &'a [u8],
+) -> PResult<(&'a [u8], BString), E> {
     (
         terminated(take_till1(SPACE_OR_NL), SPACE),
         (
@@ -42,17 +42,17 @@ pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddCont
 }
 
 pub(crate) fn header_field<'a, T, E: ParserError<&'a [u8]>>(
-    i: &'a [u8],
+    i: &mut &'a [u8],
     name: &'static [u8],
     parse_value: impl Parser<&'a [u8], T, E>,
-) -> IResult<&'a [u8], T, E> {
+) -> PResult<T, E> {
     terminated(preceded(terminated(name, SPACE), parse_value), NL).parse_next(i)
 }
 
 pub(crate) fn any_header_field<'a, T, E: ParserError<&'a [u8]>>(
-    i: &'a [u8],
+    i: &mut &'a [u8],
     parse_value: impl Parser<&'a [u8], T, E>,
-) -> IResult<&'a [u8], (&'a [u8], T), E> {
+) -> PResult<(&'a [u8], T), E> {
     terminated((terminated(take_till1(SPACE_OR_NL), SPACE), parse_value), NL).parse_next(i)
 }
 
@@ -60,7 +60,7 @@ fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')
 }
 
-pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
+pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a BStr, E> {
     take_while(
         gix_hash::Kind::shortest().len_in_hex()..=gix_hash::Kind::longest().len_in_hex(),
         is_hex_digit_lc,
@@ -70,7 +70,7 @@ pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], 
 }
 
 pub(crate) fn signature<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(
-    i: &'a [u8],
-) -> IResult<&'a [u8], gix_actor::SignatureRef<'a>, E> {
+    i: &mut &'a [u8],
+) -> PResult<gix_actor::SignatureRef<'a>, E> {
     gix_actor::signature::decode(i)
 }

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -1,4 +1,4 @@
-use nom::{
+use winnow::{
     branch::alt,
     bytes::complete::{tag, take_until, take_while, take_while1},
     character::is_alphabetic,
@@ -19,7 +19,7 @@ pub fn git_tag<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]
         parse::header_field(i, b"type", take_while1(is_alphabetic))
     })(i)?;
     let kind = crate::Kind::from_bytes(kind)
-        .map_err(|_| nom::Err::Error(E::from_error_kind(i, nom::error::ErrorKind::MapRes)))?;
+        .map_err(|_| winnow::Err::Backtrack(E::from_error_kind(i, winnow::error::ErrorKind::MapRes)))?;
 
     let (i, tag_version) = context("tag <version>", |i| {
         parse::header_field(i, b"tag", take_while1(|b| b != NL[0]))

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -4,7 +4,7 @@ use winnow::{
     character::is_alphabetic,
     combinator::{all_consuming, opt, recognize},
     error::{context, ContextError, ParseError},
-    sequence::{preceded, tuple},
+    sequence::preceded,
     IResult,
 };
 
@@ -61,21 +61,21 @@ pub fn message<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&
         Ok((&[], (i, &[])))
     }
     let (i, (message, signature)) = alt((
-        tuple((
+        (
             take_until(PGP_SIGNATURE_BEGIN),
             preceded(
-                tag(NL),
-                recognize(tuple((
-                    tag(&PGP_SIGNATURE_BEGIN[1..]),
+                NL,
+                recognize((
+                    &PGP_SIGNATURE_BEGIN[1..],
                     take_until(PGP_SIGNATURE_END),
-                    tag(PGP_SIGNATURE_END),
+                    PGP_SIGNATURE_END,
                     take_while(|_| true),
-                ))),
+                )),
             ),
-        )),
+        ),
         all_to_end,
     ))(i)?;
-    let (i, _) = opt(tag(NL))(i)?;
+    let (i, _) = opt(NL)(i)?;
     Ok((
         i,
         (

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -2,33 +2,32 @@ use winnow::{
     branch::alt,
     bytes::complete::{tag, take_until, take_while, take_while1},
     character::is_alphabetic,
-    combinator::{all_consuming, opt, recognize},
-    error::{context, ContextError, ParseError},
+    combinator::{all_consuming, opt},
+    error::{ContextError, ParseError},
+    prelude::*,
     sequence::preceded,
-    IResult,
 };
 
 use crate::{parse, parse::NL, BStr, ByteSlice, TagRef};
 
 pub fn git_tag<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], TagRef<'a>, E> {
-    let (i, target) = context("object <40 lowercase hex char>", |i| {
-        parse::header_field(i, b"object", parse::hex_hash)
-    })(i)?;
+    let (i, target) = (|i| parse::header_field(i, b"object", parse::hex_hash))
+        .context("object <40 lowercase hex char>")
+        .parse_next(i)?;
 
-    let (i, kind) = context("type <object kind>", |i| {
-        parse::header_field(i, b"type", take_while1(is_alphabetic))
-    })(i)?;
+    let (i, kind) = (|i| parse::header_field(i, b"type", take_while1(is_alphabetic)))
+        .context("type <object kind>")
+        .parse_next(i)?;
     let kind =
         crate::Kind::from_bytes(kind).map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))?;
 
-    let (i, tag_version) = context("tag <version>", |i| {
-        parse::header_field(i, b"tag", take_while1(|b| b != NL[0]))
-    })(i)?;
+    let (i, tag_version) = (|i| parse::header_field(i, b"tag", take_while1(|b| b != NL[0])))
+        .context("tag <version>")
+        .parse_next(i)?;
 
-    let (i, signature) = context(
-        "tagger <signature>",
-        opt(|i| parse::header_field(i, b"tagger", parse::signature)),
-    )(i)?;
+    let (i, signature) = opt(|i| parse::header_field(i, b"tagger", parse::signature))
+        .context("tagger <signature>")
+        .parse_next(i)?;
     let (i, (message, pgp_signature)) = all_consuming(message)(i)?;
     Ok((
         i,
@@ -65,12 +64,13 @@ pub fn message<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&
             take_until(PGP_SIGNATURE_BEGIN),
             preceded(
                 NL,
-                recognize((
+                (
                     &PGP_SIGNATURE_BEGIN[1..],
                     take_until(PGP_SIGNATURE_END),
                     PGP_SIGNATURE_END,
                     take_while(|_| true),
-                )),
+                )
+                    .recognize(),
             ),
         ),
         all_to_end,

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -18,8 +18,8 @@ pub fn git_tag<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]
     let (i, kind) = context("type <object kind>", |i| {
         parse::header_field(i, b"type", take_while1(is_alphabetic))
     })(i)?;
-    let kind = crate::Kind::from_bytes(kind)
-        .map_err(|_| winnow::Err::Backtrack(E::from_error_kind(i, winnow::error::ErrorKind::MapRes)))?;
+    let kind =
+        crate::Kind::from_bytes(kind).map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))?;
 
     let (i, tag_version) = context("tag <version>", |i| {
         parse::header_field(i, b"tag", take_while1(|b| b != NL[0]))

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -19,7 +19,7 @@ pub fn git_tag<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]
         .context("type <object kind>")
         .parse_next(i)?;
     let kind = crate::Kind::from_bytes(kind)
-        .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))?;
+        .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify))?;
 
     let (i, tag_version) = (|i| parse::header_field(i, b"tag", take_while1(|b| b != NL[0])))
         .context("tag <version>")

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -28,7 +28,7 @@ pub fn git_tag<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(i: &'a [u8]
     let (i, signature) = opt(|i| parse::header_field(i, b"tagger", parse::signature))
         .context("tagger <signature>")
         .parse_next(i)?;
-    let (i, (message, pgp_signature)) = terminated(message, eof)(i)?;
+    let (i, (message, pgp_signature)) = terminated(message, eof).parse_next(i)?;
     Ok((
         i,
         TagRef {
@@ -49,7 +49,7 @@ pub fn message<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&
     if i.is_empty() {
         return Ok((i, (i.as_bstr(), None)));
     }
-    let (i, _) = tag(NL)(i)?;
+    let (i, _) = tag(NL).parse_next(i)?;
     fn all_to_end<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&'a [u8], &'a [u8]), E> {
         if i.is_empty() {
             // Empty message. That's OK.
@@ -74,8 +74,9 @@ pub fn message<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], (&
             ),
         ),
         all_to_end,
-    ))(i)?;
-    let (i, _) = opt(NL)(i)?;
+    ))
+    .parse_next(i)?;
+    let (i, _) = opt(NL).parse_next(i)?;
     Ok((
         i,
         (

--- a/gix-object/src/tag/mod.rs
+++ b/gix-object/src/tag/mod.rs
@@ -10,10 +10,8 @@ pub mod ref_iter;
 
 impl<'a> TagRef<'a> {
     /// Deserialize a tag from `data`.
-    pub fn from_bytes(data: &'a [u8]) -> Result<TagRef<'a>, crate::decode::Error> {
-        decode::git_tag(data)
-            .map(|(_, t)| t)
-            .map_err(crate::decode::Error::from)
+    pub fn from_bytes(mut data: &'a [u8]) -> Result<TagRef<'a>, crate::decode::Error> {
+        decode::git_tag(&mut data).map_err(crate::decode::Error::from)
     }
     /// The object this tag points to as `Id`.
     pub fn target(&self) -> gix_hash::ObjectId {

--- a/gix-object/src/tag/mod.rs
+++ b/gix-object/src/tag/mod.rs
@@ -11,7 +11,7 @@ pub mod ref_iter;
 impl<'a> TagRef<'a> {
     /// Deserialize a tag from `data`.
     pub fn from_bytes(mut data: &'a [u8]) -> Result<TagRef<'a>, crate::decode::Error> {
-        decode::git_tag(&mut data).map_err(crate::decode::Error::from)
+        decode::git_tag(&mut data).map_err(crate::decode::Error::with_err)
     }
     /// The object this tag points to as `Id`.
     pub fn target(&self) -> gix_hash::ObjectId {

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -76,13 +76,8 @@ impl<'a> TagRefIter<'a> {
                 let (i, kind) = context("type <object kind>", |i| {
                     parse::header_field(i, b"type", take_while1(is_alphabetic))
                 })(i)?;
-                let kind = Kind::from_bytes(kind).map_err(|_| {
-                    #[allow(clippy::let_unit_value)]
-                    {
-                        let err = crate::decode::ParseError::from_error_kind(i, winnow::error::ErrorKind::MapRes);
-                        winnow::Err::Backtrack(err)
-                    }
-                })?;
+                let kind = Kind::from_bytes(kind)
+                    .map_err(|_| winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes))?;
                 *state = Name;
                 (i, Token::TargetKind(kind))
             }

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -1,6 +1,6 @@
 use bstr::BStr;
 use gix_hash::{oid, ObjectId};
-use nom::{
+use winnow::{
     bytes::complete::take_while1,
     character::is_alphabetic,
     combinator::{all_consuming, opt},
@@ -79,8 +79,8 @@ impl<'a> TagRefIter<'a> {
                 let kind = Kind::from_bytes(kind).map_err(|_| {
                     #[allow(clippy::let_unit_value)]
                     {
-                        let err = crate::decode::ParseError::from_error_kind(i, nom::error::ErrorKind::MapRes);
-                        nom::Err::Error(err)
+                        let err = crate::decode::ParseError::from_error_kind(i, winnow::error::ErrorKind::MapRes);
+                        winnow::Err::Backtrack(err)
                     }
                 })?;
                 *state = Name;

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -1,7 +1,7 @@
 use bstr::BStr;
 use gix_hash::{oid, ObjectId};
 use winnow::{
-    bytes::take_while1,
+    bytes::take_while,
     combinator::{eof, opt},
     error::ParseError,
     prelude::*,
@@ -75,7 +75,7 @@ impl<'a> TagRefIter<'a> {
                 )
             }
             TargetKind => {
-                let (i, kind) = (|i| parse::header_field(i, b"type", take_while1(AsChar::is_alpha)))
+                let (i, kind) = (|i| parse::header_field(i, b"type", take_while(1.., AsChar::is_alpha)))
                     .context("type <object kind>")
                     .parse_next(i)?;
                 let kind = Kind::from_bytes(kind)
@@ -84,7 +84,7 @@ impl<'a> TagRefIter<'a> {
                 (i, Token::TargetKind(kind))
             }
             Name => {
-                let (i, tag_version) = (|i| parse::header_field(i, b"tag", take_while1(|b| b != NL[0])))
+                let (i, tag_version) = (|i| parse::header_field(i, b"tag", take_while(1.., |b| b != NL[0])))
                     .context("tag <version>")
                     .parse_next(i)?;
                 *state = Tagger;

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -1,12 +1,12 @@
 use bstr::BStr;
 use gix_hash::{oid, ObjectId};
 use winnow::{
-    bytes::take_while,
+    combinator::terminated,
     combinator::{eof, opt},
-    error::ParseError,
+    error::ParserError,
     prelude::*,
-    sequence::terminated,
     stream::AsChar,
+    token::take_while,
 };
 
 use crate::{bstr::ByteSlice, parse, parse::NL, tag::decode, Kind, TagRefIter};

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -79,7 +79,7 @@ impl<'a> TagRefIter<'a> {
                     .context("type <object kind>")
                     .parse_next(i)?;
                 let kind = Kind::from_bytes(kind)
-                    .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes))?;
+                    .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify))?;
                 *state = Name;
                 (i, Token::TargetKind(kind))
             }

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -98,7 +98,7 @@ impl<'a> TagRefIter<'a> {
                 (i, Token::Tagger(signature))
             }
             Message => {
-                let (i, (message, pgp_signature)) = terminated(decode::message, eof)(i)?;
+                let (i, (message, pgp_signature)) = terminated(decode::message, eof).parse_next(i)?;
                 debug_assert!(
                     i.is_empty(),
                     "we should have consumed all data - otherwise iter may go forever"

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -60,7 +60,15 @@ fn missing_field() -> crate::decode::Error {
 }
 
 impl<'a> TagRefIter<'a> {
-    fn next_inner(mut i: &'a [u8], state: &mut State) -> Result<(&'a [u8], Token<'a>), crate::decode::Error> {
+    #[inline]
+    fn next_inner(i: &'a [u8], state: &mut State) -> Result<(&'a [u8], Token<'a>), crate::decode::Error> {
+        Self::next_inner_(i, state).map_err(crate::decode::Error::with_err)
+    }
+
+    fn next_inner_(
+        mut i: &'a [u8],
+        state: &mut State,
+    ) -> Result<(&'a [u8], Token<'a>), winnow::error::ErrMode<crate::decode::ParseError>> {
         use State::*;
         Ok(match state {
             Target => {

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -59,13 +59,13 @@ fn missing_field() -> crate::decode::Error {
 }
 
 impl<'a> TagRefIter<'a> {
-    fn next_inner(i: &'a [u8], state: &mut State) -> Result<(&'a [u8], Token<'a>), crate::decode::Error> {
+    fn next_inner(mut i: &'a [u8], state: &mut State) -> Result<(&'a [u8], Token<'a>), crate::decode::Error> {
         use State::*;
         Ok(match state {
             Target => {
-                let (i, target) = (|i| parse::header_field(i, b"object", parse::hex_hash))
+                let target = (|i: &mut _| parse::header_field(i, b"object", parse::hex_hash))
                     .context("object <40 lowercase hex char>")
-                    .parse_next(i)?;
+                    .parse_next(&mut i)?;
                 *state = TargetKind;
                 (
                     i,
@@ -75,30 +75,30 @@ impl<'a> TagRefIter<'a> {
                 )
             }
             TargetKind => {
-                let (i, kind) = (|i| parse::header_field(i, b"type", take_while(1.., AsChar::is_alpha)))
+                let kind = (|i: &mut _| parse::header_field(i, b"type", take_while(1.., AsChar::is_alpha)))
                     .context("type <object kind>")
-                    .parse_next(i)?;
+                    .parse_next(&mut i)?;
                 let kind = Kind::from_bytes(kind)
-                    .map_err(|_| winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify))?;
+                    .map_err(|_| winnow::error::ErrMode::from_error_kind(&i, winnow::error::ErrorKind::Verify))?;
                 *state = Name;
                 (i, Token::TargetKind(kind))
             }
             Name => {
-                let (i, tag_version) = (|i| parse::header_field(i, b"tag", take_while(1.., |b| b != NL[0])))
+                let tag_version = (|i: &mut _| parse::header_field(i, b"tag", take_while(1.., |b| b != NL[0])))
                     .context("tag <version>")
-                    .parse_next(i)?;
+                    .parse_next(&mut i)?;
                 *state = Tagger;
                 (i, Token::Name(tag_version.as_bstr()))
             }
             Tagger => {
-                let (i, signature) = opt(|i| parse::header_field(i, b"tagger", parse::signature))
+                let signature = opt(|i: &mut _| parse::header_field(i, b"tagger", parse::signature))
                     .context("tagger <signature>")
-                    .parse_next(i)?;
+                    .parse_next(&mut i)?;
                 *state = Message;
                 (i, Token::Tagger(signature))
             }
             Message => {
-                let (i, (message, pgp_signature)) = terminated(decode::message, eof).parse_next(i)?;
+                let (message, pgp_signature) = terminated(decode::message, eof).parse_next(&mut i)?;
                 debug_assert!(
                     i.is_empty(),
                     "we should have consumed all data - otherwise iter may go forever"

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -161,24 +161,23 @@ mod decode {
     }
 
     pub fn entry<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], EntryRef<'_>, E> {
-        let (i, mode) = terminated(take_while(5..=6, AsChar::is_dec_digit), SPACE).parse_next(i)?;
-        let mode = tree::EntryMode::try_from(mode)
-            .map_err(|invalid| winnow::error::ErrMode::from_error_kind(invalid, winnow::error::ErrorKind::Verify))?;
-        let (i, filename) = terminated(take_while(1.., |b| b != NULL[0]), NULL).parse_next(i)?;
-        let (i, oid) = take(20u8).parse_next(i)?; // TODO: make this compatible with other hash lengths
-
-        Ok((
-            i,
-            EntryRef {
+        (
+            terminated(take_while(5..=6, AsChar::is_dec_digit), SPACE)
+                .verify_map(|mode| tree::EntryMode::try_from(mode).ok()),
+            terminated(take_while(1.., |b| b != NULL[0]), NULL),
+            take(20u8),
+        )
+            .map(|(mode, filename, oid): (_, &[u8], _)| EntryRef {
                 mode,
                 filename: filename.as_bstr(),
                 oid: gix_hash::oid::try_from_bytes(oid).expect("we counted exactly 20 bytes"),
-            },
-        ))
+            })
+            .parse_next(i)
     }
 
     pub fn tree<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], TreeRef<'a>, E> {
-        let (i, entries) = terminated(repeat(0.., entry), eof).parse_next(i)?;
-        Ok((i, TreeRef { entries }))
+        terminated(repeat(0.., entry), eof)
+            .map(|entries| TreeRef { entries })
+            .parse_next(i)
     }
 }

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -118,7 +118,7 @@ mod decode {
 
     use bstr::ByteSlice;
     use winnow::{
-        bytes::complete::{tag, take, take_while1, take_while_m_n},
+        bytes::complete::{take, take_while1, take_while_m_n},
         character::is_digit,
         combinator::all_consuming,
         error::ParseError,
@@ -161,10 +161,10 @@ mod decode {
     }
 
     pub fn entry<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], EntryRef<'_>, E> {
-        let (i, mode) = terminated(take_while_m_n(5, 6, is_digit), tag(SPACE))(i)?;
+        let (i, mode) = terminated(take_while_m_n(5, 6, is_digit), SPACE)(i)?;
         let mode = tree::EntryMode::try_from(mode)
             .map_err(|invalid| winnow::Err::from_error_kind(invalid, winnow::error::ErrorKind::MapRes))?;
-        let (i, filename) = terminated(take_while1(|b| b != NULL[0]), tag(NULL))(i)?;
+        let (i, filename) = terminated(take_while1(|b| b != NULL[0]), NULL)(i)?;
         let (i, oid) = take(20u8)(i)?; // TODO: make this compatible with other hash lengths
 
         Ok((

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -69,10 +69,10 @@ impl<'a> Iterator for TreeRefIter<'a> {
             None => {
                 self.data = &[];
                 #[allow(clippy::unit_arg)]
-                Some(Err(winnow::Err::Backtrack(crate::decode::ParseError::from_error_kind(
+                Some(Err(winnow::Err::from_error_kind(
                     &[] as &[u8],
                     winnow::error::ErrorKind::MapRes,
-                ))
+                )
                 .into()))
             }
         }
@@ -163,7 +163,7 @@ mod decode {
     pub fn entry<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], EntryRef<'_>, E> {
         let (i, mode) = terminated(take_while_m_n(5, 6, is_digit), tag(SPACE))(i)?;
         let mode = tree::EntryMode::try_from(mode)
-            .map_err(|invalid| winnow::Err::Backtrack(E::from_error_kind(invalid, winnow::error::ErrorKind::MapRes)))?;
+            .map_err(|invalid| winnow::Err::from_error_kind(invalid, winnow::error::ErrorKind::MapRes))?;
         let (i, filename) = terminated(take_while1(|b| b != NULL[0]), tag(NULL))(i)?;
         let (i, oid) = take(20u8)(i)?; // TODO: make this compatible with other hash lengths
 

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -71,7 +71,7 @@ impl<'a> Iterator for TreeRefIter<'a> {
                 #[allow(clippy::unit_arg)]
                 Some(Err(winnow::error::ErrMode::from_error_kind(
                     &[] as &[u8],
-                    winnow::error::ErrorKind::MapRes,
+                    winnow::error::ErrorKind::Verify,
                 )
                 .into()))
             }
@@ -163,7 +163,7 @@ mod decode {
     pub fn entry<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], EntryRef<'_>, E> {
         let (i, mode) = terminated(take_while_m_n(5, 6, AsChar::is_dec_digit), SPACE).parse_next(i)?;
         let mode = tree::EntryMode::try_from(mode)
-            .map_err(|invalid| winnow::error::ErrMode::from_error_kind(invalid, winnow::error::ErrorKind::MapRes))?;
+            .map_err(|invalid| winnow::error::ErrMode::from_error_kind(invalid, winnow::error::ErrorKind::Verify))?;
         let (i, filename) = terminated(take_while1(|b| b != NULL[0]), NULL).parse_next(i)?;
         let (i, oid) = take(20u8).parse_next(i)?; // TODO: make this compatible with other hash lengths
 

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -118,10 +118,10 @@ mod decode {
 
     use bstr::ByteSlice;
     use winnow::{
-        bytes::{take, take_while1, take_while_m_n},
+        bytes::{take, take_while},
         combinator::eof,
+        combinator::repeat,
         error::ParseError,
-        multi::many0,
         prelude::*,
         sequence::terminated,
         stream::AsChar,
@@ -161,10 +161,10 @@ mod decode {
     }
 
     pub fn entry<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], EntryRef<'_>, E> {
-        let (i, mode) = terminated(take_while_m_n(5, 6, AsChar::is_dec_digit), SPACE).parse_next(i)?;
+        let (i, mode) = terminated(take_while(5..=6, AsChar::is_dec_digit), SPACE).parse_next(i)?;
         let mode = tree::EntryMode::try_from(mode)
             .map_err(|invalid| winnow::error::ErrMode::from_error_kind(invalid, winnow::error::ErrorKind::Verify))?;
-        let (i, filename) = terminated(take_while1(|b| b != NULL[0]), NULL).parse_next(i)?;
+        let (i, filename) = terminated(take_while(1.., |b| b != NULL[0]), NULL).parse_next(i)?;
         let (i, oid) = take(20u8).parse_next(i)?; // TODO: make this compatible with other hash lengths
 
         Ok((
@@ -178,7 +178,7 @@ mod decode {
     }
 
     pub fn tree<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], TreeRef<'a>, E> {
-        let (i, entries) = terminated(many0(entry), eof).parse_next(i)?;
+        let (i, entries) = terminated(repeat(0.., entry), eof).parse_next(i)?;
         Ok((i, TreeRef { entries }))
     }
 }

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -1,7 +1,7 @@
 use bstr::BStr;
 use std::convert::TryFrom;
 
-use nom::error::ParseError;
+use winnow::error::ParseError;
 
 use crate::{tree, tree::EntryRef, TreeRef, TreeRefIter};
 
@@ -69,9 +69,9 @@ impl<'a> Iterator for TreeRefIter<'a> {
             None => {
                 self.data = &[];
                 #[allow(clippy::unit_arg)]
-                Some(Err(nom::Err::Error(crate::decode::ParseError::from_error_kind(
+                Some(Err(winnow::Err::Backtrack(crate::decode::ParseError::from_error_kind(
                     &[] as &[u8],
-                    nom::error::ErrorKind::MapRes,
+                    winnow::error::ErrorKind::MapRes,
                 ))
                 .into()))
             }
@@ -117,7 +117,7 @@ mod decode {
     use std::convert::TryFrom;
 
     use bstr::ByteSlice;
-    use nom::{
+    use winnow::{
         bytes::complete::{tag, take, take_while1, take_while_m_n},
         character::is_digit,
         combinator::all_consuming,
@@ -163,7 +163,7 @@ mod decode {
     pub fn entry<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&[u8], EntryRef<'_>, E> {
         let (i, mode) = terminated(take_while_m_n(5, 6, is_digit), tag(SPACE))(i)?;
         let mode = tree::EntryMode::try_from(mode)
-            .map_err(|invalid| nom::Err::Error(E::from_error_kind(invalid, nom::error::ErrorKind::MapRes)))?;
+            .map_err(|invalid| winnow::Err::Backtrack(E::from_error_kind(invalid, winnow::error::ErrorKind::MapRes)))?;
         let (i, filename) = terminated(take_while1(|b| b != NULL[0]), tag(NULL))(i)?;
         let (i, oid) = take(20u8)(i)?; // TODO: make this compatible with other hash lengths
 

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -144,7 +144,7 @@ mod decode {
         let mode = tree::EntryMode::try_from(mode).ok()?;
         let (filename, i) = i.split_at(i.find_byte(0)?);
         let i = &i[1..];
-        const HASH_LEN_FIXME: usize = 20; // TODO: know actual /desired length or we may overshoot
+        const HASH_LEN_FIXME: usize = 20; // TODO(SHA256): know actual/desired length or we may overshoot
         let (oid, i) = match i.len() {
             len if len < HASH_LEN_FIXME => return None,
             _ => i.split_at(20),
@@ -164,7 +164,7 @@ mod decode {
             terminated(take_while(5..=6, AsChar::is_dec_digit), SPACE)
                 .verify_map(|mode| tree::EntryMode::try_from(mode).ok()),
             terminated(take_while(1.., |b| b != NULL[0]), NULL),
-            take(20u8),
+            take(20u8), // TODO(SHA256): make this compatible with other hash lengths
         )
             .map(|(mode, filename, oid): (_, &[u8], _)| EntryRef {
                 mode,

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -15,7 +15,7 @@ impl<'a> TreeRefIter<'a> {
 impl<'a> TreeRef<'a> {
     /// Deserialize a Tree from `data`.
     pub fn from_bytes(mut data: &'a [u8]) -> Result<TreeRef<'a>, crate::decode::Error> {
-        decode::tree(&mut data).map_err(crate::decode::Error::from)
+        decode::tree(&mut data).map_err(crate::decode::Error::with_err)
     }
 
     /// Find an entry named `name` knowing if the entry is a directory or not, using a binary search.
@@ -70,11 +70,9 @@ impl<'a> Iterator for TreeRefIter<'a> {
                 self.data = &[];
                 let empty = &[] as &[u8];
                 #[allow(clippy::unit_arg)]
-                Some(Err(winnow::error::ErrMode::from_error_kind(
-                    &empty,
-                    winnow::error::ErrorKind::Verify,
-                )
-                .into()))
+                Some(Err(crate::decode::Error::with_err(
+                    winnow::error::ErrMode::from_error_kind(&empty, winnow::error::ErrorKind::Verify),
+                )))
             }
         }
     }

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -31,7 +31,7 @@ gix-lock = { version = "^7.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^7.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-winnow = { version = "0.3", features = ["simd"] }
+winnow = { version = "0.4", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -31,7 +31,7 @@ gix-lock = { version = "^7.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^7.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-winnow = { version = "0.4", features = ["simd"] }
+winnow = { version = "0.5.12", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -31,7 +31,7 @@ gix-lock = { version = "^7.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^7.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-winnow = { version = "0.5.12", features = ["simd"] }
+winnow = { version = "0.5.14", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -31,7 +31,7 @@ gix-lock = { version = "^7.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^7.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-nom = { version = "7", default-features = false, features = ["std"]}
+winnow = { version = "0.3", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -1,10 +1,5 @@
 use gix_object::bstr::{BStr, ByteSlice};
-use winnow::{
-    branch::alt,
-    bytes::complete::{tag, take_while_m_n},
-    error::ParseError,
-    IResult,
-};
+use winnow::{branch::alt, bytes::complete::take_while_m_n, error::ParseError, IResult};
 
 fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')
@@ -23,5 +18,5 @@ pub fn hex_hash<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &
 }
 
 pub fn newline<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
-    alt((tag(b"\r\n"), tag(b"\n")))(i)
+    alt((b"\r\n", b"\n"))(i)
 }

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -1,12 +1,12 @@
 use gix_object::bstr::{BStr, ByteSlice};
-use winnow::{branch::alt, bytes::take_while, error::ParseError, prelude::*};
+use winnow::{combinator::alt, error::ParserError, prelude::*, token::take_while};
 
 fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')
 }
 
 /// Copy from https://github.com/Byron/gitoxide/blob/f270850ff92eab15258023b8e59346ec200303bd/gix-object/src/immutable/parse.rs#L64
-pub fn hex_hash<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
+pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
     // NOTE: It's important to be able to read all hashes, do not parameterize it. Hashes can be rejected at a later stage
     // if needed.
     take_while(
@@ -17,6 +17,6 @@ pub fn hex_hash<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &
     .map(|(i, hex)| (i, hex.as_bstr()))
 }
 
-pub fn newline<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
+pub fn newline<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
     alt((b"\r\n", b"\n")).parse_next(i)
 }

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -1,5 +1,5 @@
 use gix_object::bstr::{BStr, ByteSlice};
-use winnow::{branch::alt, bytes::complete::take_while_m_n, error::ParseError, IResult};
+use winnow::{branch::alt, bytes::take_while_m_n, error::ParseError, IResult};
 
 fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -1,5 +1,5 @@
 use gix_object::bstr::{BStr, ByteSlice};
-use winnow::{branch::alt, bytes::take_while_m_n, error::ParseError, prelude::*};
+use winnow::{branch::alt, bytes::take_while, error::ParseError, prelude::*};
 
 fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')
@@ -9,9 +9,8 @@ fn is_hex_digit_lc(b: u8) -> bool {
 pub fn hex_hash<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
     // NOTE: It's important to be able to read all hashes, do not parameterize it. Hashes can be rejected at a later stage
     // if needed.
-    take_while_m_n(
-        gix_hash::Kind::shortest().len_in_hex(),
-        gix_hash::Kind::longest().len_in_hex(),
+    take_while(
+        gix_hash::Kind::shortest().len_in_hex()..=gix_hash::Kind::longest().len_in_hex(),
         is_hex_digit_lc,
     )
     .parse_next(i)

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -1,5 +1,5 @@
 use gix_object::bstr::{BStr, ByteSlice};
-use winnow::{branch::alt, bytes::take_while_m_n, error::ParseError, IResult};
+use winnow::{branch::alt, bytes::take_while_m_n, error::ParseError, prelude::*};
 
 fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')
@@ -13,10 +13,11 @@ pub fn hex_hash<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &
         gix_hash::Kind::shortest().len_in_hex(),
         gix_hash::Kind::longest().len_in_hex(),
         is_hex_digit_lc,
-    )(i)
+    )
+    .parse_next(i)
     .map(|(i, hex)| (i, hex.as_bstr()))
 }
 
 pub fn newline<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
-    alt((b"\r\n", b"\n"))(i)
+    alt((b"\r\n", b"\n")).parse_next(i)
 }

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -1,5 +1,5 @@
 use gix_object::bstr::{BStr, ByteSlice};
-use nom::{
+use winnow::{
     branch::alt,
     bytes::complete::{tag, take_while_m_n},
     error::ParseError,

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -6,7 +6,7 @@ fn is_hex_digit_lc(b: u8) -> bool {
 }
 
 /// Copy from https://github.com/Byron/gitoxide/blob/f270850ff92eab15258023b8e59346ec200303bd/gix-object/src/immutable/parse.rs#L64
-pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
+pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a BStr, E> {
     // NOTE: It's important to be able to read all hashes, do not parameterize it. Hashes can be rejected at a later stage
     // if needed.
     take_while(
@@ -17,6 +17,6 @@ pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], 
     .parse_next(i)
 }
 
-pub fn newline<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
+pub fn newline<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a [u8], E> {
     alt((b"\r\n", b"\n")).parse_next(i)
 }

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -13,8 +13,8 @@ pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], 
         gix_hash::Kind::shortest().len_in_hex()..=gix_hash::Kind::longest().len_in_hex(),
         is_hex_digit_lc,
     )
+    .map(ByteSlice::as_bstr)
     .parse_next(i)
-    .map(|(i, hex)| (i, hex.as_bstr()))
 }
 
 pub fn newline<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -75,7 +75,7 @@ impl<'a> From<LineRef<'a>> for Line {
 pub mod decode {
     use gix_object::bstr::{BStr, ByteSlice};
     use winnow::{
-        bytes::take_while0,
+        bytes::take_while,
         combinator::opt,
         error::{ContextError, ParseError},
         prelude::*,
@@ -127,7 +127,7 @@ pub mod decode {
         if i.is_empty() {
             Ok((&[], i.as_bstr()))
         } else {
-            terminated(take_while0(|c| c != b'\n'), opt(b'\n'))
+            terminated(take_while(0.., |c| c != b'\n'), opt(b'\n'))
                 .parse_next(i)
                 .map(|(i, o)| (i, o.as_bstr()))
         }

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -75,10 +75,10 @@ impl<'a> From<LineRef<'a>> for Line {
 pub mod decode {
     use gix_object::bstr::{BStr, ByteSlice};
     use winnow::{
-        bytes::complete::{tag, take_while},
+        bytes::complete::take_while,
         combinator::opt,
         error::{context, ContextError, ParseError},
-        sequence::{terminated, tuple},
+        sequence::terminated,
         IResult,
     };
 
@@ -127,20 +127,20 @@ pub mod decode {
         if i.is_empty() {
             Ok((&[], i.as_bstr()))
         } else {
-            terminated(take_while(|c| c != b'\n'), opt(tag(b"\n")))(i).map(|(i, o)| (i, o.as_bstr()))
+            terminated(take_while(|c| c != b'\n'), opt(b'\n'))(i).map(|(i, o)| (i, o.as_bstr()))
         }
     }
 
     fn one<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(bytes: &'a [u8]) -> IResult<&[u8], LineRef<'a>, E> {
         let (i, (old, new, signature, message_sep, message)) = context(
             "<old-hexsha> <new-hexsha> <name> <<email>> <timestamp> <tz>\\t<message>",
-            tuple((
-                context("<old-hexsha>", terminated(hex_hash, tag(b" "))),
-                context("<new-hexsha>", terminated(hex_hash, tag(b" "))),
+            (
+                context("<old-hexsha>", terminated(hex_hash, b" ")),
+                context("<new-hexsha>", terminated(hex_hash, b" ")),
                 context("<name> <<email>> <timestamp>", gix_actor::signature::decode),
-                opt(tag(b"\t")),
+                opt(b'\t'),
                 context("<optional message>", message),
-            )),
+            ),
         )(bytes)?;
 
         if message_sep.is_none() {

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -127,7 +127,9 @@ pub mod decode {
         if i.is_empty() {
             Ok((&[], i.as_bstr()))
         } else {
-            terminated(take_while0(|c| c != b'\n'), opt(b'\n'))(i).map(|(i, o)| (i, o.as_bstr()))
+            terminated(take_while0(|c| c != b'\n'), opt(b'\n'))
+                .parse_next(i)
+                .map(|(i, o)| (i, o.as_bstr()))
         }
     }
 

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -148,7 +148,7 @@ pub mod decode {
             if let Some(first) = message.first() {
                 if !first.is_ascii_whitespace() {
                     return Err(
-                        winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes).map(|err: E| {
+                        winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Verify).map(|err: E| {
                             err.add_context(i, "log message must be separated from signature with whitespace")
                         }),
                     );

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -146,11 +146,11 @@ pub mod decode {
         if message_sep.is_none() {
             if let Some(first) = message.first() {
                 if !first.is_ascii_whitespace() {
-                    return Err(winnow::Err::Backtrack(E::add_context(
-                        E::from_error_kind(i, winnow::error::ErrorKind::MapRes),
-                        i,
-                        "log message must be separated from signature with whitespace",
-                    )));
+                    return Err(
+                        winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes).map(|err: E| {
+                            err.add_context(i, "log message must be separated from signature with whitespace")
+                        }),
+                    );
                 }
             }
         }

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -75,7 +75,7 @@ impl<'a> From<LineRef<'a>> for Line {
 pub mod decode {
     use gix_object::bstr::{BStr, ByteSlice};
     use winnow::{
-        bytes::complete::take_while,
+        bytes::take_while0,
         combinator::opt,
         error::{ContextError, ParseError},
         prelude::*,
@@ -127,7 +127,7 @@ pub mod decode {
         if i.is_empty() {
             Ok((&[], i.as_bstr()))
         } else {
-            terminated(take_while(|c| c != b'\n'), opt(b'\n'))(i).map(|(i, o)| (i, o.as_bstr()))
+            terminated(take_while0(|c| c != b'\n'), opt(b'\n'))(i).map(|(i, o)| (i, o.as_bstr()))
         }
     }
 
@@ -146,7 +146,7 @@ pub mod decode {
             if let Some(first) = message.first() {
                 if !first.is_ascii_whitespace() {
                     return Err(
-                        winnow::Err::from_error_kind(i, winnow::error::ErrorKind::MapRes).map(|err: E| {
+                        winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::MapRes).map(|err: E| {
                             err.add_context(i, "log message must be separated from signature with whitespace")
                         }),
                     );

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -75,11 +75,11 @@ impl<'a> From<LineRef<'a>> for Line {
 pub mod decode {
     use gix_object::bstr::{BStr, ByteSlice};
     use winnow::{
-        bytes::take_while,
         combinator::opt,
-        error::{ContextError, ParseError},
+        combinator::terminated,
+        error::{AddContext, ParserError},
         prelude::*,
-        sequence::terminated,
+        token::take_while,
     };
 
     use crate::{file::log::LineRef, parse::hex_hash};
@@ -123,7 +123,7 @@ pub mod decode {
         }
     }
 
-    fn message<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
+    fn message<'a, E: ParserError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E> {
         if i.is_empty() {
             Ok((&[], i.as_bstr()))
         } else {
@@ -133,7 +133,7 @@ pub mod decode {
         }
     }
 
-    fn one<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(bytes: &'a [u8]) -> IResult<&[u8], LineRef<'a>, E> {
+    fn one<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8]>>(bytes: &'a [u8]) -> IResult<&[u8], LineRef<'a>, E> {
         let (i, (old, new, signature, message_sep, message)) = (
             terminated(hex_hash, b" ").context("<old-hexsha>"),
             terminated(hex_hash, b" ").context("<new-hexsha>"),

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -181,14 +181,14 @@ pub mod decode {
 
         mod invalid {
             use gix_testtools::to_bstr_err;
-            use winnow::error::VerboseError;
+            use winnow::error::TreeError;
             use winnow::prelude::*;
 
             use super::one;
 
             #[test]
             fn completely_bogus_shows_error_with_context() {
-                let err = one::<VerboseError<&[u8], &'static str>>
+                let err = one::<TreeError<&[u8], &'static str>>
                     .parse_peek(b"definitely not a log entry")
                     .map_err(to_bstr_err)
                     .expect_err("this should fail");
@@ -198,7 +198,7 @@ pub mod decode {
             #[test]
             fn missing_whitespace_between_signature_and_message() {
                 let line = "0000000000000000000000000000000000000000 0000000000000000000000000000000000000000 one <foo@example.com> 1234567890 -0000message";
-                let err = one::<VerboseError<&[u8], &'static str>>
+                let err = one::<TreeError<&[u8], &'static str>>
                     .parse_peek(line.as_bytes())
                     .map_err(to_bstr_err)
                     .expect_err("this should fail");

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use gix_hash::ObjectId;
 use gix_object::bstr::BString;
-use winnow::{bytes::take_while0, combinator::opt, prelude::*, sequence::terminated};
+use winnow::{bytes::take_while, combinator::opt, prelude::*, sequence::terminated};
 
 use crate::{
     parse::{hex_hash, newline},
@@ -67,8 +67,8 @@ impl Reference {
 
 fn parse(bytes: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
     let is_space = |b: u8| b == b' ';
-    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while0(is_space))).parse_next(bytes)? {
-        terminated(take_while0(|b| b != b'\r' && b != b'\n'), opt(newline))
+    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while(0.., is_space))).parse_next(bytes)? {
+        terminated(take_while(0.., |b| b != b'\r' && b != b'\n'), opt(newline))
             .map(|path| MaybeUnsafeState::UnvalidatedPath(path.into()))
             .parse_next(path)
     } else {

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -3,7 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use gix_hash::ObjectId;
 use gix_object::bstr::BString;
 use winnow::{
-    bytes::complete::{tag, take_while},
+    bytes::complete::take_while,
     combinator::{map, opt},
     sequence::terminated,
     IResult,
@@ -72,7 +72,7 @@ impl Reference {
 
 fn parse(bytes: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
     let is_space = |b: u8| b == b' ';
-    if let (path, Some(_ref_prefix)) = opt(terminated(tag("ref: "), take_while(is_space)))(bytes)? {
+    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while(is_space)))(bytes)? {
         map(
             terminated(take_while(|b| b != b'\r' && b != b'\n'), opt(newline)),
             |path| MaybeUnsafeState::UnvalidatedPath(path.into()),

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -67,7 +67,7 @@ impl Reference {
 
 fn parse(bytes: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
     let is_space = |b: u8| b == b' ';
-    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while0(is_space)))(bytes)? {
+    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while0(is_space))).parse_next(bytes)? {
         terminated(take_while0(|b| b != b'\r' && b != b'\n'), opt(newline))
             .map(|path| MaybeUnsafeState::UnvalidatedPath(path.into()))
             .parse_next(path)

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use gix_hash::ObjectId;
 use gix_object::bstr::BString;
-use nom::{
+use winnow::{
     bytes::complete::{tag, take_while},
     combinator::{map, opt},
     sequence::terminated,

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use gix_hash::ObjectId;
 use gix_object::bstr::BString;
-use winnow::{bytes::complete::take_while, combinator::opt, prelude::*, sequence::terminated};
+use winnow::{bytes::take_while0, combinator::opt, prelude::*, sequence::terminated};
 
 use crate::{
     parse::{hex_hash, newline},
@@ -67,8 +67,8 @@ impl Reference {
 
 fn parse(bytes: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
     let is_space = |b: u8| b == b' ';
-    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while(is_space)))(bytes)? {
-        terminated(take_while(|b| b != b'\r' && b != b'\n'), opt(newline))
+    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while0(is_space)))(bytes)? {
+        terminated(take_while0(|b| b != b'\r' && b != b'\n'), opt(newline))
             .map(|path| MaybeUnsafeState::UnvalidatedPath(path.into()))
             .parse_next(path)
     } else {

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -52,21 +52,20 @@ impl TryFrom<MaybeUnsafeState> for Target {
 impl Reference {
     /// Create a new reference of the given `parent` store with `relative_path` service as unique identifier
     /// at which the `path_contents` was read to obtain the refs value.
-    pub fn try_from_path(name: FullName, path_contents: &[u8]) -> Result<Self, Error> {
+    pub fn try_from_path(name: FullName, mut path_contents: &[u8]) -> Result<Self, Error> {
         Ok(Reference {
             name,
-            target: parse(path_contents)
+            target: parse(&mut path_contents)
                 .map_err(|_| Error::Parse {
                     content: path_contents.into(),
                 })?
-                .1
                 .try_into()?,
         })
     }
 }
 
-fn parse(i: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
-    if let (i, Some(_ref_prefix)) = opt(terminated("ref: ", take_while(0.., b' '))).parse_next(i)? {
+fn parse(i: &mut &[u8]) -> PResult<MaybeUnsafeState> {
+    if let Some(_ref_prefix) = opt(terminated("ref: ", take_while(0.., b' '))).parse_next(i)? {
         terminated(take_while(0.., |b| b != b'\r' && b != b'\n'), opt(newline))
             .map(|path| MaybeUnsafeState::UnvalidatedPath(path.into()))
             .parse_next(i)

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -65,15 +65,14 @@ impl Reference {
     }
 }
 
-fn parse(bytes: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
-    let is_space = |b: u8| b == b' ';
-    if let (path, Some(_ref_prefix)) = opt(terminated("ref: ", take_while(0.., is_space))).parse_next(bytes)? {
+fn parse(i: &[u8]) -> IResult<&[u8], MaybeUnsafeState> {
+    if let (i, Some(_ref_prefix)) = opt(terminated("ref: ", take_while(0.., b' '))).parse_next(i)? {
         terminated(take_while(0.., |b| b != b'\r' && b != b'\n'), opt(newline))
             .map(|path| MaybeUnsafeState::UnvalidatedPath(path.into()))
-            .parse_next(path)
+            .parse_next(i)
     } else {
         terminated(hex_hash, opt(newline))
             .map(|hex| MaybeUnsafeState::Id(ObjectId::from_hex(hex).expect("prior validation")))
-            .parse_next(bytes)
+            .parse_next(i)
     }
 }

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use gix_hash::ObjectId;
 use gix_object::bstr::BString;
-use winnow::{bytes::take_while, combinator::opt, prelude::*, sequence::terminated};
+use winnow::{combinator::opt, combinator::terminated, prelude::*, token::take_while};
 
 use crate::{
     parse::{hex_hash, newline},

--- a/gix-ref/src/store/packed/buffer.rs
+++ b/gix-ref/src/store/packed/buffer.rs
@@ -47,12 +47,12 @@ pub mod open {
                 };
 
                 let (offset, sorted) = {
-                    let input = backing.as_ref();
+                    let mut input = backing.as_ref();
                     if *input.first().unwrap_or(&b' ') == b'#' {
-                        let (input, header) = packed::decode::header::<()>
-                            .parse_next(input)
+                        let header = packed::decode::header::<()>
+                            .parse_next(&mut input)
                             .map_err(|_| Error::HeaderParsing)?;
-                        let offset = input.offset_from(backing.as_ref());
+                        let offset = input.offset_from(&backing.as_ref());
                         (offset, header.sorted)
                     } else {
                         (0, false)

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use gix_object::bstr::{BStr, ByteSlice};
 use winnow::{
     bytes::complete::take_while,
-    combinator::{map, map_res, opt},
+    combinator::opt,
     error::{FromExternalError, ParseError},
     prelude::*,
     sequence::{delimited, preceded, terminated},
@@ -41,10 +41,9 @@ fn until_newline<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E>
 where
     E: ParseError<&'a [u8]>,
 {
-    map(
-        terminated(take_while(|b: u8| b != b'\r' && b != b'\n'), newline),
-        ByteSlice::as_bstr,
-    )(input)
+    terminated(take_while(|b: u8| b != b'\r' && b != b'\n'), newline)
+        .map(ByteSlice::as_bstr)
+        .parse_next(input)
 }
 
 pub fn header<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], Header, E>
@@ -72,7 +71,7 @@ pub fn reference<'a, E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], crate
     input: &'a [u8],
 ) -> IResult<&'a [u8], packed::Reference<'a>, E> {
     let (input, (target, name)) =
-        (terminated(hex_hash, b" "), map_res(until_newline, TryInto::try_into)).parse_next(input)?;
+        (terminated(hex_hash, b" "), until_newline.map_res(TryInto::try_into)).parse_next(input)?;
     let (rest, object) = opt(delimited(b"^", hex_hash, newline))(input)?;
     Ok((rest, packed::Reference { name, target, object }))
 }

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 
 use gix_object::bstr::{BStr, ByteSlice};
-use nom::{
+use winnow::{
     bytes::complete::{tag, take_while},
     combinator::{map, map_res, opt},
     error::{FromExternalError, ParseError},

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use gix_object::bstr::{BStr, ByteSlice};
 use winnow::{
-    bytes::complete::take_while,
+    bytes::take_while0,
     combinator::opt,
     error::{FromExternalError, ParseError},
     prelude::*,
@@ -41,7 +41,7 @@ fn until_newline<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E>
 where
     E: ParseError<&'a [u8]>,
 {
-    terminated(take_while(|b: u8| b != b'\r' && b != b'\n'), newline)
+    terminated(take_while0(|b: u8| b != b'\r' && b != b'\n'), newline)
         .map(ByteSlice::as_bstr)
         .parse_next(input)
 }

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use gix_object::bstr::{BStr, ByteSlice};
 use winnow::{
-    bytes::take_while0,
+    bytes::take_while,
     combinator::opt,
     error::{FromExternalError, ParseError},
     prelude::*,
@@ -41,7 +41,7 @@ fn until_newline<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E>
 where
     E: ParseError<&'a [u8]>,
 {
-    terminated(take_while0(|b: u8| b != b'\r' && b != b'\n'), newline)
+    terminated(take_while(0.., |b: u8| b != b'\r' && b != b'\n'), newline)
         .map(ByteSlice::as_bstr)
         .parse_next(input)
 }
@@ -71,7 +71,7 @@ pub fn reference<'a, E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], crate
     input: &'a [u8],
 ) -> IResult<&'a [u8], packed::Reference<'a>, E> {
     let (input, (target, name)) =
-        (terminated(hex_hash, b" "), until_newline.map_res(TryInto::try_into)).parse_next(input)?;
+        (terminated(hex_hash, b" "), until_newline.try_map(TryInto::try_into)).parse_next(input)?;
     let (rest, object) = opt(delimited(b"^", hex_hash, newline)).parse_next(input)?;
     Ok((rest, packed::Reference { name, target, object }))
 }

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -50,7 +50,7 @@ pub fn header<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], Header, E>
 where
     E: ParseError<&'a [u8]>,
 {
-    let (rest, traits) = preceded(b"# pack-refs with: ", until_newline)(input)?;
+    let (rest, traits) = preceded(b"# pack-refs with: ", until_newline).parse_next(input)?;
 
     let mut peeled = Peeled::Unspecified;
     let mut sorted = false;
@@ -72,7 +72,7 @@ pub fn reference<'a, E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], crate
 ) -> IResult<&'a [u8], packed::Reference<'a>, E> {
     let (input, (target, name)) =
         (terminated(hex_hash, b" "), until_newline.map_res(TryInto::try_into)).parse_next(input)?;
-    let (rest, object) = opt(delimited(b"^", hex_hash, newline))(input)?;
+    let (rest, object) = opt(delimited(b"^", hex_hash, newline)).parse_next(input)?;
     Ok((rest, packed::Reference { name, target, object }))
 }
 

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -37,7 +37,7 @@ impl Default for Header {
     }
 }
 
-fn until_newline<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], &'a BStr, E>
+fn until_newline<'a, E>(input: &mut &'a [u8]) -> PResult<&'a BStr, E>
 where
     E: ParserError<&'a [u8]>,
 {
@@ -46,7 +46,7 @@ where
         .parse_next(input)
 }
 
-pub fn header<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], Header, E>
+pub fn header<'a, E>(input: &mut &'a [u8]) -> PResult<Header, E>
 where
     E: ParserError<&'a [u8]>,
 {
@@ -69,8 +69,8 @@ where
 }
 
 pub fn reference<'a, E: ParserError<&'a [u8]> + FromExternalError<&'a [u8], crate::name::Error>>(
-    input: &'a [u8],
-) -> IResult<&'a [u8], packed::Reference<'a>, E> {
+    input: &mut &'a [u8],
+) -> PResult<packed::Reference<'a>, E> {
     (
         terminated(hex_hash, b" "),
         until_newline.try_map(TryInto::try_into),

--- a/gix-ref/src/store/packed/decode/tests.rs
+++ b/gix-ref/src/store/packed/decode/tests.rs
@@ -1,7 +1,7 @@
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 mod reference {
-    use nom::error::VerboseError;
+    use winnow::error::VerboseError;
 
     use super::Result;
     use crate::{
@@ -27,7 +27,7 @@ mod reference {
     fn two_refs_in_a_row() -> Result {
         let input: &[u8] = b"d53c4b0f91f1b29769c9430f2d1c0bcab1170c75 refs/heads/alternates-after-packs-and-loose
 ^e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37\neaae9c1bc723209d793eb93f5587fa2604d5cd92 refs/heads/avoid-double-lookup\n";
-        let (input, parsed) = decode::reference::<VerboseError<_>>(input)?;
+        let (input, parsed) = decode::reference::<VerboseError<_>>(input).unwrap();
 
         assert_eq!(
             parsed,
@@ -40,7 +40,7 @@ mod reference {
         assert_eq!(parsed.target(), hex_to_id("d53c4b0f91f1b29769c9430f2d1c0bcab1170c75"));
         assert_eq!(parsed.object(), hex_to_id("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37"));
 
-        let (input, parsed) = decode::reference::<VerboseError<_>>(input)?;
+        let (input, parsed) = decode::reference::<VerboseError<_>>(input).unwrap();
         assert!(input.is_empty(), "exhausted");
         assert_eq!(
             parsed.name,
@@ -78,7 +78,7 @@ mod header {
     #[test]
     fn valid_fully_peeled_stored() -> Result {
         let input: &[u8] = b"# pack-refs with: peeled fully-peeled sorted  \nsomething else";
-        let (rest, header) = decode::header::<nom::error::VerboseError<_>>(input).map_err(to_bstr_err)?;
+        let (rest, header) = decode::header::<winnow::error::VerboseError<_>>(input).map_err(to_bstr_err)?;
 
         assert_eq!(rest.as_bstr(), "something else", "remainder starts after newline");
         assert_eq!(
@@ -94,7 +94,7 @@ mod header {
     #[test]
     fn valid_peeled_unsorted() -> Result {
         let input: &[u8] = b"# pack-refs with: peeled\n";
-        let (rest, header) = decode::header::<()>(input)?;
+        let (rest, header) = decode::header::<()>(input).unwrap();
 
         assert!(rest.is_empty());
         assert_eq!(
@@ -110,7 +110,7 @@ mod header {
     #[test]
     fn valid_empty() -> Result {
         let input: &[u8] = b"# pack-refs with: \n";
-        let (rest, header) = decode::header::<()>(input)?;
+        let (rest, header) = decode::header::<()>(input).unwrap();
 
         assert!(rest.is_empty());
         assert_eq!(

--- a/gix-ref/src/store/packed/decode/tests.rs
+++ b/gix-ref/src/store/packed/decode/tests.rs
@@ -2,6 +2,7 @@ type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 mod reference {
     use winnow::error::VerboseError;
+    use winnow::prelude::*;
 
     use super::Result;
     use crate::{
@@ -16,9 +17,13 @@ mod reference {
 
     #[test]
     fn invalid() {
-        assert!(decode::reference::<()>(b"# what looks like a comment",).is_err());
+        assert!(decode::reference::<()>
+            .parse_peek(b"# what looks like a comment",)
+            .is_err());
         assert!(
-            decode::reference::<()>(b"^e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37\n",).is_err(),
+            decode::reference::<()>
+                .parse_peek(b"^e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37\n",)
+                .is_err(),
             "lonely peel"
         );
     }
@@ -27,7 +32,7 @@ mod reference {
     fn two_refs_in_a_row() -> Result {
         let input: &[u8] = b"d53c4b0f91f1b29769c9430f2d1c0bcab1170c75 refs/heads/alternates-after-packs-and-loose
 ^e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37\neaae9c1bc723209d793eb93f5587fa2604d5cd92 refs/heads/avoid-double-lookup\n";
-        let (input, parsed) = decode::reference::<VerboseError<_>>(input).unwrap();
+        let (input, parsed) = decode::reference::<VerboseError<_>>.parse_peek(input).unwrap();
 
         assert_eq!(
             parsed,
@@ -40,7 +45,7 @@ mod reference {
         assert_eq!(parsed.target(), hex_to_id("d53c4b0f91f1b29769c9430f2d1c0bcab1170c75"));
         assert_eq!(parsed.object(), hex_to_id("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37"));
 
-        let (input, parsed) = decode::reference::<VerboseError<_>>(input).unwrap();
+        let (input, parsed) = decode::reference::<VerboseError<_>>.parse_peek(input).unwrap();
         assert!(input.is_empty(), "exhausted");
         assert_eq!(
             parsed.name,
@@ -55,6 +60,7 @@ mod reference {
 mod header {
     use gix_object::bstr::ByteSlice;
     use gix_testtools::to_bstr_err;
+    use winnow::prelude::*;
 
     use super::Result;
     use crate::store_impl::packed::{
@@ -65,12 +71,15 @@ mod header {
     #[test]
     fn invalid() {
         assert!(
-            decode::header::<()>(b"# some user comment").is_err(),
+            decode::header::<()>.parse_peek(b"# some user comment").is_err(),
             "something the user put there"
         );
-        assert!(decode::header::<()>(b"# pack-refs: ").is_err(), "looks right but isn't");
         assert!(
-            decode::header::<()>(b" # pack-refs with: ").is_err(),
+            decode::header::<()>.parse_peek(b"# pack-refs: ").is_err(),
+            "looks right but isn't"
+        );
+        assert!(
+            decode::header::<()>.parse_peek(b" # pack-refs with: ").is_err(),
             "does not start with #"
         );
     }
@@ -78,7 +87,9 @@ mod header {
     #[test]
     fn valid_fully_peeled_stored() -> Result {
         let input: &[u8] = b"# pack-refs with: peeled fully-peeled sorted  \nsomething else";
-        let (rest, header) = decode::header::<winnow::error::VerboseError<_>>(input).map_err(to_bstr_err)?;
+        let (rest, header) = decode::header::<winnow::error::VerboseError<_, &'static str>>
+            .parse_peek(input)
+            .map_err(to_bstr_err)?;
 
         assert_eq!(rest.as_bstr(), "something else", "remainder starts after newline");
         assert_eq!(
@@ -94,7 +105,7 @@ mod header {
     #[test]
     fn valid_peeled_unsorted() -> Result {
         let input: &[u8] = b"# pack-refs with: peeled\n";
-        let (rest, header) = decode::header::<()>(input).unwrap();
+        let (rest, header) = decode::header::<()>.parse_peek(input).unwrap();
 
         assert!(rest.is_empty());
         assert_eq!(
@@ -110,7 +121,7 @@ mod header {
     #[test]
     fn valid_empty() -> Result {
         let input: &[u8] = b"# pack-refs with: \n";
-        let (rest, header) = decode::header::<()>(input).unwrap();
+        let (rest, header) = decode::header::<()>.parse_peek(input).unwrap();
 
         assert!(rest.is_empty());
         assert_eq!(

--- a/gix-ref/src/store/packed/decode/tests.rs
+++ b/gix-ref/src/store/packed/decode/tests.rs
@@ -87,7 +87,7 @@ mod header {
     #[test]
     fn valid_fully_peeled_stored() -> Result {
         let input: &[u8] = b"# pack-refs with: peeled fully-peeled sorted  \nsomething else";
-        let (rest, header) = decode::header::<winnow::error::TreeError<_, &'static str>>
+        let (rest, header) = decode::header::<winnow::error::TreeError<_, _>>
             .parse_peek(input)
             .map_err(to_bstr_err)?;
 

--- a/gix-ref/src/store/packed/decode/tests.rs
+++ b/gix-ref/src/store/packed/decode/tests.rs
@@ -1,7 +1,7 @@
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 mod reference {
-    use winnow::error::VerboseError;
+    use winnow::error::TreeError;
     use winnow::prelude::*;
 
     use super::Result;
@@ -32,7 +32,7 @@ mod reference {
     fn two_refs_in_a_row() -> Result {
         let input: &[u8] = b"d53c4b0f91f1b29769c9430f2d1c0bcab1170c75 refs/heads/alternates-after-packs-and-loose
 ^e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37\neaae9c1bc723209d793eb93f5587fa2604d5cd92 refs/heads/avoid-double-lookup\n";
-        let (input, parsed) = decode::reference::<VerboseError<_>>.parse_peek(input).unwrap();
+        let (input, parsed) = decode::reference::<TreeError<_>>.parse_peek(input).unwrap();
 
         assert_eq!(
             parsed,
@@ -45,7 +45,7 @@ mod reference {
         assert_eq!(parsed.target(), hex_to_id("d53c4b0f91f1b29769c9430f2d1c0bcab1170c75"));
         assert_eq!(parsed.object(), hex_to_id("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37"));
 
-        let (input, parsed) = decode::reference::<VerboseError<_>>.parse_peek(input).unwrap();
+        let (input, parsed) = decode::reference::<TreeError<_>>.parse_peek(input).unwrap();
         assert!(input.is_empty(), "exhausted");
         assert_eq!(
             parsed.name,
@@ -87,7 +87,7 @@ mod header {
     #[test]
     fn valid_fully_peeled_stored() -> Result {
         let input: &[u8] = b"# pack-refs with: peeled fully-peeled sorted  \nsomething else";
-        let (rest, header) = decode::header::<winnow::error::VerboseError<_, &'static str>>
+        let (rest, header) = decode::header::<winnow::error::TreeError<_, &'static str>>
             .parse_peek(input)
             .map_err(to_bstr_err)?;
 

--- a/gix-ref/tests/file/log.rs
+++ b/gix-ref/tests/file/log.rs
@@ -186,7 +186,7 @@ mod iter {
 
             let mut iter = gix_ref::file::log::iter::forward(log_first_broken.as_bytes());
             let err = iter.next().expect("error is not none").expect_err("the line is broken");
-            assert_eq!(err.to_string(), "In line 1: \"0000000000000000000000000000000000000000 134385fbroken7062102c6a483440bfda2a03 committer <committer@example.com> 946771200 +0000\\tcommit\" did not match '<old-hexsha> <new-hexsha> <name> <<email>> <timestamp> <tz>\\t<message>'");
+            assert_eq!(err.to_string(), "In line 1: \"134385fbroken7062102c6a483440bfda2a03 committer <committer@example.com> 946771200 +0000\\tcommit\" did not match '<old-hexsha> <new-hexsha> <name> <<email>> <timestamp> <tz>\\t<message>'");
             assert!(iter.next().expect("a second line").is_ok(), "line parses ok");
             assert!(iter.next().is_none(), "iterator exhausted");
         }

--- a/gix-revision/fuzz/Cargo.lock
+++ b/gix-revision/fuzz/Cargo.lock
@@ -499,9 +499,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.17.0"
 gix-fs = { version = "^0.4.1", path = "../../gix-fs" }
 gix-tempfile = { version = "^7.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-winnow = { version = "0.4", features = ["simd"] }
+winnow = { version = "0.5.12", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.17.0"
 gix-fs = { version = "^0.4.1", path = "../../gix-fs" }
 gix-tempfile = { version = "^7.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-nom = { version = "7", default-features = false, features = ["std"]}
+winnow = { version = "0.3", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.17.0"
 gix-fs = { version = "^0.4.1", path = "../../gix-fs" }
 gix-tempfile = { version = "^7.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-winnow = { version = "0.3", features = ["simd"] }
+winnow = { version = "0.4", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.17.0"
 gix-fs = { version = "^0.4.1", path = "../../gix-fs" }
 gix-tempfile = { version = "^7.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-winnow = { version = "0.5.12", features = ["simd"] }
+winnow = { version = "0.5.14", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -15,11 +15,11 @@ pub use bstr;
 use bstr::{BStr, ByteSlice};
 use io_close::Close;
 pub use is_ci;
-use nom::error::VerboseError;
 pub use once_cell;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 pub use tempfile;
+use winnow::error::VerboseError;
 
 /// A result type to allow using the try operator `?` in unit tests.
 ///
@@ -692,10 +692,10 @@ fn extract_archive(
 }
 
 /// Transform a verbose bom errors from raw bytes into a `BStr` to make printing/debugging human-readable.
-pub fn to_bstr_err(err: nom::Err<VerboseError<&[u8]>>) -> VerboseError<&BStr> {
+pub fn to_bstr_err(err: winnow::Err<VerboseError<&[u8]>>) -> VerboseError<&BStr> {
     let err = match err {
-        nom::Err::Error(err) | nom::Err::Failure(err) => err,
-        nom::Err::Incomplete(_) => unreachable!("not a streaming parser"),
+        winnow::Err::Backtrack(err) | winnow::Err::Cut(err) => err,
+        winnow::Err::Incomplete(_) => unreachable!("not a streaming parser"),
     };
     VerboseError {
         errors: err.errors.into_iter().map(|(i, v)| (i.as_bstr(), v)).collect(),

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -692,10 +692,10 @@ fn extract_archive(
 }
 
 /// Transform a verbose bom errors from raw bytes into a `BStr` to make printing/debugging human-readable.
-pub fn to_bstr_err(err: winnow::Err<VerboseError<&[u8]>>) -> VerboseError<&BStr> {
+pub fn to_bstr_err(err: winnow::error::ErrMode<VerboseError<&[u8]>>) -> VerboseError<&BStr> {
     let err = match err {
-        winnow::Err::Backtrack(err) | winnow::Err::Cut(err) => err,
-        winnow::Err::Incomplete(_) => unreachable!("not a streaming parser"),
+        winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => err,
+        winnow::error::ErrMode::Incomplete(_) => unreachable!("not a streaming parser"),
     };
     VerboseError {
         errors: err.errors.into_iter().map(|(i, v)| (i.as_bstr(), v)).collect(),

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -19,7 +19,6 @@ pub use once_cell;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 pub use tempfile;
-use winnow::error::TreeError;
 
 /// A result type to allow using the try operator `?` in unit tests.
 ///
@@ -691,10 +690,10 @@ fn extract_archive(
     Ok((archive_identity, platform))
 }
 
-/// Transform a verbose bom errors from raw bytes into a `BStr` to make printing/debugging human-readable.
+/// Transform a verbose parser errors from raw bytes into a `BStr` to make printing/debugging human-readable.
 pub fn to_bstr_err(
-    err: winnow::error::ErrMode<TreeError<&[u8], winnow::error::StrContext>>,
-) -> TreeError<&BStr, winnow::error::StrContext> {
+    err: winnow::error::ErrMode<winnow::error::TreeError<&[u8], winnow::error::StrContext>>,
+) -> winnow::error::TreeError<&BStr, winnow::error::StrContext> {
     let err = err.into_inner().expect("not a streaming parser");
     err.map_input(ByteSlice::as_bstr)
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -695,10 +695,7 @@ fn extract_archive(
 pub fn to_bstr_err<'i>(
     err: winnow::error::ErrMode<VerboseError<&'i [u8], &'static str>>,
 ) -> VerboseError<&'i BStr, &'static str> {
-    let err = match err {
-        winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => err,
-        winnow::error::ErrMode::Incomplete(_) => unreachable!("not a streaming parser"),
-    };
+    let err = err.into_inner().expect("not a streaming parser");
     err.map_input(ByteSlice::as_bstr)
 }
 

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -692,14 +692,14 @@ fn extract_archive(
 }
 
 /// Transform a verbose bom errors from raw bytes into a `BStr` to make printing/debugging human-readable.
-pub fn to_bstr_err(err: winnow::error::ErrMode<VerboseError<&[u8]>>) -> VerboseError<&BStr> {
+pub fn to_bstr_err<'i>(
+    err: winnow::error::ErrMode<VerboseError<&'i [u8], &'static str>>,
+) -> VerboseError<&'i BStr, &'static str> {
     let err = match err {
         winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) => err,
         winnow::error::ErrMode::Incomplete(_) => unreachable!("not a streaming parser"),
     };
-    VerboseError {
-        errors: err.errors.into_iter().map(|(i, v)| (i.as_bstr(), v)).collect(),
-    }
+    err.map_input(ByteSlice::as_bstr)
 }
 
 fn family_name() -> &'static str {

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -692,9 +692,9 @@ fn extract_archive(
 }
 
 /// Transform a verbose bom errors from raw bytes into a `BStr` to make printing/debugging human-readable.
-pub fn to_bstr_err<'i>(
-    err: winnow::error::ErrMode<TreeError<&'i [u8], &'static str>>,
-) -> TreeError<&'i BStr, &'static str> {
+pub fn to_bstr_err(
+    err: winnow::error::ErrMode<TreeError<&[u8], winnow::error::StrContext>>,
+) -> TreeError<&BStr, winnow::error::StrContext> {
     let err = err.into_inner().expect("not a streaming parser");
     err.map_input(ByteSlice::as_bstr)
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -19,7 +19,7 @@ pub use once_cell;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 pub use tempfile;
-use winnow::error::VerboseError;
+use winnow::error::TreeError;
 
 /// A result type to allow using the try operator `?` in unit tests.
 ///
@@ -693,8 +693,8 @@ fn extract_archive(
 
 /// Transform a verbose bom errors from raw bytes into a `BStr` to make printing/debugging human-readable.
 pub fn to_bstr_err<'i>(
-    err: winnow::error::ErrMode<VerboseError<&'i [u8], &'static str>>,
-) -> VerboseError<&'i BStr, &'static str> {
+    err: winnow::error::ErrMode<TreeError<&'i [u8], &'static str>>,
+) -> TreeError<&'i BStr, &'static str> {
     let err = err.into_inner().expect("not a streaming parser");
     err.map_input(ByteSlice::as_bstr)
 }


### PR DESCRIPTION
Follow up to #948 and #951

`gix-actor`, `gix-object`, `gix-ref`, and `gix-testtools` are interrelated, so this does it all at once

Things left out
- Removing `winnow` from the API of the above packages
- Switching `from_bytes` functions to using `parse` instead of (the implied) `parse_next`

BREAKING CHANGE: `nom`, and now `winnow`, is exposed in the public API of some of these packages