### PR TITLE
Remove `todo!` for submodule entry in checkout

### DIFF
--- a/gix-worktree/src/checkout/entry.rs
+++ b/gix-worktree/src/checkout/entry.rs
@@ -165,7 +165,7 @@ where
             obj.data.len()
         }
         gix_index::entry::Mode::DIR => todo!(),
-        gix_index::entry::Mode::COMMIT => todo!(),
+        gix_index::entry::Mode::COMMIT => 0,
         _ => unreachable!(),
     };
     Ok(Outcome::Written { bytes: object_size })


### PR DESCRIPTION
I'm trying to convert a project from git2 -> gix (PR https://github.com/EmbarkStudios/cargo-fetcher/pull/180), but gix currently doesn't have any functionality for submodules, so I rolled my own in the meantime since my needs are minimal (eg clone/fetch/checkout only), but unfortunately ran into this `todo!` that prevented me from using checkout. I realize why this is here, but IMO just skipping submodules is fine in this case as it then acts kind of like normal git CLI usage since submodule checkout has to be done separately from a clone/checkout anyhow.

I could also add an option to https://github.com/Byron/gitoxide/blob/daf338989e7d75d41efb1345ed95ee2a13c97007/gix-worktree/src/checkout/chunk.rs#L101-L107, that will default to panicing like the current code, if you prefer that approach  instead.

Basically, using this simple patch, I get full parity between the output of my program via gix as cargo does via git2.