### PR TITLE
gix-object: fix test for struct size for 32-bit architectures

### DIFF
--- a/gix-object/src/data.rs
+++ b/gix-object/src/data.rs
@@ -87,6 +87,9 @@ mod tests {
 
     #[test]
     fn size_of_object() {
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(std::mem::size_of::<Data<'_>>(), 24, "this shouldn't change unnoticed");
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(std::mem::size_of::<Data<'_>>(), 12, "this shouldn't change unnoticed");
     }
 }


### PR DESCRIPTION
The size of gix_object::Data is 24 bytes only on 64-bit architectures, on 32-bit architectures it's exactly half that (12 bytes).