### PR TITLE
Add commit signature extraction

### DIFF
--- a/gix-object/tests/commit/extracts_signature.rs
+++ b/gix-object/tests/commit/extracts_signature.rs
@@ -1,212 +1,64 @@
-use gix_object::{bstr::ByteSlice, commit::ref_iter::Token, CommitRefIter};
+use gix_object::{bstr::ByteSlice, CommitRef};
 
 use crate::{
-    commit::{LONG_MESSAGE, MERGE_TAG, SIGNATURE},
-    fixture_name, hex_to_id, linus_signature, signature,
+    commit::{OTHER_SIGNATURE, SIGNATURE},
+    fixture_name,
 };
 
-#[test]
-fn signed_singleline() -> crate::Result {
-    Commit::from_bytes(&fixture_name("commit", "signed-singleline.txt"))?.into_raw_iter(),
-    assert_eq!(
-        
-        CommitRef {
-            tree: b"00fc39317701176e326974ce44f5bd545a32ec0b".as_bstr(),
-            parents: SmallVec::from(vec![b"09d8d3a12e161a7f6afb522dbe8900a9c09bce06".as_bstr()]),
-            author: signature(1592391367),
-            committer: signature(1592391367),
-            encoding: None,
-            message: b"update tasks\n".as_bstr(),
-            extra_headers: vec![(b"gpgsig".as_bstr(), b"magic:signature".as_bstr().into())]
+fn extract_signed_helper(
+    fixture: &str,
+    signature: &[u8],
+    signature_lines: std::ops::RangeInclusive<usize>,
+) -> crate::Result {
+    let fixture_data = fixture_name("commit", fixture);
+    let mut signed_data = Vec::new();
+    {
+        let sig = CommitRef::extract_signature(&fixture_data, &mut signed_data)?.unwrap();
+        assert_eq!(sig.to_str(), signature.to_str());
+    }
+
+    let ends_with_newline = fixture_data[fixture_data.len() - 1] == b'\n';
+    let mut expected = Vec::new();
+    for (i, line) in String::from_utf8(fixture_data).unwrap().lines().enumerate() {
+        if signature_lines.contains(&i) {
+            if *signature_lines.end() == i {
+                expected.push(b'\n');
+            }
+            continue;
         }
-    );
-    Ok(())
-}
-
-#[test]
-fn signed_with_encoding() -> crate::Result {
-    let input = fixture_name("commit", "signed-with-encoding.txt");
-    let iter = CommitRefIter::from_bytes(&input);
-    assert_eq!(
-        iter.collect::<Result<Vec<_>, _>>()?,
-        vec![
-            Token::Tree {
-                id: hex_to_id("1973afa74d87b2bb73fa884aaaa8752aec43ea88")
-            },
-            Token::Parent {
-                id: hex_to_id("79c51cc86923e2b8ca0ee5c4eb75e48027133f9a")
-            },
-            Token::Author {
-                signature: signature(1592448995)
-            },
-            Token::Committer {
-                signature: signature(1592449083)
-            },
-            Token::Encoding(b"ISO-8859-1".as_bstr()),
-            Token::ExtraHeader((b"gpgsig".as_bstr(), SIGNATURE.as_bytes().as_bstr().into())),
-            Token::Message(b"encoding & sig".as_bstr()),
-        ]
-    );
-
-    assert_eq!(iter.author().ok(), Some(signature(1592448995)));
-    assert_eq!(iter.committer().ok(), Some(signature(1592449083)));
-    Ok(())
-}
-
-#[test]
-fn whitespace() -> crate::Result {
-    assert_eq!(
-        CommitRefIter::from_bytes(&fixture_name("commit", "whitespace.txt")).collect::<Result<Vec<_>, _>>()?,
-        vec![
-            Token::Tree {
-                id: hex_to_id("9bed6275068a0575243ba8409253e61af81ab2ff")
-            },
-            Token::Parent {
-                id: hex_to_id("26b4df046d1776c123ac69d918f5aec247b58cc6")
-            },
-            Token::Author {
-                signature: signature(1592448450)
-            },
-            Token::Committer {
-                signature: signature(1592448450)
-            },
-            Token::Message(b" nl".as_bstr())
-        ]
-    );
-    Ok(())
-}
-
-#[test]
-fn unsigned() -> crate::Result {
-    assert_eq!(
-        CommitRefIter::from_bytes(&fixture_name("commit", "unsigned.txt")).collect::<Result<Vec<_>, _>>()?,
-        vec![
-            Token::Tree {
-                id: hex_to_id("1b2dfb4ac5e42080b682fc676e9738c94ce6d54d")
-            },
-            Token::Author {
-                signature: signature(1592437401)
-            },
-            Token::Committer {
-                signature: signature(1592437401)
-            },
-            Token::Message(b"without sig".as_bstr())
-        ]
-    );
-    Ok(())
-}
-
-#[test]
-fn signed_singleline() -> crate::Result {
-    assert_eq!(
-        CommitRefIter::from_bytes(&fixture_name("commit", "signed-singleline.txt")).collect::<Result<Vec<_>, _>>()?,
-        vec![
-            Token::Tree {
-                id: hex_to_id("00fc39317701176e326974ce44f5bd545a32ec0b")
-            },
-            Token::Parent {
-                id: hex_to_id("09d8d3a12e161a7f6afb522dbe8900a9c09bce06")
-            },
-            Token::Author {
-                signature: signature(1592391367)
-            },
-            Token::Committer {
-                signature: signature(1592391367)
-            },
-            Token::ExtraHeader((b"gpgsig".as_bstr(), b"magic:signature".as_bstr().into())),
-            Token::Message(b"update tasks\n".as_bstr()),
-        ]
-    );
-    assert_eq!(
-        CommitRefIter::from_bytes(&fixture_name("commit", "signed-singleline.txt"))
-            .parent_ids()
-            .collect::<Vec<_>>(),
-        vec![hex_to_id("09d8d3a12e161a7f6afb522dbe8900a9c09bce06")]
-    );
-    Ok(())
-}
-
-#[test]
-fn error_handling() -> crate::Result {
-    let data = fixture_name("commit", "unsigned.txt");
-    let iter = CommitRefIter::from_bytes(&data[..data.len() / 2]);
-    let tokens = iter.collect::<Vec<_>>();
-    assert!(
-        tokens.last().expect("at least the errored token").is_err(),
-        "errors are propagated and none is returned from that point on"
-    );
-    Ok(())
-}
-
-#[test]
-fn mergetag() -> crate::Result {
-    let input = fixture_name("commit", "mergetag.txt");
-    let iter = CommitRefIter::from_bytes(&input);
-    assert_eq!(
-        iter.collect::<Result<Vec<_>, _>>()?,
-        vec![
-            Token::Tree {
-                id: hex_to_id("1c61918031bf2c7fab9e17dde3c52a6a9884fcb5")
-            },
-            Token::Parent {
-                id: hex_to_id("44ebe016df3aad96e3be8f95ec52397728dd7701")
-            },
-            Token::Parent {
-                id: hex_to_id("8d485da0ddee79d0e6713405694253d401e41b93")
-            },
-            Token::Author {
-                signature: linus_signature(1591996221)
-            },
-            Token::Committer {
-                signature: linus_signature(1591996221)
-            },
-            Token::ExtraHeader((b"mergetag".as_bstr(), MERGE_TAG.as_bytes().as_bstr().into())),
-            Token::Message(LONG_MESSAGE.into()),
-        ]
-    );
-    assert_eq!(
-        iter.parent_ids().collect::<Vec<_>>(),
-        vec![
-            hex_to_id("44ebe016df3aad96e3be8f95ec52397728dd7701"),
-            hex_to_id("8d485da0ddee79d0e6713405694253d401e41b93")
-        ]
-    );
-    assert_eq!(iter.message().ok(), Some(LONG_MESSAGE.into()));
-    Ok(())
-}
-
-mod method {
-    use gix_object::CommitRefIter;
-
-    use crate::{fixture_name, hex_to_id, signature};
-
-    #[test]
-    fn tree_id() -> crate::Result {
-        let input = fixture_name("commit", "unsigned.txt");
-        let iter = CommitRefIter::from_bytes(&input);
-        assert_eq!(
-            iter.clone().tree_id().ok(),
-            Some(hex_to_id("1b2dfb4ac5e42080b682fc676e9738c94ce6d54d"))
-        );
-        assert_eq!(
-            iter.signatures().collect::<Vec<_>>(),
-            vec![signature(1592437401), signature(1592437401)]
-        );
-        assert_eq!(iter.parent_ids().count(), 0);
-        Ok(())
+        expected.extend_from_slice(line.as_bytes());
+        expected.push(b'\n');
     }
 
-    #[test]
-    fn signatures() -> crate::Result {
-        let input = fixture_name("commit", "unsigned.txt");
-        let iter = CommitRefIter::from_bytes(&input);
-        assert_eq!(
-            iter.signatures().collect::<Vec<_>>(),
-            vec![signature(1592437401), signature(1592437401)]
-        );
-        assert_eq!(iter.author().ok(), Some(signature(1592437401)));
-        assert_eq!(iter.committer().ok(), Some(signature(1592437401)));
-        assert_eq!(iter.author().ok(), Some(signature(1592437401)), "it's not consuming");
-        Ok(())
+    if !ends_with_newline {
+        expected.pop();
     }
+
+    assert_eq!(signed_data.to_str(), expected.to_str());
+    Ok(())
+}
+
+#[test]
+fn extract_sig_singleline() -> crate::Result {
+    extract_signed_helper("signed-singleline.txt", b"magic:signature", 4..=4)
+}
+
+#[test]
+fn extract_sig_signed() -> crate::Result {
+    extract_signed_helper("signed.txt", b"-----BEGIN PGP SIGNATURE-----\n\niQEzBAABCAAdFiEEdjYp/sh4j8NRKLX27gKdHl60AwAFAl7p9tgACgkQ7gKdHl60\nAwBpegf+KQciv9AOIN7+yPmowecGxBnSfpKWTDzFxnyGR8dq63SpWT8WEKG5mf3a\nG6iUqpsDWaMHlzihaMKRvgRpZxFRbjnNPFBj6F4RRqfE+5R7k6DRSLUV5PqnsdSH\nuccfIDWi1imhsm7AaP5trwl1t+83U2JhHqPcPVFLMODYwWeO6NLR/JCzGSTQRa8t\nRgaVMKI19O/fge5OT5Ua8D47VKEhsJX0LfmkP5RfZQ8JJvNd40TupqKRdlv0sAzP\nya7NXkSHXCavHNR6kA+KpWxn900UoGK8/IDlwU6MeOkpPVawb3NFMqnc7KJDaC2p\nSMzpuEG8LTrCx2YSpHNLqHyzvQ1CZA==\n=5ITV\n-----END PGP SIGNATURE-----", 4..=14)
+}
+
+#[test]
+fn extract_sig_with_encoding() -> crate::Result {
+    extract_signed_helper("signed-with-encoding.txt", SIGNATURE, 5..=15)
+}
+
+#[test]
+fn extract_sig_with_msg_footer() -> crate::Result {
+    extract_signed_helper("message-with-footer.txt", b"-----BEGIN PGP SIGNATURE-----\n\niHUEABYIAB0WIQSuZwcGWSQItmusNgR5URpSUCnwXQUCYT7xpAAKCRB5URpSUCnw\nXWB3AP9q323HlxnI8MyqszNOeYDwa7Y3yEZaUM2y/IRjz+z4YQEAq0yr1Syt3mrK\nOSFCqL2vDm3uStP+vF31f6FnzayhNg0=\n=Mhpp\n-----END PGP SIGNATURE-----", 4..=10)
+}
+
+#[test]
+fn extract_sig_whitespace() -> crate::Result {
+    extract_signed_helper("signed-whitespace.txt", OTHER_SIGNATURE, 5..=15)
 }

--- a/gix-object/tests/commit/extracts_signature.rs
+++ b/gix-object/tests/commit/extracts_signature.rs
@@ -1,0 +1,212 @@
+use gix_object::{bstr::ByteSlice, commit::ref_iter::Token, CommitRefIter};
+
+use crate::{
+    commit::{LONG_MESSAGE, MERGE_TAG, SIGNATURE},
+    fixture_name, hex_to_id, linus_signature, signature,
+};
+
+#[test]
+fn signed_singleline() -> crate::Result {
+    Commit::from_bytes(&fixture_name("commit", "signed-singleline.txt"))?.into_raw_iter(),
+    assert_eq!(
+        
+        CommitRef {
+            tree: b"00fc39317701176e326974ce44f5bd545a32ec0b".as_bstr(),
+            parents: SmallVec::from(vec![b"09d8d3a12e161a7f6afb522dbe8900a9c09bce06".as_bstr()]),
+            author: signature(1592391367),
+            committer: signature(1592391367),
+            encoding: None,
+            message: b"update tasks\n".as_bstr(),
+            extra_headers: vec![(b"gpgsig".as_bstr(), b"magic:signature".as_bstr().into())]
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn signed_with_encoding() -> crate::Result {
+    let input = fixture_name("commit", "signed-with-encoding.txt");
+    let iter = CommitRefIter::from_bytes(&input);
+    assert_eq!(
+        iter.collect::<Result<Vec<_>, _>>()?,
+        vec![
+            Token::Tree {
+                id: hex_to_id("1973afa74d87b2bb73fa884aaaa8752aec43ea88")
+            },
+            Token::Parent {
+                id: hex_to_id("79c51cc86923e2b8ca0ee5c4eb75e48027133f9a")
+            },
+            Token::Author {
+                signature: signature(1592448995)
+            },
+            Token::Committer {
+                signature: signature(1592449083)
+            },
+            Token::Encoding(b"ISO-8859-1".as_bstr()),
+            Token::ExtraHeader((b"gpgsig".as_bstr(), SIGNATURE.as_bytes().as_bstr().into())),
+            Token::Message(b"encoding & sig".as_bstr()),
+        ]
+    );
+
+    assert_eq!(iter.author().ok(), Some(signature(1592448995)));
+    assert_eq!(iter.committer().ok(), Some(signature(1592449083)));
+    Ok(())
+}
+
+#[test]
+fn whitespace() -> crate::Result {
+    assert_eq!(
+        CommitRefIter::from_bytes(&fixture_name("commit", "whitespace.txt")).collect::<Result<Vec<_>, _>>()?,
+        vec![
+            Token::Tree {
+                id: hex_to_id("9bed6275068a0575243ba8409253e61af81ab2ff")
+            },
+            Token::Parent {
+                id: hex_to_id("26b4df046d1776c123ac69d918f5aec247b58cc6")
+            },
+            Token::Author {
+                signature: signature(1592448450)
+            },
+            Token::Committer {
+                signature: signature(1592448450)
+            },
+            Token::Message(b" nl".as_bstr())
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn unsigned() -> crate::Result {
+    assert_eq!(
+        CommitRefIter::from_bytes(&fixture_name("commit", "unsigned.txt")).collect::<Result<Vec<_>, _>>()?,
+        vec![
+            Token::Tree {
+                id: hex_to_id("1b2dfb4ac5e42080b682fc676e9738c94ce6d54d")
+            },
+            Token::Author {
+                signature: signature(1592437401)
+            },
+            Token::Committer {
+                signature: signature(1592437401)
+            },
+            Token::Message(b"without sig".as_bstr())
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn signed_singleline() -> crate::Result {
+    assert_eq!(
+        CommitRefIter::from_bytes(&fixture_name("commit", "signed-singleline.txt")).collect::<Result<Vec<_>, _>>()?,
+        vec![
+            Token::Tree {
+                id: hex_to_id("00fc39317701176e326974ce44f5bd545a32ec0b")
+            },
+            Token::Parent {
+                id: hex_to_id("09d8d3a12e161a7f6afb522dbe8900a9c09bce06")
+            },
+            Token::Author {
+                signature: signature(1592391367)
+            },
+            Token::Committer {
+                signature: signature(1592391367)
+            },
+            Token::ExtraHeader((b"gpgsig".as_bstr(), b"magic:signature".as_bstr().into())),
+            Token::Message(b"update tasks\n".as_bstr()),
+        ]
+    );
+    assert_eq!(
+        CommitRefIter::from_bytes(&fixture_name("commit", "signed-singleline.txt"))
+            .parent_ids()
+            .collect::<Vec<_>>(),
+        vec![hex_to_id("09d8d3a12e161a7f6afb522dbe8900a9c09bce06")]
+    );
+    Ok(())
+}
+
+#[test]
+fn error_handling() -> crate::Result {
+    let data = fixture_name("commit", "unsigned.txt");
+    let iter = CommitRefIter::from_bytes(&data[..data.len() / 2]);
+    let tokens = iter.collect::<Vec<_>>();
+    assert!(
+        tokens.last().expect("at least the errored token").is_err(),
+        "errors are propagated and none is returned from that point on"
+    );
+    Ok(())
+}
+
+#[test]
+fn mergetag() -> crate::Result {
+    let input = fixture_name("commit", "mergetag.txt");
+    let iter = CommitRefIter::from_bytes(&input);
+    assert_eq!(
+        iter.collect::<Result<Vec<_>, _>>()?,
+        vec![
+            Token::Tree {
+                id: hex_to_id("1c61918031bf2c7fab9e17dde3c52a6a9884fcb5")
+            },
+            Token::Parent {
+                id: hex_to_id("44ebe016df3aad96e3be8f95ec52397728dd7701")
+            },
+            Token::Parent {
+                id: hex_to_id("8d485da0ddee79d0e6713405694253d401e41b93")
+            },
+            Token::Author {
+                signature: linus_signature(1591996221)
+            },
+            Token::Committer {
+                signature: linus_signature(1591996221)
+            },
+            Token::ExtraHeader((b"mergetag".as_bstr(), MERGE_TAG.as_bytes().as_bstr().into())),
+            Token::Message(LONG_MESSAGE.into()),
+        ]
+    );
+    assert_eq!(
+        iter.parent_ids().collect::<Vec<_>>(),
+        vec![
+            hex_to_id("44ebe016df3aad96e3be8f95ec52397728dd7701"),
+            hex_to_id("8d485da0ddee79d0e6713405694253d401e41b93")
+        ]
+    );
+    assert_eq!(iter.message().ok(), Some(LONG_MESSAGE.into()));
+    Ok(())
+}
+
+mod method {
+    use gix_object::CommitRefIter;
+
+    use crate::{fixture_name, hex_to_id, signature};
+
+    #[test]
+    fn tree_id() -> crate::Result {
+        let input = fixture_name("commit", "unsigned.txt");
+        let iter = CommitRefIter::from_bytes(&input);
+        assert_eq!(
+            iter.clone().tree_id().ok(),
+            Some(hex_to_id("1b2dfb4ac5e42080b682fc676e9738c94ce6d54d"))
+        );
+        assert_eq!(
+            iter.signatures().collect::<Vec<_>>(),
+            vec![signature(1592437401), signature(1592437401)]
+        );
+        assert_eq!(iter.parent_ids().count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn signatures() -> crate::Result {
+        let input = fixture_name("commit", "unsigned.txt");
+        let iter = CommitRefIter::from_bytes(&input);
+        assert_eq!(
+            iter.signatures().collect::<Vec<_>>(),
+            vec![signature(1592437401), signature(1592437401)]
+        );
+        assert_eq!(iter.author().ok(), Some(signature(1592437401)));
+        assert_eq!(iter.committer().ok(), Some(signature(1592437401)));
+        assert_eq!(iter.author().ok(), Some(signature(1592437401)), "it's not consuming");
+        Ok(())
+    }
+}

--- a/gix-object/tests/commit/from_bytes.rs
+++ b/gix-object/tests/commit/from_bytes.rs
@@ -294,23 +294,11 @@ fn merge() -> crate::Result {
     Ok(())
 }
 
-const OTHER_SIGNATURE: &[u8; 455] = b"-----BEGIN PGP SIGNATURE-----
-
-wsBcBAABCAAQBQJeqxW4CRBK7hj4Ov3rIwAAdHIIAFD98qgN/k8ybukCLf6kpzvi
-5V8gf6BflONXc/oIDySurW7kfS9/r6jOgu08UN8KlQx4Q4g8yY7PROABhwGI70B3
-+mHPFcParQf5FBDDZ3GNNpJdlaI9eqzEnFk8AmHmyKHfuGLoclXUObXQ3oe3fmT7
-QdTC7JTyk/bPnZ9HQKw7depa3+7Kw4wv4DG8QcW3BG6B9bcE15qaWmOiq0ryRXsv
-k7D0LqGSXjU5wrQrKnemC7nWhmQsqaXDe89XXmliClCAx4/bepPiXK0eT/DNIKUr
-iyBBl69jASy41Ug/BlFJbw4+ItkShpXwkJKuBBV/JExChmvbxYWaS7QnyYC9UO0=
-=HLmy
------END PGP SIGNATURE-----
-";
-
 #[test]
 fn newline_right_after_signature_multiline_header() -> crate::Result {
     let fixture = fixture_name("commit", "signed-whitespace.txt");
     let commit = CommitRef::from_bytes(&fixture)?;
-    let pgp_sig = OTHER_SIGNATURE.as_bstr();
+    let pgp_sig = crate::commit::OTHER_SIGNATURE.as_bstr();
     assert_eq!(commit.extra_headers[0].1.as_ref(), pgp_sig);
     assert_eq!(commit.extra_headers().pgp_signature(), Some(pgp_sig));
     assert_eq!(commit.extra_headers().find("gpgsig"), Some(pgp_sig));

--- a/gix-object/tests/commit/mod.rs
+++ b/gix-object/tests/commit/mod.rs
@@ -130,6 +130,19 @@ zRo/4HJ04mSQYp0kluP/EBhz9g2wM/htIPyWRveB/ByKEYt3UNKjB++PJmPbu5UG
 dS3aXZhRfaPqpdsWrMB9fY7ll+oyfw==
 =T+RI
 -----END PGP SIGNATURE-----";
+
+const OTHER_SIGNATURE: &[u8; 455] = b"-----BEGIN PGP SIGNATURE-----
+
+wsBcBAABCAAQBQJeqxW4CRBK7hj4Ov3rIwAAdHIIAFD98qgN/k8ybukCLf6kpzvi
+5V8gf6BflONXc/oIDySurW7kfS9/r6jOgu08UN8KlQx4Q4g8yY7PROABhwGI70B3
++mHPFcParQf5FBDDZ3GNNpJdlaI9eqzEnFk8AmHmyKHfuGLoclXUObXQ3oe3fmT7
+QdTC7JTyk/bPnZ9HQKw7depa3+7Kw4wv4DG8QcW3BG6B9bcE15qaWmOiq0ryRXsv
+k7D0LqGSXjU5wrQrKnemC7nWhmQsqaXDe89XXmliClCAx4/bepPiXK0eT/DNIKUr
+iyBBl69jASy41Ug/BlFJbw4+ItkShpXwkJKuBBV/JExChmvbxYWaS7QnyYC9UO0=
+=HLmy
+-----END PGP SIGNATURE-----
+";
+
 mod method {
     use gix_object::CommitRef;
     use pretty_assertions::assert_eq;
@@ -146,6 +159,7 @@ mod method {
     }
 }
 
+mod extracts_signature;
 mod from_bytes;
 mod iter;
 mod message;

--- a/gix/src/object/commit.rs
+++ b/gix/src/object/commit.rs
@@ -147,6 +147,52 @@ impl<'repo> Commit<'repo> {
             max_candidates: 10,
         }
     }
+
+    /// Extracts the PGP signature and the signed commit data, if it exists.
+    pub fn extract_signature(
+        &self,
+        signed_data: &mut Vec<u8>,
+    ) -> Result<Option<std::borrow::Cow<'_, BStr>>, gix_object::decode::Error> {
+        use crate::objs::commit::ref_iter::Token;
+        let pgp_sig_header = gix_actor::bstr::BStr::new(b"gpgsig");
+
+        signed_data.clear();
+
+        let mut signature = None;
+        let out = signed_data;
+
+        for token in gix_object::CommitRefIter::from_bytes(&self.data).into_raw_iter() {
+            let token = token?;
+
+            // We don't care what the tokens are, just that they are valid, except
+            // in the case of the signature, which we skip as it is the only part
+            // of the commit that is not signed, obviously
+            if let Token::ExtraHeader((hname, hval)) = &token.token {
+                if hname == &pgp_sig_header {
+                    signature = Some(hval.clone());
+                    continue;
+                }
+            }
+
+            // There is only one exception to the outputs, which is that the message
+            // is always separated by an additional empty line from the rest of the
+            // data
+            if matches!(token.token, Token::Message(_)) {
+                // If we don't have a signature when we've reached the message,
+                // there is none and we can just short circuit
+                if signature.is_none() {
+                    out.clear();
+                    return Ok(None);
+                }
+
+                out.push(b'\n');
+            }
+
+            out.extend_from_slice(token.buffer);
+        }
+
+        Ok(signature)
+    }
 }
 
 impl<'r> std::fmt::Debug for Commit<'r> {


### PR DESCRIPTION
This PR adds the equivalent of libgit2's [`commit_extract_signature`](https://libgit2.org/libgit2/#HEAD/group/commit/git_commit_extract_signature) to Commit/Ref as I encountered a [use case](https://github.com/rustsec/rustsec/blob/76d509d014b1b0c7206f0df4e953b3b59ab4b286/rustsec/src/repository/git/commit.rs#L63) for it while porting some code from git2.

The API is admittedly wonky so let me know if you want changes.