### PR TITLE
faster hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "faster-hex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9042d281a5eec0f2387f8c3ea6c4514e2cf2732c90a85aaf383b761ee3b290d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,9 +1640,9 @@ name = "gix-hash"
 version = "0.11.4"
 dependencies = [
  "document-features",
+ "faster-hex",
  "gix-features 0.32.1",
  "gix-testtools",
- "hex",
  "serde",
  "thiserror",
 ]
@@ -1833,7 +1842,6 @@ dependencies = [
  "gix-hash 0.11.4",
  "gix-testtools",
  "gix-validate 0.8.0",
- "hex",
  "itoa",
  "nom",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,11 +1923,11 @@ dependencies = [
  "async-std",
  "bstr",
  "document-features",
+ "faster-hex",
  "futures-io",
  "futures-lite",
  "gix-hash 0.11.4",
  "gix-odb",
- "hex",
  "maybe-async",
  "pin-project-lite",
  "serde",
@@ -1940,7 +1940,7 @@ version = "0.16.4"
 dependencies = [
  "bstr",
  "document-features",
- "hex",
+ "faster-hex",
  "serde",
  "thiserror",
 ]

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -19,7 +19,7 @@ serde= ["dep:serde"]
 
 [dependencies]
 thiserror = "1.0.33"
-hex = "0.4.2"
+faster-hex = "0.8.0"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -148,7 +148,7 @@ impl oid {
     #[must_use]
     pub fn hex_to_buf(&self, buf: &mut [u8]) -> usize {
         let num_hex_bytes = self.bytes.len() * 2;
-        hex::encode_to_slice(&self.bytes, &mut buf[..num_hex_bytes]).expect("to count correctly");
+        faster_hex::hex_encode(&self.bytes, &mut buf[..num_hex_bytes]).expect("to count correctly");
         num_hex_bytes
     }
 

--- a/gix-hash/tests/object_id/mod.rs
+++ b/gix-hash/tests/object_id/mod.rs
@@ -21,7 +21,7 @@ mod from_hex {
         fn non_hex_characters() {
             assert!(matches!(
                 ObjectId::from_hex(b"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz").unwrap_err(),
-                decode::Error::Invalid { index: 0, c: 'z' }
+                decode::Error::Invalid
             ));
         }
 

--- a/gix-hash/tests/prefix/mod.rs
+++ b/gix-hash/tests/prefix/mod.rs
@@ -117,7 +117,7 @@ mod try_from {
     #[test]
     fn invalid_chars() {
         let input = "abcdfOsd";
-        let expected = Error::Invalid { c: 'O', index: 5 };
+        let expected = Error::Invalid;
         let actual = Prefix::try_from(input).unwrap_err();
         assert_eq!(actual, expected);
     }

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -31,7 +31,6 @@ gix-date = { version = "^0.7.2", path = "../gix-date" }
 btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
-hex = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
 nom = { version = "7", default-features = false, features = ["std"]}
 smallvec = { version = "1.4.0", features = ["write"] }

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -26,7 +26,7 @@ serde = ["dep:serde", "bstr/serde"]
 [dependencies]
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"]}
 thiserror = "1.0.34"
-hex = "0.4.2"
+faster-hex = "0.8.0"
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -41,7 +41,7 @@ required-features = ["blocking-io", "maybe-async/is_sync"]
 [dependencies]
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"]}
 thiserror = "1.0.34"
-hex = "0.4.2"
+faster-hex = "0.8.0"
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
 # async support
 futures-io = { version = "0.3.16", optional = true }

--- a/gix-packetline/src/decode.rs
+++ b/gix-packetline/src/decode.rs
@@ -72,7 +72,7 @@ pub fn hex_prefix(four_bytes: &[u8]) -> Result<PacketLineOrWantedSize<'_>, Error
     }
 
     let mut buf = [0u8; U16_HEX_BYTES / 2];
-    hex::decode_to_slice(four_bytes, &mut buf).map_err(|err| Error::HexDecode { err: err.to_string() })?;
+    faster_hex::hex_decode(four_bytes, &mut buf).map_err(|err| Error::HexDecode { err: err.to_string() })?;
     let wanted_bytes = u16::from_be_bytes(buf);
 
     if wanted_bytes == 3 {

--- a/gix-packetline/src/encode/mod.rs
+++ b/gix-packetline/src/encode/mod.rs
@@ -22,6 +22,6 @@ pub use blocking_io::*;
 
 pub(crate) fn u16_to_hex(value: u16) -> [u8; 4] {
     let mut buf = [0u8; 4];
-    hex::encode_to_slice(value.to_be_bytes(), &mut buf).expect("two bytes to 4 hex chars never fails");
+    faster_hex::hex_encode(&value.to_be_bytes(), &mut buf).expect("two bytes to 4 hex chars never fails");
     buf
 }

--- a/gix-packetline/tests/decode/mod.rs
+++ b/gix-packetline/tests/decode/mod.rs
@@ -126,7 +126,7 @@ mod streaming {
     fn error_on_invalid_hex() {
         assert_err_display(
             streaming(b"fooo"),
-            "Failed to decode the first four hex bytes indicating the line length: Invalid character 'o' at position 1",
+            "Failed to decode the first four hex bytes indicating the line length: Invalid character",
         );
     }
 

--- a/gix-revision/fuzz/Cargo.lock
+++ b/gix-revision/fuzz/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 
 [[package]]
+name = "faster-hex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9042d281a5eec0f2387f8c3ea6c4514e2cf2732c90a85aaf383b761ee3b290d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "gix-actor"
 version = "0.24.2"
 dependencies = [
@@ -67,8 +76,8 @@ dependencies = [
  "btoi",
  "gix-date",
  "itoa",
- "nom",
  "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -114,7 +123,7 @@ dependencies = [
 name = "gix-hash"
 version = "0.11.4"
 dependencies = [
- "hex",
+ "faster-hex",
  "thiserror",
 ]
 
@@ -138,11 +147,10 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-validate",
- "hex",
  "itoa",
- "nom",
  "smallvec",
  "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -200,12 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,22 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -360,6 +346,20 @@ name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha1_smol"
@@ -496,3 +496,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e461589e194280efaa97236b73623445efa195aa633fd7004f39805707a9d53"
+dependencies = [
+ "memchr",
+]


### PR DESCRIPTION
Use `faster-hex` as it seems to make a difference when parsing a lot of commits?
