### PR TITLE
Improve gix-config parsing

### DIFF
--- a/gix-config/src/parse/nom/mod.rs
+++ b/gix-config/src/parse/nom/mod.rs
@@ -265,62 +265,67 @@ fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut impl FnMut(Event<'i>)) -> PRe
     // Used to determine if we return a Value or Value{Not,}Done
     let mut partial_value_found = false;
 
-    while let Some(c) = i.next_token() {
-        match c {
-            b'\n' => {
-                value_end = Some(i.offset_from(&value_start_checkpoint) - 1);
-                break;
-            }
-            b';' | b'#' if !is_in_quotes => {
-                value_end = Some(i.offset_from(&value_start_checkpoint) - 1);
-                break;
-            }
-            b'\\' => {
-                let escaped_index = i.offset_from(&value_start_checkpoint);
-                let escape_index = escaped_index - 1;
-                let Some(mut c) = i.next_token() else {
-                    i.reset(start_checkpoint);
-                    return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token));
-                };
-                let mut consumed = 1;
-                if c == b'\r' {
-                    c = i.next_token().ok_or_else(|| {
-                        i.reset(start_checkpoint);
-                        winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token)
-                    })?;
-                    if c != b'\n' {
-                        i.reset(start_checkpoint);
-                        return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Slice));
-                    }
-                    consumed += 1;
+    loop {
+        let _ = take_while(0.., |c| !matches!(c, b'\n' | b'\\' | b'"' | b';' | b'#')).parse_next(i)?;
+        if let Some(c) = i.next_token() {
+            match c {
+                b'\n' => {
+                    value_end = Some(i.offset_from(&value_start_checkpoint) - 1);
+                    break;
                 }
-
-                match c {
-                    b'\n' => {
-                        partial_value_found = true;
-
-                        i.reset(value_start_checkpoint);
-
-                        let value = i.next_slice(escape_index).as_bstr();
-                        dispatch(Event::ValueNotDone(Cow::Borrowed(value)));
-
-                        i.next_token();
-
-                        let nl = i.next_slice(consumed).as_bstr();
-                        dispatch(Event::Newline(Cow::Borrowed(nl)));
-
-                        value_start_checkpoint = i.checkpoint();
-                        value_end = None;
-                    }
-                    b'n' | b't' | b'\\' | b'b' | b'"' => {}
-                    _ => {
+                b';' | b'#' if !is_in_quotes => {
+                    value_end = Some(i.offset_from(&value_start_checkpoint) - 1);
+                    break;
+                }
+                b'\\' => {
+                    let escaped_index = i.offset_from(&value_start_checkpoint);
+                    let escape_index = escaped_index - 1;
+                    let Some(mut c) = i.next_token() else {
                         i.reset(start_checkpoint);
                         return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token));
+                    };
+                    let mut consumed = 1;
+                    if c == b'\r' {
+                        c = i.next_token().ok_or_else(|| {
+                            i.reset(start_checkpoint);
+                            winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token)
+                        })?;
+                        if c != b'\n' {
+                            i.reset(start_checkpoint);
+                            return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Slice));
+                        }
+                        consumed += 1;
+                    }
+
+                    match c {
+                        b'\n' => {
+                            partial_value_found = true;
+
+                            i.reset(value_start_checkpoint);
+
+                            let value = i.next_slice(escape_index).as_bstr();
+                            dispatch(Event::ValueNotDone(Cow::Borrowed(value)));
+
+                            i.next_token();
+
+                            let nl = i.next_slice(consumed).as_bstr();
+                            dispatch(Event::Newline(Cow::Borrowed(nl)));
+
+                            value_start_checkpoint = i.checkpoint();
+                            value_end = None;
+                        }
+                        b'n' | b't' | b'\\' | b'b' | b'"' => {}
+                        _ => {
+                            i.reset(start_checkpoint);
+                            return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token));
+                        }
                     }
                 }
+                b'"' => is_in_quotes = !is_in_quotes,
+                _ => {}
             }
-            b'"' => is_in_quotes = !is_in_quotes,
-            _ => {}
+        } else {
+            break;
         }
     }
     if is_in_quotes {

--- a/gix-config/src/parse/nom/mod.rs
+++ b/gix-config/src/parse/nom/mod.rs
@@ -121,7 +121,10 @@ fn section<'i>(
             dispatch(Event::Newline(Cow::Borrowed(v.as_bstr())));
         }
 
-        let _ = key_value_pair(i, node, dispatch);
+        let before_key = i.checkpoint();
+        if key_value_pair(i, node, dispatch).is_err() {
+            i.reset(before_key);
+        }
 
         if let Some(comment) = opt(comment).parse_next(i)? {
             dispatch(Event::Comment(comment));

--- a/gix-config/src/parse/nom/tests.rs
+++ b/gix-config/src/parse/nom/tests.rs
@@ -808,7 +808,12 @@ mod key_value_pair {
     fn nonascii_is_allowed_for_values_but_not_for_keys() {
         let mut node = ParseNode::SectionHeader;
         let mut vec = Default::default();
-        assert!(key_value("你好".as_bytes(), &mut node, &mut vec).is_err());
+        // Verifying `is_ok` because bad keys get ignored
+        assert!(key_value("你好".as_bytes(), &mut node, &mut vec).is_ok());
+        assert_eq!(vec, into_events(vec![]));
+
+        let mut node = ParseNode::SectionHeader;
+        let mut vec = Default::default();
         assert!(key_value("a = 你好 ".as_bytes(), &mut node, &mut vec).is_ok());
         assert_eq!(
             vec,


### PR DESCRIPTION
The biggest improvement is in a degenerate case highlighted by 510192e0e5750bdfe461d701b3e124c03f22b7d9 which causes `d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=d[W]t=...\r` to be parsed as a value, failing when there isn't a `\n` after the `\r`, and then retrying just a couple more bytes in, slowly eating away at the input until it is empty.

This PR includes two flavors for fixing it.  The first reverts the behavior back to something more like pre-fe997c8a32b0a1dc3ad3613fe8dd48a987c3a5bf where we didn't advance `i` on failure, hitting a break if parsing didn't progress. The problem is we discard any error information in this case, so I then updated it to be slightly closer to how I would write a normal parser (if we didn't have `dispatch`).

Before I found that root cause, I found that `next_token` calls in `value_impl` were taken up significant amounts of time and that adding a fast-path for values dramatically improved it (from 8s to 5s on my machine).  I'm assuming this will carry forward to helping normal parsing cases so I left it in.