### PR TITLE
Checkout outcome now implements debug

### DIFF
--- a/gix-worktree-state/src/checkout/mod.rs
+++ b/gix-worktree-state/src/checkout/mod.rs
@@ -11,6 +11,7 @@ pub struct Collision {
 }
 
 /// A path that encountered an IO error.
+#[derive(Debug)]
 pub struct ErrorRecord {
     /// the path that encountered the error.
     pub path: BString,
@@ -19,7 +20,7 @@ pub struct ErrorRecord {
 }
 
 /// The outcome of checking out an entire index.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Outcome {
     /// The amount of files updated, or created.
     pub files_updated: usize,


### PR DESCRIPTION
As part of implementing a gitops-like feature, I found myself wanting to `dbg!()` the `Outcome` returned from `checkout()` during development. I'm guessing this is a relatively common use case, so I thought it worthwhile for it to `#[derive(Debug)]`.