### PR TITLE
adjustments for cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
  "gix-hash 0.12.0",
  "gix-hashtable 0.3.0",
  "gix-ignore 0.6.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-lock 8.0.0",
  "gix-mailmap",
  "gix-negotiate",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1766,7 +1766,7 @@ dependencies = [
  "gix",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-testtools",
 ]
 
@@ -2221,7 +2221,7 @@ dependencies = [
  "gix-features 0.33.0",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-object 0.35.0",
  "gix-path 0.9.0",
  "thiserror",
@@ -2236,7 +2236,7 @@ dependencies = [
  "gix-features 0.33.0",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-object 0.35.0",
  "gix-status",
  "gix-testtools",
@@ -2482,7 +2482,7 @@ dependencies = [
  "gix-glob 0.11.0",
  "gix-hash 0.12.0",
  "gix-ignore 0.6.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-object 0.35.0",
  "gix-path 0.9.0",
  "serde",
@@ -2498,7 +2498,7 @@ dependencies = [
  "gix-fs 0.5.0",
  "gix-glob 0.11.0",
  "gix-hash 0.12.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-object 0.35.0",
  "gix-path 0.9.0",
  "gix-worktree 0.25.0",
@@ -2515,7 +2515,7 @@ dependencies = [
  "gix-filter",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-object 0.35.0",
  "gix-odb",
  "gix-testtools",
@@ -2556,7 +2556,7 @@ dependencies = [
  "gix-glob 0.11.0",
  "gix-hash 0.12.0",
  "gix-ignore 0.6.0",
- "gix-index 0.23.0",
+ "gix-index 0.23.1",
  "gix-object 0.35.0",
  "gix-odb",
  "gix-path 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gitoxide"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "gitoxide-core"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-io",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1196,7 +1196,7 @@ dependencies = [
  "gix-commitgraph",
  "gix-config",
  "gix-credentials",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-diff",
  "gix-discover 0.23.0",
  "gix-features 0.33.0",
@@ -1206,7 +1206,7 @@ dependencies = [
  "gix-hash 0.12.0",
  "gix-hashtable 0.3.0",
  "gix-ignore 0.6.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-lock 8.0.0",
  "gix-mailmap",
  "gix-negotiate",
@@ -1230,7 +1230,7 @@ dependencies = [
  "gix-url",
  "gix-utils 0.1.5",
  "gix-validate 0.8.0",
- "gix-worktree 0.24.0",
+ "gix-worktree 0.25.0",
  "gix-worktree-state",
  "gix-worktree-stream",
  "is_ci",
@@ -1270,7 +1270,7 @@ dependencies = [
  "bstr",
  "btoi",
  "document-features",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
  "gix-testtools",
@@ -1289,14 +1289,14 @@ dependencies = [
  "document-features",
  "flate2",
  "gix-attributes 0.17.0",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-filter",
  "gix-hash 0.12.0",
  "gix-object 0.35.0",
  "gix-odb",
  "gix-path 0.9.0",
  "gix-testtools",
- "gix-worktree 0.24.0",
+ "gix-worktree 0.25.0",
  "gix-worktree-stream",
  "tar",
  "thiserror",
@@ -1379,7 +1379,7 @@ dependencies = [
  "bstr",
  "document-features",
  "gix-chunk",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
  "gix-testtools",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "bstr",
  "document-features",
@@ -1596,7 +1596,7 @@ dependencies = [
  "gix-quote 0.4.7",
  "gix-testtools",
  "gix-trace 0.1.3",
- "gix-worktree 0.24.0",
+ "gix-worktree 0.25.0",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1766,7 +1766,7 @@ dependencies = [
  "gix",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-testtools",
 ]
 
@@ -1802,7 +1802,7 @@ dependencies = [
  "bstr",
  "document-features",
  "gix-actor 0.25.0",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-testtools",
  "serde",
  "thiserror",
@@ -1814,7 +1814,7 @@ version = "0.6.0"
 dependencies = [
  "bitflags 2.3.3",
  "gix-commitgraph",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-hash 0.12.0",
  "gix-object 0.35.0",
  "gix-odb",
@@ -1857,7 +1857,7 @@ dependencies = [
  "criterion",
  "document-features",
  "gix-actor 0.25.0",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
  "gix-testtools",
@@ -1876,7 +1876,7 @@ version = "0.51.0"
 dependencies = [
  "arc-swap",
  "document-features",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
  "gix-object 0.35.0",
@@ -1895,7 +1895,7 @@ version = "0.0.0"
 dependencies = [
  "filetime",
  "gix-actor 0.25.0",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
  "gix-object 0.35.0",
@@ -2042,7 +2042,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "gix-credentials",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-hash 0.12.0",
  "gix-packetline",
@@ -2104,7 +2104,7 @@ version = "0.35.0"
 dependencies = [
  "document-features",
  "gix-actor 0.25.0",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-features 0.33.0",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
@@ -2125,7 +2125,7 @@ name = "gix-ref-tests"
 version = "0.0.0"
 dependencies = [
  "gix-actor 0.25.0",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-discover 0.23.0",
  "gix-features 0.33.0",
  "gix-fs 0.5.0",
@@ -2158,7 +2158,7 @@ dependencies = [
  "bstr",
  "document-features",
  "gix-commitgraph",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-hash 0.12.0",
  "gix-hashtable 0.3.0",
  "gix-object 0.35.0",
@@ -2175,7 +2175,7 @@ name = "gix-revwalk"
 version = "0.6.0"
 dependencies = [
  "gix-commitgraph",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-hash 0.12.0",
  "gix-hashtable 0.3.0",
  "gix-object 0.35.0",
@@ -2221,7 +2221,7 @@ dependencies = [
  "gix-features 0.33.0",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-object 0.35.0",
  "gix-path 0.9.0",
  "thiserror",
@@ -2236,7 +2236,7 @@ dependencies = [
  "gix-features 0.33.0",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-object 0.35.0",
  "gix-status",
  "gix-testtools",
@@ -2373,7 +2373,7 @@ name = "gix-traverse"
 version = "0.31.0"
 dependencies = [
  "gix-commitgraph",
- "gix-date 0.7.3",
+ "gix-date 0.7.4",
  "gix-hash 0.12.0",
  "gix-hashtable 0.3.0",
  "gix-object 0.35.0",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bstr",
  "document-features",
@@ -2482,7 +2482,7 @@ dependencies = [
  "gix-glob 0.11.0",
  "gix-hash 0.12.0",
  "gix-ignore 0.6.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-object 0.35.0",
  "gix-path 0.9.0",
  "serde",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bstr",
  "gix-features 0.33.0",
@@ -2498,10 +2498,10 @@ dependencies = [
  "gix-fs 0.5.0",
  "gix-glob 0.11.0",
  "gix-hash 0.12.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-object 0.35.0",
  "gix-path 0.9.0",
- "gix-worktree 0.24.0",
+ "gix-worktree 0.25.0",
  "io-close",
  "thiserror",
 ]
@@ -2515,7 +2515,7 @@ dependencies = [
  "gix-filter",
  "gix-fs 0.5.0",
  "gix-hash 0.12.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-object 0.35.0",
  "gix-odb",
  "gix-testtools",
@@ -2539,7 +2539,7 @@ dependencies = [
  "gix-path 0.9.0",
  "gix-testtools",
  "gix-traverse 0.31.0",
- "gix-worktree 0.24.0",
+ "gix-worktree 0.25.0",
  "parking_lot",
  "thiserror",
 ]
@@ -2556,12 +2556,12 @@ dependencies = [
  "gix-glob 0.11.0",
  "gix-hash 0.12.0",
  "gix-ignore 0.6.0",
- "gix-index 0.22.0",
+ "gix-index 0.23.0",
  "gix-object 0.35.0",
  "gix-odb",
  "gix-path 0.9.0",
  "gix-testtools",
- "gix-worktree 0.24.0",
+ "gix-worktree 0.25.0",
  "symlink",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ resolver = "2"
 
 [[bin]]
 name = "ein"
-doc = false
 path = "src/ein.rs"
+doc = false
 test = false
 doctest = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/Byron/gitoxide"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-version = "0.29.0"
+version = "0.30.0"
 default-run = "gix"
 include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 resolver = "2"
@@ -162,9 +162,9 @@ gitoxide-core-async-client = ["gitoxide-core/async-client", "futures-lite"]
 [dependencies]
 anyhow = "1.0.42"
 
-gitoxide-core = { version = "^0.31.0", path = "gitoxide-core" }
+gitoxide-core = { version = "^0.32.0", path = "gitoxide-core" }
 gix-features = { version = "^0.33.0", path = "gix-features" }
-gix = { version = "^0.52.0", path = "gix", default-features = false }
+gix = { version = "^0.53.0", path = "gix", default-features = false }
 time = "0.3.23"
 
 clap = { version = "4.1.1", features = ["derive", "cargo"] }

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gitoxide-core"
 description = "The library implementing all capabilities of the gitoxide CLI"
 repository = "https://github.com/Byron/gitoxide"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -44,7 +44,7 @@ serde = ["gix/serde", "dep:serde_json", "dep:serde", "bytesize/serde"]
 
 [dependencies]
 # deselect everything else (like "performance") as this should be controllable by the parent application.
-gix = { version = "^0.52.0", path = "../gix", default-features = false }
+gix = { version = "^0.53.0", path = "../gix", default-features = false }
 gix-pack-for-configuration-only = { package = "gix-pack", version = "^0.41.0", path = "../gix-pack", default-features = false, features = ["pack-cache-lru-dynamic", "pack-cache-lru-static"] }
 gix-transport-configuration-only = { package = "gix-transport", version = "^0.35.0", path = "../gix-transport", default-features = false }
 gix-archive-for-configuration-only = { package = "gix-archive", version = "^0.3.0", path = "../gix-archive", optional = true, features = ["tar", "tar_gz"] }

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -27,7 +27,7 @@ zip = ["dep:zip", "dep:time"]
 gix-worktree-stream = { version = "^0.3.0", path = "../gix-worktree-stream" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }
 gix-path = { version = "^0.9.0", path = "../gix-path", optional = true }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 
 flate2 = { version = "1.0.26", optional = true }
 zip = { version = "0.6.6", optional = true, default-features = false, features = ["deflate", "time"] }

--- a/gix-date/CHANGELOG.md
+++ b/gix-date/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+A maintenance release without user-facing changes.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 2 commits contributed to the release over the course of 9 calendar days.
+ - 9 days passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Thanks Clippy
+
+<csr-read-only-do-not-edit/>
+
+[Clippy](https://github.com/rust-lang/rust-clippy) helped 1 time to make code idiomatic. 
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Thanks clippy ([`5044c3b`](https://github.com/Byron/gitoxide/commit/5044c3b87456cf58ebfbbd00f23c9ba671cb290c))
+    - Merge branch 'gix-submodule' ([`363ee77`](https://github.com/Byron/gitoxide/commit/363ee77400805f473c9ad66eadad9214e7ab66f4))
+</details>
+
 ## 0.7.3 (2023-08-22)
 
 <csr-id-229bd4899213f749a7cc124aa2b82a1368fba40f/>
@@ -17,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 2 commits contributed to the release over the course of 4 calendar days.
+ - 3 commits contributed to the release over the course of 4 calendar days.
  - 15 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -29,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.7.3, gix-hash v0.12.0, gix-features v0.33.0, gix-actor v0.25.0, gix-object v0.35.0, gix-path v0.9.0, gix-glob v0.11.0, gix-quote v0.4.7, gix-attributes v0.17.0, gix-command v0.2.9, gix-packetline-blocking v0.16.5, gix-filter v0.3.0, gix-fs v0.5.0, gix-commitgraph v0.19.0, gix-hashtable v0.3.0, gix-revwalk v0.6.0, gix-traverse v0.31.0, gix-worktree-stream v0.3.0, gix-archive v0.3.0, gix-config-value v0.13.0, gix-tempfile v8.0.0, gix-lock v8.0.0, gix-ref v0.35.0, gix-sec v0.9.0, gix-config v0.28.0, gix-prompt v0.6.0, gix-url v0.22.0, gix-credentials v0.18.0, gix-diff v0.34.0, gix-discover v0.23.0, gix-ignore v0.6.0, gix-bitmap v0.2.7, gix-index v0.22.0, gix-mailmap v0.17.0, gix-negotiate v0.6.0, gix-pack v0.41.0, gix-odb v0.51.0, gix-pathspec v0.1.0, gix-packetline v0.16.5, gix-transport v0.35.0, gix-protocol v0.38.0, gix-revision v0.20.0, gix-refspec v0.16.0, gix-submodule v0.2.0, gix-worktree v0.24.0, gix-worktree-state v0.1.0, gix v0.52.0, gitoxide-core v0.31.0, gitoxide v0.29.0, safety bump 41 crates ([`30b2761`](https://github.com/Byron/gitoxide/commit/30b27615047692d3ced1b2d9c2ac15a80f79fbee))
     - Update changelogs prior to release ([`f23ea88`](https://github.com/Byron/gitoxide/commit/f23ea8828f2d9ba7559973daca388c9591bcc5fc))
     - Don't call crate 'WIP' in manifest anymore. ([`229bd48`](https://github.com/Byron/gitoxide/commit/229bd4899213f749a7cc124aa2b82a1368fba40f))
 </details>

--- a/gix-date/CHANGELOG.md
+++ b/gix-date/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.7.4 (2023-09-01)
 
 A maintenance release without user-facing changes.
 
@@ -13,7 +13,7 @@ A maintenance release without user-facing changes.
 
 <csr-read-only-do-not-edit/>
 
- - 2 commits contributed to the release over the course of 9 calendar days.
+ - 3 commits contributed to the release over the course of 9 calendar days.
  - 9 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -31,6 +31,7 @@ A maintenance release without user-facing changes.
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Prepare `gix-index` release ([`6fdbc66`](https://github.com/Byron/gitoxide/commit/6fdbc667c20f10734390341b435c15c73b7cd227))
     - Thanks clippy ([`5044c3b`](https://github.com/Byron/gitoxide/commit/5044c3b87456cf58ebfbbd00f23c9ba671cb290c))
     - Merge branch 'gix-submodule' ([`363ee77`](https://github.com/Byron/gitoxide/commit/363ee77400805f473c9ad66eadad9214e7ab66f4))
 </details>

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gix-date"
-version = "0.7.3"
+version = "0.7.4"
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project parsing dates the way git does"

--- a/gix-index/CHANGELOG.md
+++ b/gix-index/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.23.1 (2023-09-01)
+
+### Bug Fixes
+
+ - <csr-id-6a8314bb99099e2a3f5364a5761a5254aa36393a/> `prefixed_entries_range()` now works correctly with directory prefixes.
+   Previously, not all directory prefixes would work as expected due to incorrect
+   search criteria.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - `prefixed_entries_range()` now works correctly with directory prefixes. ([`6a8314b`](https://github.com/Byron/gitoxide/commit/6a8314bb99099e2a3f5364a5761a5254aa36393a))
+</details>
+
 ## 0.23.0 (2023-09-01)
 
 ### New Features
@@ -42,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 9 commits contributed to the release over the course of 9 calendar days.
+ - 10 commits contributed to the release over the course of 9 calendar days.
  - 9 days passed between releases.
  - 6 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -54,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.7.4, gix-index v0.23.0, safety bump 5 crates ([`3be2b1c`](https://github.com/Byron/gitoxide/commit/3be2b1ccfe30eeae45711c64b88efc522a2b51b7))
     - Prepare `gix-index` release ([`6fdbc66`](https://github.com/Byron/gitoxide/commit/6fdbc667c20f10734390341b435c15c73b7cd227))
     - Add `State::prefixed_range()` to obtain a range of entries matching a prefix. ([`cfbfa43`](https://github.com/Byron/gitoxide/commit/cfbfa43069c8d82fbd74b8296f63fc050a5ba02a))
     - Add `State::remove_entries()` and `entry_range()`. ([`8b689c2`](https://github.com/Byron/gitoxide/commit/8b689c222668b0c35c508f1907b03cbd4ba09bba))

--- a/gix-index/CHANGELOG.md
+++ b/gix-index/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.23.0 (2023-09-01)
 
 ### New Features
 
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 8 commits contributed to the release over the course of 9 calendar days.
+ - 9 commits contributed to the release over the course of 9 calendar days.
  - 9 days passed between releases.
  - 6 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Prepare `gix-index` release ([`6fdbc66`](https://github.com/Byron/gitoxide/commit/6fdbc667c20f10734390341b435c15c73b7cd227))
     - Add `State::prefixed_range()` to obtain a range of entries matching a prefix. ([`cfbfa43`](https://github.com/Byron/gitoxide/commit/cfbfa43069c8d82fbd74b8296f63fc050a5ba02a))
     - Add `State::remove_entries()` and `entry_range()`. ([`8b689c2`](https://github.com/Byron/gitoxide/commit/8b689c222668b0c35c508f1907b03cbd4ba09bba))
     - `gix-index` prefix matching should now work correctly with conflicting files. ([`6169325`](https://github.com/Byron/gitoxide/commit/616932516d122a24e29fb42c60147fe43c5cead9))

--- a/gix-index/CHANGELOG.md
+++ b/gix-index/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### New Features
+
+ - <csr-id-cfbfa43069c8d82fbd74b8296f63fc050a5ba02a/> add `State::prefixed_range()` to obtain a range of entries matching a prefix.
+   This makes it easier to make changes to entries of a certain prefix.
+ - <csr-id-8b689c222668b0c35c508f1907b03cbd4ba09bba/> add `State::remove_entries()` and `entry_range()`.
+   This makes it possible to, among other things, delete all
+   occurrences of a particular entry.
+ - <csr-id-2f42132410ef47a7c274030811452ef40701c8a0/> add support for `write::Options::skip_hash`.
+   With it, a hash will not be produced for indices.
+
+### Bug Fixes
+
+ - <csr-id-616932516d122a24e29fb42c60147fe43c5cead9/> `gix-index` prefix matching should now work correctly with conflicting files.
+   It was done in a rush and lacks a lot of tests. At least now it
+   has a greater chance of working, as tests that would truly validate
+   this are still missing for a lack of test date. It can be produced
+   with `git update-index`, but it wasn't yet worth it.
+
+### New Features (BREAKING)
+
+ - <csr-id-61c2e34b10c2ad5c92edd4ec1d5d1be2317ac481/> Check the hash when reading via `File::at()` just like `git`, or skip the check.
+   Note that indices written with `index.skipHash=true` will be vastly
+   faster to read by a factor of 2 or more.
+
+### Bug Fixes (BREAKING)
+
+ - <csr-id-b310d044ac5c2bb1c874d0cfe701411e4aef47be/> skip the null-hash when validating the index.
+   This is needed for compatibility with `index.skipHash`, which may skip
+   producing the hash at the end of the index file, just filling in the
+   null-hash.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 8 commits contributed to the release over the course of 9 calendar days.
+ - 9 days passed between releases.
+ - 6 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Add `State::prefixed_range()` to obtain a range of entries matching a prefix. ([`cfbfa43`](https://github.com/Byron/gitoxide/commit/cfbfa43069c8d82fbd74b8296f63fc050a5ba02a))
+    - Add `State::remove_entries()` and `entry_range()`. ([`8b689c2`](https://github.com/Byron/gitoxide/commit/8b689c222668b0c35c508f1907b03cbd4ba09bba))
+    - `gix-index` prefix matching should now work correctly with conflicting files. ([`6169325`](https://github.com/Byron/gitoxide/commit/616932516d122a24e29fb42c60147fe43c5cead9))
+    - Merge branch 'fixes' ([`4bfd1cc`](https://github.com/Byron/gitoxide/commit/4bfd1cc8f7922a8c4de6b9d078d54b93e78f51ff))
+    - Check the hash when reading via `File::at()` just like `git`, or skip the check. ([`61c2e34`](https://github.com/Byron/gitoxide/commit/61c2e34b10c2ad5c92edd4ec1d5d1be2317ac481))
+    - Add support for `write::Options::skip_hash`. ([`2f42132`](https://github.com/Byron/gitoxide/commit/2f42132410ef47a7c274030811452ef40701c8a0))
+    - Skip the null-hash when validating the index. ([`b310d04`](https://github.com/Byron/gitoxide/commit/b310d044ac5c2bb1c874d0cfe701411e4aef47be))
+    - Merge branch 'gix-submodule' ([`363ee77`](https://github.com/Byron/gitoxide/commit/363ee77400805f473c9ad66eadad9214e7ab66f4))
+</details>
+
 ## 0.22.0 (2023-08-22)
 
 <csr-id-93feea269eebd114e866e6f29f4a73c0096df9e0/>
@@ -26,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 11 commits contributed to the release over the course of 18 calendar days.
+ - 13 commits contributed to the release over the course of 18 calendar days.
  - 30 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -38,8 +97,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-url v0.22.0, gix-credentials v0.18.0, gix-diff v0.34.0, gix-discover v0.23.0, gix-ignore v0.6.0, gix-bitmap v0.2.7, gix-index v0.22.0, gix-mailmap v0.17.0, gix-negotiate v0.6.0, gix-pack v0.41.0, gix-odb v0.51.0, gix-pathspec v0.1.0, gix-packetline v0.16.5, gix-transport v0.35.0, gix-protocol v0.38.0, gix-revision v0.20.0, gix-refspec v0.16.0, gix-submodule v0.2.0, gix-worktree v0.24.0, gix-worktree-state v0.1.0, gix v0.52.0, gitoxide-core v0.31.0, gitoxide v0.29.0 ([`6c62e74`](https://github.com/Byron/gitoxide/commit/6c62e748240ac0980fc23fdf30f8477dea8b9bc3))
     - Release gix-date v0.7.3, gix-hash v0.12.0, gix-features v0.33.0, gix-actor v0.25.0, gix-object v0.35.0, gix-path v0.9.0, gix-glob v0.11.0, gix-quote v0.4.7, gix-attributes v0.17.0, gix-command v0.2.9, gix-packetline-blocking v0.16.5, gix-filter v0.3.0, gix-fs v0.5.0, gix-commitgraph v0.19.0, gix-hashtable v0.3.0, gix-revwalk v0.6.0, gix-traverse v0.31.0, gix-worktree-stream v0.3.0, gix-archive v0.3.0, gix-config-value v0.13.0, gix-tempfile v8.0.0, gix-lock v8.0.0, gix-ref v0.35.0, gix-sec v0.9.0, gix-config v0.28.0, gix-prompt v0.6.0, gix-url v0.22.0, gix-credentials v0.18.0, gix-diff v0.34.0, gix-discover v0.23.0, gix-ignore v0.6.0, gix-bitmap v0.2.7, gix-index v0.22.0, gix-mailmap v0.17.0, gix-negotiate v0.6.0, gix-pack v0.41.0, gix-odb v0.51.0, gix-pathspec v0.1.0, gix-packetline v0.16.5, gix-transport v0.35.0, gix-protocol v0.38.0, gix-revision v0.20.0, gix-refspec v0.16.0, gix-submodule v0.2.0, gix-worktree v0.24.0, gix-worktree-state v0.1.0, gix v0.52.0, gitoxide-core v0.31.0, gitoxide v0.29.0, safety bump 41 crates ([`30b2761`](https://github.com/Byron/gitoxide/commit/30b27615047692d3ced1b2d9c2ac15a80f79fbee))
     - Update changelogs prior to release ([`f23ea88`](https://github.com/Byron/gitoxide/commit/f23ea8828f2d9ba7559973daca388c9591bcc5fc))
+    - Merge branch 'gix-submodule' ([`8f3f358`](https://github.com/Byron/gitoxide/commit/8f3f358800f1fe77d7ba7ebd396a90b692d3c0c1))
     - More cleanup of test crates ([`73c685a`](https://github.com/Byron/gitoxide/commit/73c685a67debcfa26a940f37bbca69cb3a4af57e))
     - Split tests off into their own crate to allow feature toggles. ([`93feea2`](https://github.com/Byron/gitoxide/commit/93feea269eebd114e866e6f29f4a73c0096df9e0))
     - Merge branch 'submodule-in-gix' ([`36f7b78`](https://github.com/Byron/gitoxide/commit/36f7b783c67b8a087076a130f5ee9b90b23bc3cc))

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gix-index"
-version = "0.22.0"
+version = "0.23.0"
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gix-index"
-version = "0.23.0"
+version = "0.23.1"
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"

--- a/gix-index/src/access/mod.rs
+++ b/gix-index/src/access/mod.rs
@@ -198,9 +198,11 @@ impl State {
             return Some(0..self.entries.len());
         }
         let prefix_len = prefix.len();
-        let mut low = self
-            .entries
-            .partition_point(|e| e.path(self).get(..prefix_len).map_or(true, |p| p < prefix));
+        let mut low = self.entries.partition_point(|e| {
+            e.path(self)
+                .get(..prefix_len)
+                .map_or_else(|| e.path(self) <= &prefix[..e.path.len()], |p| p < prefix)
+        });
         let mut high = low
             + self.entries[low..].partition_point(|e| e.path(self).get(..prefix_len).map_or(false, |p| p <= prefix));
 
@@ -211,9 +213,9 @@ impl State {
                 .unwrap_or(low);
         }
         if let Some(high_entry) = self.entries.get(high) {
-            if high_entry.stage() != 3 {
+            if high_entry.stage() != 0 {
                 high = self
-                    .walk_entry_stages(high_entry.path(self), high, Ordering::Greater)
+                    .walk_entry_stages(high_entry.path(self), high, Ordering::Less)
                     .unwrap_or(high);
             }
         }

--- a/gix-index/tests/index/access.rs
+++ b/gix-index/tests/index/access.rs
@@ -50,6 +50,8 @@ fn prefixed_entries_with_multi_stage_file() {
         file.entries(),
         "empty prefix matches all"
     );
+    assert_eq!(file.prefixed_entries_range("".into()), Some(0..3));
+    assert_eq!(file.prefixed_entries_range("foo".into()), None);
 }
 
 #[test]

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -17,7 +17,7 @@ serde= ["dep:serde", "bstr/serde", "gix-actor/serde"]
 
 [dependencies]
 gix-actor = { version = "^0.25.0", path = "../gix-actor" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
 thiserror = "1.0.38"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 [dependencies]
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 gix-commitgraph = { version = "^0.19.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.6.0", path = "../gix-revwalk" }
 thiserror = "1.0.40"

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -20,7 +20,7 @@ serde= ["dep:serde", "gix-hash/serde", "gix-object/serde", "gix-pack/serde"]
 [dependencies]
 gix-features = { version = "^0.33.0", path = "../gix-features", features = ["rustsha1", "walkdir", "zlib", "crc32" ] }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 gix-path = { version = "^0.9.0", path = "../gix-path" }
 gix-quote = { version = "^0.4.7", path = "../gix-quote" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -43,7 +43,7 @@ required-features = ["async-client"]
 gix-features = { version = "^0.33.0", path = "../gix-features", features = ["progress"] }
 gix-transport = { version = "^0.35.0", path = "../gix-transport" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 gix-credentials = { version = "^0.18.0", path = "../gix-credentials" }
 
 thiserror = "1.0.32"

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -23,7 +23,7 @@ gix-features = { version = "^0.33.0", path = "../gix-features", features = ["wal
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-path = { version = "^0.9.0", path = "../gix-path" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }
 gix-validate = { version = "^0.8.0", path = "../gix-validate" }
 gix-actor = { version = "^0.25.0", path = "../gix-actor" }

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -19,7 +19,7 @@ serde = [ "dep:serde", "gix-hash/serde", "gix-object/serde" ]
 [dependencies]
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 gix-hashtable = { version = "^0.3.0", path = "../gix-hashtable" }
 gix-revwalk = { version = "^0.6.0", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.3", path = "../gix-trace" }

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false
 doctest = false
 
 [dependencies]
-gix-index = { version = "^0.23.0", path = "../gix-index" }
+gix-index = { version = "^0.23.1", path = "../gix-index" }
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false
 doctest = false
 
 [dependencies]
-gix-index = { version = "^0.22.0", path = "../gix-index" }
+gix-index = { version = "^0.23.0", path = "../gix-index" }
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix-submodule/src/access.rs
+++ b/gix-submodule/src/access.rs
@@ -56,13 +56,13 @@ impl File {
             ) -> bool
             + 'a,
     ) -> Result<
-        impl Iterator<Item = (&BStr, Result<bool, crate::is_active_platform::is_active::Error>)> + 'a,
+        impl Iterator<Item = (&BStr, Result<bool, gix_config::value::Error>)> + 'a,
         crate::is_active_platform::Error,
     > {
         let mut platform = self.is_active_platform(config, defaults)?;
         let iter = self
             .names()
-            .map(move |name| (name, platform.is_active(self, config, name, &mut attributes)));
+            .map(move |name| (name, platform.is_active(config, name, &mut attributes)));
         Ok(iter)
     }
 

--- a/gix-submodule/src/is_active_platform.rs
+++ b/gix-submodule/src/is_active_platform.rs
@@ -12,34 +12,19 @@ pub enum Error {
     ParsePattern(#[from] gix_pathspec::parse::Error),
 }
 
-///
-pub mod is_active {
-    /// The error returned by the iterator of [File::names_and_active_state](crate::File::names_and_active_state()).
-    #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
-    pub enum Error {
-        #[error("The value of the 'active' field of a submodule could not be decoded")]
-        ActiveField(#[from] gix_config::value::Error),
-        #[error(transparent)]
-        Url(#[from] crate::config::url::Error),
-    }
-}
-
 impl IsActivePlatform {
     /// Returns `true` if the submodule named `name` is active or `false` otherwise.
-    /// `modules` is the instance that [is_active_platform()](crate::File::is_active_platform()) was called on, and
-    /// `config` is the configuration that was passed there as well.
-    /// `attributes(relative_path, case, is_dir, outcome)` provides a way to resolve the attributes mentioned in `submodule.active` pathspecs
-    /// that are evaluated in the platforms git configuration.
+    /// `config` is the configuration that was passed to the originating [modules file](crate::File).
+    /// `attributes(relative_path, case, is_dir, outcome)` provides a way to resolve the attributes mentioned
+    /// in `submodule.active` pathspecs that are evaluated in the platforms git configuration.
     ///
     /// A submodule's active state is determined in the following order
     ///
-    /// * it's `submodule.<name>.active` configuration is set
+    /// * it's `submodule.<name>.active` is set in `config`
     /// * it matches a `submodule.active` pathspec either positively or negatively via `:!<spec>`
-    /// * it's active if it has a `url`
+    /// * it's active if it has any `url` set in `config`
     pub fn is_active(
         &mut self,
-        modules: &crate::File,
         config: &gix_config::File<'static>,
         name: &BStr,
         attributes: impl FnMut(
@@ -48,7 +33,7 @@ impl IsActivePlatform {
             bool,
             &mut gix_pathspec::attributes::search::Outcome,
         ) -> bool,
-    ) -> Result<bool, is_active::Error> {
+    ) -> Result<bool, gix_config::value::Error> {
         if let Some(val) = config.boolean("submodule", Some(name), "active").transpose()? {
             return Ok(val);
         };
@@ -59,10 +44,6 @@ impl IsActivePlatform {
         }) {
             return Ok(val);
         }
-        Ok(match modules.url(name) {
-            Ok(_) => true,
-            Err(crate::config::url::Error::Missing { .. }) => false,
-            Err(err) => return Err(err.into()),
-        })
+        Ok(config.string("submodule", Some(name), "url").is_some())
     }
 }

--- a/gix-submodule/tests/file/mod.rs
+++ b/gix-submodule/tests/file/mod.rs
@@ -46,25 +46,23 @@ mod is_active_platform {
             .map(|name| {
                 (
                     name.to_str().expect("valid"),
-                    platform
-                        .is_active(module, config, name, &mut attributes)
-                        .expect("valid"),
+                    platform.is_active(config, name, &mut attributes).expect("valid"),
                 )
             })
             .collect())
     }
 
     #[test]
-    fn without_any_additional_settings_all_are_active_if_they_have_a_url() -> crate::Result {
+    fn without_any_additional_settings_all_are_inactive_if_they_have_a_url() -> crate::Result {
         let module = multi_modules()?;
         assert_eq!(
             assume_valid_active_state(&module, &Default::default(), Default::default())?,
             &[
-                ("submodule", true),
-                ("a/b", true),
-                (".a/..c", true),
-                ("a/d\\", true),
-                ("a\\e", true)
+                ("submodule", false),
+                ("a/b", false),
+                (".a/..c", false),
+                ("a/d\\", false),
+                ("a\\e", false)
             ]
         );
         Ok(())
@@ -77,7 +75,7 @@ mod is_active_platform {
             assume_valid_active_state(
                 &module,
                 &gix_config::File::from_str(
-                    "[submodule.submodule]\n active = 0\n[submodule \"a/b\"]\n active = false"
+                    "[submodule.submodule]\n active = 0\n url = set \n[submodule \"a/b\"]\n active = false \n url = set \n[submodule \".a/..c\"] active = 1"
                 )?,
                 Default::default()
             )?,
@@ -85,8 +83,8 @@ mod is_active_platform {
                 ("submodule", false),
                 ("a/b", false),
                 (".a/..c", true),
-                ("a/d\\", true),
-                ("a\\e", true)
+                ("a/d\\", false),
+                ("a\\e", false)
             ]
         );
         Ok(())

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gix-worktree-state"
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing setting the worktree to a particular state"
@@ -14,8 +14,8 @@ autotests = false
 doctest = false
 
 [dependencies]
-gix-worktree = { version = "^0.24.0", path = "../gix-worktree" }
-gix-index = { version = "^0.22.0", path = "../gix-index" }
+gix-worktree = { version = "^0.25.0", path = "../gix-worktree" }
+gix-index = { version = "^0.23.0", path = "../gix-index" }
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 gix-worktree = { version = "^0.25.0", path = "../gix-worktree" }
-gix-index = { version = "^0.23.0", path = "../gix-index" }
+gix-index = { version = "^0.23.1", path = "../gix-index" }
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gix-worktree"
-version = "0.24.0"
+version = "0.25.0"
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for shared worktree related types and utilities."
@@ -18,7 +18,7 @@ doctest = false
 serde = [ "dep:serde", "bstr/serde", "gix-index/serde", "gix-hash/serde", "gix-object/serde", "gix-attributes/serde", "gix-ignore/serde" ]
 
 [dependencies]
-gix-index = { version = "^0.22.0", path = "../gix-index" }
+gix-index = { version = "^0.23.0", path = "../gix-index" }
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 serde = [ "dep:serde", "bstr/serde", "gix-index/serde", "gix-hash/serde", "gix-object/serde", "gix-attributes/serde", "gix-ignore/serde" ]
 
 [dependencies]
-gix-index = { version = "^0.23.0", path = "../gix-index" }
+gix-index = { version = "^0.23.1", path = "../gix-index" }
 gix-fs = { version = "^0.5.0", path = "../gix-fs" }
 gix-hash = { version = "^0.12.0", path = "../gix-hash" }
 gix-object = { version = "^0.35.0", path = "../gix-object" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -160,7 +160,7 @@ gix-ignore = { version = "^0.6.0", path = "../gix-ignore" }
 gix-glob = { version = "^0.11.0", path = "../gix-glob" }
 gix-credentials = { version = "^0.18.0", path = "../gix-credentials" }
 gix-prompt = { version = "^0.6.0", path = "../gix-prompt" }
-gix-index = { version = "^0.23.0", path = "../gix-index" }
+gix-index = { version = "^0.23.1", path = "../gix-index" }
 gix-worktree = { version = "^0.25.0", path = "../gix-worktree" }
 gix-worktree-state = { version = "^0.2.0", path = "../gix-worktree-state" }
 gix-hashtable = { version = "^0.3.0", path = "../gix-hashtable" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -3,7 +3,7 @@ name = "gix"
 repository = "https://github.com/Byron/gitoxide"
 description = "Interact with git repositories just like git would"
 license = "MIT OR Apache-2.0"
-version = "0.52.0"
+version = "0.53.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "CHANGELOG.md"]
@@ -134,7 +134,7 @@ gix-tempfile = { version = "^8.0.0", path = "../gix-tempfile", default-features 
 gix-lock = { version = "^8.0.0", path = "../gix-lock" }
 gix-validate = { version = "^0.8.0", path = "../gix-validate" }
 gix-sec = { version = "^0.9.0", path = "../gix-sec" }
-gix-date = { version = "^0.7.3", path = "../gix-date" }
+gix-date = { version = "^0.7.4", path = "../gix-date" }
 gix-refspec = { version = "^0.16.0", path = "../gix-refspec" }
 gix-filter = { version = "^0.3.0", path = "../gix-filter" }
 
@@ -160,9 +160,9 @@ gix-ignore = { version = "^0.6.0", path = "../gix-ignore" }
 gix-glob = { version = "^0.11.0", path = "../gix-glob" }
 gix-credentials = { version = "^0.18.0", path = "../gix-credentials" }
 gix-prompt = { version = "^0.6.0", path = "../gix-prompt" }
-gix-index = { version = "^0.22.0", path = "../gix-index" }
-gix-worktree = { version = "^0.24.0", path = "../gix-worktree" }
-gix-worktree-state = { version = "^0.1.0", path = "../gix-worktree-state" }
+gix-index = { version = "^0.23.0", path = "../gix-index" }
+gix-worktree = { version = "^0.25.0", path = "../gix-worktree" }
+gix-worktree-state = { version = "^0.2.0", path = "../gix-worktree-state" }
 gix-hashtable = { version = "^0.3.0", path = "../gix-hashtable" }
 gix-commitgraph = { version = "^0.19.0", path = "../gix-commitgraph" }
 gix-pathspec = { version = "^0.1.0", path = "../gix-pathspec" }

--- a/gix/src/submodule/errors.rs
+++ b/gix/src/submodule/errors.rs
@@ -39,7 +39,7 @@ pub mod is_active {
         #[error(transparent)]
         InitIsActivePlatform(#[from] gix_submodule::is_active_platform::Error),
         #[error(transparent)]
-        QueryIsActive(#[from] gix_submodule::is_active_platform::is_active::Error),
+        QueryIsActive(#[from] gix_config::value::Error),
         #[error(transparent)]
         InitAttributes(#[from] crate::config::attribute_stack::Error),
         #[error(transparent)]

--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -140,21 +140,16 @@ impl<'repo> Submodule<'repo> {
     /// Please see the [plumbing crate documentation](gix_submodule::IsActivePlatform::is_active()) for details.
     pub fn is_active(&self) -> Result<bool, is_active::Error> {
         let (mut platform, mut attributes) = self.state.active_state_mut()?;
-        let is_active = platform.is_active(
-            &self.state.modules,
-            &self.state.repo.config.resolved,
-            self.name.as_ref(),
-            {
-                |relative_path, case, is_dir, out| {
-                    attributes
-                        .set_case(case)
-                        .at_entry(relative_path, Some(is_dir), |id, buf| {
-                            self.state.repo.objects.find_blob(id, buf)
-                        })
-                        .map_or(false, |platform| platform.matching_attributes(out))
-                }
-            },
-        )?;
+        let is_active = platform.is_active(&self.state.repo.config.resolved, self.name.as_ref(), {
+            |relative_path, case, is_dir, out| {
+                attributes
+                    .set_case(case)
+                    .at_entry(relative_path, Some(is_dir), |id, buf| {
+                        self.state.repo.objects.find_blob(id, buf)
+                    })
+                    .map_or(false, |platform| platform.matching_attributes(out))
+            }
+        })?;
         Ok(is_active)
     }
 

--- a/src/gix.rs
+++ b/src/gix.rs
@@ -1,7 +1,6 @@
 #![deny(unsafe_code, rust_2018_idioms)]
 
 mod plumbing;
-mod shared;
 
 use anyhow::Result;
 

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -13,16 +13,14 @@ use gitoxide_core as core;
 use gitoxide_core::{pack::verify, repository::PathsOrPatterns};
 use gix::bstr::{io::BufReadExt, BString};
 
-use crate::{
-    plumbing::{
-        options::{
-            attributes, commit, commitgraph, config, credential, exclude, free, index, mailmap, odb, revision, tree,
-            Args, Subcommands,
-        },
-        show_progress,
+use crate::plumbing::{
+    options::{
+        attributes, commit, commitgraph, config, credential, exclude, free, index, mailmap, odb, revision, tree, Args,
+        Subcommands,
     },
-    shared::pretty::prepare_and_run,
+    show_progress,
 };
+use gitoxide::shared::pretty::prepare_and_run;
 
 #[cfg(feature = "gitoxide-core-async-client")]
 pub mod async_util {

--- a/src/uni.rs
+++ b/src/uni.rs
@@ -1,0 +1,28 @@
+//! An experiment to see how a multi-call binary could look like.
+//! For CI this would mean longer compile times though as it rebuilds `gix`
+//! with varying compile flags, which also means that it recompiles all source or `ein`.
+//!
+//! However, doing this could be interesting for distribution if the files are hard-linked
+//! instead of copied, which is why it is left here.
+#![deny(unsafe_code, rust_2018_idioms)]
+
+use anyhow::{bail, Result};
+
+mod plumbing;
+mod porcelain;
+
+#[cfg(feature = "pretty-cli")]
+fn main() -> Result<()> {
+    match std::env::current_exe()?
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("gix")
+    {
+        "gix" => plumbing::main(),
+        "ein" => porcelain::main(),
+        unknown => bail!("Executable named '{unknown}' cannot be launched. Exe must be named either `gix` or `ein`."),
+    }
+}
+
+#[cfg(not(feature = "pretty-cli"))]
+compile_error!("Please set 'pretty-cli' feature flag");


### PR DESCRIPTION
Follow-up of #995 

Everything needed to get submodules into cargo checkouts.

### Tasks

* [x] research checkout of submodules in `cargo`
    - Needs `reset()` implementation for the case that there already is a worktree checkout, but can be shortcut as long as checkout with `overwrite=true` is able to do deal with replaceing dirs with files, files with dirs, and the same with symlinks.
* [ ] Can `gix fetch` already respect submodule fetching settings?
* [ ] See if `gix clone` can handle submodules if we would write submodule configuration