### PR TITLE
perf and safety

### DIFF
--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -257,6 +257,7 @@ impl super::Store {
             refresh: RefreshMode::default(),
             ignore_replacements: false,
             token: Some(token),
+            inflate: RefCell::new(Default::default()),
             snapshot: RefCell::new(self.collect_snapshot()),
             max_recursion_depth: Self::INITIAL_MAX_RECURSION_DEPTH,
             packed_object_count: Default::default(),
@@ -273,6 +274,7 @@ impl super::Store {
             refresh: Default::default(),
             ignore_replacements: false,
             token: Some(token),
+            inflate: RefCell::new(Default::default()),
             snapshot: RefCell::new(self.collect_snapshot()),
             max_recursion_depth: Self::INITIAL_MAX_RECURSION_DEPTH,
             packed_object_count: Default::default(),
@@ -391,6 +393,7 @@ where
                 }
                 .into()
             },
+            inflate: RefCell::new(Default::default()),
             snapshot: RefCell::new(self.store.collect_snapshot()),
             max_recursion_depth: self.max_recursion_depth,
             packed_object_count: Default::default(),

--- a/gix-odb/src/store_impls/dynamic/mod.rs
+++ b/gix-odb/src/store_impls/dynamic/mod.rs
@@ -1,4 +1,5 @@
 //! The standard object store which should fit all needs.
+use gix_features::zlib;
 use std::{cell::RefCell, ops::Deref};
 
 use crate::Store;
@@ -24,6 +25,7 @@ where
 
     pub(crate) token: Option<handle::Mode>,
     snapshot: RefCell<load_index::Snapshot>,
+    inflate: RefCell<zlib::Inflate>,
     packed_object_count: RefCell<Option<u64>>,
 }
 

--- a/gix-pack/src/index/traverse/mod.rs
+++ b/gix-pack/src/index/traverse/mod.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use gix_features::{
     parallel,
     progress::{Progress, RawProgress},
+    zlib,
 };
 
 use crate::index;
@@ -155,6 +156,7 @@ impl index::File {
         pack: &crate::data::File,
         cache: &mut C,
         buf: &mut Vec<u8>,
+        inflate: &mut zlib::Inflate,
         progress: &mut dyn RawProgress,
         index_entry: &index::Entry,
         processor: &mut impl FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn RawProgress) -> Result<(), E>,
@@ -169,6 +171,7 @@ impl index::File {
             .decode_entry(
                 pack_entry,
                 buf,
+                inflate,
                 |id, _| {
                     self.lookup(id).map(|index| {
                         crate::data::decode::entry::ResolvedBase::InPack(pack.entry(self.pack_offset_at_index(index)))

--- a/gix-pack/tests/pack/data/file.rs
+++ b/gix-pack/tests/pack/data/file.rs
@@ -105,8 +105,14 @@ mod decode_entry {
         let p = pack_at(SMALL_PACK);
         let entry = p.entry(offset);
         let mut buf = Vec::new();
-        p.decode_entry(entry, &mut buf, resolve_with_panic, &mut cache::Never)
-            .expect("valid offset provides valid entry");
+        p.decode_entry(
+            entry,
+            &mut buf,
+            &mut Default::default(),
+            resolve_with_panic,
+            &mut cache::Never,
+        )
+        .expect("valid offset provides valid entry");
         buf
     }
 }
@@ -154,7 +160,7 @@ mod resolve_header {
 
         let p = pack_at(SMALL_PACK);
         let entry = p.entry(offset);
-        p.decode_header(entry, resolve_with_panic)
+        p.decode_header(entry, &mut Default::default(), resolve_with_panic)
             .expect("valid offset provides valid entry")
     }
 }
@@ -206,7 +212,8 @@ mod decompress_entry {
 
         let size = entry.decompressed_size as usize;
         let mut buf = vec![0; size];
-        p.decompress_entry(&entry, &mut buf).expect("valid offset");
+        p.decompress_entry(&entry, &mut Default::default(), &mut buf)
+            .expect("valid offset");
 
         buf.resize(entry.decompressed_size as usize, 0);
         buf

--- a/gix-pack/tests/pack/index.rs
+++ b/gix-pack/tests/pack/index.rs
@@ -417,7 +417,7 @@ fn pack_lookup() -> Result<(), Box<dyn std::error::Error>> {
                 entry.pack_offset,
                 "index entry offset and computed pack offset must match"
             );
-            pack.decompress_entry(&pack_entry, &mut buf)?;
+            pack.decompress_entry(&pack_entry, &mut Default::default(), &mut buf)?;
 
             assert_eq!(
                 buf.len() as u64,

--- a/gix-worktree-stream/src/protocol.rs
+++ b/gix-worktree-stream/src/protocol.rs
@@ -126,13 +126,5 @@ fn mode_to_byte(m: gix_object::tree::EntryMode) -> u8 {
 
 fn clear_and_set_len(buf: &mut Vec<u8>, len: usize) {
     buf.clear();
-    if buf.capacity() < len {
-        buf.reserve(len);
-        assert!(buf.capacity() >= len, "{} >= {}", buf.capacity(), len);
-    }
-    // SAFETY: we just assured that `buf` has the right capacity to hold `cap`
-    #[allow(unsafe_code)]
-    unsafe {
-        buf.set_len(len);
-    }
+    buf.resize(len, 0);
 }


### PR DESCRIPTION
- feat!: Make usage of decompression context explicit.
- adapt to changes in `gix-pack`
- fix: Use `Vec::resize()` instead of set_len()
