### PR TITLE
improvements

### DIFF
--- a/gitoxide-core/src/hours/core.rs
+++ b/gitoxide-core/src/hours/core.rs
@@ -6,7 +6,7 @@ use std::{
     },
 };
 
-use gix::{bstr::BStr, odb::FindExt};
+use gix::bstr::BStr;
 use itertools::Itertools;
 use smallvec::SmallVec;
 
@@ -182,11 +182,7 @@ pub fn spawn_tree_delta_threads<'scope>(
                                                 (true, true) => {
                                                     files.modified += 1;
                                                     if let Some((attrs, matches)) = attributes.as_mut() {
-                                                        let entry = attrs.at_entry(
-                                                            change.location,
-                                                            Some(false),
-                                                            |id, buf| repo.objects.find_blob(id, buf),
-                                                        )?;
+                                                        let entry = attrs.at_entry(change.location, Some(false))?;
                                                         let is_text_file = if entry.matching_attributes(matches) {
                                                             let attrs: SmallVec<[_; 2]> =
                                                                 matches.iter_selected().collect();

--- a/gitoxide-core/src/repository/attributes/query.rs
+++ b/gitoxide-core/src/repository/attributes/query.rs
@@ -11,7 +11,7 @@ pub(crate) mod function {
     use std::{io, path::Path};
 
     use anyhow::{anyhow, bail};
-    use gix::{bstr::BStr, prelude::FindExt};
+    use gix::bstr::BStr;
 
     use crate::{
         repository::{
@@ -40,7 +40,7 @@ pub(crate) mod function {
                 for path in paths {
                     let is_dir = gix::path::from_bstr(path.as_ref()).metadata().ok().map(|m| m.is_dir());
 
-                    let entry = cache.at_entry(path.as_slice(), is_dir, |oid, buf| repo.objects.find_blob(oid, buf))?;
+                    let entry = cache.at_entry(path.as_slice(), is_dir)?;
                     if !entry.matching_attributes(&mut matches) {
                         continue;
                     }
@@ -59,7 +59,7 @@ pub(crate) mod function {
                     .index_entries_with_paths(&index)
                     .ok_or_else(|| anyhow!("Pathspec didn't match a single path in the index"))?
                 {
-                    let entry = cache.at_entry(path, Some(false), |oid, buf| repo.objects.find_blob(oid, buf))?;
+                    let entry = cache.at_entry(path, Some(false))?;
                     if !entry.matching_attributes(&mut matches) {
                         continue;
                     }
@@ -97,7 +97,7 @@ pub(crate) mod function {
 
 pub(crate) fn attributes_cache(
     repo: &gix::Repository,
-) -> anyhow::Result<(gix::worktree::Stack, IndexPersistedOrInMemory)> {
+) -> anyhow::Result<(gix::AttributeStack<'_>, IndexPersistedOrInMemory)> {
     let index = repo.index_or_load_from_head()?;
     let cache = repo.attributes(
         &index,

--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -18,7 +18,7 @@ pub(crate) mod function {
     };
 
     use anyhow::{anyhow, bail};
-    use gix::{attrs::Assignment, bstr::BString, odb::FindExt, Progress};
+    use gix::{attrs::Assignment, bstr::BString, Progress};
 
     use crate::{
         repository::attributes::{query::attributes_cache, validate_baseline::Options},
@@ -192,9 +192,7 @@ pub(crate) mod function {
         );
 
         for (rela_path, baseline) in rx_base {
-            let entry = cache.at_entry(rela_path.as_str(), Some(false), |oid, buf| {
-                repo.objects.find_blob(oid, buf)
-            })?;
+            let entry = cache.at_entry(rela_path.as_str(), Some(false))?;
             match baseline {
                 Baseline::Attribute { assignments: expected } => {
                     entry.matching_attributes(&mut matches);

--- a/gix-attributes/src/state.rs
+++ b/gix-attributes/src/state.rs
@@ -13,7 +13,7 @@ pub struct Value(KString);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueRef<'a>(#[cfg_attr(feature = "serde", serde(borrow))] KStringRef<'a>);
 
-/// Conversions
+/// Lifecycle
 impl<'a> ValueRef<'a> {
     /// Keep `input` as our value.
     pub fn from_bytes(input: &'a [u8]) -> Self {
@@ -25,7 +25,10 @@ impl<'a> ValueRef<'a> {
             },
         ))
     }
+}
 
+/// Access and conversions
+impl ValueRef<'_> {
     /// Access this value as byte string.
     pub fn as_bstr(&self) -> &BStr {
         self.0.as_bytes().as_bstr()
@@ -78,6 +81,14 @@ impl StateRef<'_> {
     /// Return `true` if the associated attribute was set with `-attr` to specifically remove it.
     pub fn is_unset(&self) -> bool {
         matches!(self, StateRef::Unset)
+    }
+
+    /// Attempt to obtain the string value of this state, or return `None` if there is no such value.
+    pub fn as_bstr(&self) -> Option<&BStr> {
+        match self {
+            StateRef::Value(v) => Some(v.as_bstr()),
+            _ => None,
+        }
     }
 }
 

--- a/gix/src/attribute_stack.rs
+++ b/gix/src/attribute_stack.rs
@@ -1,0 +1,69 @@
+use crate::bstr::BStr;
+use crate::types::AttributeStack;
+use crate::Repository;
+use gix_odb::FindExt;
+use std::ops::{Deref, DerefMut};
+
+/// Lifecycle
+impl<'repo> AttributeStack<'repo> {
+    /// Create a new instance from a `repo` and the underlying pre-configured `stack`.
+    ///
+    /// Note that this type is typically created by [`Repository::attributes()`] or [`Repository::attributes_only()`].
+    pub fn new(stack: gix_worktree::Stack, repo: &'repo Repository) -> Self {
+        AttributeStack { repo, inner: stack }
+    }
+
+    /// Detach the repository and return the underlying plumbing datatype.
+    pub fn detach(self) -> gix_worktree::Stack {
+        self.inner
+    }
+}
+
+impl Deref for AttributeStack<'_> {
+    type Target = gix_worktree::Stack;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for AttributeStack<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// Platform retrieval
+impl<'repo> AttributeStack<'repo> {
+    /// Append the `relative` path to the root directory of the cache and efficiently create leading directories, while assuring that no
+    /// symlinks are in that path.
+    /// Unless `is_dir` is known with `Some(…)`, then `relative` points to a directory itself in which case the entire resulting
+    /// path is created as directory. If it's not known it is assumed to be a file.
+    ///
+    /// Provide access to cached information for that `relative` path via the returned platform.
+    pub fn at_path(
+        &mut self,
+        relative: impl AsRef<std::path::Path>,
+        is_dir: Option<bool>,
+    ) -> std::io::Result<gix_worktree::stack::Platform<'_>> {
+        self.inner
+            .at_path(relative, is_dir, |id, buf| self.repo.objects.find_blob(id, buf))
+    }
+
+    /// Obtain a platform for lookups from a repo-`relative` path, typically obtained from an index entry. `is_dir` should reflect
+    /// whether it's a directory or not, or left at `None` if unknown.
+    ///
+    /// If `relative` ends with `/` and `is_dir` is `None`, it is automatically assumed to be a directory.
+    ///
+    /// ### Panics
+    ///
+    /// - on illformed UTF8 in `relative`
+    pub fn at_entry<'r>(
+        &mut self,
+        relative: impl Into<&'r BStr>,
+        is_dir: Option<bool>,
+    ) -> std::io::Result<gix_worktree::stack::Platform<'_>> {
+        self.inner
+            .at_entry(relative, is_dir, |id, buf| self.repo.objects.find_blob(id, buf))
+    }
+}

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -117,6 +117,8 @@ mod ext;
 ///
 pub mod prelude;
 
+mod attribute_stack;
+
 ///
 pub mod path;
 
@@ -129,7 +131,7 @@ pub(crate) type Config = OwnShared<gix_config::File<'static>>;
 
 mod types;
 pub use types::{
-    Commit, Head, Id, Object, ObjectDetached, Pathspec, Reference, Remote, Repository, Submodule, Tag,
+    AttributeStack, Commit, Head, Id, Object, ObjectDetached, Pathspec, Reference, Remote, Repository, Submodule, Tag,
     ThreadSafeRepository, Tree, Worktree,
 };
 

--- a/gix/src/repository/filter.rs
+++ b/gix/src/repository/filter.rs
@@ -59,6 +59,6 @@ impl Repository {
             )?;
             (cache, IndexPersistedOrInMemory::Persisted(index))
         };
-        Ok((filter::Pipeline::new(self, cache)?, index))
+        Ok((filter::Pipeline::new(self, cache.detach())?, index))
     }
 }

--- a/gix/src/repository/pathspec.rs
+++ b/gix/src/repository/pathspec.rs
@@ -1,6 +1,6 @@
 use gix_pathspec::MagicSignature;
 
-use crate::{bstr::BStr, config::cache::util::ApplyLeniencyDefault, Pathspec, Repository};
+use crate::{bstr::BStr, config::cache::util::ApplyLeniencyDefault, AttributeStack, Pathspec, Repository};
 
 impl Repository {
     /// Create a new pathspec abstraction that allows to conduct searches using `patterns`.
@@ -20,7 +20,9 @@ impl Repository {
         attributes_source: gix_worktree::stack::state::attributes::Source,
     ) -> Result<Pathspec<'_>, crate::pathspec::init::Error> {
         Pathspec::new(self, patterns, inherit_ignore_case, || {
-            self.attributes_only(index, attributes_source).map_err(Into::into)
+            self.attributes_only(index, attributes_source)
+                .map(AttributeStack::detach)
+                .map_err(Into::into)
         })
     }
 

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -75,7 +75,9 @@ impl crate::Repository {
         // TODO(perf): when loading a non-HEAD tree, we effectively traverse the tree twice. This is usually fast though, and sharing
         //             an object cache between the copies of the ODB handles isn't trivial and needs a lock.
         let index = self.index_from_tree(&id)?;
-        let mut cache = self.attributes_only(&index, gix_worktree::stack::state::attributes::Source::IdMapping)?;
+        let mut cache = self
+            .attributes_only(&index, gix_worktree::stack::state::attributes::Source::IdMapping)?
+            .detach();
         let pipeline =
             gix_filter::Pipeline::new(cache.attributes_collection(), crate::filter::Pipeline::options(self)?);
         let objects = self.objects.clone().into_arc().expect("TBD error handling");

--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -61,11 +61,14 @@ impl<'repo> SharedState<'repo> {
                 .modules
                 .is_active_platform(&self.repo.config.resolved, self.repo.config.pathspec_defaults()?)?;
             let index = self.index()?;
-            let attributes = self.repo.attributes_only(
-                &index,
-                gix_worktree::stack::state::attributes::Source::WorktreeThenIdMapping
-                    .adjust_for_bare(self.repo.is_bare()),
-            )?;
+            let attributes = self
+                .repo
+                .attributes_only(
+                    &index,
+                    gix_worktree::stack::state::attributes::Source::WorktreeThenIdMapping
+                        .adjust_for_bare(self.repo.is_bare()),
+                )?
+                .detach();
             *state = Some(IsActiveState { platform, attributes });
         }
         Ok(RefMut::map_split(state, |opt| {

--- a/gix/src/types.rs
+++ b/gix/src/types.rs
@@ -208,7 +208,7 @@ pub struct Remote<'repo> {
 pub struct Pathspec<'repo> {
     pub(crate) repo: &'repo Repository,
     /// The cache to power attribute access. It's only initialized if we have a pattern with attributes.
-    pub(crate) cache: Option<gix_worktree::Stack>,
+    pub(crate) stack: Option<gix_worktree::Stack>,
     /// The prepared search to use for checking matches.
     pub(crate) search: gix_pathspec::Search,
 }
@@ -218,4 +218,10 @@ pub struct Pathspec<'repo> {
 pub struct Submodule<'repo> {
     pub(crate) state: Rc<crate::submodule::SharedState<'repo>>,
     pub(crate) name: BString,
+}
+
+/// A utility to access `.gitattributes` and `.gitignore` information efficiently.
+pub struct AttributeStack<'repo> {
+    pub(crate) repo: &'repo Repository,
+    pub(crate) inner: gix_worktree::Stack,
 }

--- a/gix/src/types.rs
+++ b/gix/src/types.rs
@@ -150,6 +150,9 @@ pub struct Repository {
 ///
 /// Note that this type purposefully isn't very useful until it is converted into a thread-local repository with `to_thread_local()`,
 /// it's merely meant to be able to exist in a `Sync` context.
+///
+/// Note that it can also cheaply be cloned, and it will retain references to all contained resources.
+#[derive(Clone)]
 pub struct ThreadSafeRepository {
     /// A store for references to point at objects
     pub refs: crate::RefStore,

--- a/gix/src/worktree/mod.rs
+++ b/gix/src/worktree/mod.rs
@@ -145,7 +145,7 @@ pub mod excludes {
 
 ///
 pub mod attributes {
-    use crate::Worktree;
+    use crate::{AttributeStack, Worktree};
 
     /// The error returned by [`Worktree::attributes()`].
     #[derive(Debug, thiserror::Error)]
@@ -164,7 +164,7 @@ pub mod attributes {
         ///
         /// * `$XDG_CONFIG_HOME/…/ignore|attributes` if `core.excludesFile|attributesFile` is *not* set, otherwise use the configured file.
         /// * `$GIT_DIR/info/exclude|attributes` if present.
-        pub fn attributes(&self, overrides: Option<gix_ignore::Search>) -> Result<gix_worktree::Stack, Error> {
+        pub fn attributes(&self, overrides: Option<gix_ignore::Search>) -> Result<AttributeStack<'repo>, Error> {
             let index = self.index()?;
             Ok(self.parent.attributes(
                 &index,
@@ -175,7 +175,7 @@ pub mod attributes {
         }
 
         /// Like [attributes()][Self::attributes()], but without access to exclude/ignore information.
-        pub fn attributes_only(&self) -> Result<gix_worktree::Stack, Error> {
+        pub fn attributes_only(&self) -> Result<AttributeStack<'repo>, Error> {
             let index = self.index()?;
             self.parent
                 .attributes_only(


### PR DESCRIPTION
### Tasks

* [x] worktree stack access without having to implement `find` - wrap it
* ~~`gix-index::State` with 'insert' support - efficiently insert another index at a location, replacing another entry, probably while prefixing all their paths with the entry prefix. That way submodules can be merged back into place.~~ - submodules need their own repo to access its objects anyway, so the caller would have to track this somehow. Probably easier to just handle one index at a time.
* ~~maybe provide a `get_attr` like accessor, even though I don't like the implications. Maybe there is a better way.~~ - let's not suggest an API that is much slower than the alternative.