### PR TITLE
worktree reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
  "is-terminal",
  "once_cell",
  "owo-colors",
- "prodash 26.2.0",
+ "prodash 26.2.1",
  "serde_derive",
  "tabled",
  "time",
@@ -1237,7 +1237,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "prodash 26.2.0",
+ "prodash 26.2.1",
  "regex",
  "reqwest",
  "serde",
@@ -1570,7 +1570,7 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot",
- "prodash 26.2.0",
+ "prodash 26.2.1",
  "sha1",
  "sha1_smol",
  "thiserror",
@@ -3503,9 +3503,9 @@ checksum = "9516b775656bc3e8985e19cd4b8c0c0de045095074e453d2c0a513b5f978392d"
 
 [[package]]
 name = "prodash"
-version = "26.2.0"
+version = "26.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc60e4df7c418baa9fbfc62b5054b06745dfc3a2aee40294ad390b701f6351"
+checksum = "50bcc40e3e88402f12b15f94d43a2c7673365e9601cc52795e119b95a266100c"
 dependencies = [
  "async-io",
  "bytesize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
  "is-terminal",
  "once_cell",
  "owo-colors",
- "prodash 26.0.0",
+ "prodash 26.2.0",
  "serde_derive",
  "tabled",
  "time",
@@ -1237,7 +1237,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "prodash 26.0.0",
+ "prodash 26.2.0",
  "regex",
  "reqwest",
  "serde",
@@ -1570,7 +1570,7 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot",
- "prodash 26.0.0",
+ "prodash 26.2.0",
  "sha1",
  "sha1_smol",
  "thiserror",
@@ -3503,9 +3503,9 @@ checksum = "9516b775656bc3e8985e19cd4b8c0c0de045095074e453d2c0a513b5f978392d"
 
 [[package]]
 name = "prodash"
-version = "26.0.0"
+version = "26.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c85fe210cada0bbfc863bddeac230f5894e00d1617aa32d924302a36cf3e965"
+checksum = "0fdc60e4df7c418baa9fbfc62b5054b06745dfc3a2aee40294ad390b701f6351"
 dependencies = [
  "async-io",
  "bytesize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
  "is-terminal",
  "once_cell",
  "owo-colors",
- "prodash 25.0.2",
+ "prodash 26.0.0",
  "serde_derive",
  "tabled",
  "time",
@@ -1237,7 +1237,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "prodash 25.0.2",
+ "prodash 26.0.0",
  "regex",
  "reqwest",
  "serde",
@@ -1570,7 +1570,7 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot",
- "prodash 25.0.2",
+ "prodash 26.0.0",
  "sha1",
  "sha1_smol",
  "thiserror",
@@ -3503,9 +3503,9 @@ checksum = "9516b775656bc3e8985e19cd4b8c0c0de045095074e453d2c0a513b5f978392d"
 
 [[package]]
 name = "prodash"
-version = "25.0.2"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d67eb4220992a4a052a4bb03cf776e493ecb1a3a36bab551804153d63486af7"
+checksum = "2c85fe210cada0bbfc863bddeac230f5894e00d1617aa32d924302a36cf3e965"
 dependencies = [
  "async-io",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ gix = { version = "^0.53.0", path = "gix", default-features = false }
 time = "0.3.23"
 
 clap = { version = "4.1.1", features = ["derive", "cargo"] }
-prodash = { version = "25.0.0", optional = true, default-features = false }
+prodash = { version = "26.0.0", optional = true, default-features = false }
 is-terminal = { version = "0.4.0", optional = true }
 env_logger = { version = "0.10.0", default-features = false }
 crosstermion = { version = "0.11.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ gix = { version = "^0.53.0", path = "gix", default-features = false }
 time = "0.3.23"
 
 clap = { version = "4.1.1", features = ["derive", "cargo"] }
-prodash = { version = "26.0.0", optional = true, default-features = false }
+prodash = { version = "26.2.0", optional = true, default-features = false }
 is-terminal = { version = "0.4.0", optional = true }
 env_logger = { version = "0.10.0", default-features = false }
 crosstermion = { version = "0.11.0", optional = true, default-features = false }

--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -39,7 +39,7 @@ pub(crate) mod function {
         W1: io::Write,
         W2: io::Write,
     {
-        let g = Graph::at(path).with_context(|| "Could not open commit graph")?;
+        let g = Graph::at(path.as_ref()).with_context(|| "Could not open commit graph")?;
 
         #[allow(clippy::unnecessary_wraps, unknown_lints)]
         fn noop_processor(_commit: &gix::commitgraph::file::Commit<'_>) -> std::result::Result<(), std::fmt::Error> {

--- a/gitoxide-core/src/corpus/run.rs
+++ b/gitoxide-core/src/corpus/run.rs
@@ -1,3 +1,4 @@
+use gix::progress::DynNestedProgress;
 use std::{path::Path, sync::atomic::AtomicBool};
 
 use crate::{
@@ -141,7 +142,7 @@ impl Execute for VerifyOdb {
         crate::repository::verify::integrity(
             repo,
             std::io::sink(),
-            progress,
+            progress.add_child("integrity".into()),
             should_interrupt,
             crate::repository::verify::Context {
                 output_statistics: None,

--- a/gitoxide-core/src/corpus/trace.rs
+++ b/gitoxide-core/src/corpus/trace.rs
@@ -51,11 +51,11 @@ impl tracing_forest::printer::Formatter for StoreTreeToDb {
             use gix::Progress;
             if self.reverse_lines {
                 for line in tree.lines().rev() {
-                    progress.info(line);
+                    progress.info(line.into());
                 }
             } else {
                 for line in tree.lines() {
-                    progress.info(line);
+                    progress.info(line.into());
                 }
             }
         }

--- a/gitoxide-core/src/hours/mod.rs
+++ b/gitoxide-core/src/hours/mod.rs
@@ -5,7 +5,7 @@ use gix::{
     actor,
     bstr::{BStr, ByteSlice},
     prelude::*,
-    progress, Progress,
+    progress, Count, NestedProgress, Progress,
 };
 
 /// Additional configuration for the hours estimation functionality.
@@ -49,7 +49,7 @@ pub fn estimate<W, P>(
 ) -> anyhow::Result<()>
 where
     W: io::Write,
-    P: Progress,
+    P: NestedProgress,
 {
     let repo = gix::discover(working_dir)?;
     let commit_id = repo.rev_parse_single(rev_spec)?.detach();

--- a/gitoxide-core/src/hours/util.rs
+++ b/gitoxide-core/src/hours/util.rs
@@ -158,22 +158,18 @@ impl LineStats {
 /// An index able to address any commit
 pub type CommitIdx = u32;
 
-pub fn add_lines(line_stats: bool, lines_counter: Option<&AtomicUsize>, lines: &mut LineStats, id: gix::Id<'_>) {
+pub fn add_lines(line_stats: bool, lines_counter: &AtomicUsize, lines: &mut LineStats, id: gix::Id<'_>) {
     if let Some(Ok(blob)) = line_stats.then(|| id.object()) {
         let nl = blob.data.lines_with_terminator().count();
         lines.added += nl;
-        if let Some(c) = lines_counter {
-            c.fetch_add(nl, Ordering::SeqCst);
-        }
+        lines_counter.fetch_add(nl, Ordering::Relaxed);
     }
 }
 
-pub fn remove_lines(line_stats: bool, lines_counter: Option<&AtomicUsize>, lines: &mut LineStats, id: gix::Id<'_>) {
+pub fn remove_lines(line_stats: bool, lines_counter: &AtomicUsize, lines: &mut LineStats, id: gix::Id<'_>) {
     if let Some(Ok(blob)) = line_stats.then(|| id.object()) {
         let nl = blob.data.lines_with_terminator().count();
         lines.removed += nl;
-        if let Some(c) = lines_counter {
-            c.fetch_add(nl, Ordering::SeqCst);
-        }
+        lines_counter.fetch_add(nl, Ordering::Relaxed);
     }
 }

--- a/gitoxide-core/src/index/checkout.rs
+++ b/gitoxide-core/src/index/checkout.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::bail;
-use gix::{odb::FindExt, worktree::state::checkout, Progress};
+use gix::{odb::FindExt, worktree::state::checkout, NestedProgress, Progress};
 
 use crate::{
     index,
@@ -16,7 +16,7 @@ pub fn checkout_exclusive(
     dest_directory: impl AsRef<Path>,
     repo: Option<PathBuf>,
     mut err: impl std::io::Write,
-    mut progress: impl Progress,
+    mut progress: impl NestedProgress,
     should_interrupt: &AtomicBool,
     index::checkout_exclusive::Options {
         index: Options { object_hash, .. },

--- a/gitoxide-core/src/index/checkout.rs
+++ b/gitoxide-core/src/index/checkout.rs
@@ -104,8 +104,8 @@ pub fn checkout_exclusive(
                     }
                 }
             },
-            &mut files,
-            &mut bytes,
+            &files,
+            &bytes,
             should_interrupt,
             opts,
         ),
@@ -116,8 +116,8 @@ pub fn checkout_exclusive(
                 buf.clear();
                 Ok(gix::objs::BlobRef { data: buf })
             },
-            &mut files,
-            &mut bytes,
+            &files,
+            &bytes,
             should_interrupt,
             opts,
         ),

--- a/gitoxide-core/src/organize.rs
+++ b/gitoxide-core/src/organize.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use gix::{objs::bstr::ByteSlice, progress, Progress};
+use gix::{objs::bstr::ByteSlice, progress, NestedProgress, Progress};
 
 #[derive(Default, Copy, Clone, Eq, PartialEq)]
 pub enum Mode {
@@ -207,7 +207,7 @@ fn handle(
 }
 
 /// Find all working directories in the given `source_dir` and print them to `out` while providing `progress`.
-pub fn discover<P: Progress>(
+pub fn discover<P: NestedProgress>(
     source_dir: impl AsRef<Path>,
     mut out: impl std::io::Write,
     mut progress: P,
@@ -222,7 +222,7 @@ pub fn discover<P: Progress>(
     Ok(())
 }
 
-pub fn run<P: Progress>(
+pub fn run<P: NestedProgress>(
     mode: Mode,
     source_dir: impl AsRef<Path>,
     destination: impl AsRef<Path>,

--- a/gitoxide-core/src/organize.rs
+++ b/gitoxide-core/src/organize.rs
@@ -92,8 +92,8 @@ pub fn find_git_repository_workdirs(
 fn find_origin_remote(repo: &Path) -> anyhow::Result<Option<gix_url::Url>> {
     let non_bare = repo.join(".git").join("config");
     let local = gix::config::Source::Local;
-    let config = gix::config::File::from_path_no_includes(non_bare.as_path(), local)
-        .or_else(|_| gix::config::File::from_path_no_includes(repo.join("config").as_path(), local))?;
+    let config = gix::config::File::from_path_no_includes(non_bare.as_path().into(), local)
+        .or_else(|_| gix::config::File::from_path_no_includes(repo.join("config"), local))?;
     Ok(config
         .string_by_key("remote.origin.url")
         .map(|url| gix_url::Url::from_bytes(url.as_ref()))

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -9,7 +9,7 @@ use gix::{
     odb::{pack, pack::FindExt},
     parallel::InOrderIter,
     prelude::Finalize,
-    progress, traverse, Progress,
+    progress, traverse, Count, NestedProgress, Progress,
 };
 
 use crate::OutputFormat;
@@ -109,7 +109,7 @@ pub fn create<W, P>(
 ) -> anyhow::Result<()>
 where
     W: std::io::Write,
-    P: Progress,
+    P: NestedProgress,
     P::SubProgress: 'static,
 {
     let repo = gix::discover(repository_path)?.into_sync();
@@ -179,7 +179,7 @@ where
             Some(1)
         };
         if nondeterministic_thread_count.is_some() && !may_use_multiple_threads {
-            progress.fail("Cannot use multi-threaded counting in tree-diff object expansion mode as it may yield way too many objects.");
+            progress.fail("Cannot use multi-threaded counting in tree-diff object expansion mode as it may yield way too many objects.".into());
         }
         let (_, _, thread_count) = gix::parallel::optimize_chunk_size_and_thread_limit(50, None, thread_limit, None);
         let progress = progress::ThroughputOnDrop::new(progress);

--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -97,19 +97,22 @@ enum OutputWriter {
 }
 
 impl gix::odb::Write for OutputWriter {
-    type Error = Error;
-
-    fn write_buf(&self, kind: object::Kind, from: &[u8]) -> Result<ObjectId, Self::Error> {
+    fn write_buf(&self, kind: object::Kind, from: &[u8]) -> Result<ObjectId, gix::odb::write::Error> {
         match self {
-            OutputWriter::Loose(db) => db.write_buf(kind, from).map_err(Into::into),
-            OutputWriter::Sink(db) => db.write_buf(kind, from).map_err(Into::into),
+            OutputWriter::Loose(db) => db.write_buf(kind, from),
+            OutputWriter::Sink(db) => db.write_buf(kind, from),
         }
     }
 
-    fn write_stream(&self, kind: object::Kind, size: u64, from: impl Read) -> Result<ObjectId, Self::Error> {
+    fn write_stream(
+        &self,
+        kind: object::Kind,
+        size: u64,
+        from: &mut dyn Read,
+    ) -> Result<ObjectId, gix::odb::write::Error> {
         match self {
-            OutputWriter::Loose(db) => db.write_stream(kind, size, from).map_err(Into::into),
-            OutputWriter::Sink(db) => db.write_stream(kind, size, from).map_err(Into::into),
+            OutputWriter::Loose(db) => db.write_stream(kind, size, from),
+            OutputWriter::Sink(db) => db.write_stream(kind, size, from),
         }
     }
 }
@@ -137,7 +140,7 @@ pub fn pack_or_pack_index(
     pack_path: impl AsRef<Path>,
     object_path: Option<impl AsRef<Path>>,
     check: SafetyCheck,
-    progress: impl NestedProgress,
+    mut progress: impl NestedProgress + 'static,
     Context {
         thread_limit,
         delete_pack,
@@ -178,11 +181,11 @@ pub fn pack_or_pack_index(
         |_| pack::index::traverse::Algorithm::Lookup,
     );
 
-    let pack::index::traverse::Outcome { progress, .. } = bundle
+    let pack::index::traverse::Outcome { .. } = bundle
         .index
         .traverse(
             &bundle.pack,
-            progress,
+            &mut progress,
             &should_interrupt,
             {
                 let object_path = object_path.map(|p| p.as_ref().to_owned());
@@ -193,7 +196,7 @@ pub fn pack_or_pack_index(
                 let mut read_buf = Vec::new();
                 move |object_kind, buf, index_entry, progress| {
                     let written_id = out.write_buf(object_kind, buf).map_err(|err| Error::Write {
-                        source: Box::new(err) as Box<dyn std::error::Error + Send + Sync>,
+                        source: err,
                         kind: object_kind,
                         id: index_entry.oid,
                     })?;
@@ -213,13 +216,13 @@ pub fn pack_or_pack_index(
                     }
                     if let Some(verifier) = loose_odb.as_ref() {
                         let obj = verifier
-                            .try_find(written_id, &mut read_buf)
+                            .try_find(&written_id, &mut read_buf)
                             .map_err(|err| Error::WrittenFileCorrupt {
                                 source: err,
                                 id: written_id,
                             })?
                             .ok_or(Error::WrittenFileMissing { id: written_id })?;
-                        obj.verify_checksum(written_id)?;
+                        obj.verify_checksum(&written_id)?;
                     }
                     Ok(())
                 }

--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -10,7 +10,7 @@ use gix::{
     hash::ObjectId,
     object, objs, odb,
     odb::{loose, pack, Write},
-    Progress,
+    NestedProgress,
 };
 
 #[derive(Default, Clone, Eq, PartialEq, Debug)]
@@ -137,7 +137,7 @@ pub fn pack_or_pack_index(
     pack_path: impl AsRef<Path>,
     object_path: Option<impl AsRef<Path>>,
     check: SafetyCheck,
-    progress: impl Progress,
+    progress: impl NestedProgress,
     Context {
         thread_limit,
         delete_pack,

--- a/gitoxide-core/src/pack/index.rs
+++ b/gitoxide-core/src/pack/index.rs
@@ -1,6 +1,6 @@
 use std::{fs, io, path::PathBuf, str::FromStr, sync::atomic::AtomicBool};
 
-use gix::{odb::pack, Progress};
+use gix::{odb::pack, NestedProgress};
 
 use crate::OutputFormat;
 
@@ -77,7 +77,7 @@ pub fn from_pack<P>(
     ctx: Context<'static, impl io::Write>,
 ) -> anyhow::Result<()>
 where
-    P: Progress,
+    P: NestedProgress,
     P::SubProgress: 'static,
 {
     use anyhow::Context;

--- a/gitoxide-core/src/pack/index.rs
+++ b/gitoxide-core/src/pack/index.rs
@@ -70,16 +70,12 @@ pub enum PathOrRead {
     Read(Box<dyn std::io::Read + Send + 'static>),
 }
 
-pub fn from_pack<P>(
+pub fn from_pack(
     pack: PathOrRead,
     directory: Option<PathBuf>,
-    progress: P,
+    mut progress: impl NestedProgress + 'static,
     ctx: Context<'static, impl io::Write>,
-) -> anyhow::Result<()>
-where
-    P: NestedProgress,
-    P::SubProgress: 'static,
-{
+) -> anyhow::Result<()> {
     use anyhow::Context;
     let options = pack::bundle::write::Options {
         thread_limit: ctx.thread_limit,
@@ -94,10 +90,10 @@ where
             let pack_len = pack.metadata()?.len();
             let pack_file = fs::File::open(pack)?;
             pack::Bundle::write_to_directory_eagerly(
-                pack_file,
+                Box::new(pack_file),
                 Some(pack_len),
                 directory,
-                progress,
+                &mut progress,
                 ctx.should_interrupt,
                 None,
                 options,
@@ -107,7 +103,7 @@ where
             input,
             None,
             directory,
-            progress,
+            &mut progress,
             ctx.should_interrupt,
             None,
             options,

--- a/gitoxide-core/src/pack/multi_index.rs
+++ b/gitoxide-core/src/pack/multi_index.rs
@@ -9,17 +9,17 @@ pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
 
 pub fn verify(
     multi_index_path: PathBuf,
-    progress: impl NestedProgress,
+    mut progress: impl NestedProgress + 'static,
     should_interrupt: &AtomicBool,
 ) -> anyhow::Result<()> {
-    gix::odb::pack::multi_index::File::at(multi_index_path)?.verify_integrity_fast(progress, should_interrupt)?;
+    gix::odb::pack::multi_index::File::at(multi_index_path)?.verify_integrity_fast(&mut progress, should_interrupt)?;
     Ok(())
 }
 
 pub fn create(
     index_paths: Vec<PathBuf>,
     output_path: PathBuf,
-    progress: impl NestedProgress,
+    mut progress: impl NestedProgress + 'static,
     should_interrupt: &AtomicBool,
     object_hash: gix::hash::Kind,
 ) -> anyhow::Result<()> {
@@ -31,7 +31,7 @@ pub fn create(
     gix::odb::pack::multi_index::File::write_from_index_paths(
         index_paths,
         &mut out,
-        progress,
+        &mut progress,
         should_interrupt,
         gix::odb::pack::multi_index::write::Options { object_hash },
     )?;

--- a/gitoxide-core/src/pack/multi_index.rs
+++ b/gitoxide-core/src/pack/multi_index.rs
@@ -1,13 +1,17 @@
 use std::{io::BufWriter, path::PathBuf, sync::atomic::AtomicBool};
 
 use anyhow::bail;
-use gix::Progress;
+use gix::NestedProgress;
 
 use crate::OutputFormat;
 
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
 
-pub fn verify(multi_index_path: PathBuf, progress: impl Progress, should_interrupt: &AtomicBool) -> anyhow::Result<()> {
+pub fn verify(
+    multi_index_path: PathBuf,
+    progress: impl NestedProgress,
+    should_interrupt: &AtomicBool,
+) -> anyhow::Result<()> {
     gix::odb::pack::multi_index::File::at(multi_index_path)?.verify_integrity_fast(progress, should_interrupt)?;
     Ok(())
 }
@@ -15,7 +19,7 @@ pub fn verify(multi_index_path: PathBuf, progress: impl Progress, should_interru
 pub fn create(
     index_paths: Vec<PathBuf>,
     output_path: PathBuf,
-    progress: impl Progress,
+    progress: impl NestedProgress,
     should_interrupt: &AtomicBool,
     object_hash: gix::hash::Kind,
 ) -> anyhow::Result<()> {

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -120,7 +120,7 @@ mod blocking_io {
         bstr::BString,
         protocol,
         protocol::{fetch::Response, handshake::Ref},
-        Progress,
+        NestedProgress,
     };
 
     use super::{receive_pack_blocking, CloneDelegate, Context};
@@ -130,7 +130,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl BufRead,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             _previous_response: &Response,
         ) -> io::Result<()> {
@@ -156,7 +156,7 @@ mod blocking_io {
     ) -> anyhow::Result<()>
     where
         W: std::io::Write,
-        P: Progress,
+        P: NestedProgress,
         P::SubProgress: 'static,
     {
         let transport = net::connect(
@@ -188,6 +188,7 @@ mod blocking_io {
 #[cfg(feature = "blocking-client")]
 pub use blocking_io::receive;
 use gix::protocol::ls_refs;
+use gix::NestedProgress;
 
 #[cfg(feature = "async-client")]
 mod async_io {
@@ -211,7 +212,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl Progress,
+            progress: impl gix::NestedProgress,
             refs: &[Ref],
             _previous_response: &Response,
         ) -> io::Result<()> {
@@ -236,7 +237,7 @@ mod async_io {
         ctx: Context<W>,
     ) -> anyhow::Result<()>
     where
-        P: Progress + 'static,
+        P: gix::NestedProgress + 'static,
         W: io::Write + Send + 'static,
     {
         let transport = net::connect(
@@ -367,7 +368,7 @@ fn receive_pack_blocking<W: io::Write>(
     mut refs_directory: Option<PathBuf>,
     ctx: &mut Context<W>,
     input: impl io::BufRead,
-    progress: impl Progress,
+    progress: impl NestedProgress,
     refs: &[Ref],
 ) -> io::Result<()> {
     let options = pack::bundle::write::Options {

--- a/gitoxide-core/src/pack/verify.rs
+++ b/gitoxide-core/src/pack/verify.rs
@@ -5,7 +5,7 @@ use bytesize::ByteSize;
 use gix::{
     object, odb,
     odb::{pack, pack::index},
-    Progress,
+    NestedProgress,
 };
 pub use index::verify::Mode;
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=2;
@@ -87,7 +87,7 @@ impl<const SIZE: usize> pack::cache::DecodeEntry for EitherCache<SIZE> {
 
 pub fn pack_or_pack_index<W1, W2>(
     path: impl AsRef<Path>,
-    mut progress: impl Progress,
+    mut progress: impl NestedProgress,
     Context {
         mut out,
         mut err,

--- a/gitoxide-core/src/pack/verify.rs
+++ b/gitoxide-core/src/pack/verify.rs
@@ -87,7 +87,7 @@ impl<const SIZE: usize> pack::cache::DecodeEntry for EitherCache<SIZE> {
 
 pub fn pack_or_pack_index<W1, W2>(
     path: impl AsRef<Path>,
-    mut progress: impl NestedProgress,
+    mut progress: impl NestedProgress + 'static,
     Context {
         mut out,
         mut err,
@@ -121,7 +121,7 @@ where
     let res = match ext {
         "pack" => {
             let pack = odb::pack::data::File::at(path, object_hash).with_context(|| "Could not open pack file")?;
-            pack.verify_checksum(progress.add_child("Sha1 of pack"), should_interrupt)
+            pack.verify_checksum(&mut progress.add_child("Sha1 of pack"), should_interrupt)
                 .map(|id| (id, None))?
         }
         "idx" => {
@@ -151,7 +151,7 @@ where
                         thread_limit
                     }
                 }),
-                progress,
+                &mut progress,
                 should_interrupt,
             )
             .map(|o| (o.actual_index_checksum, o.pack_traverse_statistics))
@@ -161,7 +161,7 @@ where
             match path.file_name() {
                 Some(file_name) if file_name == "multi-pack-index" => {
                     let multi_index = gix::odb::pack::multi_index::File::at(path)?;
-                    let res = multi_index.verify_integrity(progress, should_interrupt, gix::odb::pack::index::verify::integrity::Options{
+                    let res = multi_index.verify_integrity(&mut progress, should_interrupt, gix::odb::pack::index::verify::integrity::Options{
                         verify_mode: mode,
                         traversal: algorithm.into(),
                         thread_limit,

--- a/gitoxide-core/src/query/engine/command.rs
+++ b/gitoxide-core/src/query/engine/command.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{bail, Context};
-use gix::{bstr::ByteSlice, prelude::ObjectIdExt, Progress};
+use gix::{bstr::ByteSlice, prelude::ObjectIdExt, Count, Progress};
 use rusqlite::{params, OptionalExtension};
 
 use crate::{
@@ -14,7 +14,7 @@ impl query::Engine {
         &self,
         cmd: Command,
         mut out: impl std::io::Write,
-        mut progress: impl gix::Progress,
+        mut progress: impl gix::NestedProgress,
     ) -> anyhow::Result<()> {
         match cmd {
             Command::TracePath { spec } => {

--- a/gitoxide-core/src/query/mod.rs
+++ b/gitoxide-core/src/query/mod.rs
@@ -17,7 +17,7 @@ pub use engine::Command;
 
 pub fn prepare(
     repo_dir: &std::path::Path,
-    mut progress: impl gix::Progress,
+    mut progress: impl gix::NestedProgress,
     err: impl std::io::Write,
     opts: Options,
 ) -> anyhow::Result<Engine> {

--- a/gitoxide-core/src/repository/archive.rs
+++ b/gitoxide-core/src/repository/archive.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail};
-use gix::{worktree::archive, Progress};
+use gix::{worktree::archive, NestedProgress, Progress};
 
 pub struct Options {
     pub format: Option<archive::Format>,
@@ -14,7 +14,7 @@ pub fn stream(
     repo: gix::Repository,
     destination_path: &Path,
     rev_spec: Option<&str>,
-    mut progress: impl Progress,
+    mut progress: impl NestedProgress,
     Options {
         format,
         prefix,

--- a/gitoxide-core/src/repository/archive.rs
+++ b/gitoxide-core/src/repository/archive.rs
@@ -34,7 +34,7 @@ pub fn stream(
                 .ok_or_else(|| anyhow!("Adding files requires a worktree directory that contains them"))?,
         )?;
         for path in add_paths {
-            stream.add_entry_from_path(&root, &gix::path::realpath(path)?)?;
+            stream.add_entry_from_path(&root, &gix::path::realpath(&path)?)?;
         }
     }
     for (path, content) in files {

--- a/gitoxide-core/src/repository/attributes/query.rs
+++ b/gitoxide-core/src/repository/attributes/query.rs
@@ -8,6 +8,7 @@ pub struct Options {
 }
 
 pub(crate) mod function {
+    use std::borrow::Cow;
     use std::{io, path::Path};
 
     use anyhow::{anyhow, bail};
@@ -38,7 +39,10 @@ pub(crate) mod function {
         match input {
             PathsOrPatterns::Paths(paths) => {
                 for path in paths {
-                    let is_dir = gix::path::from_bstr(path.as_ref()).metadata().ok().map(|m| m.is_dir());
+                    let is_dir = gix::path::from_bstr(Cow::Borrowed(path.as_ref()))
+                        .metadata()
+                        .ok()
+                        .map(|m| m.is_dir());
 
                     let entry = cache.at_entry(path.as_slice(), is_dir)?;
                     if !entry.matching_attributes(&mut matches) {

--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -18,7 +18,7 @@ pub(crate) mod function {
     };
 
     use anyhow::{anyhow, bail};
-    use gix::{attrs::Assignment, bstr::BString, Progress};
+    use gix::{attrs::Assignment, bstr::BString, Count, Progress};
 
     use crate::{
         repository::attributes::{query::attributes_cache, validate_baseline::Options},
@@ -28,7 +28,7 @@ pub(crate) mod function {
     pub fn validate_baseline(
         repo: gix::Repository,
         paths: Option<impl Iterator<Item = BString> + Send + 'static>,
-        mut progress: impl Progress + 'static,
+        mut progress: impl gix::NestedProgress + 'static,
         mut out: impl io::Write,
         mut err: impl io::Write,
         Options {
@@ -249,10 +249,7 @@ pub(crate) mod function {
                 "{}: Validation failed with {} mismatches out of {}",
                 gix::path::realpath(repo.work_dir().unwrap_or(repo.git_dir()))?.display(),
                 mismatches.len(),
-                progress
-                    .counter()
-                    .map(|a| a.load(Ordering::Relaxed))
-                    .unwrap_or_default()
+                progress.counter().load(Ordering::Relaxed)
             );
         }
     }

--- a/gitoxide-core/src/repository/clone.rs
+++ b/gitoxide-core/src/repository/clone.rs
@@ -14,7 +14,7 @@ pub(crate) mod function {
     use std::ffi::OsStr;
 
     use anyhow::{bail, Context};
-    use gix::{bstr::BString, remote::fetch::Status, Progress};
+    use gix::{bstr::BString, remote::fetch::Status, NestedProgress};
 
     use super::Options;
     use crate::{repository::fetch::function::print_updates, OutputFormat};
@@ -35,7 +35,7 @@ pub(crate) mod function {
         }: Options,
     ) -> anyhow::Result<()>
     where
-        P: Progress,
+        P: NestedProgress,
         P::SubProgress: 'static,
     {
         if format != OutputFormat::Human {

--- a/gitoxide-core/src/repository/clone.rs
+++ b/gitoxide-core/src/repository/clone.rs
@@ -11,6 +11,7 @@ pub struct Options {
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
 
 pub(crate) mod function {
+    use std::borrow::Cow;
     use std::ffi::OsStr;
 
     use anyhow::{bail, Context};
@@ -45,7 +46,7 @@ pub(crate) mod function {
         let url: gix::Url = url.as_ref().try_into()?;
         let directory = directory.map_or_else(
             || {
-                gix::path::from_bstr(url.path.as_ref())
+                gix::path::from_bstr(Cow::Borrowed(url.path.as_ref()))
                     .as_ref()
                     .file_stem()
                     .map(Into::into)

--- a/gitoxide-core/src/repository/fetch.rs
+++ b/gitoxide-core/src/repository/fetch.rs
@@ -49,7 +49,7 @@ pub(crate) mod function {
         }: Options,
     ) -> anyhow::Result<()>
     where
-        P: gix::Progress,
+        P: gix::NestedProgress,
         P::SubProgress: 'static,
     {
         if format != OutputFormat::Human {
@@ -134,7 +134,7 @@ pub(crate) mod function {
         mut progress: impl gix::Progress,
     ) -> anyhow::Result<()> {
         progress.init(Some(graph.len()), gix::progress::count("commits"));
-        progress.set_name("building graph");
+        progress.set_name("building graph".into());
 
         let mut map = gix::hashtable::HashMap::default();
         let mut vg = layout::topo::layout::VisualGraph::new(Orientation::TopToBottom);
@@ -168,7 +168,7 @@ pub(crate) mod function {
         }
 
         let start = std::time::Instant::now();
-        progress.set_name("layout graph");
+        progress.set_name("layout graph".into());
         progress.info(format!("writing {path:?}…"));
         let mut svg = SVGWriter::new();
         vg.do_it(false, false, false, &mut svg);

--- a/gitoxide-core/src/repository/index/entries.rs
+++ b/gitoxide-core/src/repository/index/entries.rs
@@ -158,26 +158,30 @@ pub(crate) mod function {
                 // Note that we intentionally ignore `_case` so that we act like git does, attribute matching case is determined
                 // by the repository, not the pathspec.
                 let entry_is_excluded = pathspec
-                    .pattern_matching_relative_path(entry.path(&index), Some(false), |rela_path, _case, is_dir, out| {
-                        cache
-                            .as_mut()
-                            .map(|(attrs, cache)| {
-                                match last_match {
-                                    // The user wants the attributes for display, so the match happened already.
-                                    Some(matched) => {
-                                        attrs.copy_into(cache.attributes_collection(), out);
-                                        matched
+                    .pattern_matching_relative_path(
+                        entry.path(&index),
+                        Some(false),
+                        &mut |rela_path, _case, is_dir, out| {
+                            cache
+                                .as_mut()
+                                .map(|(attrs, cache)| {
+                                    match last_match {
+                                        // The user wants the attributes for display, so the match happened already.
+                                        Some(matched) => {
+                                            attrs.copy_into(cache.attributes_collection(), out);
+                                            matched
+                                        }
+                                        // The user doesn't want attributes, so we set the cache position on demand only
+                                        None => cache
+                                            .at_entry(rela_path, Some(is_dir))
+                                            .ok()
+                                            .map(|platform| platform.matching_attributes(out))
+                                            .unwrap_or_default(),
                                     }
-                                    // The user doesn't want attributes, so we set the cache position on demand only
-                                    None => cache
-                                        .at_entry(rela_path, Some(is_dir))
-                                        .ok()
-                                        .map(|platform| platform.matching_attributes(out))
-                                        .unwrap_or_default(),
-                                }
-                            })
-                            .unwrap_or_default()
-                    })
+                                })
+                                .unwrap_or_default()
+                        },
+                    )
                     .map_or(true, |m| m.is_excluded());
 
                 let entry_is_submodule = entry.mode.is_submodule();

--- a/gitoxide-core/src/repository/odb.rs
+++ b/gitoxide-core/src/repository/odb.rs
@@ -69,7 +69,7 @@ pub fn statistics(
     }
 
     progress.init(None, gix::progress::count("objects"));
-    progress.set_name("counting");
+    progress.set_name("counting".into());
     let counter = progress.counter();
     let start = std::time::Instant::now();
 
@@ -169,9 +169,7 @@ pub fn statistics(
             move |_| (repo.objects.clone().into_inner(), counter),
             |ids, (handle, counter)| {
                 let ids = ids?;
-                if let Some(counter) = counter {
-                    counter.fetch_add(ids.len(), std::sync::atomic::Ordering::SeqCst);
-                }
+                counter.fetch_add(ids.len(), std::sync::atomic::Ordering::Relaxed);
                 let out = ids
                     .into_iter()
                     .map(|id| handle.header(id))

--- a/gitoxide-core/src/repository/revision/list.rs
+++ b/gitoxide-core/src/repository/revision/list.rs
@@ -65,7 +65,7 @@ pub(crate) mod function {
             Format::Text => None,
         };
         progress.init(None, gix::progress::count("commits"));
-        progress.set_name("traverse");
+        progress.set_name("traverse".into());
 
         let start = std::time::Instant::now();
         for commit in commits {
@@ -116,7 +116,7 @@ pub(crate) mod function {
         progress.show_throughput(start);
         if let Some((mut vg, path, _)) = vg {
             let start = std::time::Instant::now();
-            progress.set_name("layout graph");
+            progress.set_name("layout graph".into());
             progress.info(format!("writing {path:?}…"));
             let mut svg = SVGWriter::new();
             vg.do_it(false, false, false, &mut svg);

--- a/gitoxide-core/src/repository/verify.rs
+++ b/gitoxide-core/src/repository/verify.rs
@@ -1,7 +1,5 @@
 use std::sync::atomic::AtomicBool;
 
-use gix::Progress;
-
 use crate::{pack, OutputFormat};
 
 /// A general purpose context for many operations provided here
@@ -21,7 +19,7 @@ pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
 pub fn integrity(
     repo: gix::Repository,
     mut out: impl std::io::Write,
-    progress: impl Progress,
+    progress: impl gix::NestedProgress,
     should_interrupt: &AtomicBool,
     Context {
         output_statistics,

--- a/gitoxide-core/src/repository/verify.rs
+++ b/gitoxide-core/src/repository/verify.rs
@@ -19,7 +19,7 @@ pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
 pub fn integrity(
     repo: gix::Repository,
     mut out: impl std::io::Write,
-    progress: impl gix::NestedProgress,
+    mut progress: impl gix::NestedProgress + 'static,
     should_interrupt: &AtomicBool,
     Context {
         output_statistics,
@@ -30,7 +30,7 @@ pub fn integrity(
 ) -> anyhow::Result<()> {
     #[cfg_attr(not(feature = "serde"), allow(unused))]
     let outcome = repo.objects.store_ref().verify_integrity(
-        progress,
+        &mut progress,
         should_interrupt,
         gix::odb::pack::index::verify::integrity::Options {
             verify_mode,
@@ -48,9 +48,7 @@ pub fn integrity(
             let objects = repo.objects;
             move |oid, buf: &mut Vec<u8>| objects.find_tree_iter(oid, buf).ok()
         })?;
-        outcome
-            .progress
-            .info(format!("Index at '{}' OK", index.path().display()));
+        progress.info(format!("Index at '{}' OK", index.path().display()));
     }
     match output_statistics {
         Some(OutputFormat::Human) => writeln!(out, "Human output is currently unsupported, use JSON instead")?,

--- a/gix-actor/src/identity.rs
+++ b/gix-actor/src/identity.rs
@@ -35,14 +35,14 @@ mod write {
     /// Output
     impl Identity {
         /// Serialize this instance to `out` in the git serialization format for signatures (but without timestamp).
-        pub fn write_to(&self, out: impl std::io::Write) -> std::io::Result<()> {
+        pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
             self.to_ref().write_to(out)
         }
     }
 
     impl<'a> IdentityRef<'a> {
         /// Serialize this instance to `out` in the git serialization format for signatures (but without timestamp).
-        pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+        pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
             out.write_all(validated_token(self.name)?)?;
             out.write_all(b" ")?;
             out.write_all(b"<")?;

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -95,7 +95,7 @@ pub(crate) mod write {
     /// Output
     impl Signature {
         /// Serialize this instance to `out` in the git serialization format for actors.
-        pub fn write_to(&self, out: impl std::io::Write) -> std::io::Result<()> {
+        pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
             self.to_ref().write_to(out)
         }
         /// Computes the number of bytes necessary to serialize this signature
@@ -106,7 +106,7 @@ pub(crate) mod write {
 
     impl<'a> SignatureRef<'a> {
         /// Serialize this instance to `out` in the git serialization format for actors.
-        pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+        pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
             out.write_all(validated_token(self.name)?)?;
             out.write_all(b" ")?;
             out.write_all(b"<")?;

--- a/gix-actor/tests/signature/mod.rs
+++ b/gix-actor/tests/signature/mod.rs
@@ -11,7 +11,7 @@ mod write_to {
                 time: default_time(),
             };
             assert_eq!(
-                format!("{:?}", signature.write_to(Vec::new())),
+                format!("{:?}", signature.write_to(&mut Vec::new())),
                 "Err(Custom { kind: Other, error: IllegalCharacter })"
             );
         }
@@ -24,7 +24,7 @@ mod write_to {
                 time: default_time(),
             };
             assert_eq!(
-                format!("{:?}", signature.write_to(Vec::new())),
+                format!("{:?}", signature.write_to(&mut Vec::new())),
                 "Err(Custom { kind: Other, error: IllegalCharacter })"
             );
         }
@@ -37,7 +37,7 @@ mod write_to {
                 time: default_time(),
             };
             assert_eq!(
-                format!("{:?}", signature.write_to(Vec::new())),
+                format!("{:?}", signature.write_to(&mut Vec::new())),
                 "Err(Custom { kind: Other, error: IllegalCharacter })"
             );
         }

--- a/gix-attributes/src/search/attributes.rs
+++ b/gix-attributes/src/search/attributes.rs
@@ -27,14 +27,14 @@ impl Search {
         let mut group = Self::default();
         group.add_patterns_buffer(
             b"[attr]binary -diff -merge -text",
-            "[builtin]",
+            "[builtin]".into(),
             None,
             collection,
             true, /* allow macros */
         );
 
         for path in files.into_iter() {
-            group.add_patterns_file(path, true, None, buf, collection, true /* allow macros */)?;
+            group.add_patterns_file(path.into(), true, None, buf, collection, true /* allow macros */)?;
         }
         Ok(group)
     }
@@ -49,7 +49,7 @@ impl Search {
     /// Returns `true` if the file was added, or `false` if it didn't exist.
     pub fn add_patterns_file(
         &mut self,
-        source: impl Into<PathBuf>,
+        source: PathBuf,
         follow_symlinks: bool,
         root: Option<&Path>,
         buf: &mut Vec<u8>,
@@ -75,7 +75,7 @@ impl Search {
     pub fn add_patterns_buffer(
         &mut self,
         bytes: &[u8],
-        source: impl Into<PathBuf>,
+        source: PathBuf,
         root: Option<&Path>,
         collection: &mut MetadataCollection,
         allow_macros: bool,
@@ -99,14 +99,13 @@ impl Search {
 impl Search {
     /// Match `relative_path`, a path relative to the repository, while respective `case`-sensitivity and write them to `out`
     /// Return `true` if at least one pattern matched.
-    pub fn pattern_matching_relative_path<'a, 'b>(
-        &'a self,
-        relative_path: impl Into<&'b BStr>,
+    pub fn pattern_matching_relative_path(
+        &self,
+        relative_path: &BStr,
         case: gix_glob::pattern::Case,
         is_dir: Option<bool>,
         out: &mut Outcome,
     ) -> bool {
-        let relative_path = relative_path.into();
         let basename_pos = relative_path.rfind(b"/").map(|p| p + 1);
         let mut has_match = false;
         self.patterns.iter().rev().any(|pl| {

--- a/gix-attributes/src/search/outcome.rs
+++ b/gix-attributes/src/search/outcome.rs
@@ -46,11 +46,18 @@ impl Outcome {
         collection: &MetadataCollection,
         attribute_names: impl IntoIterator<Item = impl Into<KStringRef<'a>>>,
     ) {
+        self.initialize_with_selection_inner(collection, &mut attribute_names.into_iter().map(Into::into))
+    }
+
+    fn initialize_with_selection_inner(
+        &mut self,
+        collection: &MetadataCollection,
+        attribute_names: &mut dyn Iterator<Item = KStringRef<'_>>,
+    ) {
         self.initialize(collection);
 
         self.selected.clear();
-        self.selected.extend(attribute_names.into_iter().map(|name| {
-            let name = name.into();
+        self.selected.extend(attribute_names.map(|name| {
             (
                 name.to_owned(),
                 collection.name_to_meta.get(name.as_str()).map(|meta| meta.id),

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -50,7 +50,7 @@ mod specials {
         );
         let mut out = Outcome::default();
         out.initialize(&collection);
-        search.pattern_matching_relative_path(path, case, None, &mut out)
+        search.pattern_matching_relative_path(path.into(), case, None, &mut out)
     }
 
     fn searchi(pattern: &str, path: &str, rela_containing_dir: Option<&str>) -> bool {
@@ -66,7 +66,7 @@ fn baseline() -> crate::Result {
     let mut buf = Vec::new();
     // Due to the way our setup differs from gits dynamic stack (which involves trying to read files from disk
     // by path) we can only test one case baseline, so we require multiple platforms (or filesystems) to run this.
-    let case = if gix_fs::Capabilities::probe("../.git").ignore_case {
+    let case = if gix_fs::Capabilities::probe("../.git".as_ref()).ignore_case {
         Case::Fold
     } else {
         Case::Sensitive
@@ -307,7 +307,11 @@ mod baseline {
 
         let mut buf = Vec::new();
         let mut collection = MetadataCollection::default();
-        let group = gix_attributes::Search::new_globals([base.join("user.attributes")], &mut buf, &mut collection)?;
+        let group = gix_attributes::Search::new_globals(
+            &mut [base.join("user.attributes")].into_iter(),
+            &mut buf,
+            &mut collection,
+        )?;
 
         Ok((group, collection, base, input))
     }

--- a/gix-commitgraph/src/file/access.rs
+++ b/gix-commitgraph/src/file/access.rs
@@ -74,7 +74,10 @@ impl File {
     /// Translate the given object hash to its position within this file, if present.
     // copied from gix-odb/src/pack/index/ext
     pub fn lookup(&self, id: impl AsRef<gix_hash::oid>) -> Option<file::Position> {
-        let id = id.as_ref();
+        self.lookup_inner(id.as_ref())
+    }
+
+    fn lookup_inner(&self, id: &gix_hash::oid) -> Option<file::Position> {
         let first_byte = usize::from(id.first_byte());
         let mut upper_bound = self.fan[first_byte];
         let mut lower_bound = if first_byte != 0 { self.fan[first_byte - 1] } else { 0 };

--- a/gix-commitgraph/src/file/verify.rs
+++ b/gix-commitgraph/src/file/verify.rs
@@ -160,8 +160,7 @@ impl File {
 
 /// If the given path's filename matches "graph-{hash}.graph", check that `hash` matches the
 /// expected hash.
-fn verify_split_chain_filename_hash(path: impl AsRef<Path>, expected: &gix_hash::oid) -> Result<(), String> {
-    let path = path.as_ref();
+fn verify_split_chain_filename_hash(path: &Path, expected: &gix_hash::oid) -> Result<(), String> {
     path.file_name()
         .and_then(std::ffi::OsStr::to_str)
         .and_then(|filename| filename.strip_suffix(".graph"))

--- a/gix-commitgraph/src/init.rs
+++ b/gix-commitgraph/src/init.rs
@@ -41,13 +41,13 @@ pub enum Error {
 /// Instantiate a `Graph` from various sources.
 impl Graph {
     /// Instantiate a commit graph from `path` which may be a directory containing graph files or the graph file itself.
-    pub fn at(path: impl AsRef<Path>) -> Result<Self, Error> {
-        Self::try_from(path.as_ref())
+    pub fn at(path: &Path) -> Result<Self, Error> {
+        Self::try_from(path)
     }
 
     /// Instantiate a commit graph from the directory containing all of its files.
-    pub fn from_commit_graphs_dir(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let commit_graphs_dir = path.as_ref();
+    pub fn from_commit_graphs_dir(path: &Path) -> Result<Self, Error> {
+        let commit_graphs_dir = path;
         let chain_file_path = commit_graphs_dir.join("commit-graph-chain");
         let chain_file = std::fs::File::open(&chain_file_path).map_err(|e| Error::Io {
             err: e,
@@ -70,8 +70,7 @@ impl Graph {
 
     /// Instantiate a commit graph from a `.git/objects/info/commit-graph` or
     /// `.git/objects/info/commit-graphs/graph-*.graph` file.
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let path = path.as_ref();
+    pub fn from_file(path: &Path) -> Result<Self, Error> {
         let file = File::at(path).map_err(|e| Error::File {
             err: e,
             path: path.to_owned(),
@@ -80,9 +79,9 @@ impl Graph {
     }
 
     /// Instantiate a commit graph from an `.git/objects/info` directory.
-    pub fn from_info_dir(info_dir: impl AsRef<Path>) -> Result<Self, Error> {
-        Self::from_file(info_dir.as_ref().join("commit-graph"))
-            .or_else(|_| Self::from_commit_graphs_dir(info_dir.as_ref().join("commit-graphs")))
+    pub fn from_info_dir(info_dir: &Path) -> Result<Self, Error> {
+        Self::from_file(&info_dir.join("commit-graph"))
+            .or_else(|_| Self::from_commit_graphs_dir(&info_dir.join("commit-graphs")))
     }
 
     /// Create a new commit graph from a list of `files`.

--- a/gix-commitgraph/src/lib.rs
+++ b/gix-commitgraph/src/lib.rs
@@ -45,7 +45,7 @@ pub struct Graph {
 
 /// Instantiate a commit graph from an `.git/objects/info` directory, or one of the various commit-graph files.
 pub fn at(path: impl AsRef<Path>) -> Result<Graph, init::Error> {
-    Graph::at(path)
+    Graph::at(path.as_ref())
 }
 
 mod access;

--- a/gix-commitgraph/tests/commitgraph.rs
+++ b/gix-commitgraph/tests/commitgraph.rs
@@ -80,7 +80,8 @@ pub fn graph_and_expected_named(
         .expect("script succeeds all the time")
         .join(name);
     let expected = inspect_refs(&repo_dir, refs);
-    let cg = Graph::from_info_dir(repo_dir.join(".git").join("objects").join("info")).expect("graph present and valid");
+    let cg =
+        Graph::from_info_dir(&repo_dir.join(".git").join("objects").join("info")).expect("graph present and valid");
     (cg, expected)
 }
 

--- a/gix-config/fuzz/fuzz_targets/parse.rs
+++ b/gix-config/fuzz/fuzz_targets/parse.rs
@@ -4,5 +4,5 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     // Don't name this _; Rust may optimize it out.
-    let _a = gix_config::parse::from_bytes(data, |_e| ());
+    let _a = gix_config::parse::from_bytes(data, &mut |_e| ());
 });

--- a/gix-config/src/file/access/comfort.rs
+++ b/gix-config/src/file/access/comfort.rs
@@ -31,7 +31,8 @@ impl<'event> File<'event> {
         key: impl AsRef<str>,
         filter: &mut MetadataFilter,
     ) -> Option<Cow<'_, BStr>> {
-        self.raw_value_filter(section_name, subsection_name, key, filter).ok()
+        self.raw_value_filter(section_name.as_ref(), subsection_name, key.as_ref(), filter)
+            .ok()
     }
 
     /// Like [`string_filter()`][File::string_filter()], but suitable for statically known `key`s like `remote.origin.url`.
@@ -40,7 +41,7 @@ impl<'event> File<'event> {
         key: impl Into<&'a BStr>,
         filter: &mut MetadataFilter,
     ) -> Option<Cow<'_, BStr>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.raw_value_filter(key.section_name, key.subsection_name, key.value_name, filter)
             .ok()
     }
@@ -78,7 +79,7 @@ impl<'event> File<'event> {
         key: impl AsRef<str>,
         filter: &mut MetadataFilter,
     ) -> Option<crate::Path<'_>> {
-        self.raw_value_filter(section_name, subsection_name, key, filter)
+        self.raw_value_filter(section_name.as_ref(), subsection_name, key.as_ref(), filter)
             .ok()
             .map(crate::Path::from)
     }
@@ -89,7 +90,7 @@ impl<'event> File<'event> {
         key: impl Into<&'a BStr>,
         filter: &mut MetadataFilter,
     ) -> Option<crate::Path<'_>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.path_filter(key.section_name, key.subsection_name, key.value_name, filter)
     }
 
@@ -141,7 +142,7 @@ impl<'event> File<'event> {
         key: impl Into<&'a BStr>,
         filter: &mut MetadataFilter,
     ) -> Option<Result<bool, value::Error>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.boolean_filter(key.section_name, key.subsection_name, key.value_name, filter)
     }
 
@@ -168,7 +169,9 @@ impl<'event> File<'event> {
         key: impl AsRef<str>,
         filter: &mut MetadataFilter,
     ) -> Option<Result<i64, value::Error>> {
-        let int = self.raw_value_filter(section_name, subsection_name, key, filter).ok()?;
+        let int = self
+            .raw_value_filter(section_name.as_ref(), subsection_name, key.as_ref(), filter)
+            .ok()?;
         Some(crate::Integer::try_from(int.as_ref()).and_then(|b| {
             b.to_decimal()
                 .ok_or_else(|| value::Error::new("Integer overflow", int.into_owned()))
@@ -181,7 +184,7 @@ impl<'event> File<'event> {
         key: impl Into<&'a BStr>,
         filter: &mut MetadataFilter,
     ) -> Option<Result<i64, value::Error>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.integer_filter(key.section_name, key.subsection_name, key.value_name, filter)
     }
 
@@ -192,12 +195,13 @@ impl<'event> File<'event> {
         subsection_name: Option<&BStr>,
         key: impl AsRef<str>,
     ) -> Option<Vec<Cow<'_, BStr>>> {
-        self.raw_values(section_name, subsection_name, key).ok()
+        self.raw_values(section_name.as_ref(), subsection_name, key.as_ref())
+            .ok()
     }
 
     /// Like [`strings()`][File::strings()], but suitable for statically known `key`s like `remote.origin.url`.
     pub fn strings_by_key<'a>(&self, key: impl Into<&'a BStr>) -> Option<Vec<Cow<'_, BStr>>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.strings(key.section_name, key.subsection_name, key.value_name)
     }
 
@@ -209,7 +213,8 @@ impl<'event> File<'event> {
         key: impl AsRef<str>,
         filter: &mut MetadataFilter,
     ) -> Option<Vec<Cow<'_, BStr>>> {
-        self.raw_values_filter(section_name, subsection_name, key, filter).ok()
+        self.raw_values_filter(section_name.as_ref(), subsection_name, key.as_ref(), filter)
+            .ok()
     }
 
     /// Like [`strings_filter()`][File::strings_filter()], but suitable for statically known `key`s like `remote.origin.url`.
@@ -218,7 +223,7 @@ impl<'event> File<'event> {
         key: impl Into<&'a BStr>,
         filter: &mut MetadataFilter,
     ) -> Option<Vec<Cow<'_, BStr>>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.strings_filter(key.section_name, key.subsection_name, key.value_name, filter)
     }
 
@@ -247,7 +252,7 @@ impl<'event> File<'event> {
         key: impl AsRef<str>,
         filter: &mut MetadataFilter,
     ) -> Option<Result<Vec<i64>, value::Error>> {
-        self.raw_values_filter(section_name, subsection_name, key, filter)
+        self.raw_values_filter(section_name.as_ref(), subsection_name, key.as_ref(), filter)
             .ok()
             .map(|values| {
                 values
@@ -268,7 +273,7 @@ impl<'event> File<'event> {
         key: impl Into<&'a BStr>,
         filter: &mut MetadataFilter,
     ) -> Option<Result<Vec<i64>, value::Error>> {
-        let key = crate::parse::key(key)?;
+        let key = crate::parse::key(key.into())?;
         self.integers_filter(key.section_name, key.subsection_name, key.value_name, filter)
     }
 }

--- a/gix-config/src/file/access/read_only.rs
+++ b/gix-config/src/file/access/read_only.rs
@@ -131,7 +131,7 @@ impl<'event> File<'event> {
     /// Returns the last found immutable section with a given `name` and optional `subsection_name`.
     pub fn section(
         &self,
-        name: impl AsRef<str>,
+        name: &str,
         subsection_name: Option<&BStr>,
     ) -> Result<&file::Section<'event>, lookup::existing::Error> {
         self.section_filter(name, subsection_name, &mut |_| true)?
@@ -140,10 +140,7 @@ impl<'event> File<'event> {
 
     /// Returns the last found immutable section with a given `key`, identifying the name and subsection name like `core`
     /// or `remote.origin`.
-    pub fn section_by_key<'a>(
-        &self,
-        key: impl Into<&'a BStr>,
-    ) -> Result<&file::Section<'event>, lookup::existing::Error> {
+    pub fn section_by_key(&self, key: &BStr) -> Result<&file::Section<'event>, lookup::existing::Error> {
         let key = crate::parse::section::unvalidated::Key::parse(key).ok_or(lookup::existing::Error::KeyMissing)?;
         self.section(key.section_name, key.subsection_name)
     }
@@ -154,7 +151,7 @@ impl<'event> File<'event> {
     /// is returned.
     pub fn section_filter<'a>(
         &'a self,
-        name: impl AsRef<str>,
+        name: &str,
         subsection_name: Option<&BStr>,
         filter: &mut MetadataFilter,
     ) -> Result<Option<&'a file::Section<'event>>, lookup::existing::Error> {
@@ -171,9 +168,9 @@ impl<'event> File<'event> {
     }
 
     /// Like [`section_filter()`][File::section_filter()], but identifies the section with `key` like `core` or `remote.origin`.
-    pub fn section_filter_by_key<'a, 'b>(
+    pub fn section_filter_by_key<'a>(
         &'a self,
-        key: impl Into<&'b BStr>,
+        key: &BStr,
         filter: &mut MetadataFilter,
     ) -> Result<Option<&'a file::Section<'event>>, lookup::existing::Error> {
         let key = crate::parse::section::unvalidated::Key::parse(key).ok_or(lookup::existing::Error::KeyMissing)?;

--- a/gix-config/src/file/init/comfort.rs
+++ b/gix-config/src/file/init/comfort.rs
@@ -82,16 +82,16 @@ impl File<'static> {
     ///
     /// Includes will be resolved within limits as some information like the git installation directory is missing to interpolate
     /// paths with as well as git repository information like the branch name.
-    pub fn from_git_dir(dir: impl Into<std::path::PathBuf>) -> Result<File<'static>, from_git_dir::Error> {
+    pub fn from_git_dir(dir: std::path::PathBuf) -> Result<File<'static>, from_git_dir::Error> {
         let (mut local, git_dir) = {
             let source = Source::Local;
-            let mut path = dir.into();
+            let mut path = dir;
             path.push(
                 source
                     .storage_location(&mut gix_path::env::var)
                     .expect("location available for local"),
             );
-            let local = Self::from_path_no_includes(&path, source)?;
+            let local = Self::from_path_no_includes(path.clone(), source)?;
             path.pop();
             (local, path)
         };

--- a/gix-config/src/file/mutable/section.rs
+++ b/gix-config/src/file/mutable/section.rs
@@ -123,10 +123,10 @@ impl<'a, 'event> SectionMut<'a, 'event> {
     /// Sets the last key value pair if it exists, or adds the new value.
     /// Returns the previous value if it replaced a value, or None if it adds
     /// the value.
-    pub fn set<'b>(&mut self, key: Key<'event>, value: impl Into<&'b BStr>) -> Option<Cow<'event, BStr>> {
+    pub fn set(&mut self, key: Key<'event>, value: &BStr) -> Option<Cow<'event, BStr>> {
         match self.key_and_value_range_by(&key) {
             None => {
-                self.push(key, Some(value.into()));
+                self.push(key, Some(value));
                 None
             }
             Some((key_range, value_range)) => {
@@ -136,15 +136,15 @@ impl<'a, 'event> SectionMut<'a, 'event> {
                 self.section
                     .body
                     .0
-                    .insert(range_start, Event::Value(escape_value(value.into()).into()));
+                    .insert(range_start, Event::Value(escape_value(value).into()));
                 Some(ret)
             }
         }
     }
 
     /// Removes the latest value by key and returns it, if it exists.
-    pub fn remove(&mut self, key: impl AsRef<str>) -> Option<Cow<'event, BStr>> {
-        let key = Key::from_str_unchecked(key.as_ref());
+    pub fn remove(&mut self, key: &str) -> Option<Cow<'event, BStr>> {
+        let key = Key::from_str_unchecked(key);
         let (key_range, _value_range) = self.key_and_value_range_by(&key)?;
         Some(self.remove_internal(key_range, true))
     }

--- a/gix-config/src/file/section/body.rs
+++ b/gix-config/src/file/section/body.rs
@@ -18,14 +18,14 @@ impl<'event> Body<'event> {
     /// Note that we consider values without key separator `=` non-existing.
     #[must_use]
     pub fn value(&self, key: impl AsRef<str>) -> Option<Cow<'_, BStr>> {
-        self.value_implicit(key).flatten()
+        self.value_implicit(key.as_ref()).flatten()
     }
 
     /// Retrieves the last matching value in a section with the given key, if present, and indicates an implicit value with `Some(None)`,
     /// and a non-existing one as `None`
     #[must_use]
-    pub fn value_implicit(&self, key: impl AsRef<str>) -> Option<Option<Cow<'_, BStr>>> {
-        let key = Key::from_str_unchecked(key.as_ref());
+    pub fn value_implicit(&self, key: &str) -> Option<Option<Cow<'_, BStr>>> {
+        let key = Key::from_str_unchecked(key);
         let (_key_range, range) = self.key_and_value_range_by(&key)?;
         let range = match range {
             None => return Some(None),
@@ -54,8 +54,8 @@ impl<'event> Body<'event> {
     /// Retrieves all values that have the provided key name. This may return
     /// an empty vec, which implies there were no values with the provided key.
     #[must_use]
-    pub fn values(&self, key: impl AsRef<str>) -> Vec<Cow<'_, BStr>> {
-        let key = &Key::from_str_unchecked(key.as_ref());
+    pub fn values(&self, key: &str) -> Vec<Cow<'_, BStr>> {
+        let key = &Key::from_str_unchecked(key);
         let mut values = Vec::new();
         let mut expect_value = false;
         let mut concatenated_value = BString::default();
@@ -92,8 +92,8 @@ impl<'event> Body<'event> {
 
     /// Returns true if the section contains the provided key.
     #[must_use]
-    pub fn contains_key(&self, key: impl AsRef<str>) -> bool {
-        let key = &Key::from_str_unchecked(key.as_ref());
+    pub fn contains_key(&self, key: &str) -> bool {
+        let key = &Key::from_str_unchecked(key);
         self.0.iter().any(|e| {
             matches!(e,
                 Event::SectionKey(k) if k == key

--- a/gix-config/src/file/section/mod.rs
+++ b/gix-config/src/file/section/mod.rs
@@ -74,7 +74,7 @@ impl<'a> Section<'a> {
 
     /// Stream ourselves to the given `out`, in order to reproduce this section mostly losslessly
     /// as it was parsed.
-    pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_to(&self, mut out: &mut dyn std::io::Write) -> std::io::Result<()> {
         self.header.write_to(&mut out)?;
 
         if self.body.0.is_empty() {

--- a/gix-config/src/file/write.rs
+++ b/gix-config/src/file/write.rs
@@ -17,8 +17,8 @@ impl File<'_> {
     /// as it was parsed, while writing only sections for which `filter` returns true.
     pub fn write_to_filter(
         &self,
-        mut out: impl std::io::Write,
-        mut filter: impl FnMut(&Section<'_>) -> bool,
+        mut out: &mut dyn std::io::Write,
+        mut filter: &mut dyn FnMut(&Section<'_>) -> bool,
     ) -> std::io::Result<()> {
         let nl = self.detect_newline_style();
 
@@ -65,8 +65,8 @@ impl File<'_> {
 
     /// Stream ourselves to the given `out`, in order to reproduce this file mostly losslessly
     /// as it was parsed.
-    pub fn write_to(&self, out: impl std::io::Write) -> std::io::Result<()> {
-        self.write_to_filter(out, |_| true)
+    pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
+        self.write_to_filter(out, &mut |_| true)
     }
 }
 

--- a/gix-config/src/parse/event.rs
+++ b/gix-config/src/parse/event.rs
@@ -33,7 +33,7 @@ impl Event<'_> {
 
     /// Stream ourselves to the given `out`, in order to reproduce this event mostly losslessly
     /// as it was parsed.
-    pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_to(&self, mut out: &mut dyn std::io::Write) -> std::io::Result<()> {
         match self {
             Self::ValueNotDone(e) => {
                 out.write_all(e.as_ref())?;

--- a/gix-config/src/parse/key.rs
+++ b/gix-config/src/parse/key.rs
@@ -14,8 +14,7 @@ pub struct Key<'a> {
 /// Parse `input` like `core.bare` or `remote.origin.url` as a `Key` to make its fields available,
 /// or `None` if there were not at least 2 tokens separated by `.`.
 /// Note that `input` isn't validated, and is `str` as ascii is a subset of UTF-8 which is required for any valid keys.
-pub fn parse_unvalidated<'a>(input: impl Into<&'a BStr>) -> Option<Key<'a>> {
-    let input = input.into();
+pub fn parse_unvalidated(input: &BStr) -> Option<Key<'_>> {
     let mut tokens = input.splitn(2, |b| *b == b'.');
     let section_name = tokens.next()?;
     let subsection_or_key = tokens.next()?;

--- a/gix-config/tests/config.rs
+++ b/gix-config/tests/config.rs
@@ -1,4 +1,4 @@
-type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub use gix_testtools::Result;
 
 mod file;
 mod parse;

--- a/gix-config/tests/file/init/from_env.rs
+++ b/gix-config/tests/file/init/from_env.rs
@@ -44,7 +44,7 @@ fn single_key_value_pair() -> crate::Result {
     let config = File::from_env(Default::default())?.unwrap();
     assert_eq!(config.raw_value("core", None, "key")?, Cow::<[u8]>::Borrowed(b"value"));
     assert_eq!(
-        config.section_by_key("core")?.meta(),
+        config.section_by_key("core".into())?.meta(),
         &gix_config::file::Metadata::from(gix_config::Source::Env),
         "source if configured correctly"
     );

--- a/gix-config/tests/file/mod.rs
+++ b/gix-config/tests/file/mod.rs
@@ -21,7 +21,7 @@ mod open {
 
     #[test]
     fn parse_config_with_windows_line_endings_successfully() {
-        File::from_path_no_includes(&fixture_path_standalone("repo-config.crlf"), gix_config::Source::Local).unwrap();
+        File::from_path_no_includes(fixture_path_standalone("repo-config.crlf"), gix_config::Source::Local).unwrap();
     }
 }
 

--- a/gix-config/tests/file/mutable/section.rs
+++ b/gix-config/tests/file/mutable/section.rs
@@ -51,7 +51,7 @@ mod remove {
         let prev_values = vec!["v", "", "", "", "a        b        c"];
         let mut num_values = section.num_values();
         for (key, expected_prev_value) in ('a'..='e').zip(prev_values) {
-            let prev_value = section.remove(key.to_string());
+            let prev_value = section.remove(&key.to_string());
             num_values -= 1;
             assert_eq!(prev_value.expect("present").as_ref(), expected_prev_value);
             assert_eq!(section.num_values(), num_values);
@@ -104,7 +104,7 @@ mod set {
 
         for (key, (new_value, expected_prev_value)) in (b'a'..=b'e').zip(values.into_iter().zip(prev_values)) {
             let key = std::str::from_utf8(std::slice::from_ref(&key))?.to_owned();
-            let prev_value = section.set(key.try_into()?, new_value);
+            let prev_value = section.set(key.try_into()?, new_value.as_ref());
             assert_eq!(prev_value.as_deref().expect("prev value set"), expected_prev_value);
         }
 
@@ -112,7 +112,7 @@ mod set {
         assert_eq!(
             config
                 .section_mut("a", None)?
-                .set("new-one".to_owned().try_into()?, "value"),
+                .set("new-one".to_owned().try_into()?, "value".into()),
             None,
             "new values don't replace an existing one"
         );

--- a/gix-config/tests/file/write.rs
+++ b/gix-config/tests/file/write.rs
@@ -137,7 +137,7 @@ mod to_filter {
             .push("c".try_into()?, Some("d".into()));
 
         let mut buf = Vec::<u8>::new();
-        config.write_to_filter(&mut buf, |s| s.meta().source == gix_config::Source::Local)?;
+        config.write_to_filter(&mut buf, &mut |s| s.meta().source == gix_config::Source::Local)?;
         let nl = config.detect_newline_style();
         assert_eq!(buf.to_str_lossy(), format!("[a \"local\"]{nl}\tb = c{nl}\tc = d{nl}"));
 

--- a/gix-config/tests/parse/key.rs
+++ b/gix-config/tests/parse/key.rs
@@ -2,13 +2,13 @@ use gix_config::parse;
 
 #[test]
 fn missing_dot_is_invalid() {
-    assert_eq!(parse::key("hello"), None);
+    assert_eq!(parse::key("hello".into()), None);
 }
 
 #[test]
 fn section_name_and_key() {
     assert_eq!(
-        parse::key("core.bare"),
+        parse::key("core.bare".into()),
         Some(parse::Key {
             section_name: "core",
             subsection_name: None,
@@ -20,7 +20,7 @@ fn section_name_and_key() {
 #[test]
 fn section_name_subsection_and_key() {
     assert_eq!(
-        parse::key("remote.origin.url"),
+        parse::key("remote.origin.url".into()),
         Some(parse::Key {
             section_name: "remote",
             subsection_name: Some("origin".into()),
@@ -29,7 +29,7 @@ fn section_name_subsection_and_key() {
     );
 
     assert_eq!(
-        parse::key("includeIf.gitdir/i:C:\\bare.git.path"),
+        parse::key("includeIf.gitdir/i:C:\\bare.git.path".into()),
         Some(parse::Key {
             section_name: "includeIf",
             subsection_name: Some("gitdir/i:C:\\bare.git".into()),

--- a/gix-date/src/time/format.rs
+++ b/gix-date/src/time/format.rs
@@ -68,7 +68,11 @@ impl Time {
     /// Use the [`format_description`](https://time-rs.github.io/book/api/format-description.html) macro to create and
     /// validate formats at compile time, courtesy of the [`time`] crate.
     pub fn format<'a>(&self, format: impl Into<Format<'a>>) -> String {
-        match format.into() {
+        self.format_inner(format.into())
+    }
+
+    fn format_inner(&self, format: Format<'_>) -> String {
+        match format {
             Format::Custom(format) => self
                 .to_time()
                 .format(&format)

--- a/gix-date/src/time/write.rs
+++ b/gix-date/src/time/write.rs
@@ -12,7 +12,7 @@ impl Time {
     }
 
     /// Serialize this instance to `out` in a format suitable for use in header fields of serialized git commits or tags.
-    pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
         let mut itoa = itoa::Buffer::new();
         out.write_all(itoa.format(self.seconds).as_bytes())?;
         out.write_all(b" ")?;

--- a/gix-date/tests/time/baseline.rs
+++ b/gix-date/tests/time/baseline.rs
@@ -6,7 +6,7 @@ use gix_date::{
 };
 use once_cell::sync::Lazy;
 
-type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+use gix_testtools::Result;
 
 struct Sample {
     format_name: Option<String>,

--- a/gix-diff/tests/diff.rs
+++ b/gix-diff/tests/diff.rs
@@ -1,4 +1,4 @@
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+use gix_testtools::Result;
 
 fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
     gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")

--- a/gix-diff/tests/tree/mod.rs
+++ b/gix-diff/tests/tree/mod.rs
@@ -38,7 +38,7 @@ mod changes {
                 .tree();
 
             Ok(db
-                .try_find(tree_id, buf)?
+                .try_find(&tree_id, buf)?
                 .expect("main tree present")
                 .0
                 .try_into_tree_iter()
@@ -88,7 +88,7 @@ mod changes {
                 })
             };
             let current_tree = db
-                .try_find(main_tree_id, &mut buf)?
+                .try_find(&main_tree_id, &mut buf)?
                 .expect("main tree present")
                 .0
                 .try_into_tree_iter()
@@ -96,11 +96,11 @@ mod changes {
             let mut buf2 = Vec::new();
             let previous_tree: Option<_> = {
                 parent_commit_id
-                    .and_then(|id| db.try_find(id, &mut buf2).ok().flatten())
+                    .and_then(|id| db.try_find(&id, &mut buf2).ok().flatten())
                     .and_then(|(c, _l)| c.decode().ok())
                     .and_then(gix_object::ObjectRef::into_commit)
                     .map(|c| c.tree())
-                    .and_then(|tree| db.try_find(tree, &mut buf2).ok().flatten())
+                    .and_then(|tree| db.try_find(&tree, &mut buf2).ok().flatten())
                     .and_then(|(tree, _)| tree.try_into_tree_iter())
             };
 
@@ -151,7 +151,7 @@ mod changes {
             .map(|c| {
                 use gix_odb::FindExt;
                 (
-                    db.find_commit(c.id, &mut buf)
+                    db.find_commit(&c.id, &mut buf)
                         .unwrap()
                         .message
                         .trim()

--- a/gix-discover/src/path.rs
+++ b/gix-discover/src/path.rs
@@ -15,8 +15,7 @@ pub mod from_gitdir_file {
     }
 }
 
-fn read_regular_file_content_with_size_limit(path: impl AsRef<std::path::Path>) -> std::io::Result<Vec<u8>> {
-    let path = path.as_ref();
+fn read_regular_file_content_with_size_limit(path: &std::path::Path) -> std::io::Result<Vec<u8>> {
     let mut file = std::fs::File::open(path)?;
     let max_file_size = 1024 * 64; // NOTE: git allows 1MB here
     let file_size = file.metadata()?.len();
@@ -37,7 +36,7 @@ fn read_regular_file_content_with_size_limit(path: impl AsRef<std::path::Path>) 
 }
 
 /// Reads a plain path from a file that contains it as its only content, with trailing newlines trimmed.
-pub fn from_plain_file(path: impl AsRef<std::path::Path>) -> Option<std::io::Result<PathBuf>> {
+pub fn from_plain_file(path: &std::path::Path) -> Option<std::io::Result<PathBuf>> {
     use bstr::ByteSlice;
     let mut buf = match read_regular_file_content_with_size_limit(path) {
         Ok(buf) => buf,
@@ -50,8 +49,7 @@ pub fn from_plain_file(path: impl AsRef<std::path::Path>) -> Option<std::io::Res
 }
 
 /// Reads typical `gitdir: ` files from disk as used by worktrees and submodules.
-pub fn from_gitdir_file(path: impl AsRef<std::path::Path>) -> Result<PathBuf, from_gitdir_file::Error> {
-    let path = path.as_ref();
+pub fn from_gitdir_file(path: &std::path::Path) -> Result<PathBuf, from_gitdir_file::Error> {
     let buf = read_regular_file_content_with_size_limit(path)?;
     let mut gitdir = crate::parse::gitdir(&buf)?;
     if let Some(parent) = path.parent() {

--- a/gix-discover/src/repository.rs
+++ b/gix-discover/src/repository.rs
@@ -48,25 +48,20 @@ mod path {
         /// as needed.
         ///
         /// `None` is returned if `dir` could not be resolved due to being relative and trying to reach outside of the filesystem root.
-        pub fn from_dot_git_dir(
-            dir: impl Into<PathBuf>,
-            kind: Kind,
-            current_dir: impl AsRef<std::path::Path>,
-        ) -> Option<Self> {
-            let cwd = current_dir.as_ref();
+        pub fn from_dot_git_dir(dir: PathBuf, kind: Kind, current_dir: &std::path::Path) -> Option<Self> {
+            let cwd = current_dir;
             let normalize_on_trailing_dot_dot = |dir: PathBuf| -> Option<PathBuf> {
                 if !matches!(dir.components().next_back(), Some(std::path::Component::ParentDir)) {
                     dir
                 } else {
-                    gix_path::normalize(&dir, cwd)?.into_owned()
+                    gix_path::normalize(dir.into(), cwd)?.into_owned()
                 }
                 .into()
             };
 
-            let dir = dir.into();
             match kind {
                 Kind::Submodule { git_dir } => Path::LinkedWorkTree {
-                    git_dir: gix_path::normalize(git_dir, cwd)?.into_owned(),
+                    git_dir: gix_path::normalize(git_dir.into(), cwd)?.into_owned(),
                     work_dir: without_dot_git_dir(normalize_on_trailing_dot_dot(dir)?),
                 },
                 Kind::SubmoduleGitDir => Path::Repository(dir),

--- a/gix-discover/src/upwards/util.rs
+++ b/gix-discover/src/upwards/util.rs
@@ -50,9 +50,9 @@ pub(crate) fn find_ceiling_height(search_dir: &Path, ceiling_dirs: &[PathBuf], c
         .filter_map(|ceiling_dir| {
             #[cfg(windows)]
             let ceiling_dir = dunce::simplified(ceiling_dir);
-            let mut ceiling_dir = gix_path::normalize(ceiling_dir, cwd)?;
+            let mut ceiling_dir = gix_path::normalize(ceiling_dir.into(), cwd)?;
             if !ceiling_dir.is_absolute() {
-                ceiling_dir = gix_path::normalize(cwd.join(ceiling_dir.as_ref()), cwd)?;
+                ceiling_dir = gix_path::normalize(cwd.join(ceiling_dir.as_ref()).into(), cwd)?;
             }
             search_dir
                 .strip_prefix(ceiling_dir.as_ref())

--- a/gix-discover/tests/is_git/mod.rs
+++ b/gix-discover/tests/is_git/mod.rs
@@ -31,7 +31,7 @@ fn verify_on_exfat() -> crate::Result<()> {
         })
     };
 
-    let is_git = gix_discover::is_git(mount_point.path().join(".git"));
+    let is_git = gix_discover::is_git(&mount_point.path().join(".git"));
 
     assert!(
         matches!(is_git, Ok(Kind::WorkTree { linked_git_dir: None })),
@@ -44,7 +44,7 @@ fn verify_on_exfat() -> crate::Result<()> {
 fn missing_configuration_file_is_not_a_dealbreaker_in_bare_repo() -> crate::Result {
     for name in ["bare-no-config-after-init.git", "bare-no-config.git"] {
         let repo = repo_path()?.join(name);
-        let kind = gix_discover::is_git(repo)?;
+        let kind = gix_discover::is_git(&repo)?;
         assert_eq!(kind, gix_discover::repository::Kind::Bare);
     }
     Ok(())
@@ -53,7 +53,7 @@ fn missing_configuration_file_is_not_a_dealbreaker_in_bare_repo() -> crate::Resu
 #[test]
 fn bare_repo_with_index_file_looks_still_looks_like_bare() -> crate::Result {
     let repo = repo_path()?.join("bare-with-index.git");
-    let kind = gix_discover::is_git(repo)?;
+    let kind = gix_discover::is_git(&repo)?;
     assert_eq!(kind, gix_discover::repository::Kind::Bare);
     Ok(())
 }
@@ -62,7 +62,7 @@ fn bare_repo_with_index_file_looks_still_looks_like_bare() -> crate::Result {
 fn bare_repo_with_index_file_looks_still_looks_like_bare_if_it_was_renamed() -> crate::Result {
     for repo_name in ["bare-with-index-bare", "bare-with-index-no-config-bare"] {
         let repo = repo_path()?.join(repo_name);
-        let kind = gix_discover::is_git(repo)?;
+        let kind = gix_discover::is_git(&repo)?;
         assert_eq!(kind, gix_discover::repository::Kind::Bare);
     }
     Ok(())
@@ -71,7 +71,7 @@ fn bare_repo_with_index_file_looks_still_looks_like_bare_if_it_was_renamed() -> 
 #[test]
 fn no_bare_repo_without_index_file_looks_like_worktree() -> crate::Result {
     let repo = repo_path()?.join("non-bare-without-index").join(".git");
-    let kind = gix_discover::is_git(repo)?;
+    let kind = gix_discover::is_git(&repo)?;
     assert_eq!(kind, gix_discover::repository::Kind::WorkTree { linked_git_dir: None });
     Ok(())
 }
@@ -80,7 +80,7 @@ fn no_bare_repo_without_index_file_looks_like_worktree() -> crate::Result {
 fn missing_configuration_file_is_not_a_dealbreaker_in_nonbare_repo() -> crate::Result {
     for name in ["worktree-no-config-after-init/.git", "worktree-no-config/.git"] {
         let repo = repo_path()?.join(name);
-        let kind = gix_discover::is_git(repo)?;
+        let kind = gix_discover::is_git(&repo)?;
         assert_eq!(kind, gix_discover::repository::Kind::WorkTree { linked_git_dir: None });
     }
     Ok(())

--- a/gix-discover/tests/isolated.rs
+++ b/gix-discover/tests/isolated.rs
@@ -9,7 +9,7 @@ fn upwards_bare_repo_with_index() -> gix_testtools::Result {
     let repo = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
 
     let _keep = gix_testtools::set_current_dir(repo.join("bare-with-index.git"))?;
-    let (repo_path, _trust) = gix_discover::upwards(".")?;
+    let (repo_path, _trust) = gix_discover::upwards(".".as_ref())?;
     assert_eq!(
         repo_path.kind(),
         gix_discover::repository::Kind::Bare,
@@ -24,7 +24,7 @@ fn in_cwd_upwards_bare_repo_without_index() -> gix_testtools::Result {
     let repo = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
 
     let _keep = gix_testtools::set_current_dir(repo.join("bare.git"))?;
-    let (repo_path, _trust) = gix_discover::upwards(".")?;
+    let (repo_path, _trust) = gix_discover::upwards(".".as_ref())?;
     assert_eq!(repo_path.kind(), gix_discover::repository::Kind::Bare);
     Ok(())
 }
@@ -35,7 +35,7 @@ fn in_cwd_upwards_nonbare_repo_without_index() -> gix_testtools::Result {
     let repo = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
 
     let _keep = gix_testtools::set_current_dir(repo.join("non-bare-without-index"))?;
-    let (repo_path, _trust) = gix_discover::upwards(".")?;
+    let (repo_path, _trust) = gix_discover::upwards(".".as_ref())?;
     assert_eq!(
         repo_path.kind(),
         gix_discover::repository::Kind::WorkTree { linked_git_dir: None },
@@ -59,7 +59,7 @@ fn upwards_with_relative_directories_and_optional_ceiling() -> gix_testtools::Re
     ] {
         let ceiling_dir = cwd.join(ceiling_dir_component);
         let (repo_path, _trust) = gix_discover::upwards_opts(
-            search_dir,
+            search_dir.as_ref(),
             Options {
                 ceiling_dirs: vec![ceiling_dir],
                 ..Default::default()
@@ -68,12 +68,12 @@ fn upwards_with_relative_directories_and_optional_ceiling() -> gix_testtools::Re
         .expect("ceiling dir should allow us to discover the repo");
         assert_repo_is_current_workdir(repo_path, Path::new(".."));
 
-        let (repo_path, _trust) =
-            gix_discover::upwards_opts(search_dir, Default::default()).expect("without ceiling dir we see the same");
+        let (repo_path, _trust) = gix_discover::upwards_opts(search_dir.as_ref(), Default::default())
+            .expect("without ceiling dir we see the same");
         assert_repo_is_current_workdir(repo_path, Path::new(".."));
 
         let (repo_path, _trust) = gix_discover::upwards_opts(
-            search_dir,
+            search_dir.as_ref(),
             Options {
                 ceiling_dirs: vec![PathBuf::from("..")],
                 ..Default::default()
@@ -83,7 +83,7 @@ fn upwards_with_relative_directories_and_optional_ceiling() -> gix_testtools::Re
         assert_repo_is_current_workdir(repo_path, Path::new(".."));
 
         let err = gix_discover::upwards_opts(
-            search_dir,
+            search_dir.as_ref(),
             Options {
                 ceiling_dirs: vec![PathBuf::from(".")],
                 ..Default::default()

--- a/gix-discover/tests/upwards/ceiling_dirs.rs
+++ b/gix-discover/tests/upwards/ceiling_dirs.rs
@@ -19,7 +19,7 @@ fn git_dir_candidate_within_ceiling_allows_discovery() -> crate::Result {
     let work_dir = repo_path()?;
     let dir = work_dir.join("some/very/deeply/nested/subdir");
     let (repo_path, _trust) = gix_discover::upwards_opts(
-        dir,
+        &dir,
         Options {
             ceiling_dirs: vec![work_dir.clone()],
             ..Default::default()
@@ -39,7 +39,7 @@ fn ceiling_dir_is_ignored_if_we_are_standing_on_the_ceiling_and_no_match_is_requ
     // But we can ignore that just like git does (see https://github.com/Byron/gitoxide/pull/723 for more information)
     // and imagine us to 'stand on the ceiling', hence we are already past it.
     let (repo_path, _trust) = gix_discover::upwards_opts(
-        dir.clone(),
+        &dir.clone(),
         Options {
             ceiling_dirs: vec![dir],
             match_ceiling_dir_or_error: false,
@@ -57,7 +57,7 @@ fn discovery_fails_if_we_require_a_matching_ceiling_dir_but_are_standing_on_it()
     let work_dir = repo_path()?;
     let dir = work_dir.join("some/very/deeply/nested/subdir");
     let err = gix_discover::upwards_opts(
-        dir.clone(),
+        &dir.clone(),
         Options {
             ceiling_dirs: vec![dir],
             match_ceiling_dir_or_error: true,
@@ -79,7 +79,7 @@ fn ceiling_dir_limits_are_respected_and_prevent_discovery() -> crate::Result {
     let dir = work_dir.join("some/very/deeply/nested/subdir");
 
     let err = gix_discover::upwards_opts(
-        dir,
+        &dir,
         Options {
             ceiling_dirs: vec![work_dir.join("some/../some")],
             ..Default::default()
@@ -99,7 +99,7 @@ fn no_matching_ceiling_dir_error_can_be_suppressed() -> crate::Result {
     let work_dir = repo_path()?;
     let dir = work_dir.join("some/very/deeply/nested/subdir");
     let (repo_path, _trust) = gix_discover::upwards_opts(
-        dir,
+        &dir,
         Options {
             match_ceiling_dir_or_error: false,
             ceiling_dirs: vec![
@@ -122,7 +122,7 @@ fn more_restrictive_ceiling_dirs_overrule_less_restrictive_ones() -> crate::Resu
     let work_dir = repo_path()?;
     let dir = work_dir.join("some/very/deeply/nested/subdir");
     let err = gix_discover::upwards_opts(
-        dir,
+        &dir,
         Options {
             ceiling_dirs: vec![work_dir.clone(), work_dir.join("some")],
             ..Default::default()
@@ -142,7 +142,7 @@ fn ceiling_dirs_are_not_processed_differently_than_the_git_dir_candidate() -> cr
     let work_dir = repo_path()?;
     let dir = work_dir.join("some/very/deeply/nested/subdir/../../../../../..");
     let (repo_path, _trust) = gix_discover::upwards_opts(
-        dir,
+        &dir,
         Options {
             match_ceiling_dir_or_error: false,
             ceiling_dirs: vec![Path::new("./some").into()],
@@ -165,7 +165,7 @@ fn no_matching_ceiling_dirs_errors_by_default() -> crate::Result {
     let relative_work_dir = repo_path()?;
     let dir = relative_work_dir.join("some");
     let res = gix_discover::upwards_opts(
-        dir,
+        &dir,
         Options {
             ceiling_dirs: vec!["/something/somewhere".into()],
             ..Default::default()
@@ -196,9 +196,9 @@ fn ceilings_are_adjusted_to_match_search_dir() -> crate::Result {
     assert_repo_is_current_workdir(repo_path, &relative_work_dir);
 
     assert!(relative_work_dir.is_relative());
-    let absolute_dir = gix_path::realpath_opts(relative_work_dir.join("some"), cwd, 8)?;
+    let absolute_dir = gix_path::realpath_opts(relative_work_dir.join("some").as_ref(), &cwd, 8)?;
     let (repo_path, _trust) = gix_discover::upwards_opts(
-        absolute_dir,
+        &absolute_dir,
         Options {
             ceiling_dirs: vec![relative_work_dir.clone()],
             ..Default::default()

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -129,7 +129,7 @@ crc32fast = { version = "1.2.1", optional = true }
 sha1 = { version = "0.10.0", optional = true }
 
 # progress
-prodash = { version = "25.0.0", optional = true, default-features = false }
+prodash = { version = "26.0.0", optional = true, default-features = false }
 bytesize = { version = "1.0.1", optional = true }
 
 # pipe

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -129,7 +129,7 @@ crc32fast = { version = "1.2.1", optional = true }
 sha1 = { version = "0.10.0", optional = true }
 
 # progress
-prodash = { version = "26.0.0", optional = true, default-features = false }
+prodash = { version = "26.2.0", optional = true, default-features = false }
 bytesize = { version = "1.0.1", optional = true }
 
 # pipe

--- a/gix-features/src/cache.rs
+++ b/gix-features/src/cache.rs
@@ -11,9 +11,9 @@ mod impl_ {
     impl Debug {
         /// Create a new instance
         #[inline]
-        pub fn new(owner: impl Into<String>) -> Self {
+        pub fn new(owner: String) -> Self {
             Debug {
-                owner: owner.into(),
+                owner,
                 hits: 0,
                 puts: 0,
                 misses: 0,
@@ -61,7 +61,7 @@ mod impl_ {
     impl Debug {
         /// Create a new instance
         #[inline]
-        pub fn new(_owner: impl Into<String>) -> Self {
+        pub fn new(_owner: String) -> Self {
             Debug
         }
         /// noop

--- a/gix-features/src/fs.rs
+++ b/gix-features/src/fs.rs
@@ -58,12 +58,12 @@ pub mod walkdir {
     }
 
     /// Instantiate a new directory iterator which will not skip hidden files, with the given level of `parallelism`.
-    pub fn walkdir_new(root: impl AsRef<Path>, parallelism: Parallelism) -> WalkDir {
+    pub fn walkdir_new(root: &Path, parallelism: Parallelism) -> WalkDir {
         WalkDir::new(root).skip_hidden(false).parallelism(parallelism.into())
     }
 
     /// Instantiate a new directory iterator which will not skip hidden files and is sorted
-    pub fn walkdir_sorted_new(root: impl AsRef<Path>, parallelism: Parallelism) -> WalkDir {
+    pub fn walkdir_sorted_new(root: &Path, parallelism: Parallelism) -> WalkDir {
         WalkDir::new(root)
             .skip_hidden(false)
             .sort(true)
@@ -84,12 +84,12 @@ pub mod walkdir {
     pub use super::shared::Parallelism;
 
     /// Instantiate a new directory iterator which will not skip hidden files, with the given level of `parallelism`.
-    pub fn walkdir_new(root: impl AsRef<Path>, _: Parallelism) -> WalkDir {
+    pub fn walkdir_new(root: &Path, _: Parallelism) -> WalkDir {
         WalkDir::new(root)
     }
 
     /// Instantiate a new directory iterator which will not skip hidden files and is sorted, with the given level of `parallelism`.
-    pub fn walkdir_sorted_new(root: impl AsRef<Path>, _: Parallelism) -> WalkDir {
+    pub fn walkdir_sorted_new(root: &Path, _: Parallelism) -> WalkDir {
         WalkDir::new(root).sort_by_file_name()
     }
 

--- a/gix-features/src/hash.rs
+++ b/gix-features/src/hash.rs
@@ -95,14 +95,14 @@ pub fn hasher(kind: gix_hash::Kind) -> Sha1 {
 /// * [Interrupts][crate::interrupt] are supported.
 #[cfg(all(feature = "progress", any(feature = "rustsha1", feature = "fast-sha1")))]
 pub fn bytes_of_file(
-    path: impl AsRef<std::path::Path>,
+    path: &std::path::Path,
     num_bytes_from_start: usize,
     kind: gix_hash::Kind,
-    progress: &mut impl crate::progress::Progress,
+    progress: &mut dyn crate::progress::Progress,
     should_interrupt: &std::sync::atomic::AtomicBool,
 ) -> std::io::Result<gix_hash::ObjectId> {
     bytes(
-        std::fs::File::open(path)?,
+        &mut std::fs::File::open(path)?,
         num_bytes_from_start,
         kind,
         progress,
@@ -113,10 +113,10 @@ pub fn bytes_of_file(
 /// Similar to [`bytes_of_file`], but operates on an already open file.
 #[cfg(all(feature = "progress", any(feature = "rustsha1", feature = "fast-sha1")))]
 pub fn bytes(
-    mut read: impl std::io::Read,
+    read: &mut dyn std::io::Read,
     num_bytes_from_start: usize,
     kind: gix_hash::Kind,
-    progress: &mut impl crate::progress::Progress,
+    progress: &mut dyn crate::progress::Progress,
     should_interrupt: &std::sync::atomic::AtomicBool,
 ) -> std::io::Result<gix_hash::ObjectId> {
     let mut hasher = hasher(kind);

--- a/gix-features/src/io.rs
+++ b/gix-features/src/io.rs
@@ -77,9 +77,9 @@ pub mod pipe {
     /// Returns the _([`write`][Writer], [`read`][Reader])_ ends of a pipe for transferring bytes, analogous to a unix pipe.
     ///
     /// * `in_flight_writes` defines the amount of chunks of bytes to keep in memory until the `write` end will block when writing.
-    ///    If `None` or `0`, the `write` end will always block until the `read` end consumes the transferred bytes.
-    pub fn unidirectional(in_flight_writes: impl Into<Option<usize>>) -> (Writer, Reader) {
-        let (tx, rx) = std::sync::mpsc::sync_channel(in_flight_writes.into().unwrap_or(0));
+    ///    If `0`, the `write` end will always block until the `read` end consumes the transferred bytes.
+    pub fn unidirectional(in_flight_writes: usize) -> (Writer, Reader) {
+        let (tx, rx) = std::sync::mpsc::sync_channel(in_flight_writes);
         (
             Writer {
                 channel: tx,

--- a/gix-features/src/progress.rs
+++ b/gix-features/src/progress.rs
@@ -6,7 +6,9 @@ pub use bytesize;
 pub use prodash::{
     self,
     messages::MessageLevel,
-    progress::{Discard, DoOrDiscard, Either, Id, Step, StepShared, Task, ThroughputOnDrop, Value, UNKNOWN},
+    progress::{
+        AtomicStep, Discard, DoOrDiscard, Either, Id, Step, StepShared, Task, ThroughputOnDrop, Value, UNKNOWN,
+    },
     unit, Count, NestedProgress, Progress, Unit,
 };
 /// A stub for the portions of the `bytesize` crate that we use internally in `gitoxide`.

--- a/gix-features/src/progress.rs
+++ b/gix-features/src/progress.rs
@@ -9,7 +9,7 @@ pub use prodash::{
     progress::{
         AtomicStep, Discard, DoOrDiscard, Either, Id, Step, StepShared, Task, ThroughputOnDrop, Value, UNKNOWN,
     },
-    unit, Count, NestedProgress, Progress, Unit,
+    unit, Count, DynNestedProgress, NestedProgress, Progress, Unit,
 };
 /// A stub for the portions of the `bytesize` crate that we use internally in `gitoxide`.
 #[cfg(not(feature = "progress-unit-bytes"))]

--- a/gix-features/src/progress.rs
+++ b/gix-features/src/progress.rs
@@ -7,7 +7,7 @@ pub use prodash::{
     self,
     messages::MessageLevel,
     progress::{Discard, DoOrDiscard, Either, Id, Step, StepShared, Task, ThroughputOnDrop, Value, UNKNOWN},
-    unit, Progress, RawProgress, Unit,
+    unit, Count, NestedProgress, Progress, Unit,
 };
 /// A stub for the portions of the `bytesize` crate that we use internally in `gitoxide`.
 #[cfg(not(feature = "progress-unit-bytes"))]
@@ -77,7 +77,7 @@ pub fn steps() -> Option<Unit> {
     Some(unit::dynamic(unit::Range::new("steps")))
 }
 
-/// A structure passing every [`read`][std::io::Read::read()] call through to the contained Progress instance using [`inc_by(bytes_read)`][Progress::inc_by()].
+/// A structure passing every [`read`](std::io::Read::read()) call through to the contained Progress instance using [`inc_by(bytes_read)`](Count::inc_by()).
 pub struct Read<T, P> {
     /// The implementor of [`std::io::Read`] to which progress is added
     pub inner: T,
@@ -111,7 +111,7 @@ where
     }
 }
 
-/// A structure passing every [`write`][std::io::Write::write()] call through to the contained Progress instance using [`inc_by(bytes_written)`][Progress::inc_by()].
+/// A structure passing every [`write`][std::io::Write::write()] call through to the contained Progress instance using [`inc_by(bytes_written)`](Count::inc_by()).
 ///
 /// This is particularly useful if the final size of the bytes to write is known or can be estimated precisely enough.
 pub struct Write<T, P> {

--- a/gix-features/tests/pipe.rs
+++ b/gix-features/tests/pipe.rs
@@ -22,7 +22,7 @@ mod io {
 
     #[test]
     fn lack_of_reader_fails_with_broken_pipe() {
-        let (mut writer, _) = io::pipe::unidirectional(None);
+        let (mut writer, _) = io::pipe::unidirectional(0);
         assert_eq!(
             writer.write_all(b"must fail").unwrap_err().kind(),
             ErrorKind::BrokenPipe
@@ -96,7 +96,7 @@ mod io {
     fn small_reads() {
         const BLOCK_SIZE: usize = 20;
         let block_count = 20;
-        let (mut writer, mut reader) = io::pipe::unidirectional(Some(4));
+        let (mut writer, mut reader) = io::pipe::unidirectional(4);
         std::thread::spawn(move || {
             for _ in 0..block_count {
                 let data = &[0; BLOCK_SIZE];

--- a/gix-filter/examples/arrow.rs
+++ b/gix-filter/examples/arrow.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 stdin(),
                 stdout(),
                 "git-filter",
-                |versions| versions.contains(&2).then_some(2),
+                &mut |versions| versions.contains(&2).then_some(2),
                 if disallow_delay {
                     &["clean", "smudge"]
                 } else {

--- a/gix-filter/src/driver/apply.rs
+++ b/gix-filter/src/driver/apply.rs
@@ -124,7 +124,7 @@ impl State {
 
                 let invoke_result = client.invoke(
                     command,
-                    [
+                    &mut [
                         ("pathname", Some(ctx.rela_path.to_owned())),
                         ("ref", ctx.ref_name.map(ToOwned::to_owned)),
                         ("treeish", ctx.treeish.map(|id| id.to_hex().to_string().into())),

--- a/gix-filter/src/driver/delayed.rs
+++ b/gix-filter/src/driver/delayed.rs
@@ -65,7 +65,7 @@ impl State {
             })?;
 
         let mut out = Vec::new();
-        let result = client.invoke_without_content("list_available_blobs", None, |line| {
+        let result = client.invoke_without_content("list_available_blobs", &mut None.into_iter(), &mut |line| {
             if let Some(path) = line.strip_prefix(b"pathname=") {
                 out.push(path.into())
             }
@@ -111,7 +111,11 @@ impl State {
                 wanted: process.clone(),
             })?;
 
-        let result = client.invoke(operation.as_str(), [("pathname", path.to_owned())], &b""[..]);
+        let result = client.invoke(
+            operation.as_str(),
+            &mut [("pathname", path.to_owned())].into_iter(),
+            &mut &b""[..],
+        );
         let status = match result {
             Ok(status) => status,
             Err(err) => {

--- a/gix-filter/src/driver/process/server.rs
+++ b/gix-filter/src/driver/process/server.rs
@@ -60,7 +60,7 @@ impl Server {
         stdin: std::io::Stdin,
         stdout: std::io::Stdout,
         welcome_prefix: &str,
-        pick_version: impl FnOnce(&[usize]) -> Option<usize>,
+        pick_version: &mut dyn FnMut(&[usize]) -> Option<usize>,
         available_capabilities: &[&str],
     ) -> Result<Self, handshake::Error> {
         let mut input =

--- a/gix-filter/src/pipeline/util.rs
+++ b/gix-filter/src/pipeline/util.rs
@@ -75,7 +75,7 @@ impl<'driver> Configuration<'driver> {
         rela_path: &BStr,
         drivers: &'driver [Driver],
         attrs: &mut gix_attributes::search::Outcome,
-        attributes: impl FnOnce(&BStr, &mut gix_attributes::search::Outcome),
+        attributes: &mut dyn FnMut(&BStr, &mut gix_attributes::search::Outcome),
         config: eol::Configuration,
     ) -> Result<Configuration<'driver>, configuration::Error> {
         fn extract_driver<'a>(drivers: &'a [Driver], attr: &gix_attributes::search::Match<'_>) -> Option<&'a Driver> {

--- a/gix-filter/tests/driver/mod.rs
+++ b/gix-filter/tests/driver/mod.rs
@@ -60,7 +60,9 @@ mod shutdown {
         let client = extract_client(state.maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?);
 
         assert!(
-            client.invoke("wait-1-s", None, &b""[..])?.is_success(),
+            client
+                .invoke("wait-1-s", &mut None.into_iter(), &mut &b""[..])?
+                .is_success(),
             "this lets the process wait for a second using our hidden command"
         );
 
@@ -170,7 +172,9 @@ pub(crate) mod apply {
         let driver = driver_with_process();
         let client = extract_client(state.maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?);
 
-        assert!(client.invoke("next-smudge-aborts", None, &b""[..])?.is_success());
+        assert!(client
+            .invoke("next-smudge-aborts", &mut None.into_iter(), &mut &b""[..])?
+            .is_success());
         assert!(
             matches!(state.apply(&driver, &mut std::io::empty(), Operation::Smudge, context_from_path("any")), Err(driver::apply::Error::ProcessStatus {status: driver::process::Status::Named(name), ..}) if name == "abort")
         );
@@ -197,8 +201,8 @@ pub(crate) mod apply {
         assert!(client
             .invoke(
                 "next-invocation-returns-strange-status-and-smudge-fails-permanently",
-                None,
-                &b""[..]
+                &mut None.into_iter(),
+                &mut &b""[..]
             )?
             .is_success());
         assert!(

--- a/gix-filter/tests/filter.rs
+++ b/gix-filter/tests/filter.rs
@@ -4,4 +4,4 @@ mod ident;
 mod pipeline;
 mod worktree;
 
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub use gix_testtools::Result;

--- a/gix-filter/tests/pipeline/convert_to_worktree.rs
+++ b/gix-filter/tests/pipeline/convert_to_worktree.rs
@@ -19,7 +19,7 @@ fn all_stages() -> gix_testtools::Result {
     let mut out = pipe.convert_to_worktree(
         b"a\nb\n$Id$",
         "any.txt".into(),
-        |path, attrs| {
+        &mut |path, attrs| {
             cache
                 .at_entry(path, Some(false), |_oid, _buf| -> Result<_, std::convert::Infallible> {
                     unreachable!("index access disabled")
@@ -54,7 +54,7 @@ fn all_stages_no_filter() -> gix_testtools::Result {
     let mut out = pipe.convert_to_worktree(
         b"$Id$a\nb\n",
         "other.txt".into(),
-        |path, attrs| {
+        &mut |path, attrs| {
             cache
                 .at_entry(path, Some(false), |_oid, _buf| -> Result<_, std::convert::Infallible> {
                     unreachable!("index access disabled")
@@ -88,7 +88,7 @@ fn no_filter() -> gix_testtools::Result {
     let out = pipe.convert_to_worktree(
         input,
         "other.txt".into(),
-        |path, attrs| {
+        &mut |path, attrs| {
             cache
                 .at_entry(path, Some(false), |_oid, _buf| -> Result<_, std::convert::Infallible> {
                     unreachable!("index access disabled")

--- a/gix-filter/tests/pipeline/mod.rs
+++ b/gix-filter/tests/pipeline/mod.rs
@@ -8,7 +8,12 @@ mod convert_to_worktree;
 #[test]
 fn default() -> crate::Result {
     let mut filters = gix_filter::Pipeline::default();
-    let out = filters.convert_to_worktree(b"hi", "file".into(), |_, _| {}, gix_filter::driver::apply::Delay::Allow)?;
+    let out = filters.convert_to_worktree(
+        b"hi",
+        "file".into(),
+        &mut |_, _| {},
+        gix_filter::driver::apply::Delay::Allow,
+    )?;
     assert_eq!(
         out.as_bytes().expect("unchanged").as_bstr(),
         "hi",

--- a/gix-fs/src/capabilities.rs
+++ b/gix-fs/src/capabilities.rs
@@ -45,14 +45,13 @@ impl Capabilities {
     /// `git_dir` is a typical git repository, expected to be populated with the typical files like `config`.
     ///
     /// All errors are ignored and interpreted on top of the default for the platform the binary is compiled for.
-    pub fn probe(git_dir: impl AsRef<Path>) -> Self {
-        let root = git_dir.as_ref();
+    pub fn probe(git_dir: &Path) -> Self {
         let ctx = Capabilities::default();
         Capabilities {
-            symlink: Self::probe_symlink(root).unwrap_or(ctx.symlink),
-            ignore_case: Self::probe_ignore_case(root).unwrap_or(ctx.ignore_case),
-            precompose_unicode: Self::probe_precompose_unicode(root).unwrap_or(ctx.precompose_unicode),
-            executable_bit: Self::probe_file_mode(root).unwrap_or(ctx.executable_bit),
+            symlink: Self::probe_symlink(git_dir).unwrap_or(ctx.symlink),
+            ignore_case: Self::probe_ignore_case(git_dir).unwrap_or(ctx.ignore_case),
+            precompose_unicode: Self::probe_precompose_unicode(git_dir).unwrap_or(ctx.precompose_unicode),
+            executable_bit: Self::probe_file_mode(git_dir).unwrap_or(ctx.executable_bit),
         }
     }
 

--- a/gix-fs/src/dir/create.rs
+++ b/gix-fs/src/dir/create.rs
@@ -116,7 +116,7 @@ impl<'a> Iter<'a> {
 }
 
 impl<'a> Iter<'a> {
-    fn pernanent_failure(
+    fn permanent_failure(
         &mut self,
         dir: &'a Path,
         err: impl Into<std::io::Error>,
@@ -151,24 +151,24 @@ impl<'a> Iterator for Iter<'a> {
                         self.state = State::CurrentlyCreatingDirectories;
                         Some(Ok(dir))
                     }
-                    AlreadyExists => self.pernanent_failure(dir, err), // is non-directory
+                    AlreadyExists => self.permanent_failure(dir, err), // is non-directory
                     NotFound => {
                         self.retries.on_create_directory_failure -= 1;
                         if let State::CurrentlyCreatingDirectories = self.state {
                             self.state = State::SearchingUpwardsForExistingDirectory;
                             self.retries.to_create_entire_directory -= 1;
                             if self.retries.to_create_entire_directory < 1 {
-                                return self.pernanent_failure(dir, NotFound);
+                                return self.permanent_failure(dir, NotFound);
                             }
                             self.retries.on_create_directory_failure =
                                 self.original_retries.on_create_directory_failure;
                         }
                         if self.retries.on_create_directory_failure < 1 {
-                            return self.pernanent_failure(dir, NotFound);
+                            return self.permanent_failure(dir, NotFound);
                         };
                         self.cursors.push(dir);
                         self.cursors.push(match dir.parent() {
-                            None => return self.pernanent_failure(dir, InvalidInput),
+                            None => return self.permanent_failure(dir, InvalidInput),
                             Some(parent) => parent,
                         });
                         self.intermediate_failure(dir, err)
@@ -176,12 +176,12 @@ impl<'a> Iterator for Iter<'a> {
                     Interrupted => {
                         self.retries.on_interrupt -= 1;
                         if self.retries.on_interrupt <= 1 {
-                            return self.pernanent_failure(dir, Interrupted);
+                            return self.permanent_failure(dir, Interrupted);
                         };
                         self.cursors.push(dir);
                         self.intermediate_failure(dir, err)
                     }
-                    _unexpected_kind => self.pernanent_failure(dir, err),
+                    _unexpected_kind => self.permanent_failure(dir, err),
                 },
             },
             None => None,

--- a/gix-fs/src/dir/remove.rs
+++ b/gix-fs/src/dir/remove.rs
@@ -78,8 +78,7 @@ pub fn empty_upward_until_boundary<'a>(delete_dir: &'a Path, boundary_dir: &'a P
 /// If any encountered directory contains a file the entire operation is aborted.
 /// Please note that this is inherently racy and no attempts are made to counter that, which will allow creators to win
 /// as long as they retry.
-pub fn empty_depth_first(delete_dir: impl Into<PathBuf>) -> std::io::Result<()> {
-    let delete_dir = delete_dir.into();
+pub fn empty_depth_first(delete_dir: PathBuf) -> std::io::Result<()> {
     if let Ok(()) = std::fs::remove_dir(&delete_dir) {
         return Ok(());
     }

--- a/gix-fs/src/stack.rs
+++ b/gix-fs/src/stack.rs
@@ -42,8 +42,7 @@ pub trait Delegate {
 impl Stack {
     /// Create a new instance with `root` being the base for all future paths we handle, assuming it to be valid which includes
     /// symbolic links to be included in it as well.
-    pub fn new(root: impl Into<PathBuf>) -> Self {
-        let root = root.into();
+    pub fn new(root: PathBuf) -> Self {
         Stack {
             current: root.clone(),
             current_relative: PathBuf::with_capacity(128),
@@ -59,12 +58,7 @@ impl Stack {
     /// The full path to `relative` will be returned along with the data returned by `push_comp`.
     /// Note that this only works correctly for the delegate's `push_directory()` and `pop_directory()` methods if
     /// `relative` paths are terminal, so point to their designated file or directory.
-    pub fn make_relative_path_current(
-        &mut self,
-        relative: impl AsRef<Path>,
-        delegate: &mut impl Delegate,
-    ) -> std::io::Result<()> {
-        let relative = relative.as_ref();
+    pub fn make_relative_path_current(&mut self, relative: &Path, delegate: &mut dyn Delegate) -> std::io::Result<()> {
         debug_assert!(
             relative.is_relative(),
             "only index paths are handled correctly here, must be relative"

--- a/gix-fs/tests/dir/remove.rs
+++ b/gix-fs/tests/dir/remove.rs
@@ -115,7 +115,7 @@ mod empty_depth_first {
         create_dir_all(tree_parent.join("one").join("two").join("three")).unwrap();
         create_dir_all(tree_parent.join("c")).unwrap();
         for empty in &[nested_parent, single_parent, tree_parent] {
-            gix_fs::dir::remove::empty_depth_first(empty).unwrap();
+            gix_fs::dir::remove::empty_depth_first(empty.into()).unwrap();
         }
     }
 }

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -29,13 +29,13 @@ impl gix_fs::stack::Delegate for Record {
 #[test]
 fn delegate_calls_are_consistent() -> crate::Result {
     let root = PathBuf::from(".");
-    let mut s = Stack::new(&root);
+    let mut s = Stack::new(root.clone());
 
     assert_eq!(s.current(), root);
     assert_eq!(s.current_relative(), Path::new(""));
 
     let mut r = Record::default();
-    s.make_relative_path_current("a/b", &mut r)?;
+    s.make_relative_path_current("a/b".as_ref(), &mut r)?;
     let mut dirs = vec![root.clone(), root.join("a")];
     assert_eq!(
         r,
@@ -46,7 +46,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
         }
     );
 
-    s.make_relative_path_current("a/b2", &mut r)?;
+    s.make_relative_path_current("a/b2".as_ref(), &mut r)?;
     assert_eq!(
         r,
         Record {
@@ -56,7 +56,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
         }
     );
 
-    s.make_relative_path_current("c/d/e", &mut r)?;
+    s.make_relative_path_current("c/d/e".as_ref(), &mut r)?;
     dirs.pop();
     dirs.extend([root.join("c"), root.join("c").join("d")]);
     assert_eq!(
@@ -69,7 +69,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
     );
 
     dirs.push(root.join("c").join("d").join("x"));
-    s.make_relative_path_current("c/d/x/z", &mut r)?;
+    s.make_relative_path_current("c/d/x/z".as_ref(), &mut r)?;
     assert_eq!(
         r,
         Record {
@@ -80,7 +80,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
     );
 
     dirs.drain(dirs.len() - 3..).count();
-    s.make_relative_path_current("f", &mut r)?;
+    s.make_relative_path_current("f".as_ref(), &mut r)?;
     assert_eq!(s.current_relative(), Path::new("f"));
     assert_eq!(
         r,
@@ -92,7 +92,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
     );
 
     dirs.push(root.join("x"));
-    s.make_relative_path_current("x/z", &mut r)?;
+    s.make_relative_path_current("x/z".as_ref(), &mut r)?;
     assert_eq!(
         r,
         Record {
@@ -103,7 +103,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
     );
 
     dirs.push(root.join("x").join("z"));
-    s.make_relative_path_current("x/z/a", &mut r)?;
+    s.make_relative_path_current("x/z/a".as_ref(), &mut r)?;
     assert_eq!(
         r,
         Record {
@@ -115,7 +115,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
 
     dirs.push(root.join("x").join("z").join("a"));
     dirs.push(root.join("x").join("z").join("a").join("b"));
-    s.make_relative_path_current("x/z/a/b/c", &mut r)?;
+    s.make_relative_path_current("x/z/a/b/c".as_ref(), &mut r)?;
     assert_eq!(
         r,
         Record {
@@ -126,7 +126,7 @@ fn delegate_calls_are_consistent() -> crate::Result {
     );
 
     dirs.drain(dirs.len() - 2..).count();
-    s.make_relative_path_current("x/z", &mut r)?;
+    s.make_relative_path_current("x/z".as_ref(), &mut r)?;
     assert_eq!(
         r,
         Record {

--- a/gix-glob/src/pattern.rs
+++ b/gix-glob/src/pattern.rs
@@ -78,9 +78,9 @@ impl Pattern {
     ///
     /// `case` folding can be configured as well.
     /// `mode` is used to control how [`crate::wildmatch()`] should operate.
-    pub fn matches_repo_relative_path<'a>(
+    pub fn matches_repo_relative_path(
         &self,
-        path: impl Into<&'a BStr>,
+        path: &BStr,
         basename_start_pos: Option<usize>,
         is_dir: Option<bool>,
         case: Case,
@@ -96,7 +96,6 @@ impl Pattern {
                 Case::Fold => wildmatch::Mode::IGNORE_CASE,
                 Case::Sensitive => wildmatch::Mode::empty(),
             };
-        let path = path.into();
         #[cfg(debug_assertions)]
         {
             if basename_start_pos.is_some() {
@@ -124,8 +123,7 @@ impl Pattern {
     ///
     /// Note that this method uses some shortcuts to accelerate simple patterns, but falls back to
     /// [wildmatch()][crate::wildmatch()] if these fail.
-    pub fn matches<'a>(&self, value: impl Into<&'a BStr>, mode: wildmatch::Mode) -> bool {
-        let value = value.into();
+    pub fn matches(&self, value: &BStr, mode: wildmatch::Mode) -> bool {
         match self.first_wildcard_pos {
             // "*literal" case, overrides starts-with
             Some(pos)

--- a/gix-glob/src/search/mod.rs
+++ b/gix-glob/src/search/mod.rs
@@ -23,17 +23,12 @@ pub trait Pattern: Clone + PartialEq + Eq + std::fmt::Debug + std::hash::Hash + 
 /// Returns `true` if the file was added, or `false` if it didn't exist.
 pub fn add_patterns_file<T: Pattern>(
     patterns: &mut Vec<pattern::List<T>>,
-    source: impl Into<PathBuf>,
+    source: PathBuf,
     follow_symlinks: bool,
     root: Option<&Path>,
     buf: &mut Vec<u8>,
 ) -> std::io::Result<bool> {
     let previous_len = patterns.len();
-    patterns.extend(pattern::List::<T>::from_file(
-        source.into(),
-        root,
-        follow_symlinks,
-        buf,
-    )?);
+    patterns.extend(pattern::List::<T>::from_file(source, root, follow_symlinks, buf)?);
     Ok(patterns.len() != previous_len)
 }

--- a/gix-glob/src/search/pattern.rs
+++ b/gix-glob/src/search/pattern.rs
@@ -66,12 +66,10 @@ where
     /// `source_file` is the location of the `bytes` which represents a list of patterns, one pattern per line.
     /// If `root` is `Some(…)` it's used to see `source_file` as relative to itself, if `source_file` is absolute.
     /// If source is relative and should be treated as base, set `root` to `Some("")`.
-    pub fn from_bytes(bytes: &[u8], source_file: impl Into<PathBuf>, root: Option<&Path>) -> Self {
-        let source = source_file.into();
-        let patterns = T::bytes_to_patterns(bytes, source.as_path());
-
+    pub fn from_bytes(bytes: &[u8], source_file: PathBuf, root: Option<&Path>) -> Self {
+        let patterns = T::bytes_to_patterns(bytes, source_file.as_path());
         let base = root
-            .and_then(|root| source.parent().expect("file").strip_prefix(root).ok())
+            .and_then(|root| source_file.parent().expect("file").strip_prefix(root).ok())
             .and_then(|base| {
                 (!base.as_os_str().is_empty()).then(|| {
                     let mut base: BString =
@@ -83,7 +81,7 @@ where
             });
         List {
             patterns,
-            source: Some(source),
+            source: Some(source_file),
             base,
         }
     }

--- a/gix-glob/tests/pattern/matching.rs
+++ b/gix-glob/tests/pattern/matching.rs
@@ -112,7 +112,7 @@ fn non_dirs_for_must_be_dir_patterns_are_ignored() {
     let path = "hello";
     assert!(
         !pattern.matches_repo_relative_path(
-            path,
+            path.into(),
             None,
             false.into(), /* is-dir */
             Case::Sensitive,
@@ -122,7 +122,7 @@ fn non_dirs_for_must_be_dir_patterns_are_ignored() {
     );
     assert!(
         pattern.matches_repo_relative_path(
-            path,
+            path.into(),
             None,
             true.into(), /* is-dir */
             Case::Sensitive,

--- a/gix-glob/tests/search/pattern.rs
+++ b/gix-glob/tests/search/pattern.rs
@@ -23,7 +23,7 @@ mod list {
     #[test]
     fn from_bytes_base() {
         {
-            let list = List::<Dummy>::from_bytes(&[], "a/b/source", None);
+            let list = List::<Dummy>::from_bytes(&[], "a/b/source".into(), None);
             assert_eq!(list.base, None, "no root always means no-base, i.e. globals lists");
             assert_eq!(
                 list.source.as_deref(),
@@ -48,7 +48,7 @@ mod list {
         }
 
         {
-            let list = List::<Dummy>::from_bytes(&[], "a/b/source", Some(Path::new("c/")));
+            let list = List::<Dummy>::from_bytes(&[], "a/b/source".into(), Some(Path::new("c/")));
             assert_eq!(
                 list.base, None,
                 "if root doesn't contain source, it silently skips it as base"
@@ -63,7 +63,7 @@ mod list {
 
     #[test]
     fn strip_base_handle_recompute_basename_pos() {
-        let list = List::<Dummy>::from_bytes(&[], "a/b/source", Some(Path::new("")));
+        let list = List::<Dummy>::from_bytes(&[], "a/b/source".into(), Some(Path::new("")));
         assert_eq!(
             list.base.as_ref().expect("set"),
             "a/b/",

--- a/gix-glob/tests/wildmatch/mod.rs
+++ b/gix-glob/tests/wildmatch/mod.rs
@@ -368,7 +368,7 @@ impl Display for MatchResult {
 
 fn match_file_path(pattern: &gix_glob::Pattern, path: &str, case: Case) -> bool {
     pattern.matches_repo_relative_path(
-        path,
+        path.into(),
         basename_of(path),
         false.into(), /* is_dir */
         case,

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -154,7 +154,7 @@ impl oid {
 
     /// Write ourselves to `out` in hexadecimal notation.
     #[inline]
-    pub fn write_hex_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_hex_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
         let mut hex = crate::Kind::hex_buf();
         let hex_len = self.hex_to_buf(&mut hex);
         out.write_all(&hex[..hex_len])

--- a/gix-hash/src/prefix.rs
+++ b/gix-hash/src/prefix.rs
@@ -41,8 +41,7 @@ impl Prefix {
     ///
     /// For instance, with `hex_len` of 7 the resulting prefix is 3.5 bytes, or 3 bytes and 4 bits
     /// wide, with all other bytes and bits set to zero.
-    pub fn new(id: impl AsRef<oid>, hex_len: usize) -> Result<Self, Error> {
-        let id = id.as_ref();
+    pub fn new(id: &oid, hex_len: usize) -> Result<Self, Error> {
         if hex_len > id.kind().len_in_hex() {
             Err(Error::TooLong {
                 object_kind: id.kind(),

--- a/gix-hash/tests/prefix/mod.rs
+++ b/gix-hash/tests/prefix/mod.rs
@@ -5,7 +5,7 @@ mod cmp_oid {
 
     #[test]
     fn it_detects_inequality() {
-        let prefix = gix_hash::Prefix::new(hex_to_id("b920bbb055e1efb9080592a409d3975738b6efb3"), 7).unwrap();
+        let prefix = gix_hash::Prefix::new(&hex_to_id("b920bbb055e1efb9080592a409d3975738b6efb3"), 7).unwrap();
         assert_eq!(
             prefix.cmp_oid(&hex_to_id("a920bbb055e1efb9080592a409d3975738b6efb3")),
             Ordering::Greater
@@ -20,7 +20,7 @@ mod cmp_oid {
     #[test]
     fn it_detects_equality() {
         let id = hex_to_id("a920bbb055e1efb9080592a409d3975738b6efb3");
-        let prefix = gix_hash::Prefix::new(id, 6).unwrap();
+        let prefix = gix_hash::Prefix::new(&id, 6).unwrap();
         assert_eq!(prefix.cmp_oid(&id), Ordering::Equal);
         assert_eq!(
             prefix.cmp_oid(&hex_to_id("a920bbffffffffffffffffffffffffffffffffff")),
@@ -46,7 +46,7 @@ mod new {
             let mut expected = String::from(&oid_hex[..hex_len]);
             let num_of_zeros = oid.kind().len_in_hex() - hex_len;
             expected.extend(std::iter::repeat('0').take(num_of_zeros));
-            let prefix = gix_hash::Prefix::new(oid, hex_len).unwrap();
+            let prefix = gix_hash::Prefix::new(&oid, hex_len).unwrap();
             assert_eq!(prefix.as_oid().to_hex().to_string(), expected, "{hex_len}");
             assert_eq!(prefix.hex_len(), hex_len);
             assert_eq!(prefix.cmp_oid(&oid), Ordering::Equal);
@@ -57,7 +57,7 @@ mod new {
     fn errors_if_hex_len_is_longer_than_oid_len_in_hex() {
         let kind = Kind::Sha1;
         assert!(matches!(
-            gix_hash::Prefix::new(ObjectId::null(kind), kind.len_in_hex() + 1),
+            gix_hash::Prefix::new(&ObjectId::null(kind), kind.len_in_hex() + 1),
             Err(gix_hash::prefix::Error::TooLong { .. })
         ));
     }
@@ -66,7 +66,7 @@ mod new {
     fn errors_if_hex_len_is_too_short() {
         let kind = Kind::Sha1;
         assert!(matches!(
-            gix_hash::Prefix::new(ObjectId::null(kind), 3),
+            gix_hash::Prefix::new(&ObjectId::null(kind), 3),
             Err(gix_hash::prefix::Error::TooShort { .. })
         ));
     }

--- a/gix-ignore/tests/search/mod.rs
+++ b/gix-ignore/tests/search/mod.rs
@@ -31,7 +31,7 @@ impl<'a> Iterator for Expectations<'a> {
 
 #[test]
 fn baseline_from_git_dir() -> crate::Result {
-    let case = if gix_fs::Capabilities::probe("../.git").ignore_case {
+    let case = if gix_fs::Capabilities::probe("../.git".as_ref()).ignore_case {
         Case::Fold
     } else {
         Case::Sensitive
@@ -41,10 +41,10 @@ fn baseline_from_git_dir() -> crate::Result {
     let git_dir = repo_dir.join(".git");
     let baseline = std::fs::read(git_dir.parent().unwrap().join("git-check-ignore.baseline"))?;
     let mut buf = Vec::new();
-    let mut group = gix_ignore::Search::from_git_dir(git_dir, Some(dir.join("user.exclude")), &mut buf)?;
+    let mut group = gix_ignore::Search::from_git_dir(&git_dir, Some(dir.join("user.exclude")), &mut buf)?;
 
     assert!(
-        !gix_glob::search::add_patterns_file(&mut group.patterns, "not-a-file", false, None, &mut buf)?,
+        !gix_glob::search::add_patterns_file(&mut group.patterns, "not-a-file".into(), false, None, &mut buf)?,
         "missing files are no problem and cause a negative response"
     );
     assert!(
@@ -102,13 +102,13 @@ fn baseline_from_git_dir() -> crate::Result {
 #[test]
 fn from_overrides() {
     let input = ["simple", "pattern/"];
-    let group = gix_ignore::Search::from_overrides(input);
+    let group = gix_ignore::Search::from_overrides(input.iter());
     assert_eq!(
-        group.pattern_matching_relative_path("Simple", None, gix_glob::pattern::Case::Fold),
+        group.pattern_matching_relative_path("Simple".into(), None, gix_glob::pattern::Case::Fold),
         Some(pattern_to_match(&gix_glob::parse("simple").unwrap(), 0))
     );
     assert_eq!(
-        group.pattern_matching_relative_path("pattern", Some(true), gix_glob::pattern::Case::Sensitive),
+        group.pattern_matching_relative_path("pattern".into(), Some(true), gix_glob::pattern::Case::Sensitive),
         Some(pattern_to_match(&gix_glob::parse("pattern/").unwrap(), 1))
     );
     assert_eq!(group.patterns.len(), 1);

--- a/gix-index/src/file/init.rs
+++ b/gix-index/src/file/init.rs
@@ -61,7 +61,7 @@ impl File {
         let _span = gix_features::trace::detail!("gix_index::File::at()");
         let path = path.into();
         let (data, mtime) = {
-            let file = std::fs::File::open(&path)?;
+            let mut file = std::fs::File::open(&path)?;
             // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
             #[allow(unsafe_code)]
             let data = unsafe { Mmap::map(&file)? };
@@ -77,7 +77,7 @@ impl File {
                     let meta = file.metadata()?;
                     let num_bytes_to_hash = meta.len() - object_hash.len_in_bytes() as u64;
                     let actual_hash = gix_features::hash::bytes(
-                        &file,
+                        &mut file,
                         num_bytes_to_hash as usize,
                         object_hash,
                         &mut gix_features::progress::Discard,

--- a/gix-lock/src/acquire.rs
+++ b/gix-lock/src/acquire.rs
@@ -54,7 +54,7 @@ impl File {
         mode: Fail,
         boundary_directory: Option<PathBuf>,
     ) -> Result<File, Error> {
-        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, |p, d, c| {
+        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, &|p, d, c| {
             gix_tempfile::writable_at(p, d, c)
         })?;
         Ok(File {
@@ -75,7 +75,7 @@ impl Marker {
         mode: Fail,
         boundary_directory: Option<PathBuf>,
     ) -> Result<Marker, Error> {
-        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, |p, d, c| {
+        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, &|p, d, c| {
             gix_tempfile::mark_at(p, d, c)
         })?;
         Ok(Marker {
@@ -100,7 +100,7 @@ fn lock_with_mode<T>(
     resource: &Path,
     mode: Fail,
     boundary_directory: Option<PathBuf>,
-    try_lock: impl Fn(&Path, ContainingDirectory, AutoRemove) -> std::io::Result<T>,
+    try_lock: &dyn Fn(&Path, ContainingDirectory, AutoRemove) -> std::io::Result<T>,
 ) -> Result<(PathBuf, T), Error> {
     use std::io::ErrorKind::*;
     let (directory, cleanup) = dir_cleanup(boundary_directory);

--- a/gix-negotiate/src/lib.rs
+++ b/gix-negotiate/src/lib.rs
@@ -88,8 +88,8 @@ impl std::fmt::Display for Algorithm {
 
 /// Calculate how many `HAVE` lines we may send in one round, with variation depending on whether the `transport_is_stateless` or not.
 /// `window_size` is the previous (or initial) value of the window size.
-pub fn window_size(transport_is_stateless: bool, window_size: impl Into<Option<usize>>) -> usize {
-    let current_size = match window_size.into() {
+pub fn window_size(transport_is_stateless: bool, window_size: Option<usize>) -> usize {
+    let current_size = match window_size {
         None => return 16,
         Some(cs) => cs,
     };

--- a/gix-negotiate/tests/baseline/mod.rs
+++ b/gix-negotiate/tests/baseline/mod.rs
@@ -35,8 +35,8 @@ fn run() -> crate::Result {
                     .iter()
                     .filter_map(|name| {
                         refs.try_find(*name).expect("one tag per commit").map(|mut r| {
-                            r.peel_to_id_in_place(&refs, |id, buf| {
-                                store.try_find(id, buf).map(|d| d.map(|d| (d.kind, d.data)))
+                            r.peel_to_id_in_place(&refs, &mut |id, buf| {
+                                store.try_find(&id, buf).map(|d| d.map(|d| (d.kind, d.data)))
                             })
                             .expect("works");
                             r.target.into_id()
@@ -44,9 +44,9 @@ fn run() -> crate::Result {
                     })
                     .collect()
             };
-            let message = |id| {
+            let message = |id: gix_hash::ObjectId| {
                 store
-                    .find_commit(id, obj_buf.borrow_mut().as_mut())
+                    .find_commit(&id, obj_buf.borrow_mut().as_mut())
                     .expect("present")
                     .message
                     .trim()
@@ -80,7 +80,7 @@ fn run() -> crate::Result {
                 // }
                 for tip in lookup_names(&["HEAD"]).into_iter().chain(
                     refs.iter()?
-                        .prefixed("refs/heads")?
+                        .prefixed("refs/heads".as_ref())?
                         .filter_map(Result::ok)
                         .map(|r| r.target.into_id()),
                 ) {

--- a/gix-negotiate/tests/negotiate.rs
+++ b/gix-negotiate/tests/negotiate.rs
@@ -13,7 +13,7 @@ mod window_size {
     fn transport_is_stateless() {
         let mut ws = window_size(true, None);
         for expected in [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 18022, 19824] {
-            ws = window_size(true, ws);
+            ws = window_size(true, Some(ws));
             assert_eq!(ws, expected);
         }
     }
@@ -22,13 +22,13 @@ mod window_size {
     fn transport_is_not_stateless() {
         let mut ws = window_size(false, None);
         for expected in [32, 64, 96] {
-            ws = window_size(false, ws);
+            ws = window_size(false, Some(ws));
             assert_eq!(ws, expected);
         }
 
         let mut ws = 4;
         for expected in [8, 16, 32, 64, 96] {
-            ws = window_size(false, ws);
+            ws = window_size(false, Some(ws));
             assert_eq!(ws, expected);
         }
     }

--- a/gix-object/src/blob.rs
+++ b/gix-object/src/blob.rs
@@ -4,31 +4,31 @@ use crate::{Blob, BlobRef, Kind};
 
 impl<'a> crate::WriteTo for BlobRef<'a> {
     /// Write the blobs data to `out` verbatim.
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
         out.write_all(self.data)
+    }
+
+    fn kind(&self) -> Kind {
+        Kind::Blob
     }
 
     fn size(&self) -> usize {
         self.data.len()
     }
-
-    fn kind(&self) -> Kind {
-        Kind::Blob
-    }
 }
 
 impl crate::WriteTo for Blob {
     /// Write the blobs data to `out` verbatim.
-    fn write_to(&self, out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
         self.to_ref().write_to(out)
-    }
-
-    fn size(&self) -> usize {
-        self.to_ref().size()
     }
 
     fn kind(&self) -> Kind {
         Kind::Blob
+    }
+
+    fn size(&self) -> usize {
+        self.to_ref().size()
     }
 }
 

--- a/gix-object/src/commit/write.rs
+++ b/gix-object/src/commit/write.rs
@@ -6,7 +6,7 @@ use crate::{encode, encode::NL, Commit, CommitRef, Kind};
 
 impl crate::WriteTo for Commit {
     /// Serializes this instance to `out` in the git serialization format.
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, mut out: &mut dyn io::Write) -> io::Result<()> {
         encode::trusted_header_id(b"tree", &self.tree, &mut out)?;
         for parent in &self.parents {
             encode::trusted_header_id(b"parent", parent, &mut out)?;
@@ -52,7 +52,7 @@ impl crate::WriteTo for Commit {
 
 impl<'a> crate::WriteTo for CommitRef<'a> {
     /// Serializes this instance to `out` in the git serialization format.
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, mut out: &mut dyn io::Write) -> io::Result<()> {
         encode::trusted_header_id(b"tree", &self.tree(), &mut out)?;
         for parent in self.parents() {
             encode::trusted_header_id(b"parent", &parent, &mut out)?;

--- a/gix-object/src/data.rs
+++ b/gix-object/src/data.rs
@@ -67,8 +67,7 @@ pub mod verify {
         /// Compute the checksum of `self` and compare it with the `desired` hash.
         /// If the hashes do not match, an [`Error`] is returned, containing the actual
         /// hash of `self`.
-        pub fn verify_checksum(&self, desired: impl AsRef<gix_hash::oid>) -> Result<(), Error> {
-            let desired = desired.as_ref();
+        pub fn verify_checksum(&self, desired: &gix_hash::oid) -> Result<(), Error> {
             let actual_id = crate::compute_hash(desired.kind(), self.kind, self.data);
             if desired != actual_id {
                 return Err(Error::ChecksumMismatch {

--- a/gix-object/src/encode.rs
+++ b/gix-object/src/encode.rs
@@ -34,9 +34,9 @@ impl From<Error> for io::Error {
     }
 }
 
-pub(crate) fn header_field_multi_line(name: &[u8], value: &[u8], mut out: impl io::Write) -> io::Result<()> {
+pub(crate) fn header_field_multi_line(name: &[u8], value: &[u8], out: &mut dyn io::Write) -> io::Result<()> {
     let mut lines = value.as_bstr().split_str(b"\n");
-    trusted_header_field(name, lines.next().ok_or(Error::EmptyValue)?, &mut out)?;
+    trusted_header_field(name, lines.next().ok_or(Error::EmptyValue)?, out)?;
     for line in lines {
         out.write_all(SPACE)?;
         out.write_all(line)?;
@@ -45,7 +45,7 @@ pub(crate) fn header_field_multi_line(name: &[u8], value: &[u8], mut out: impl i
     Ok(())
 }
 
-pub(crate) fn trusted_header_field(name: &[u8], value: &[u8], mut out: impl io::Write) -> io::Result<()> {
+pub(crate) fn trusted_header_field(name: &[u8], value: &[u8], out: &mut dyn io::Write) -> io::Result<()> {
     out.write_all(name)?;
     out.write_all(SPACE)?;
     out.write_all(value)?;
@@ -55,22 +55,26 @@ pub(crate) fn trusted_header_field(name: &[u8], value: &[u8], mut out: impl io::
 pub(crate) fn trusted_header_signature(
     name: &[u8],
     value: &gix_actor::SignatureRef<'_>,
-    mut out: impl io::Write,
+    out: &mut dyn io::Write,
 ) -> io::Result<()> {
     out.write_all(name)?;
     out.write_all(SPACE)?;
-    value.write_to(&mut out)?;
+    value.write_to(out)?;
     out.write_all(NL)
 }
 
-pub(crate) fn trusted_header_id(name: &[u8], value: &gix_hash::ObjectId, mut out: impl io::Write) -> io::Result<()> {
+pub(crate) fn trusted_header_id(
+    name: &[u8],
+    value: &gix_hash::ObjectId,
+    mut out: &mut dyn io::Write,
+) -> io::Result<()> {
     out.write_all(name)?;
     out.write_all(SPACE)?;
     value.write_hex_to(&mut out)?;
     out.write_all(NL)
 }
 
-pub(crate) fn header_field(name: &[u8], value: &[u8], out: impl io::Write) -> io::Result<()> {
+pub(crate) fn header_field(name: &[u8], value: &[u8], out: &mut dyn io::Write) -> io::Result<()> {
     if value.is_empty() {
         return Err(Error::EmptyValue.into());
     }

--- a/gix-object/src/object/mod.rs
+++ b/gix-object/src/object/mod.rs
@@ -10,7 +10,7 @@ mod write {
     /// Serialization
     impl<'a> WriteTo for ObjectRef<'a> {
         /// Write the contained object to `out` in the git serialization format.
-        fn write_to(&self, out: impl io::Write) -> io::Result<()> {
+        fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
             use crate::ObjectRef::*;
             match self {
                 Tree(v) => v.write_to(out),
@@ -18,6 +18,10 @@ mod write {
                 Commit(v) => v.write_to(out),
                 Tag(v) => v.write_to(out),
             }
+        }
+
+        fn kind(&self) -> Kind {
+            self.kind()
         }
 
         fn size(&self) -> usize {
@@ -28,17 +32,13 @@ mod write {
                 Commit(v) => v.size(),
                 Tag(v) => v.size(),
             }
-        }
-
-        fn kind(&self) -> Kind {
-            self.kind()
         }
     }
 
     /// Serialization
     impl WriteTo for Object {
         /// Write the contained object to `out` in the git serialization format.
-        fn write_to(&self, out: impl io::Write) -> io::Result<()> {
+        fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
             use crate::Object::*;
             match self {
                 Tree(v) => v.write_to(out),
@@ -46,6 +46,10 @@ mod write {
                 Commit(v) => v.write_to(out),
                 Tag(v) => v.write_to(out),
             }
+        }
+
+        fn kind(&self) -> Kind {
+            self.kind()
         }
 
         fn size(&self) -> usize {
@@ -56,10 +60,6 @@ mod write {
                 Commit(v) => v.size(),
                 Tag(v) => v.size(),
             }
-        }
-
-        fn kind(&self) -> Kind {
-            self.kind()
         }
     }
 }

--- a/gix-object/src/tag/write.rs
+++ b/gix-object/src/tag/write.rs
@@ -21,12 +21,12 @@ impl From<Error> for io::Error {
 }
 
 impl crate::WriteTo for Tag {
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
-        encode::trusted_header_id(b"object", &self.target, &mut out)?;
-        encode::trusted_header_field(b"type", self.target_kind.as_bytes(), &mut out)?;
-        encode::header_field(b"tag", validated_name(self.name.as_ref())?, &mut out)?;
+    fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
+        encode::trusted_header_id(b"object", &self.target, out)?;
+        encode::trusted_header_field(b"type", self.target_kind.as_bytes(), out)?;
+        encode::header_field(b"tag", validated_name(self.name.as_ref())?, out)?;
         if let Some(tagger) = &self.tagger {
-            encode::trusted_header_signature(b"tagger", &tagger.to_ref(), &mut out)?;
+            encode::trusted_header_signature(b"tagger", &tagger.to_ref(), out)?;
         }
 
         out.write_all(NL)?;
@@ -58,7 +58,7 @@ impl crate::WriteTo for Tag {
 }
 
 impl<'a> crate::WriteTo for TagRef<'a> {
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, mut out: &mut dyn io::Write) -> io::Result<()> {
         encode::trusted_header_field(b"object", self.target, &mut out)?;
         encode::trusted_header_field(b"type", self.target_kind.as_bytes(), &mut out)?;
         encode::header_field(b"tag", validated_name(self.name)?, &mut out)?;

--- a/gix-object/src/traits.rs
+++ b/gix-object/src/traits.rs
@@ -5,7 +5,7 @@ use crate::Kind;
 /// Writing of objects to a `Write` implementation
 pub trait WriteTo {
     /// Write a representation of this instance to `out`.
-    fn write_to(&self, out: impl std::io::Write) -> std::io::Result<()>;
+    fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()>;
 
     /// Returns the type of this object.
     fn kind(&self) -> Kind;
@@ -29,15 +29,15 @@ impl<T> WriteTo for &T
 where
     T: WriteTo,
 {
-    fn write_to(&self, out: impl Write) -> std::io::Result<()> {
+    fn write_to(&self, out: &mut dyn Write) -> std::io::Result<()> {
         <T as WriteTo>::write_to(self, out)
-    }
-
-    fn size(&self) -> usize {
-        <T as WriteTo>::size(self)
     }
 
     fn kind(&self) -> Kind {
         <T as WriteTo>::kind(self)
+    }
+
+    fn size(&self) -> usize {
+        <T as WriteTo>::size(self)
     }
 }

--- a/gix-object/src/tree/write.rs
+++ b/gix-object/src/tree/write.rs
@@ -25,7 +25,7 @@ impl From<Error> for io::Error {
 /// Serialization
 impl crate::WriteTo for Tree {
     /// Serialize this tree to `out` in the git internal format.
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
         debug_assert_eq!(
             &{
                 let mut entries_sorted = self.entries.clone();
@@ -68,7 +68,7 @@ impl crate::WriteTo for Tree {
 /// Serialization
 impl<'a> crate::WriteTo for TreeRef<'a> {
     /// Serialize this tree to `out` in the git internal format.
-    fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+    fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
         debug_assert_eq!(
             &{
                 let mut entries_sorted = self.entries.clone();

--- a/gix-object/tests/object.rs
+++ b/gix-object/tests/object.rs
@@ -21,7 +21,7 @@ fn compute_hash() {
     );
 }
 
-type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+use gix_testtools::Result;
 
 #[cfg(not(windows))]
 fn fixup(v: Vec<u8>) -> Vec<u8> {

--- a/gix-odb/src/find.rs
+++ b/gix-odb/src/find.rs
@@ -1,3 +1,5 @@
+/// The error type returned by the [`Find`](crate::Find) and [`Header`](crate::Header) traits.
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
 pub mod existing {
     use gix_hash::ObjectId;
@@ -5,9 +7,9 @@ pub mod existing {
     /// The error returned by the [`find(…)`][crate::FindExt::find()] trait methods.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<T: std::error::Error + 'static> {
+    pub enum Error {
         #[error(transparent)]
-        Find(T),
+        Find(crate::find::Error),
         #[error("An object with id {} could not be found", .oid)]
         NotFound { oid: ObjectId },
     }
@@ -20,9 +22,9 @@ pub mod existing_object {
     /// The error returned by the various [`find_*()`][crate::FindExt::find_commit()] trait methods.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<T: std::error::Error + 'static> {
+    pub enum Error {
         #[error(transparent)]
-        Find(T),
+        Find(crate::find::Error),
         #[error(transparent)]
         Decode(gix_object::decode::Error),
         #[error("An object with id {oid} could not be found")]
@@ -39,9 +41,9 @@ pub mod existing_iter {
     /// The error returned by the various [`find_*_iter()`][crate::FindExt::find_commit_iter()] trait methods.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<T: std::error::Error + 'static> {
+    pub enum Error {
         #[error(transparent)]
-        Find(T),
+        Find(crate::find::Error),
         #[error("An object with id {oid} could not be found")]
         NotFound { oid: ObjectId },
         #[error("Expected object of kind {expected}")]

--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -76,6 +76,12 @@ mod traits;
 
 pub use traits::{Find, FindExt, Header, HeaderExt, Write};
 
+///
+pub mod write {
+    /// The error type returned by the [`Write`](crate::Write) trait.
+    pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+}
+
 /// A thread-local handle to access any object.
 pub type Handle = Cache<store::Handle<OwnShared<Store>>>;
 /// A thread-local handle to access any object, but thread-safe and independent of the actual type of `OwnShared` or feature toggles in `gix-features`.
@@ -142,7 +148,12 @@ pub fn at_opts(
     replacements: impl IntoIterator<Item = (gix_hash::ObjectId, gix_hash::ObjectId)>,
     options: store::init::Options,
 ) -> std::io::Result<Handle> {
-    let handle = OwnShared::new(Store::at_opts(objects_dir, replacements, options)?).to_handle();
+    let handle = OwnShared::new(Store::at_opts(
+        objects_dir.into(),
+        &mut replacements.into_iter(),
+        options,
+    )?)
+    .to_handle();
     Ok(Cache::from(handle))
 }
 

--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -346,8 +346,8 @@ impl TryFrom<&super::Store> for super::Store {
 
     fn try_from(s: &super::Store) -> Result<Self, Self::Error> {
         super::Store::at_opts(
-            s.path(),
-            s.replacements(),
+            s.path().into(),
+            &mut s.replacements(),
             crate::store::init::Options {
                 slots: crate::store::init::Slots::Given(s.files.len().try_into().expect("BUG: too many slots")),
                 object_hash: Default::default(),

--- a/gix-odb/src/store_impls/dynamic/header.rs
+++ b/gix-odb/src/store_impls/dynamic/header.rs
@@ -73,7 +73,7 @@ where
                             },
                         };
                         let entry = pack.entry(pack_offset);
-                        let res = match pack.decode_header(entry, inflate, |id| {
+                        let res = match pack.decode_header(entry, inflate, &|id| {
                             index_file.pack_offset_by_id(id).map(|pack_offset| {
                                 gix_pack::data::decode::header::ResolvedBase::InPack(pack.entry(pack_offset))
                             })
@@ -130,7 +130,7 @@ where
                                     .as_ref()
                                     .expect("pack to still be available like just now");
                                 let entry = pack.entry(pack_offset);
-                                pack.decode_header(entry, inflate, |id| {
+                                pack.decode_header(entry, inflate, &|id| {
                                     index_file
                                         .pack_offset_by_id(id)
                                         .map(|pack_offset| {
@@ -182,12 +182,10 @@ impl<S> crate::Header for super::Handle<S>
 where
     S: Deref<Target = super::Store> + Clone,
 {
-    type Error = Error;
-
-    fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
-        let id = id.as_ref();
+    fn try_header(&self, id: &oid) -> Result<Option<Header>, crate::find::Error> {
         let mut snapshot = self.snapshot.borrow_mut();
         let mut inflate = self.inflate.borrow_mut();
         self.try_header_inner(id, &mut inflate, &mut snapshot, None)
+            .map_err(|err| Box::new(err) as _)
     }
 }

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -206,7 +206,7 @@ impl super::Store {
         self.num_disk_state_consolidation.fetch_add(1, Ordering::Relaxed);
 
         let db_paths: Vec<_> = std::iter::once(objects_directory.to_owned())
-            .chain(crate::alternate::resolve(objects_directory, &self.current_dir)?)
+            .chain(crate::alternate::resolve(objects_directory.clone(), &self.current_dir)?)
             .collect();
 
         // turn db paths into loose object databases. Reuse what's there, but only if it is in the right order.

--- a/gix-odb/src/store_impls/dynamic/prefix.rs
+++ b/gix-odb/src/store_impls/dynamic/prefix.rs
@@ -40,13 +40,13 @@ pub mod disambiguate {
         /// matching this prefix.
         pub fn new(id: impl Into<gix_hash::ObjectId>, hex_len: usize) -> Result<Self, gix_hash::prefix::Error> {
             let id = id.into();
-            gix_hash::Prefix::new(id, hex_len)?;
+            gix_hash::Prefix::new(&id, hex_len)?;
             Ok(Candidate { id, hex_len })
         }
 
         /// Transform ourselves into a `Prefix` with our current hex lengths.
         pub fn to_prefix(&self) -> gix_hash::Prefix {
-            gix_hash::Prefix::new(self.id, self.hex_len).expect("our hex-len to always be in bounds")
+            gix_hash::Prefix::new(&self.id, self.hex_len).expect("our hex-len to always be in bounds")
         }
 
         pub(crate) fn inc_hex_len(&mut self) {

--- a/gix-odb/src/store_impls/dynamic/verify.rs
+++ b/gix-odb/src/store_impls/dynamic/verify.rs
@@ -4,7 +4,7 @@ use std::{
     time::Instant,
 };
 
-use gix_features::progress::{MessageLevel, NestedProgress, Progress};
+use gix_features::progress::{DynNestedProgress, MessageLevel, Progress};
 
 use crate::{
     pack,
@@ -73,13 +73,11 @@ pub mod integrity {
     }
 
     /// Returned by [`Store::verify_integrity()`][crate::Store::verify_integrity()].
-    pub struct Outcome<P> {
+    pub struct Outcome {
         /// Statistics for validated loose object stores.
         pub loose_object_stores: Vec<LooseObjectStatistics>,
         /// Pack traversal statistics for each index and their pack(s)
         pub index_statistics: Vec<IndexStatistics>,
-        /// The provided progress instance.
-        pub progress: P,
     }
 
     /// The progress ids used in [`Store::verify_integrity()`][crate::Store::verify_integrity()].
@@ -111,14 +109,13 @@ impl super::Store {
     ///
     /// Note that this will not force loading all indices or packs permanently, as we will only use the momentarily loaded disk state.
     /// This does, however, include all alternates.
-    pub fn verify_integrity<C, P, F>(
+    pub fn verify_integrity<C, F>(
         &self,
-        mut progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         options: integrity::Options<F>,
-    ) -> Result<integrity::Outcome<P>, integrity::Error>
+    ) -> Result<integrity::Outcome, integrity::Error>
     where
-        P: NestedProgress,
         C: pack::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
@@ -173,15 +170,16 @@ impl super::Store {
                                 &pack
                             }
                         };
+                        let mut child_progress = progress.add_child_with_id(
+                            "verify index".into(),
+                            integrity::ProgressId::VerifyIndex(Default::default()).into(),
+                        );
                         let outcome = index.verify_integrity(
                             Some(pack::index::verify::PackContext {
                                 data,
                                 options: options.clone(),
                             }),
-                            progress.add_child_with_id(
-                                "verify index",
-                                integrity::ProgressId::VerifyIndex(Default::default()).into(),
-                            ),
+                            &mut child_progress,
                             should_interrupt,
                         )?;
                         statistics.push(IndexStatistics {
@@ -192,7 +190,7 @@ impl super::Store {
                                     .expect("pack provided so there are stats"),
                             ),
                         });
-                        (outcome.progress, index.num_objects(), index.path().to_owned())
+                        (child_progress, index.num_objects(), index.path().to_owned())
                     }
                     IndexAndPacks::MultiIndex(bundle) => {
                         let index;
@@ -203,14 +201,11 @@ impl super::Store {
                                 &index
                             }
                         };
-                        let outcome = index.verify_integrity(
-                            progress.add_child_with_id(
-                                "verify multi-index",
-                                integrity::ProgressId::VerifyMultiIndex(Default::default()).into(),
-                            ),
-                            should_interrupt,
-                            options.clone(),
-                        )?;
+                        let mut child_progress = progress.add_child_with_id(
+                            "verify multi-index".into(),
+                            integrity::ProgressId::VerifyMultiIndex(Default::default()).into(),
+                        );
+                        let outcome = index.verify_integrity(&mut child_progress, should_interrupt, options.clone())?;
 
                         let index_dir = bundle.multi_index.path().parent().expect("file in a directory");
                         statistics.push(IndexStatistics {
@@ -224,7 +219,7 @@ impl super::Store {
                                     .collect(),
                             ),
                         });
-                        (outcome.progress, index.num_objects(), index.path().to_owned())
+                        (child_progress, index.num_objects(), index.path().to_owned())
                     }
                 };
 
@@ -250,7 +245,7 @@ impl super::Store {
                 for loose_db in &*index.loose_dbs {
                     let out = loose_db
                         .verify_integrity(
-                            progress.add_child_with_id(
+                            &mut progress.add_child_with_id(
                                 loose_db.path().display().to_string(),
                                 integrity::ProgressId::VerifyLooseObjectDbPath.into(),
                             ),
@@ -269,7 +264,6 @@ impl super::Store {
         Ok(integrity::Outcome {
             loose_object_stores,
             index_statistics: statistics,
-            progress,
         })
     }
 }

--- a/gix-odb/src/store_impls/dynamic/verify.rs
+++ b/gix-odb/src/store_impls/dynamic/verify.rs
@@ -4,7 +4,7 @@ use std::{
     time::Instant,
 };
 
-use gix_features::progress::{MessageLevel, Progress};
+use gix_features::progress::{MessageLevel, NestedProgress, Progress};
 
 use crate::{
     pack,
@@ -118,7 +118,7 @@ impl super::Store {
         options: integrity::Options<F>,
     ) -> Result<integrity::Outcome<P>, integrity::Error>
     where
-        P: Progress,
+        P: NestedProgress,
         C: pack::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {

--- a/gix-odb/src/store_impls/dynamic/write.rs
+++ b/gix-odb/src/store_impls/dynamic/write.rs
@@ -28,16 +28,15 @@ impl<S> crate::Write for store::Handle<S>
 where
     S: Deref<Target = dynamic::Store> + Clone,
 {
-    type Error = Error;
-
-    fn write_stream(&self, kind: Kind, size: u64, from: impl Read) -> Result<ObjectId, Self::Error> {
+    fn write_stream(&self, kind: Kind, size: u64, from: &mut dyn Read) -> Result<ObjectId, crate::write::Error> {
         let mut snapshot = self.snapshot.borrow_mut();
         Ok(match snapshot.loose_dbs.first() {
             Some(ldb) => ldb.write_stream(kind, size, from)?,
             None => {
                 let new_snapshot = self
                     .store
-                    .load_one_index(self.refresh, snapshot.marker)?
+                    .load_one_index(self.refresh, snapshot.marker)
+                    .map_err(Box::new)?
                     .expect("there is always at least one ODB, and this code runs only once for initialization");
                 *snapshot = new_snapshot;
                 snapshot.loose_dbs[0].write_stream(kind, size, from)?

--- a/gix-odb/src/store_impls/loose/verify.rs
+++ b/gix-odb/src/store_impls/loose/verify.rs
@@ -3,7 +3,7 @@ use std::{
     time::Instant,
 };
 
-use gix_features::progress::{Count, NestedProgress, Progress};
+use gix_features::progress::{Count, DynNestedProgress, Progress};
 
 use crate::{loose::Store, Write};
 
@@ -61,7 +61,7 @@ impl Store {
     /// Check all loose objects for their integrity checking their hash matches the actual data and by decoding them fully.
     pub fn verify_integrity(
         &self,
-        mut progress: impl NestedProgress,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
     ) -> Result<integrity::Statistics, integrity::Error> {
         let mut buf = Vec::new();
@@ -69,11 +69,11 @@ impl Store {
 
         let mut num_objects = 0;
         let start = Instant::now();
-        let mut progress = progress.add_child_with_id("Validating", integrity::ProgressId::LooseObjects.into());
+        let mut progress = progress.add_child_with_id("Validating".into(), integrity::ProgressId::LooseObjects.into());
         progress.init(None, gix_features::progress::count("loose objects"));
         for id in self.iter().filter_map(Result::ok) {
             let object = self
-                .try_find(id, &mut buf)
+                .try_find(&id, &mut buf)
                 .map_err(|_| integrity::Error::Retry)?
                 .ok_or(integrity::Error::Retry)?;
             let actual_id = sink.write_buf(object.kind, object.data).expect("sink never fails");

--- a/gix-odb/src/store_impls/loose/verify.rs
+++ b/gix-odb/src/store_impls/loose/verify.rs
@@ -3,7 +3,7 @@ use std::{
     time::Instant,
 };
 
-use gix_features::progress::Progress;
+use gix_features::progress::{Count, NestedProgress, Progress};
 
 use crate::{loose::Store, Write};
 
@@ -61,7 +61,7 @@ impl Store {
     /// Check all loose objects for their integrity checking their hash matches the actual data and by decoding them fully.
     pub fn verify_integrity(
         &self,
-        mut progress: impl Progress,
+        mut progress: impl NestedProgress,
         should_interrupt: &AtomicBool,
     ) -> Result<integrity::Statistics, integrity::Error> {
         let mut buf = Vec::new();

--- a/gix-odb/src/traits.rs
+++ b/gix-odb/src/traits.rs
@@ -4,21 +4,16 @@ use gix_object::WriteTo;
 
 /// Describe the capability to write git objects into an object store.
 pub trait Write {
-    /// The error type used for all trait methods.
-    ///
-    /// _Note_ the default implementations require the `From<io::Error>` bound.
-    type Error: std::error::Error + From<io::Error>;
-
     /// Write objects using the intrinsic kind of [`hash`][gix_hash::Kind] into the database,
     /// returning id to reference it in subsequent reads.
-    fn write(&self, object: impl WriteTo) -> Result<gix_hash::ObjectId, Self::Error> {
+    fn write(&self, object: &dyn WriteTo) -> Result<gix_hash::ObjectId, crate::write::Error> {
         let mut buf = Vec::with_capacity(2048);
         object.write_to(&mut buf)?;
-        self.write_stream(object.kind(), buf.len() as u64, buf.as_slice())
+        self.write_stream(object.kind(), buf.len() as u64, &mut buf.as_slice())
     }
     /// As [`write`][Write::write], but takes an [`object` kind][gix_object::Kind] along with its encoded bytes.
-    fn write_buf(&self, object: gix_object::Kind, from: &[u8]) -> Result<gix_hash::ObjectId, Self::Error> {
-        self.write_stream(object, from.len() as u64, from)
+    fn write_buf(&self, object: gix_object::Kind, mut from: &[u8]) -> Result<gix_hash::ObjectId, crate::write::Error> {
+        self.write_stream(object, from.len() as u64, &mut from)
     }
     /// As [`write`][Write::write], but takes an input stream.
     /// This is commonly used for writing blobs directly without reading them to memory first.
@@ -26,8 +21,8 @@ pub trait Write {
         &self,
         kind: gix_object::Kind,
         size: u64,
-        from: impl io::Read,
-    ) -> Result<gix_hash::ObjectId, Self::Error>;
+        from: &mut dyn io::Read,
+    ) -> Result<gix_hash::ObjectId, crate::write::Error>;
 }
 
 /// Describe how object can be located in an object store.
@@ -39,11 +34,8 @@ pub trait Write {
 ///
 /// [issue]: https://github.com/rust-lang/rust/issues/44265
 pub trait Find {
-    /// The error returned by [`try_find()`][Find::try_find()]
-    type Error: std::error::Error + 'static;
-
     /// Returns true if the object exists in the database.
-    fn contains(&self, id: impl AsRef<gix_hash::oid>) -> bool;
+    fn contains(&self, id: &gix_hash::oid) -> bool;
 
     /// Find an object matching `id` in the database while placing its raw, possibly encoded data into `buffer`.
     ///
@@ -51,17 +43,15 @@ pub trait Find {
     /// retrieval.
     fn try_find<'a>(
         &self,
-        id: impl AsRef<gix_hash::oid>,
+        id: &gix_hash::oid,
         buffer: &'a mut Vec<u8>,
-    ) -> Result<Option<gix_object::Data<'a>>, Self::Error>;
+    ) -> Result<Option<gix_object::Data<'a>>, find::Error>;
 }
 
 /// A way to obtain object properties without fully decoding it.
 pub trait Header {
-    /// The error returned by [`try_header()`][Header::try_header()].
-    type Error: std::error::Error + 'static;
     /// Try to read the header of the object associated with `id` or return `None` if it could not be found.
-    fn try_header(&self, id: impl AsRef<gix_hash::oid>) -> Result<Option<find::Header>, Self::Error>;
+    fn try_header(&self, id: &gix_hash::oid) -> Result<Option<find::Header>, find::Error>;
 }
 
 mod _impls {
@@ -76,17 +66,15 @@ mod _impls {
     where
         T: crate::Write,
     {
-        type Error = T::Error;
-
-        fn write(&self, object: impl WriteTo) -> Result<ObjectId, Self::Error> {
+        fn write(&self, object: &dyn WriteTo) -> Result<ObjectId, crate::write::Error> {
             (*self).write(object)
         }
 
-        fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, Self::Error> {
+        fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, crate::write::Error> {
             (*self).write_buf(object, from)
         }
 
-        fn write_stream(&self, kind: Kind, size: u64, from: impl Read) -> Result<ObjectId, Self::Error> {
+        fn write_stream(&self, kind: Kind, size: u64, from: &mut dyn Read) -> Result<ObjectId, crate::write::Error> {
             (*self).write_stream(kind, size, from)
         }
     }
@@ -95,17 +83,15 @@ mod _impls {
     where
         T: crate::Write,
     {
-        type Error = T::Error;
-
-        fn write(&self, object: impl WriteTo) -> Result<ObjectId, Self::Error> {
+        fn write(&self, object: &dyn WriteTo) -> Result<ObjectId, crate::write::Error> {
             self.deref().write(object)
         }
 
-        fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, Self::Error> {
+        fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, crate::write::Error> {
             self.deref().write_buf(object, from)
         }
 
-        fn write_stream(&self, kind: Kind, size: u64, from: impl Read) -> Result<ObjectId, Self::Error> {
+        fn write_stream(&self, kind: Kind, size: u64, from: &mut dyn Read) -> Result<ObjectId, crate::write::Error> {
             self.deref().write_stream(kind, size, from)
         }
     }
@@ -114,17 +100,15 @@ mod _impls {
     where
         T: crate::Write,
     {
-        type Error = T::Error;
-
-        fn write(&self, object: impl WriteTo) -> Result<ObjectId, Self::Error> {
+        fn write(&self, object: &dyn WriteTo) -> Result<ObjectId, crate::write::Error> {
             self.deref().write(object)
         }
 
-        fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, Self::Error> {
+        fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, crate::write::Error> {
             self.deref().write_buf(object, from)
         }
 
-        fn write_stream(&self, kind: Kind, size: u64, from: impl Read) -> Result<ObjectId, Self::Error> {
+        fn write_stream(&self, kind: Kind, size: u64, from: &mut dyn Read) -> Result<ObjectId, crate::write::Error> {
             self.deref().write_stream(kind, size, from)
         }
     }
@@ -133,13 +117,11 @@ mod _impls {
     where
         T: crate::Find,
     {
-        type Error = T::Error;
-
-        fn contains(&self, id: impl AsRef<oid>) -> bool {
+        fn contains(&self, id: &oid) -> bool {
             (*self).contains(id)
         }
 
-        fn try_find<'a>(&self, id: impl AsRef<oid>, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, Self::Error> {
+        fn try_find<'a>(&self, id: &oid, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, crate::find::Error> {
             (*self).try_find(id, buffer)
         }
     }
@@ -148,9 +130,7 @@ mod _impls {
     where
         T: crate::Header,
     {
-        type Error = T::Error;
-
-        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+        fn try_header(&self, id: &oid) -> Result<Option<Header>, crate::find::Error> {
             (*self).try_header(id)
         }
     }
@@ -159,13 +139,11 @@ mod _impls {
     where
         T: crate::Find,
     {
-        type Error = T::Error;
-
-        fn contains(&self, id: impl AsRef<oid>) -> bool {
+        fn contains(&self, id: &oid) -> bool {
             self.deref().contains(id)
         }
 
-        fn try_find<'a>(&self, id: impl AsRef<oid>, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, Self::Error> {
+        fn try_find<'a>(&self, id: &oid, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, crate::find::Error> {
             self.deref().try_find(id, buffer)
         }
     }
@@ -174,9 +152,7 @@ mod _impls {
     where
         T: crate::Header,
     {
-        type Error = T::Error;
-
-        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+        fn try_header(&self, id: &oid) -> Result<Option<Header>, crate::find::Error> {
             self.deref().try_header(id)
         }
     }
@@ -185,13 +161,11 @@ mod _impls {
     where
         T: crate::Find,
     {
-        type Error = T::Error;
-
-        fn contains(&self, id: impl AsRef<oid>) -> bool {
+        fn contains(&self, id: &oid) -> bool {
             self.deref().contains(id)
         }
 
-        fn try_find<'a>(&self, id: impl AsRef<oid>, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, Self::Error> {
+        fn try_find<'a>(&self, id: &oid, buffer: &'a mut Vec<u8>) -> Result<Option<Data<'a>>, crate::find::Error> {
             self.deref().try_find(id, buffer)
         }
     }
@@ -200,9 +174,7 @@ mod _impls {
     where
         T: crate::Header,
     {
-        type Error = T::Error;
-
-        fn try_header(&self, id: impl AsRef<oid>) -> Result<Option<Header>, Self::Error> {
+        fn try_header(&self, id: &oid) -> Result<Option<Header>, crate::find::Error> {
             self.deref().try_header(id)
         }
     }
@@ -219,10 +191,9 @@ mod ext {
             /// while returning the desired object type.
             fn $method<'a>(
                 &self,
-                id: impl AsRef<gix_hash::oid>,
+                id: &gix_hash::oid,
                 buffer: &'a mut Vec<u8>,
-            ) -> Result<$object_type, find::existing_object::Error<Self::Error>> {
-                let id = id.as_ref();
+            ) -> Result<$object_type, find::existing_object::Error> {
                 self.try_find(id, buffer)
                     .map_err(find::existing_object::Error::Find)?
                     .ok_or_else(|| find::existing_object::Error::NotFound {
@@ -245,10 +216,9 @@ mod ext {
             /// while returning the desired iterator type.
             fn $method<'a>(
                 &self,
-                id: impl AsRef<gix_hash::oid>,
+                id: &gix_hash::oid,
                 buffer: &'a mut Vec<u8>,
-            ) -> Result<$object_type, find::existing_iter::Error<Self::Error>> {
-                let id = id.as_ref();
+            ) -> Result<$object_type, find::existing_iter::Error> {
                 self.try_find(id, buffer)
                     .map_err(find::existing_iter::Error::Find)?
                     .ok_or_else(|| find::existing_iter::Error::NotFound {
@@ -267,10 +237,7 @@ mod ext {
     /// An extension trait with convenience functions.
     pub trait HeaderExt: super::Header {
         /// Like [`try_header(…)`][super::Header::try_header()], but flattens the `Result<Option<_>>` into a single `Result` making a non-existing object an error.
-        fn header(
-            &self,
-            id: impl AsRef<gix_hash::oid>,
-        ) -> Result<crate::find::Header, find::existing::Error<Self::Error>> {
+        fn header(&self, id: impl AsRef<gix_hash::oid>) -> Result<find::Header, find::existing::Error> {
             let id = id.as_ref();
             self.try_header(id)
                 .map_err(find::existing::Error::Find)?
@@ -285,10 +252,9 @@ mod ext {
         /// Like [`try_find(…)`][super::Find::try_find()], but flattens the `Result<Option<_>>` into a single `Result` making a non-existing object an error.
         fn find<'a>(
             &self,
-            id: impl AsRef<gix_hash::oid>,
+            id: &gix_hash::oid,
             buffer: &'a mut Vec<u8>,
-        ) -> Result<gix_object::Data<'a>, find::existing::Error<Self::Error>> {
-            let id = id.as_ref();
+        ) -> Result<gix_object::Data<'a>, find::existing::Error> {
             self.try_find(id, buffer)
                 .map_err(find::existing::Error::Find)?
                 .ok_or_else(|| find::existing::Error::NotFound { oid: id.to_owned() })

--- a/gix-odb/tests/odb/alternate/mod.rs
+++ b/gix-odb/tests/odb/alternate/mod.rs
@@ -67,7 +67,7 @@ fn circular_alternates_are_detected_with_relative_paths() -> crate::Result {
         None,
     )?;
 
-    match alternate::resolve(from, std::env::current_dir()?) {
+    match alternate::resolve(from, &std::env::current_dir()?) {
         Err(alternate::Error::Cycle(chain)) => {
             assert_eq!(
                 chain
@@ -88,7 +88,7 @@ fn single_link_with_comment_before_path_and_ansi_c_escape() -> crate::Result {
     let non_alternate = tmp.path().join("actual");
 
     let (from, to) = alternate_with(tmp.path().join("a"), non_alternate, Some("# comment\n"))?;
-    let alternates = alternate::resolve(from, std::env::current_dir()?)?;
+    let alternates = alternate::resolve(from, &std::env::current_dir()?)?;
     assert_eq!(alternates.len(), 1);
     assert_eq!(alternates[0], to);
     Ok(())
@@ -97,6 +97,6 @@ fn single_link_with_comment_before_path_and_ansi_c_escape() -> crate::Result {
 #[test]
 fn no_alternate_in_first_objects_dir() -> crate::Result {
     let tmp = gix_testtools::tempfile::TempDir::new()?;
-    assert!(alternate::resolve(tmp.path(), std::env::current_dir()?)?.is_empty());
+    assert!(alternate::resolve(tmp.path().to_owned(), &std::env::current_dir()?)?.is_empty());
     Ok(())
 }

--- a/gix-odb/tests/odb/find/mod.rs
+++ b/gix-odb/tests/odb/find/mod.rs
@@ -9,7 +9,7 @@ use crate::hex_to_id;
 fn can_find(db: impl gix_odb::Find, hex_id: &str) {
     let mut buf = vec![];
     assert!(db
-        .try_find(hex_to_id(hex_id), &mut buf)
+        .try_find(&hex_to_id(hex_id), &mut buf)
         .expect("no read error")
         .is_some());
 }

--- a/gix-odb/tests/odb/header/mod.rs
+++ b/gix-odb/tests/odb/header/mod.rs
@@ -1,7 +1,7 @@
 use crate::{hex_to_id, odb::db};
 
 fn find_header(db: impl gix_odb::Header, hex_id: &str) -> gix_odb::find::Header {
-    db.try_header(hex_to_id(hex_id))
+    db.try_header(&hex_to_id(hex_id))
         .expect("no read error")
         .expect("object exists")
 }

--- a/gix-odb/tests/odb/mod.rs
+++ b/gix-odb/tests/odb/mod.rs
@@ -6,7 +6,7 @@ pub fn hex_to_id(hex: &str) -> ObjectId {
     ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
 }
 
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn db() -> gix_odb::Handle {
     gix_odb::at(fixture_path_standalone("objects")).expect("valid object path")

--- a/gix-odb/tests/odb/regression/mod.rs
+++ b/gix-odb/tests/odb/regression/mod.rs
@@ -9,7 +9,7 @@ mod repo_with_small_packs {
         let mut buf = Vec::new();
         assert!(
             store
-                .try_find(hex_to_id("ecc68100297fff843a7eef8df0d0fb80c1c8bac5"), &mut buf)?
+                .try_find(&hex_to_id("ecc68100297fff843a7eef8df0d0fb80c1c8bac5"), &mut buf)?
                 .is_some(),
             "object is present and available"
         );

--- a/gix-odb/tests/odb/sink/mod.rs
+++ b/gix-odb/tests/odb/sink/mod.rs
@@ -3,7 +3,7 @@ use gix_odb::Write;
 use crate::store::loose::{locate_oid, object_ids};
 
 #[test]
-fn write() -> Result<(), Box<dyn std::error::Error>> {
+fn write() -> crate::Result {
     let mut buf = Vec::new();
     for oid in object_ids() {
         let obj = locate_oid(oid, &mut buf);

--- a/gix-odb/tests/odb/store/compound.rs
+++ b/gix-odb/tests/odb/store/compound.rs
@@ -10,7 +10,7 @@ mod locate {
     fn can_locate(db: &gix_odb::Handle, hex_id: &str) {
         let mut buf = vec![];
         assert!(db
-            .try_find(hex_to_id(hex_id), &mut buf)
+            .try_find(&hex_to_id(hex_id), &mut buf)
             .expect("no read error")
             .is_some());
     }

--- a/gix-odb/tests/odb/store/linked.rs
+++ b/gix-odb/tests/odb/store/linked.rs
@@ -19,8 +19,8 @@ mod iter {
         assert_eq!(iter.count(), 146, "it sees the correct amount of objects");
         for id in db.iter()? {
             let id = id?;
-            assert!(db.contains(id), "each object exists");
-            assert!(db.try_header(id)?.is_some(), "header is readable");
+            assert!(db.contains(&id), "each object exists");
+            assert!(db.try_header(&id)?.is_some(), "header is readable");
         }
         Ok(())
     }
@@ -35,7 +35,7 @@ mod locate {
     fn can_locate(db: &Handle, hex_id: &str) {
         let mut buf = vec![];
         assert!(db
-            .try_find(hex_to_id(hex_id), &mut buf)
+            .try_find(&hex_to_id(hex_id), &mut buf)
             .expect("no read error")
             .is_some());
     }
@@ -64,7 +64,7 @@ mod init {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let (object_path, _linked_object_path) = alternate(tmp.path().join("a"), tmp.path().join("b"))?;
         let db = gix_odb::at(object_path.clone())?;
-        db.contains(ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
+        db.contains(&ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
 
         assert_eq!(db.store_ref().metrics().loose_dbs, 2);
         assert_eq!(db.iter()?.count(), 0, "the test locations are actually empty");
@@ -76,7 +76,7 @@ mod init {
     fn a_db_without_alternates() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let db = gix_odb::at(tmp.path())?;
-        db.contains(ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
+        db.contains(&ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
         assert_eq!(db.store_ref().metrics().loose_dbs, 1);
         assert_eq!(db.store_ref().path(), tmp.path());
         Ok(())
@@ -85,7 +85,7 @@ mod init {
     #[test]
     fn has_packs() {
         let db = db();
-        db.contains(ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
+        db.contains(&ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
         assert_eq!(db.store_ref().metrics().known_packs, 3);
     }
 }

--- a/gix-pack/src/bundle/find.rs
+++ b/gix-pack/src/bundle/find.rs
@@ -10,10 +10,10 @@ impl crate::Bundle {
     /// for thin packs, which by now are expected to be resolved already.
     pub fn find<'a>(
         &self,
-        id: impl AsRef<gix_hash::oid>,
+        id: &gix_hash::oid,
         out: &'a mut Vec<u8>,
         inflate: &mut zlib::Inflate,
-        cache: &mut impl crate::cache::DecodeEntry,
+        cache: &mut dyn crate::cache::DecodeEntry,
     ) -> Result<Option<(gix_object::Data<'a>, crate::data::entry::Location)>, crate::data::decode::Error> {
         let idx = match self.index.lookup(id) {
             Some(idx) => idx,
@@ -34,7 +34,7 @@ impl crate::Bundle {
         idx: u32,
         out: &'a mut Vec<u8>,
         inflate: &mut zlib::Inflate,
-        cache: &mut impl crate::cache::DecodeEntry,
+        cache: &mut dyn crate::cache::DecodeEntry,
     ) -> Result<(gix_object::Data<'a>, crate::data::entry::Location), crate::data::decode::Error> {
         let ofs = self.index.pack_offset_at_index(idx);
         let pack_entry = self.pack.entry(ofs);
@@ -44,7 +44,7 @@ impl crate::Bundle {
                 pack_entry,
                 out,
                 inflate,
-                |id, _out| {
+                &|id, _out| {
                     self.index.lookup(id).map(|idx| {
                         crate::data::decode::entry::ResolvedBase::InPack(
                             self.pack.entry(self.index.pack_offset_at_index(idx)),

--- a/gix-pack/src/bundle/mod.rs
+++ b/gix-pack/src/bundle/mod.rs
@@ -10,18 +10,16 @@ pub mod write;
 pub mod verify {
     use std::sync::atomic::AtomicBool;
 
-    use gix_features::progress::NestedProgress;
+    use gix_features::progress::DynNestedProgress;
 
     ///
     pub mod integrity {
         /// Returned by [`Bundle::verify_integrity()`][crate::Bundle::verify_integrity()].
-        pub struct Outcome<P> {
+        pub struct Outcome {
             /// The computed checksum of the index which matched the stored one.
             pub actual_index_checksum: gix_hash::ObjectId,
             /// The packs traversal outcome
             pub pack_traverse_outcome: crate::index::traverse::Statistics,
-            /// The provided progress instance.
-            pub progress: P,
         }
     }
 
@@ -30,14 +28,13 @@ pub mod verify {
     impl Bundle {
         /// Similar to [`crate::index::File::verify_integrity()`] but more convenient to call as the presence of the
         /// pack file is a given.
-        pub fn verify_integrity<C, P, F>(
+        pub fn verify_integrity<C, F>(
             &self,
-            progress: P,
+            progress: &mut dyn DynNestedProgress,
             should_interrupt: &AtomicBool,
             options: crate::index::verify::integrity::Options<F>,
-        ) -> Result<integrity::Outcome<P>, crate::index::traverse::Error<crate::index::verify::integrity::Error>>
+        ) -> Result<integrity::Outcome, crate::index::traverse::Error<crate::index::verify::integrity::Error>>
         where
-            P: NestedProgress,
             C: crate::cache::DecodeEntry,
             F: Fn() -> C + Send + Clone,
         {
@@ -53,7 +50,6 @@ pub mod verify {
                 .map(|o| integrity::Outcome {
                     actual_index_checksum: o.actual_index_checksum,
                     pack_traverse_outcome: o.pack_traverse_statistics.expect("pack is set"),
-                    progress: o.progress,
                 })
         }
     }

--- a/gix-pack/src/bundle/mod.rs
+++ b/gix-pack/src/bundle/mod.rs
@@ -10,7 +10,7 @@ pub mod write;
 pub mod verify {
     use std::sync::atomic::AtomicBool;
 
-    use gix_features::progress::Progress;
+    use gix_features::progress::NestedProgress;
 
     ///
     pub mod integrity {
@@ -37,7 +37,7 @@ pub mod verify {
             options: crate::index::verify::integrity::Options<F>,
         ) -> Result<integrity::Outcome<P>, crate::index::traverse::Error<crate::index::verify::integrity::Error>>
         where
-            P: Progress,
+            P: NestedProgress,
             C: crate::cache::DecodeEntry,
             F: Fn() -> C + Send + Clone,
         {

--- a/gix-pack/src/bundle/write/mod.rs
+++ b/gix-pack/src/bundle/write/mod.rs
@@ -6,16 +6,14 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-use gix_features::{
-    interrupt, progress,
-    progress::{NestedProgress, Progress},
-};
+use gix_features::{interrupt, progress, progress::Progress};
 use gix_tempfile::{AutoRemove, ContainingDirectory};
 
 use crate::data;
 
 mod error;
 pub use error::Error;
+use gix_features::progress::prodash::DynNestedProgress;
 
 mod types;
 use types::{LockWriter, PassThrough};
@@ -66,15 +64,15 @@ impl crate::Bundle {
     ///   be accounted for.
     ///   - Empty packs always have the same name and not handling this case will result in at most one superfluous pack.
     pub fn write_to_directory(
-        pack: impl io::BufRead,
-        directory: Option<impl AsRef<Path>>,
-        mut progress: impl NestedProgress,
+        pack: &mut dyn io::BufRead,
+        directory: Option<&Path>,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         thin_pack_base_object_lookup_fn: Option<ThinPackLookupFn>,
         options: Options,
     ) -> Result<Outcome, Error> {
         let _span = gix_features::trace::coarse!("gix_pack::Bundle::write_to_directory()");
-        let mut read_progress = progress.add_child_with_id("read pack", ProgressId::ReadPackBytes.into());
+        let mut read_progress = progress.add_child_with_id("read pack".into(), ProgressId::ReadPackBytes.into());
         read_progress.init(None, progress::bytes());
         let pack = progress::Read {
             inner: pack,
@@ -174,21 +172,17 @@ impl crate::Bundle {
     /// As it sends portions of the input to a thread it requires the 'static lifetime for the interrupt flags. This can only
     /// be satisfied by a static `AtomicBool` which is only suitable for programs that only run one of these operations at a time
     /// or don't mind that all of them abort when the flag is set.
-    pub fn write_to_directory_eagerly<P>(
-        pack: impl io::Read + Send + 'static,
+    pub fn write_to_directory_eagerly(
+        pack: Box<dyn io::Read + Send + 'static>,
         pack_size: Option<u64>,
         directory: Option<impl AsRef<Path>>,
-        mut progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &'static AtomicBool,
         thin_pack_base_object_lookup_fn: Option<ThinPackLookupFnSend>,
         options: Options,
-    ) -> Result<Outcome, Error>
-    where
-        P: NestedProgress,
-        P::SubProgress: 'static,
-    {
+    ) -> Result<Outcome, Error> {
         let _span = gix_features::trace::coarse!("gix_pack::Bundle::write_to_directory_eagerly()");
-        let mut read_progress = progress.add_child_with_id("read pack", ProgressId::ReadPackBytes.into()); /* Bundle Write Read pack Bytes*/
+        let mut read_progress = progress.add_child_with_id("read pack".into(), ProgressId::ReadPackBytes.into()); /* Bundle Write Read pack Bytes*/
         read_progress.init(pack_size.map(|s| s as usize), progress::bytes());
         let pack = progress::Read {
             inner: pack,
@@ -256,7 +250,7 @@ impl crate::Bundle {
             progress,
             options,
             data_file,
-            pack_entries_iter,
+            Box::new(pack_entries_iter),
             should_interrupt,
             pack_version,
         )?;
@@ -271,9 +265,9 @@ impl crate::Bundle {
         })
     }
 
-    fn inner_write(
+    fn inner_write<'a>(
         directory: Option<impl AsRef<Path>>,
-        mut progress: impl NestedProgress,
+        progress: &mut dyn DynNestedProgress,
         Options {
             thread_limit,
             iteration_mode: _,
@@ -281,12 +275,12 @@ impl crate::Bundle {
             object_hash,
         }: Options,
         data_file: SharedTempFile,
-        pack_entries_iter: impl Iterator<Item = Result<data::input::Entry, data::input::Error>>,
+        mut pack_entries_iter: Box<dyn Iterator<Item = Result<data::input::Entry, data::input::Error>> + 'a>,
         should_interrupt: &AtomicBool,
         pack_version: data::Version,
     ) -> Result<WriteOutcome, Error> {
-        let indexing_progress = progress.add_child_with_id(
-            "create index file",
+        let mut indexing_progress = progress.add_child_with_id(
+            "create index file".into(),
             ProgressId::IndexingSteps(Default::default()).into(),
         );
         Ok(match directory {
@@ -300,14 +294,15 @@ impl crate::Bundle {
                         let data_file = Arc::clone(&data_file);
                         move || new_pack_file_resolver(data_file)
                     },
-                    pack_entries_iter,
+                    &mut pack_entries_iter,
                     thread_limit,
-                    indexing_progress,
+                    &mut indexing_progress,
                     &mut index_file,
                     should_interrupt,
                     object_hash,
                     pack_version,
                 )?;
+                drop(pack_entries_iter);
 
                 let data_path = directory.join(format!("pack-{}.pack", outcome.data_hash.to_hex()));
                 let index_path = data_path.with_extension("idx");
@@ -340,10 +335,10 @@ impl crate::Bundle {
                 outcome: crate::index::File::write_data_iter_to_stream(
                     index_kind,
                     move || new_pack_file_resolver(data_file),
-                    pack_entries_iter,
+                    &mut pack_entries_iter,
                     thread_limit,
-                    indexing_progress,
-                    io::sink(),
+                    &mut indexing_progress,
+                    &mut io::sink(),
                     should_interrupt,
                     object_hash,
                     pack_version,

--- a/gix-pack/src/bundle/write/mod.rs
+++ b/gix-pack/src/bundle/write/mod.rs
@@ -6,7 +6,10 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-use gix_features::{interrupt, progress, progress::Progress};
+use gix_features::{
+    interrupt, progress,
+    progress::{NestedProgress, Progress},
+};
 use gix_tempfile::{AutoRemove, ContainingDirectory};
 
 use crate::data;
@@ -65,7 +68,7 @@ impl crate::Bundle {
     pub fn write_to_directory(
         pack: impl io::BufRead,
         directory: Option<impl AsRef<Path>>,
-        mut progress: impl Progress,
+        mut progress: impl NestedProgress,
         should_interrupt: &AtomicBool,
         thin_pack_base_object_lookup_fn: Option<ThinPackLookupFn>,
         options: Options,
@@ -181,7 +184,7 @@ impl crate::Bundle {
         options: Options,
     ) -> Result<Outcome, Error>
     where
-        P: Progress,
+        P: NestedProgress,
         P::SubProgress: 'static,
     {
         let _span = gix_features::trace::coarse!("gix_pack::Bundle::write_to_directory_eagerly()");
@@ -270,7 +273,7 @@ impl crate::Bundle {
 
     fn inner_write(
         directory: Option<impl AsRef<Path>>,
-        mut progress: impl Progress,
+        mut progress: impl NestedProgress,
         Options {
             thread_limit,
             iteration_mode: _,

--- a/gix-pack/src/cache/delta/from_offsets.rs
+++ b/gix-pack/src/cache/delta/from_offsets.rs
@@ -42,11 +42,11 @@ impl<T> Tree<T> {
     ///
     /// Note that the sort order is ascending. The given pack file path must match the provided offsets.
     pub fn from_offsets_in_pack(
-        pack_path: impl AsRef<std::path::Path>,
+        pack_path: &std::path::Path,
         data_sorted_by_offsets: impl Iterator<Item = T>,
-        get_pack_offset: impl Fn(&T) -> data::Offset,
-        resolve_in_pack_id: impl Fn(&gix_hash::oid) -> Option<data::Offset>,
-        mut progress: impl Progress,
+        get_pack_offset: &dyn Fn(&T) -> data::Offset,
+        resolve_in_pack_id: &dyn Fn(&gix_hash::oid) -> Option<data::Offset>,
+        progress: &mut dyn Progress,
         should_interrupt: &AtomicBool,
         object_hash: gix_hash::Kind,
     ) -> Result<Self, Error> {

--- a/gix-pack/src/cache/delta/mod.rs
+++ b/gix-pack/src/cache/delta/mod.rs
@@ -179,11 +179,11 @@ mod tests {
             fn tree(index_path: &str, pack_path: &str) -> Result<(), Box<dyn std::error::Error>> {
                 let idx = pack::index::File::at(fixture_path(index_path), gix_hash::Kind::Sha1)?;
                 crate::cache::delta::Tree::from_offsets_in_pack(
-                    fixture_path(pack_path),
+                    &fixture_path(pack_path),
                     idx.sorted_offsets().into_iter(),
-                    |ofs| *ofs,
-                    |id| idx.lookup(id).map(|index| idx.pack_offset_at_index(index)),
-                    gix_features::progress::Discard,
+                    &|ofs| *ofs,
+                    &|id| idx.lookup(id).map(|index| idx.pack_offset_at_index(index)),
+                    &mut gix_features::progress::Discard,
                     &AtomicBool::new(false),
                     gix_hash::Kind::Sha1,
                 )?;

--- a/gix-pack/src/cache/delta/traverse/mod.rs
+++ b/gix-pack/src/cache/delta/traverse/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use gix_features::progress::NestedProgress;
+use gix_features::progress::DynNestedProgress;
 use gix_features::{
     parallel::in_parallel_with_slice,
     progress::{self, Progress},
@@ -56,11 +56,11 @@ pub struct Context<'a> {
 }
 
 /// Options for [`Tree::traverse()`].
-pub struct Options<'a, P1, P2> {
+pub struct Options<'a, 's> {
     /// is a progress instance to track progress for each object in the traversal.
-    pub object_progress: P1,
+    pub object_progress: Box<dyn DynNestedProgress>,
     /// is a progress instance to track the overall progress.
-    pub size_progress: P2,
+    pub size_progress: &'s mut dyn Progress,
     /// If `Some`, only use the given amount of threads. Otherwise, the amount of threads to use will be selected based on
     /// the amount of available logical cores.
     pub thread_limit: Option<usize>,
@@ -100,7 +100,7 @@ where
     /// This method returns a vector of all tree items, along with their potentially modified custom node data.
     ///
     /// _Note_ that this method consumed the Tree to assure safe parallel traversal with mutation support.
-    pub fn traverse<F, P1, P2, MBFN, E, R>(
+    pub fn traverse<F, MBFN, E, R>(
         mut self,
         resolve: F,
         resolve_data: &R,
@@ -109,17 +109,15 @@ where
         Options {
             thread_limit,
             mut object_progress,
-            mut size_progress,
+            size_progress,
             should_interrupt,
             object_hash,
-        }: Options<'_, P1, P2>,
+        }: Options<'_, '_>,
     ) -> Result<Outcome<T>, Error>
     where
         F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
         R: Send + Sync,
-        P1: NestedProgress,
-        P2: Progress,
-        MBFN: FnMut(&mut T, &<P1 as NestedProgress>::SubProgress, Context<'_>) -> Result<(), E> + Send + Clone,
+        MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send + Clone,
         E: std::error::Error + Send + Sync + 'static,
     {
         self.set_pack_entries_end_and_resolve_ref_offsets(pack_entries_end)?;
@@ -151,7 +149,9 @@ where
                         resolve::State {
                             delta_bytes: Vec::<u8>::with_capacity(4096),
                             fully_resolved_delta_bytes: Vec::<u8>::with_capacity(4096),
-                            progress: threading::lock(&object_progress).add_child(format!("thread {thread_index}")),
+                            progress: Box::new(
+                                threading::lock(&object_progress).add_child(format!("thread {thread_index}")),
+                            ),
                             resolve: resolve.clone(),
                             modify_base: inspect_object.clone(),
                             child_items: child_items.clone(),

--- a/gix-pack/src/cache/delta/traverse/mod.rs
+++ b/gix-pack/src/cache/delta/traverse/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use gix_features::progress::NestedProgress;
 use gix_features::{
     parallel::in_parallel_with_slice,
     progress::{self, Progress},
@@ -116,9 +117,9 @@ where
     where
         F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
         R: Send + Sync,
-        P1: Progress,
+        P1: NestedProgress,
         P2: Progress,
-        MBFN: FnMut(&mut T, &<P1 as Progress>::SubProgress, Context<'_>) -> Result<(), E> + Send + Clone,
+        MBFN: FnMut(&mut T, &<P1 as NestedProgress>::SubProgress, Context<'_>) -> Result<(), E> + Send + Clone,
         E: std::error::Error + Send + Sync + 'static,
     {
         self.set_pack_entries_end_and_resolve_ref_offsets(pack_entries_end)?;

--- a/gix-pack/src/data/entry/decode.rs
+++ b/gix-pack/src/data/entry/decode.rs
@@ -47,16 +47,16 @@ impl data::Entry {
 
     /// Instantiate an `Entry` from the reader `r`, providing the `pack_offset` to allow tracking the start of the entry data section.
     pub fn from_read(
-        mut r: impl io::Read,
+        r: &mut dyn io::Read,
         pack_offset: data::Offset,
         hash_len: usize,
     ) -> Result<data::Entry, io::Error> {
-        let (type_id, size, mut consumed) = streaming_parse_header_info(&mut r)?;
+        let (type_id, size, mut consumed) = streaming_parse_header_info(r)?;
 
         use crate::data::entry::Header::*;
         let object = match type_id {
             OFS_DELTA => {
-                let (distance, leb_bytes) = leb64_from_read(&mut r)?;
+                let (distance, leb_bytes) = leb64_from_read(r)?;
                 let delta = OfsDelta {
                     base_distance: distance,
                 };
@@ -89,7 +89,7 @@ impl data::Entry {
 }
 
 #[inline]
-fn streaming_parse_header_info(mut read: impl io::Read) -> Result<(u8, u64, usize), io::Error> {
+fn streaming_parse_header_info(read: &mut dyn io::Read) -> Result<(u8, u64, usize), io::Error> {
     let mut byte = [0u8; 1];
     read.read_exact(&mut byte)?;
     let mut c = byte[0];

--- a/gix-pack/src/data/entry/header.rs
+++ b/gix-pack/src/data/entry/header.rs
@@ -83,7 +83,7 @@ impl Header {
     ///
     /// Returns the amount of bytes written to `out`.
     /// `decompressed_size_in_bytes` is the full size in bytes of the object that this header represents
-    pub fn write_to(&self, decompressed_size_in_bytes: u64, mut out: impl io::Write) -> io::Result<usize> {
+    pub fn write_to(&self, decompressed_size_in_bytes: u64, out: &mut dyn io::Write) -> io::Result<usize> {
         let mut size = decompressed_size_in_bytes;
         let mut written = 1;
         let mut c: u8 = (self.as_type_id() << 4) | (size as u8 & 0b0000_1111);
@@ -115,7 +115,7 @@ impl Header {
 
     /// The size of the header in bytes when serialized
     pub fn size(&self, decompressed_size: u64) -> usize {
-        self.write_to(decompressed_size, io::sink())
+        self.write_to(decompressed_size, &mut io::sink())
             .expect("io::sink() to never fail")
     }
 }

--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -171,8 +171,8 @@ impl File {
         entry: data::Entry,
         out: &mut Vec<u8>,
         inflate: &mut zlib::Inflate,
-        resolve: impl Fn(&gix_hash::oid, &mut Vec<u8>) -> Option<ResolvedBase>,
-        delta_cache: &mut impl cache::DecodeEntry,
+        resolve: &dyn Fn(&gix_hash::oid, &mut Vec<u8>) -> Option<ResolvedBase>,
+        delta_cache: &mut dyn cache::DecodeEntry,
     ) -> Result<Outcome, Error> {
         use crate::data::entry::Header::*;
         match entry.header {
@@ -203,10 +203,10 @@ impl File {
     fn resolve_deltas(
         &self,
         last: data::Entry,
-        resolve: impl Fn(&gix_hash::oid, &mut Vec<u8>) -> Option<ResolvedBase>,
+        resolve: &dyn Fn(&gix_hash::oid, &mut Vec<u8>) -> Option<ResolvedBase>,
         inflate: &mut zlib::Inflate,
         out: &mut Vec<u8>,
-        cache: &mut impl cache::DecodeEntry,
+        cache: &mut dyn cache::DecodeEntry,
     ) -> Result<Outcome, Error> {
         // all deltas, from the one that produces the desired object (first) to the oldest at the end of the chain
         let mut chain = SmallVec::<[Delta; 10]>::default();

--- a/gix-pack/src/data/file/decode/header.rs
+++ b/gix-pack/src/data/file/decode/header.rs
@@ -46,7 +46,7 @@ impl File {
         &self,
         mut entry: data::Entry,
         inflate: &mut zlib::Inflate,
-        resolve: impl Fn(&gix_hash::oid) -> Option<ResolvedBase>,
+        resolve: &dyn Fn(&gix_hash::oid) -> Option<ResolvedBase>,
     ) -> Result<Outcome, Error> {
         use crate::data::entry::Header::*;
         let mut num_deltas = 0;

--- a/gix-pack/src/data/file/verify.rs
+++ b/gix-pack/src/data/file/verify.rs
@@ -1,6 +1,5 @@
-use std::sync::atomic::AtomicBool;
-
 use gix_features::progress::Progress;
+use std::sync::atomic::AtomicBool;
 
 use crate::data::File;
 

--- a/gix-pack/src/data/file/verify.rs
+++ b/gix-pack/src/data/file/verify.rs
@@ -26,7 +26,7 @@ impl File {
     /// even more thorough integrity check.
     pub fn verify_checksum(
         &self,
-        progress: impl Progress,
+        progress: &mut dyn Progress,
         should_interrupt: &AtomicBool,
     ) -> Result<gix_hash::ObjectId, checksum::Error> {
         crate::verify::checksum_on_disk_or_mmap(

--- a/gix-pack/src/data/input/bytes_to_entries.rs
+++ b/gix-pack/src/data/input/bytes_to_entries.rs
@@ -138,7 +138,7 @@ where
 
         let crc32 = if self.compressed.crc32() {
             let mut header_buf = [0u8; 12 + gix_hash::Kind::longest().len_in_bytes()];
-            let header_len = entry.header.write_to(bytes_copied, header_buf.as_mut())?;
+            let header_len = entry.header.write_to(bytes_copied, &mut header_buf.as_mut())?;
             let state = gix_features::hash::crc32_update(0, &header_buf[..header_len]);
             Some(gix_features::hash::crc32_update(state, &compressed))
         } else {

--- a/gix-pack/src/data/input/entry.rs
+++ b/gix-pack/src/data/input/entry.rs
@@ -33,7 +33,7 @@ impl input::Entry {
         let mut header_buf = [0u8; 12 + gix_hash::Kind::longest().len_in_bytes()];
         let header_len = self
             .header
-            .write_to(self.decompressed_size, header_buf.as_mut())
+            .write_to(self.decompressed_size, &mut header_buf.as_mut())
             .expect("write to memory will not fail");
         let state = gix_features::hash::crc32_update(0, &header_buf[..header_len]);
         gix_features::hash::crc32_update(state, self.compressed.as_ref().expect("we always set it"))

--- a/gix-pack/src/data/input/lookup_ref_delta_objects.rs
+++ b/gix-pack/src/data/input/lookup_ref_delta_objects.rs
@@ -47,13 +47,7 @@ where
 
     /// positive `size_change` values mean an object grew or was more commonly, was inserted. Negative values
     /// mean the object shrunk, usually because there header changed from ref-deltas to ofs deltas.
-    fn track_change(
-        &mut self,
-        shifted_pack_offset: u64,
-        pack_offset: u64,
-        size_change: i64,
-        oid: impl Into<Option<ObjectId>>,
-    ) {
+    fn track_change(&mut self, shifted_pack_offset: u64, pack_offset: u64, size_change: i64, oid: Option<ObjectId>) {
         if size_change == 0 {
             return;
         }
@@ -61,7 +55,7 @@ where
             shifted_pack_offset,
             pack_offset,
             size_change_in_bytes: size_change,
-            oid: oid.into().unwrap_or_else(||
+            oid: oid.unwrap_or_else(||
                 // NOTE: this value acts as sentinel and the actual hash kind doesn't matter.
                 gix_hash::Kind::Sha1.null()),
         });
@@ -112,7 +106,7 @@ where
                                         entry.pack_offset,
                                         current_pack_offset,
                                         entry.bytes_in_pack() as i64,
-                                        base_id,
+                                        Some(base_id),
                                     );
                                     entry
                                 }

--- a/gix-pack/src/data/output/count/mod.rs
+++ b/gix-pack/src/data/output/count/mod.rs
@@ -45,5 +45,5 @@ pub use objects_impl::{objects, objects_unthreaded};
 
 ///
 pub mod objects {
-    pub use super::objects_impl::{Error, ObjectExpansion, Options, Outcome, Result};
+    pub use super::objects_impl::{Error, ObjectExpansion, Options, Outcome};
 }

--- a/gix-pack/src/data/output/count/objects/mod.rs
+++ b/gix-pack/src/data/output/count/objects/mod.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
+use gix_features::progress::NestedProgress;
 use gix_features::{parallel, progress::Progress};
 use gix_hash::ObjectId;
 
@@ -38,7 +39,7 @@ pub type Result<E1, E2> = std::result::Result<(Vec<output::Count>, Outcome), Err
 pub fn objects<Find, Iter, IterErr, Oid>(
     db: Find,
     objects_ids: Iter,
-    progress: impl Progress,
+    progress: impl NestedProgress,
     should_interrupt: &AtomicBool,
     Options {
         thread_limit,

--- a/gix-pack/src/data/output/count/objects/types.rs
+++ b/gix-pack/src/data/output/count/objects/types.rs
@@ -80,17 +80,13 @@ impl Default for Options {
 /// The error returned by the pack generation iterator [`bytes::FromEntriesIter`][crate::data::output::bytes::FromEntriesIter].
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
-pub enum Error<FindErr, IterErr>
-where
-    FindErr: std::error::Error + 'static,
-    IterErr: std::error::Error + 'static,
-{
+pub enum Error {
     #[error(transparent)]
     CommitDecode(gix_object::decode::Error),
     #[error(transparent)]
-    FindExisting(#[from] FindErr),
+    FindExisting(#[from] crate::find::existing::Error),
     #[error(transparent)]
-    InputIteration(IterErr),
+    InputIteration(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error(transparent)]
     TreeTraverse(gix_traverse::tree::breadthfirst::Error),
     #[error(transparent)]

--- a/gix-pack/src/data/output/entry/iter_from_counts.rs
+++ b/gix-pack/src/data/output/entry/iter_from_counts.rs
@@ -1,6 +1,8 @@
 pub(crate) mod function {
     use std::{cmp::Ordering, sync::Arc};
 
+    use gix_features::progress::prodash::Count;
+    use gix_features::progress::NestedProgress;
     use gix_features::{parallel, parallel::SequenceId, progress::Progress};
 
     use super::{reduce, util, Error, Mode, Options, Outcome, ProgressId};
@@ -38,7 +40,7 @@ pub(crate) mod function {
     pub fn iter_from_counts<Find>(
         mut counts: Vec<output::Count>,
         db: Find,
-        mut progress: impl Progress + 'static,
+        mut progress: impl NestedProgress + 'static,
         Options {
             version,
             mode,

--- a/gix-pack/src/data/output/entry/iter_from_counts.rs
+++ b/gix-pack/src/data/output/entry/iter_from_counts.rs
@@ -1,8 +1,7 @@
 pub(crate) mod function {
     use std::{cmp::Ordering, sync::Arc};
 
-    use gix_features::progress::prodash::Count;
-    use gix_features::progress::NestedProgress;
+    use gix_features::progress::prodash::{Count, DynNestedProgress};
     use gix_features::{parallel, parallel::SequenceId, progress::Progress};
 
     use super::{reduce, util, Error, Mode, Options, Outcome, ProgressId};
@@ -40,7 +39,7 @@ pub(crate) mod function {
     pub fn iter_from_counts<Find>(
         mut counts: Vec<output::Count>,
         db: Find,
-        mut progress: impl NestedProgress + 'static,
+        mut progress: Box<dyn DynNestedProgress + 'static>,
         Options {
             version,
             mode,
@@ -48,11 +47,10 @@ pub(crate) mod function {
             thread_limit,
             chunk_size,
         }: Options,
-    ) -> impl Iterator<Item = Result<(SequenceId, Vec<output::Entry>), Error<Find::Error>>>
-           + parallel::reduce::Finalize<Reduce = reduce::Statistics<Error<Find::Error>>>
+    ) -> impl Iterator<Item = Result<(SequenceId, Vec<output::Entry>), Error>>
+           + parallel::reduce::Finalize<Reduce = reduce::Statistics<Error>>
     where
         Find: crate::Find + Send + Clone + 'static,
-        <Find as crate::Find>::Error: Send,
     {
         assert!(
             matches!(version, crate::data::Version::V2),
@@ -62,7 +60,7 @@ pub(crate) mod function {
             parallel::optimize_chunk_size_and_thread_limit(chunk_size, Some(counts.len()), thread_limit, None);
         {
             let progress = Arc::new(parking_lot::Mutex::new(
-                progress.add_child_with_id("resolving", ProgressId::ResolveCounts.into()),
+                progress.add_child_with_id("resolving".into(), ProgressId::ResolveCounts.into()),
             ));
             progress.lock().init(None, gix_features::progress::count("counts"));
             let enough_counts_present = counts.len() > 4_000;
@@ -81,7 +79,7 @@ pub(crate) mod function {
                             use crate::data::output::count::PackLocation::*;
                             match count.entry_pack_location {
                                 LookedUp(_) => continue,
-                                NotLookedUp => count.entry_pack_location = LookedUp(db.location_by_oid(count.id, buf)),
+                                NotLookedUp => count.entry_pack_location = LookedUp(db.location_by_oid(&count.id, buf)),
                             }
                         }
                         progress.lock().inc_by(chunk_size);
@@ -95,7 +93,7 @@ pub(crate) mod function {
         }
         let counts_range_by_pack_id = match mode {
             Mode::PackCopyAndBaseObjects => {
-                let mut progress = progress.add_child_with_id("sorting", ProgressId::SortEntries.into());
+                let mut progress = progress.add_child_with_id("sorting".into(), ProgressId::SortEntries.into());
                 progress.init(Some(counts.len()), gix_features::progress::count("counts"));
                 let start = std::time::Instant::now();
 
@@ -206,7 +204,7 @@ pub(crate) mod function {
                                         stats.objects_copied_from_pack += 1;
                                         entry
                                     }
-                                    None => match db.try_find(count.id, buf).map_err(Error::FindExisting)? {
+                                    None => match db.try_find(&count.id, buf).map_err(Error::FindExisting)? {
                                         Some((obj, _location)) => {
                                             stats.decoded_and_recompressed_objects += 1;
                                             output::Entry::from_data(count, &obj)
@@ -218,7 +216,7 @@ pub(crate) mod function {
                                     },
                                 }
                             }
-                            None => match db.try_find(count.id, buf).map_err(Error::FindExisting)? {
+                            None => match db.try_find(&count.id, buf).map_err(Error::FindExisting)? {
                                 Some((obj, _location)) => {
                                     stats.decoded_and_recompressed_objects += 1;
                                     output::Entry::from_data(count, &obj)
@@ -397,12 +395,9 @@ mod types {
     /// The error returned by the pack generation function [`iter_from_counts()`][crate::data::output::entry::iter_from_counts()].
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<FindErr>
-    where
-        FindErr: std::error::Error + 'static,
-    {
+    pub enum Error {
         #[error(transparent)]
-        FindExisting(FindErr),
+        FindExisting(crate::find::Error),
         #[error(transparent)]
         NewEntry(#[from] entry::Error),
     }

--- a/gix-pack/src/data/output/entry/mod.rs
+++ b/gix-pack/src/data/output/entry/mod.rs
@@ -66,15 +66,14 @@ impl output::Entry {
         potential_bases: &[output::Count],
         bases_index_offset: usize,
         pack_offset_to_oid: Option<impl FnMut(u32, u64) -> Option<ObjectId>>,
-        target_version: crate::data::Version,
+        target_version: data::Version,
     ) -> Option<Result<Self, Error>> {
         if entry.version != target_version {
             return None;
         };
 
         let pack_offset_must_be_zero = 0;
-        let pack_entry =
-            crate::data::Entry::from_bytes(&entry.data, pack_offset_must_be_zero, count.id.as_slice().len());
+        let pack_entry = data::Entry::from_bytes(&entry.data, pack_offset_must_be_zero, count.id.as_slice().len());
 
         use crate::data::entry::Header::*;
         match pack_entry.header {
@@ -153,9 +152,9 @@ impl output::Entry {
     /// This information is known to the one calling the method.
     pub fn to_entry_header(
         &self,
-        version: crate::data::Version,
+        version: data::Version,
         index_to_base_distance: impl FnOnce(usize) -> u64,
-    ) -> crate::data::entry::Header {
+    ) -> data::entry::Header {
         assert!(
             matches!(version, data::Version::V2),
             "we can only write V2 pack entries for now"

--- a/gix-pack/src/find.rs
+++ b/gix-pack/src/find.rs
@@ -1,13 +1,16 @@
+/// The error returned by methods of the [Find](crate::Find) trait.
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 ///
 pub mod existing {
     use gix_hash::ObjectId;
 
-    /// The error returned by the [`find(…)`][crate::FindExt::find()] trait methods.
+    /// The error returned by the [`find(…)`](crate::FindExt::find()) trait methods.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<T: std::error::Error + 'static> {
+    pub enum Error {
         #[error(transparent)]
-        Find(T),
+        Find(crate::find::Error),
         #[error("An object with id {} could not be found", .oid)]
         NotFound { oid: ObjectId },
     }
@@ -17,12 +20,12 @@ pub mod existing {
 pub mod existing_object {
     use gix_hash::ObjectId;
 
-    /// The error returned by the various [`find_*`][crate::FindExt::find_commit()] trait methods.
+    /// The error returned by the various [`find_*`](crate::FindExt::find_commit()) trait methods.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<T: std::error::Error + 'static> {
+    pub enum Error {
         #[error(transparent)]
-        Find(T),
+        Find(crate::find::Error),
         #[error(transparent)]
         Decode(gix_object::decode::Error),
         #[error("An object with id {} could not be found", .oid)]
@@ -36,12 +39,12 @@ pub mod existing_object {
 pub mod existing_iter {
     use gix_hash::ObjectId;
 
-    /// The error returned by the various [`find_*`][crate::FindExt::find_commit()] trait methods.
+    /// The error returned by the various [`find_*`](crate::FindExt::find_commit()) trait methods.
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
-    pub enum Error<T: std::error::Error + 'static> {
+    pub enum Error {
         #[error(transparent)]
-        Find(T),
+        Find(crate::find::Error),
         #[error("An object with id {} could not be found", .oid)]
         NotFound { oid: ObjectId },
         #[error("Expected object of kind {} something else", .expected)]

--- a/gix-pack/src/index/traverse/with_index.rs
+++ b/gix-pack/src/index/traverse/with_index.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use gix_features::progress::NestedProgress;
 use gix_features::{parallel, progress::Progress};
 
 use super::Error;
@@ -65,8 +66,8 @@ impl index::File {
         Options { check, thread_limit }: Options,
     ) -> Result<Outcome<P>, Error<E>>
     where
-        P: Progress,
-        Processor: FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn gix_features::progress::RawProgress) -> Result<(), E>
+        P: NestedProgress,
+        Processor: FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn gix_features::progress::Progress) -> Result<(), E>
             + Send
             + Clone,
         E: std::error::Error + Send + Sync + 'static,

--- a/gix-pack/src/index/traverse/with_index.rs
+++ b/gix-pack/src/index/traverse/with_index.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use gix_features::progress::NestedProgress;
-use gix_features::{parallel, progress::Progress};
+use gix_features::parallel;
+use gix_features::progress::DynNestedProgress;
 
 use super::Error;
 use crate::{
@@ -57,16 +57,15 @@ impl index::File {
     /// at the cost of memory.
     ///
     /// For more details, see the documentation on the [`traverse()`][index::File::traverse()] method.
-    pub fn traverse_with_index<P, Processor, E>(
+    pub fn traverse_with_index<Processor, E>(
         &self,
         pack: &crate::data::File,
         mut processor: Processor,
-        mut progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         Options { check, thread_limit }: Options,
-    ) -> Result<Outcome<P>, Error<E>>
+    ) -> Result<Outcome, Error<E>>
     where
-        P: NestedProgress,
         Processor: FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn gix_features::progress::Progress) -> Result<(), E>
             + Send
             + Clone,
@@ -74,14 +73,14 @@ impl index::File {
     {
         let (verify_result, traversal_result) = parallel::join(
             {
-                let pack_progress = progress.add_child_with_id(
+                let mut pack_progress = progress.add_child_with_id(
                     format!(
                         "Hash of pack '{}'",
                         pack.path().file_name().expect("pack has filename").to_string_lossy()
                     ),
                     ProgressId::HashPackDataBytes.into(),
                 );
-                let index_progress = progress.add_child_with_id(
+                let mut index_progress = progress.add_child_with_id(
                     format!(
                         "Hash of index '{}'",
                         self.path.file_name().expect("index has filename").to_string_lossy()
@@ -89,7 +88,8 @@ impl index::File {
                     ProgressId::HashPackIndexBytes.into(),
                 );
                 move || {
-                    let res = self.possibly_verify(pack, check, pack_progress, index_progress, should_interrupt);
+                    let res =
+                        self.possibly_verify(pack, check, &mut pack_progress, &mut index_progress, should_interrupt);
                     if res.is_err() {
                         should_interrupt.store(true, Ordering::SeqCst);
                     }
@@ -99,14 +99,17 @@ impl index::File {
             || -> Result<_, Error<_>> {
                 let sorted_entries = index_entries_sorted_by_offset_ascending(
                     self,
-                    progress.add_child_with_id("collecting sorted index", ProgressId::CollectSortedIndexEntries.into()),
+                    &mut progress.add_child_with_id(
+                        "collecting sorted index".into(),
+                        ProgressId::CollectSortedIndexEntries.into(),
+                    ),
                 ); /* Pack Traverse Collect sorted Entries */
                 let tree = crate::cache::delta::Tree::from_offsets_in_pack(
                     pack.path(),
                     sorted_entries.into_iter().map(Entry::from),
-                    |e| e.index_entry.pack_offset,
-                    |id| self.lookup(id).map(|idx| self.pack_offset_at_index(idx)),
-                    progress.add_child_with_id("indexing", ProgressId::TreeFromOffsetsObjects.into()),
+                    &|e| e.index_entry.pack_offset,
+                    &|id| self.lookup(id).map(|idx| self.pack_offset_at_index(idx)),
+                    &mut progress.add_child_with_id("indexing".into(), ProgressId::TreeFromOffsetsObjects.into()),
                     should_interrupt,
                     self.object_hash,
                 )?;
@@ -154,8 +157,11 @@ impl index::File {
                         }
                     },
                     traverse::Options {
-                        object_progress: progress.add_child_with_id("Resolving", ProgressId::DecodedObjects.into()),
-                        size_progress: progress.add_child_with_id("Decoding", ProgressId::DecodedBytes.into()),
+                        object_progress: Box::new(
+                            progress.add_child_with_id("Resolving".into(), ProgressId::DecodedObjects.into()),
+                        ),
+                        size_progress:
+                            &mut progress.add_child_with_id("Decoding".into(), ProgressId::DecodedBytes.into()),
                         thread_limit,
                         should_interrupt,
                         object_hash: self.object_hash,
@@ -168,7 +174,6 @@ impl index::File {
         Ok(Outcome {
             actual_index_checksum: verify_result?,
             statistics: traversal_result?,
-            progress,
         })
     }
 }

--- a/gix-pack/src/index/traverse/with_lookup.rs
+++ b/gix-pack/src/index/traverse/with_lookup.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use gix_features::progress::{Count, NestedProgress};
 use gix_features::{
     parallel::{self, in_parallel_if},
     progress::{self, Progress},
@@ -79,12 +80,10 @@ impl index::File {
         }: Options<F>,
     ) -> Result<Outcome<P>, Error<E>>
     where
-        P: Progress,
+        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         E: std::error::Error + Send + Sync + 'static,
-        Processor: FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn gix_features::progress::RawProgress) -> Result<(), E>
-            + Send
-            + Clone,
+        Processor: FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn Progress) -> Result<(), E> + Send + Clone,
         F: Fn() -> C + Send + Clone,
     {
         let (verify_result, traversal_result) = parallel::join(

--- a/gix-pack/src/index/traverse/with_lookup.rs
+++ b/gix-pack/src/index/traverse/with_lookup.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use gix_features::progress::{Count, NestedProgress};
+use gix_features::progress::{Count, DynNestedProgress};
 use gix_features::{
     parallel::{self, in_parallel_if},
     progress::{self, Progress},
@@ -67,20 +67,19 @@ impl index::File {
     /// waste while decoding objects.
     ///
     /// For more details, see the documentation on the [`traverse()`][index::File::traverse()] method.
-    pub fn traverse_with_lookup<P, C, Processor, E, F>(
+    pub fn traverse_with_lookup<C, Processor, E, F>(
         &self,
         mut processor: Processor,
         pack: &data::File,
-        mut progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         Options {
             thread_limit,
             check,
             make_pack_lookup_cache,
         }: Options<F>,
-    ) -> Result<Outcome<P>, Error<E>>
+    ) -> Result<Outcome, Error<E>>
     where
-        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         E: std::error::Error + Send + Sync + 'static,
         Processor: FnMut(gix_object::Kind, &[u8], &index::Entry, &dyn Progress) -> Result<(), E> + Send + Clone,
@@ -88,14 +87,14 @@ impl index::File {
     {
         let (verify_result, traversal_result) = parallel::join(
             {
-                let pack_progress = progress.add_child_with_id(
+                let mut pack_progress = progress.add_child_with_id(
                     format!(
                         "Hash of pack '{}'",
                         pack.path().file_name().expect("pack has filename").to_string_lossy()
                     ),
                     ProgressId::HashPackDataBytes.into(),
                 );
-                let index_progress = progress.add_child_with_id(
+                let mut index_progress = progress.add_child_with_id(
                     format!(
                         "Hash of index '{}'",
                         self.path.file_name().expect("index has filename").to_string_lossy()
@@ -103,7 +102,8 @@ impl index::File {
                     ProgressId::HashPackIndexBytes.into(),
                 );
                 move || {
-                    let res = self.possibly_verify(pack, check, pack_progress, index_progress, should_interrupt);
+                    let res =
+                        self.possibly_verify(pack, check, &mut pack_progress, &mut index_progress, should_interrupt);
                     if res.is_err() {
                         should_interrupt.store(true, Ordering::SeqCst);
                     }
@@ -113,7 +113,10 @@ impl index::File {
             || {
                 let index_entries = util::index_entries_sorted_by_offset_ascending(
                     self,
-                    progress.add_child_with_id("collecting sorted index", ProgressId::CollectSortedIndexEntries.into()),
+                    &mut progress.add_child_with_id(
+                        "collecting sorted index".into(),
+                        ProgressId::CollectSortedIndexEntries.into(),
+                    ),
                 );
 
                 let (chunk_size, thread_limit, available_cores) =
@@ -121,7 +124,7 @@ impl index::File {
                 let there_are_enough_entries_to_process = || index_entries.len() > chunk_size * available_cores;
                 let input_chunks = index_entries.chunks(chunk_size.max(chunk_size));
                 let reduce_progress = OwnShared::new(Mutable::new({
-                    let mut p = progress.add_child_with_id("Traversing", ProgressId::DecodedObjects.into());
+                    let mut p = progress.add_child_with_id("Traversing".into(), ProgressId::DecodedObjects.into());
                     p.init(Some(self.num_objects() as usize), progress::count("objects"));
                     p
                 }));
@@ -185,7 +188,6 @@ impl index::File {
         Ok(Outcome {
             actual_index_checksum: verify_result?,
             statistics: traversal_result?,
-            progress,
         })
     }
 }

--- a/gix-pack/src/index/util.rs
+++ b/gix-pack/src/index/util.rs
@@ -4,7 +4,7 @@ use gix_features::progress::{self, Progress};
 
 pub(crate) fn index_entries_sorted_by_offset_ascending(
     idx: &crate::index::File,
-    mut progress: impl Progress,
+    progress: &mut dyn Progress,
 ) -> Vec<crate::index::Entry> {
     progress.init(Some(idx.num_objects as usize), progress::count("entries"));
     let start = Instant::now();

--- a/gix-pack/src/index/verify.rs
+++ b/gix-pack/src/index/verify.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use gix_features::progress::{NestedProgress, Progress};
+use gix_features::progress::{DynNestedProgress, Progress};
 use gix_object::{bstr::ByteSlice, WriteTo};
 
 use crate::index;
@@ -35,13 +35,11 @@ pub mod integrity {
     }
 
     /// Returned by [`index::File::verify_integrity()`][crate::index::File::verify_integrity()].
-    pub struct Outcome<P> {
+    pub struct Outcome {
         /// The computed checksum of the index which matched the stored one.
         pub actual_index_checksum: gix_hash::ObjectId,
         /// The packs traversal outcome, if one was provided
         pub pack_traverse_statistics: Option<crate::index::traverse::Statistics>,
-        /// The provided progress instance.
-        pub progress: P,
     }
 
     /// Additional options to define how the integrity should be verified.
@@ -138,7 +136,7 @@ impl index::File {
     /// of this index file, and return it if it does.
     pub fn verify_checksum(
         &self,
-        progress: impl Progress,
+        progress: &mut dyn Progress,
         should_interrupt: &AtomicBool,
     ) -> Result<gix_hash::ObjectId, checksum::Error> {
         crate::verify::checksum_on_disk_or_mmap(
@@ -168,14 +166,13 @@ impl index::File {
     ///
     /// The given `progress` is inevitably consumed if there is an error, which is a tradeoff chosen to easily allow using `?` in the
     /// error case.
-    pub fn verify_integrity<P, C, F>(
+    pub fn verify_integrity<C, F>(
         &self,
         pack: Option<PackContext<'_, F>>,
-        mut progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
-    ) -> Result<integrity::Outcome<P>, index::traverse::Error<index::verify::integrity::Error>>
+    ) -> Result<integrity::Outcome, index::traverse::Error<index::verify::integrity::Error>>
     where
-        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
@@ -216,18 +213,17 @@ impl index::File {
                 .map(|o| integrity::Outcome {
                     actual_index_checksum: o.actual_index_checksum,
                     pack_traverse_statistics: Some(o.statistics),
-                    progress: o.progress,
                 }),
             None => self
                 .verify_checksum(
-                    progress.add_child_with_id("Sha1 of index", integrity::ProgressId::ChecksumBytes.into()),
+                    &mut progress
+                        .add_child_with_id("Sha1 of index".into(), integrity::ProgressId::ChecksumBytes.into()),
                     should_interrupt,
                 )
                 .map_err(Into::into)
                 .map(|id| integrity::Outcome {
                     actual_index_checksum: id,
                     pack_traverse_statistics: None,
-                    progress,
                 }),
         }
     }

--- a/gix-pack/src/index/verify.rs
+++ b/gix-pack/src/index/verify.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use gix_features::progress::Progress;
+use gix_features::progress::{NestedProgress, Progress};
 use gix_object::{bstr::ByteSlice, WriteTo};
 
 use crate::index;
@@ -175,7 +175,7 @@ impl index::File {
         should_interrupt: &AtomicBool,
     ) -> Result<integrity::Outcome<P>, index::traverse::Error<index::verify::integrity::Error>>
     where
-        P: Progress,
+        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
@@ -239,7 +239,7 @@ impl index::File {
         object_kind: gix_object::Kind,
         buf: &[u8],
         index_entry: &index::Entry,
-        progress: &dyn gix_features::progress::RawProgress,
+        progress: &dyn gix_features::progress::Progress,
     ) -> Result<(), integrity::Error> {
         if let Mode::HashCrc32Decode | Mode::HashCrc32DecodeEncode = verify_mode {
             use gix_object::Kind::*;

--- a/gix-pack/src/index/write/encode.rs
+++ b/gix-pack/src/index/write/encode.rs
@@ -5,7 +5,7 @@ pub(crate) const HIGH_BIT: u32 = 0x8000_0000;
 
 use gix_features::{
     hash,
-    progress::{self, Progress},
+    progress::{self, NestedProgress},
 };
 
 use crate::index::{util::Count, V2_SIGNATURE};
@@ -15,7 +15,7 @@ pub(crate) fn write_to(
     entries_sorted_by_oid: Vec<crate::cache::delta::Item<crate::index::write::TreeEntry>>,
     pack_hash: &gix_hash::ObjectId,
     kind: crate::index::Version,
-    mut progress: impl Progress,
+    mut progress: impl NestedProgress,
 ) -> io::Result<gix_hash::ObjectId> {
     use io::Write;
     assert_eq!(kind, crate::index::Version::V2, "Can only write V2 packs right now");

--- a/gix-pack/src/index/write/encode.rs
+++ b/gix-pack/src/index/write/encode.rs
@@ -5,17 +5,17 @@ pub(crate) const HIGH_BIT: u32 = 0x8000_0000;
 
 use gix_features::{
     hash,
-    progress::{self, NestedProgress},
+    progress::{self, DynNestedProgress},
 };
 
 use crate::index::{util::Count, V2_SIGNATURE};
 
 pub(crate) fn write_to(
-    out: impl io::Write,
+    out: &mut dyn io::Write,
     entries_sorted_by_oid: Vec<crate::cache::delta::Item<crate::index::write::TreeEntry>>,
     pack_hash: &gix_hash::ObjectId,
     kind: crate::index::Version,
-    mut progress: impl NestedProgress,
+    progress: &mut dyn DynNestedProgress,
 ) -> io::Result<gix_hash::ObjectId> {
     use io::Write;
     assert_eq!(kind, crate::index::Version::V2, "Can only write V2 packs right now");
@@ -34,27 +34,27 @@ pub(crate) fn write_to(
 
     progress.init(Some(4), progress::steps());
     let start = std::time::Instant::now();
-    let _info = progress.add_child_with_id("writing fan-out table", gix_features::progress::UNKNOWN);
-    let fan_out = fanout(entries_sorted_by_oid.iter().map(|e| e.data.id.first_byte()));
+    let _info = progress.add_child_with_id("writing fan-out table".into(), gix_features::progress::UNKNOWN);
+    let fan_out = fanout(&mut entries_sorted_by_oid.iter().map(|e| e.data.id.first_byte()));
 
     for value in fan_out.iter() {
         out.write_all(&value.to_be_bytes())?;
     }
 
     progress.inc();
-    let _info = progress.add_child_with_id("writing ids", gix_features::progress::UNKNOWN);
+    let _info = progress.add_child_with_id("writing ids".into(), gix_features::progress::UNKNOWN);
     for entry in &entries_sorted_by_oid {
         out.write_all(entry.data.id.as_slice())?;
     }
 
     progress.inc();
-    let _info = progress.add_child_with_id("writing crc32", gix_features::progress::UNKNOWN);
+    let _info = progress.add_child_with_id("writing crc32".into(), gix_features::progress::UNKNOWN);
     for entry in &entries_sorted_by_oid {
         out.write_all(&entry.data.crc32.to_be_bytes())?;
     }
 
     progress.inc();
-    let _info = progress.add_child_with_id("writing offsets", gix_features::progress::UNKNOWN);
+    let _info = progress.add_child_with_id("writing offsets".into(), gix_features::progress::UNKNOWN);
     {
         let mut offsets64 = Vec::<u64>::new();
         for entry in &entries_sorted_by_oid {
@@ -78,7 +78,7 @@ pub(crate) fn write_to(
     out.write_all(pack_hash.as_slice())?;
 
     let bytes_written_without_trailer = out.bytes;
-    let mut out = out.inner.into_inner()?;
+    let out = out.inner.into_inner()?;
     let index_hash: gix_hash::ObjectId = out.hash.digest().into();
     out.inner.write_all(index_hash.as_slice())?;
     out.inner.flush()?;
@@ -94,7 +94,7 @@ pub(crate) fn write_to(
     Ok(index_hash)
 }
 
-pub(crate) fn fanout(iter: impl ExactSizeIterator<Item = u8>) -> [u32; 256] {
+pub(crate) fn fanout(iter: &mut dyn ExactSizeIterator<Item = u8>) -> [u32; 256] {
     let mut fan_out = [0u32; 256];
     let entries_len = iter.len() as u32;
     let mut iter = iter.enumerate();

--- a/gix-pack/src/index/write/mod.rs
+++ b/gix-pack/src/index/write/mod.rs
@@ -1,7 +1,8 @@
 use std::{convert::TryInto, io, sync::atomic::AtomicBool};
 
 pub use error::Error;
-use gix_features::progress::{self, Count, NestedProgress, Progress};
+use gix_features::progress::prodash::DynNestedProgress;
+use gix_features::progress::{self, Count, Progress};
 
 use crate::cache::delta::{traverse, Tree};
 
@@ -83,13 +84,13 @@ impl crate::index::File {
     /// It should return `None` if the entry cannot be resolved from the pack that produced the `entries` iterator, causing
     /// the write operation to fail.
     #[allow(clippy::too_many_arguments)]
-    pub fn write_data_iter_to_stream<F, F2, R, P>(
+    pub fn write_data_iter_to_stream<F, F2, R>(
         version: crate::index::Version,
         make_resolver: F,
-        entries: impl Iterator<Item = Result<crate::data::input::Entry, crate::data::input::Error>>,
+        entries: &mut dyn Iterator<Item = Result<crate::data::input::Entry, crate::data::input::Error>>,
         thread_limit: Option<usize>,
-        mut root_progress: P,
-        out: impl io::Write,
+        root_progress: &mut dyn DynNestedProgress,
+        out: &mut dyn io::Write,
         should_interrupt: &AtomicBool,
         object_hash: gix_hash::Kind,
         pack_version: crate::data::Version,
@@ -98,7 +99,6 @@ impl crate::index::File {
         F: FnOnce() -> io::Result<(F2, R)>,
         R: Send + Sync,
         F2: for<'r> Fn(crate::data::EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
-        P: NestedProgress,
     {
         if version != crate::index::Version::default() {
             return Err(Error::Unsupported(version));
@@ -111,10 +111,10 @@ impl crate::index::File {
         let indexing_start = std::time::Instant::now();
 
         root_progress.init(Some(4), progress::steps());
-        let mut objects_progress = root_progress.add_child_with_id("indexing", ProgressId::IndexObjects.into());
+        let mut objects_progress = root_progress.add_child_with_id("indexing".into(), ProgressId::IndexObjects.into());
         objects_progress.init(Some(anticipated_num_objects), progress::count("objects"));
         let mut decompressed_progress =
-            root_progress.add_child_with_id("decompressing", ProgressId::DecompressedBytes.into());
+            root_progress.add_child_with_id("decompressing".into(), ProgressId::DecompressedBytes.into());
         decompressed_progress.init(None, progress::bytes());
         let mut pack_entries_end: u64 = 0;
 
@@ -199,8 +199,11 @@ impl crate::index::File {
                     Ok::<_, Error>(())
                 },
                 traverse::Options {
-                    object_progress: root_progress.add_child_with_id("Resolving", ProgressId::ResolveObjects.into()),
-                    size_progress: root_progress.add_child_with_id("Decoding", ProgressId::DecodedBytes.into()),
+                    object_progress: Box::new(
+                        root_progress.add_child_with_id("Resolving".into(), ProgressId::ResolveObjects.into()),
+                    ),
+                    size_progress: &mut root_progress
+                        .add_child_with_id("Decoding".into(), ProgressId::DecodedBytes.into()),
                     thread_limit,
                     should_interrupt,
                     object_hash,
@@ -211,7 +214,8 @@ impl crate::index::File {
             let mut items = roots;
             items.extend(children);
             {
-                let _progress = root_progress.add_child_with_id("sorting by id", gix_features::progress::UNKNOWN);
+                let _progress =
+                    root_progress.add_child_with_id("sorting by id".into(), gix_features::progress::UNKNOWN);
                 items.sort_by_key(|e| e.data.id);
             }
 
@@ -234,7 +238,7 @@ impl crate::index::File {
             sorted_pack_offsets_by_oid,
             &pack_hash,
             version,
-            root_progress.add_child_with_id("writing index file", ProgressId::IndexBytesWritten.into()),
+            &mut root_progress.add_child_with_id("writing index file".into(), ProgressId::IndexBytesWritten.into()),
         )?;
         root_progress.show_throughput_with(
             indexing_start,

--- a/gix-pack/src/index/write/mod.rs
+++ b/gix-pack/src/index/write/mod.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryInto, io, sync::atomic::AtomicBool};
 
 pub use error::Error;
-use gix_features::progress::{self, Progress};
+use gix_features::progress::{self, Count, NestedProgress, Progress};
 
 use crate::cache::delta::{traverse, Tree};
 
@@ -98,7 +98,7 @@ impl crate::index::File {
         F: FnOnce() -> io::Result<(F2, R)>,
         R: Send + Sync,
         F2: for<'r> Fn(crate::data::EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
-        P: Progress,
+        P: NestedProgress,
     {
         if version != crate::index::Version::default() {
             return Err(Error::Unsupported(version));

--- a/gix-pack/src/multi_index/access.rs
+++ b/gix-pack/src/multi_index/access.rs
@@ -89,7 +89,7 @@ impl File {
             prefix,
             candidates,
             &self.fan,
-            |idx| self.oid_at_index(idx),
+            &|idx| self.oid_at_index(idx),
             self.num_objects,
         )
     }
@@ -98,7 +98,7 @@ impl File {
     ///
     /// Use this index for finding additional information via [`File::pack_id_and_pack_offset_at_index()`].
     pub fn lookup(&self, id: impl AsRef<gix_hash::oid>) -> Option<EntryIndex> {
-        crate::index::access::lookup(id, &self.fan, |idx| self.oid_at_index(idx))
+        crate::index::access::lookup(id.as_ref(), &self.fan, &|idx| self.oid_at_index(idx))
     }
 
     /// Given the `index` ranging from 0 to [File::num_objects()], return the pack index and its absolute offset into the pack.

--- a/gix-pack/src/multi_index/chunk.rs
+++ b/gix-pack/src/multi_index/chunk.rs
@@ -82,7 +82,7 @@ pub mod index_names {
     /// Write all `paths` in order to `out`, including padding.
     pub fn write(
         paths: impl IntoIterator<Item = impl AsRef<Path>>,
-        mut out: impl std::io::Write,
+        out: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
         let mut written_bytes = 0;
         for path in paths {
@@ -130,9 +130,9 @@ pub mod fanout {
     /// Write the fanout for the given entries, which must be sorted by oid
     pub(crate) fn write(
         sorted_entries: &[multi_index::write::Entry],
-        mut out: impl std::io::Write,
+        out: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
-        let fanout = crate::index::write::encode::fanout(sorted_entries.iter().map(|e| e.id.first_byte()));
+        let fanout = crate::index::write::encode::fanout(&mut sorted_entries.iter().map(|e| e.id.first_byte()));
 
         for value in fanout.iter() {
             out.write_all(&value.to_be_bytes())?;
@@ -157,7 +157,7 @@ pub mod lookup {
 
     pub(crate) fn write(
         sorted_entries: &[multi_index::write::Entry],
-        mut out: impl std::io::Write,
+        out: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
         for entry in sorted_entries {
             out.write_all(entry.id.as_slice())?;
@@ -188,7 +188,7 @@ pub mod offsets {
     pub(crate) fn write(
         sorted_entries: &[multi_index::write::Entry],
         large_offsets_needed: bool,
-        mut out: impl std::io::Write,
+        out: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
         use crate::index::write::encode::{HIGH_BIT, LARGE_OFFSET_THRESHOLD};
         let mut num_large_offsets = 0u32;
@@ -254,7 +254,7 @@ pub mod large_offsets {
     pub(crate) fn write(
         sorted_entries: &[multi_index::write::Entry],
         mut num_large_offsets: usize,
-        mut out: impl std::io::Write,
+        out: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
         for offset in sorted_entries
             .iter()

--- a/gix-pack/src/multi_index/verify.rs
+++ b/gix-pack/src/multi_index/verify.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, sync::atomic::AtomicBool, time::Instant};
 
-use gix_features::progress::Progress;
+use gix_features::progress::{Count, NestedProgress, Progress};
 
 use crate::{index, multi_index::File};
 
@@ -102,7 +102,7 @@ impl File {
         should_interrupt: &AtomicBool,
     ) -> Result<(gix_hash::ObjectId, P), integrity::Error>
     where
-        P: Progress,
+        P: NestedProgress,
     {
         self.verify_integrity_inner(
             progress,
@@ -127,7 +127,7 @@ impl File {
         options: index::verify::integrity::Options<F>,
     ) -> Result<integrity::Outcome<P>, index::traverse::Error<integrity::Error>>
     where
-        P: Progress,
+        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
@@ -142,7 +142,7 @@ impl File {
         options: index::verify::integrity::Options<F>,
     ) -> Result<integrity::Outcome<P>, index::traverse::Error<integrity::Error>>
     where
-        P: Progress,
+        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
@@ -325,7 +325,7 @@ impl File {
             "BUG: our slicing should allow to visit all objects"
         );
 
-        progress.set_name("Validating multi-pack");
+        progress.set_name("Validating multi-pack".into());
         progress.show_throughput(operation_start);
 
         Ok(integrity::Outcome {

--- a/gix-pack/src/multi_index/verify.rs
+++ b/gix-pack/src/multi_index/verify.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, sync::atomic::AtomicBool, time::Instant};
 
-use gix_features::progress::{Count, NestedProgress, Progress};
+use gix_features::progress::{Count, DynNestedProgress, Progress};
 
 use crate::{index, multi_index::File};
 
@@ -39,13 +39,11 @@ pub mod integrity {
     }
 
     /// Returned by [`multi_index::File::verify_integrity()`][crate::multi_index::File::verify_integrity()].
-    pub struct Outcome<P> {
+    pub struct Outcome {
         /// The computed checksum of the multi-index which matched the stored one.
         pub actual_index_checksum: gix_hash::ObjectId,
         /// The for each entry in [`index_names()`][super::File::index_names()] provide the corresponding pack traversal outcome.
         pub pack_traverse_statistics: Vec<crate::index::traverse::Statistics>,
-        /// The provided progress instance.
-        pub progress: P,
     }
 
     /// The progress ids used in [`multi_index::File::verify_integrity()`][crate::multi_index::File::verify_integrity()].
@@ -80,7 +78,7 @@ impl File {
     /// of this index file, and return it if it does.
     pub fn verify_checksum(
         &self,
-        progress: impl Progress,
+        progress: &mut dyn Progress,
         should_interrupt: &AtomicBool,
     ) -> Result<gix_hash::ObjectId, checksum::Error> {
         crate::verify::checksum_on_disk_or_mmap(
@@ -96,14 +94,11 @@ impl File {
     /// Similar to [`verify_integrity()`][File::verify_integrity()] but without any deep inspection of objects.
     ///
     /// Instead we only validate the contents of the multi-index itself.
-    pub fn verify_integrity_fast<P>(
+    pub fn verify_integrity_fast(
         &self,
-        progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
-    ) -> Result<(gix_hash::ObjectId, P), integrity::Error>
-    where
-        P: NestedProgress,
-    {
+    ) -> Result<gix_hash::ObjectId, integrity::Error> {
         self.verify_integrity_inner(
             progress,
             should_interrupt,
@@ -114,35 +109,33 @@ impl File {
             index::traverse::Error::Processor(err) => err,
             _ => unreachable!("BUG: no other error type is possible"),
         })
-        .map(|o| (o.actual_index_checksum, o.progress))
+        .map(|o| o.actual_index_checksum)
     }
 
     /// Similar to [`crate::Bundle::verify_integrity()`] but checks all contained indices and their packs.
     ///
     /// Note that it's considered a failure if an index doesn't have a corresponding pack.
-    pub fn verify_integrity<C, P, F>(
+    pub fn verify_integrity<C, F>(
         &self,
-        progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         options: index::verify::integrity::Options<F>,
-    ) -> Result<integrity::Outcome<P>, index::traverse::Error<integrity::Error>>
+    ) -> Result<integrity::Outcome, index::traverse::Error<integrity::Error>>
     where
-        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
         self.verify_integrity_inner(progress, should_interrupt, true, options)
     }
 
-    fn verify_integrity_inner<C, P, F>(
+    fn verify_integrity_inner<C, F>(
         &self,
-        mut progress: P,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         deep_check: bool,
         options: index::verify::integrity::Options<F>,
-    ) -> Result<integrity::Outcome<P>, index::traverse::Error<integrity::Error>>
+    ) -> Result<integrity::Outcome, index::traverse::Error<integrity::Error>>
     where
-        P: NestedProgress,
         C: crate::cache::DecodeEntry,
         F: Fn() -> C + Send + Clone,
     {
@@ -150,7 +143,7 @@ impl File {
 
         let actual_index_checksum = self
             .verify_checksum(
-                progress.add_child_with_id(
+                &mut progress.add_child_with_id(
                     format!("{}: checksum", self.path.display()),
                     integrity::ProgressId::ChecksumBytes.into(),
                 ),
@@ -176,7 +169,7 @@ impl File {
         let mut pack_ids_and_offsets = Vec::with_capacity(self.num_objects as usize);
         {
             let order_start = Instant::now();
-            let mut progress = progress.add_child_with_id("checking oid order", gix_features::progress::UNKNOWN);
+            let mut progress = progress.add_child_with_id("checking oid order".into(), gix_features::progress::UNKNOWN);
             progress.init(
                 Some(self.num_objects as usize),
                 gix_features::progress::count("objects"),
@@ -238,8 +231,10 @@ impl File {
             let multi_index_entries_to_check = &pack_ids_slice[..slice_end];
             {
                 let offset_start = Instant::now();
-                let mut offsets_progress =
-                    progress.add_child_with_id("verify object offsets", integrity::ProgressId::ObjectOffsets.into());
+                let mut offsets_progress = progress.add_child_with_id(
+                    "verify object offsets".into(),
+                    integrity::ProgressId::ObjectOffsets.into(),
+                );
                 offsets_progress.init(
                     Some(pack_ids_and_offsets.len()),
                     gix_features::progress::count("objects"),
@@ -278,7 +273,6 @@ impl File {
                 let crate::bundle::verify::integrity::Outcome {
                     actual_index_checksum: _,
                     pack_traverse_outcome,
-                    progress: returned_progress,
                 } = bundle
                     .verify_integrity(progress, should_interrupt, options.clone())
                     .map_err(|err| {
@@ -315,7 +309,6 @@ impl File {
                             Interrupted => Interrupted,
                         }
                     })?;
-                progress = returned_progress;
                 pack_traverse_statistics.push(pack_traverse_outcome);
             }
         }
@@ -331,7 +324,6 @@ impl File {
         Ok(integrity::Outcome {
             actual_index_checksum,
             pack_traverse_statistics,
-            progress,
         })
     }
 }

--- a/gix-pack/src/multi_index/write.rs
+++ b/gix-pack/src/multi_index/write.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Instant, SystemTime},
 };
 
-use gix_features::progress::Progress;
+use gix_features::progress::{Count, NestedProgress, Progress};
 
 use crate::multi_index;
 
@@ -87,7 +87,7 @@ impl multi_index::File {
         Options { object_hash }: Options,
     ) -> Result<Outcome<P>, Error>
     where
-        P: Progress,
+        P: NestedProgress,
     {
         let out = gix_features::hash::Write::new(out, object_hash);
         let (index_paths_sorted, index_filenames_sorted) = {
@@ -129,7 +129,7 @@ impl multi_index::File {
             progress.show_throughput(start);
 
             let start = Instant::now();
-            progress.set_name("Deduplicate");
+            progress.set_name("Deduplicate".into());
             progress.init(Some(entries.len()), gix_features::progress::count("entries"));
             entries.sort_by(|l, r| {
                 l.id.cmp(&r.id)
@@ -187,7 +187,7 @@ impl multi_index::File {
         )?;
 
         {
-            progress.set_name("Writing chunks");
+            progress.set_name("Writing chunks".into());
             progress.init(Some(cf.num_chunks()), gix_features::progress::count("chunks"));
 
             let mut chunk_write = cf.into_write(&mut out, bytes_written)?;

--- a/gix-pack/src/multi_index/write.rs
+++ b/gix-pack/src/multi_index/write.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Instant, SystemTime},
 };
 
-use gix_features::progress::{Count, NestedProgress, Progress};
+use gix_features::progress::{Count, DynNestedProgress, Progress};
 
 use crate::multi_index;
 
@@ -40,11 +40,9 @@ pub struct Options {
 }
 
 /// The result of [`multi_index::File::write_from_index_paths()`].
-pub struct Outcome<P> {
+pub struct Outcome {
     /// The calculated multi-index checksum of the file at `multi_index_path`.
     pub multi_index_checksum: gix_hash::ObjectId,
-    /// The input progress
-    pub progress: P,
 }
 
 /// The progress ids used in [`write_from_index_paths()`][multi_index::File::write_from_index_paths()].
@@ -79,16 +77,13 @@ impl multi_index::File {
     /// Create a new multi-index file for writing to `out` from the pack index files at `index_paths`.
     ///
     /// Progress is sent to `progress` and interruptions checked via `should_interrupt`.
-    pub fn write_from_index_paths<P>(
+    pub fn write_from_index_paths(
         mut index_paths: Vec<PathBuf>,
-        out: impl std::io::Write,
-        mut progress: P,
+        out: &mut dyn std::io::Write,
+        progress: &mut dyn DynNestedProgress,
         should_interrupt: &AtomicBool,
         Options { object_hash }: Options,
-    ) -> Result<Outcome<P>, Error>
-    where
-        P: NestedProgress,
-    {
+    ) -> Result<Outcome, Error> {
         let out = gix_features::hash::Write::new(out, object_hash);
         let (index_paths_sorted, index_filenames_sorted) = {
             index_paths.sort();
@@ -102,8 +97,10 @@ impl multi_index::File {
         let entries = {
             let mut entries = Vec::new();
             let start = Instant::now();
-            let mut progress =
-                progress.add_child_with_id("Collecting entries", ProgressId::FromPathsCollectingEntries.into());
+            let mut progress = progress.add_child_with_id(
+                "Collecting entries".into(),
+                ProgressId::FromPathsCollectingEntries.into(),
+            );
             progress.init(Some(index_paths_sorted.len()), gix_features::progress::count("indices"));
 
             // This could be parallelized… but it's probably not worth it unless you have 500mio objects.
@@ -168,7 +165,8 @@ impl multi_index::File {
             );
         }
 
-        let mut write_progress = progress.add_child_with_id("Writing multi-index", ProgressId::BytesWritten.into());
+        let mut write_progress =
+            progress.add_child_with_id("Writing multi-index".into(), ProgressId::BytesWritten.into());
         let write_start = Instant::now();
         write_progress.init(
             Some(cf.planned_storage_size() as usize + Self::HEADER_LEN),
@@ -220,14 +218,11 @@ impl multi_index::File {
         out.inner.inner.write_all(multi_index_checksum.as_slice())?;
         out.progress.show_throughput(write_start);
 
-        Ok(Outcome {
-            multi_index_checksum,
-            progress,
-        })
+        Ok(Outcome { multi_index_checksum })
     }
 
     fn write_header(
-        mut out: impl std::io::Write,
+        out: &mut dyn std::io::Write,
         num_chunks: u8,
         num_indices: u32,
         object_hash: gix_hash::Kind,

--- a/gix-pack/src/verify.rs
+++ b/gix-pack/src/verify.rs
@@ -33,7 +33,7 @@ pub fn checksum_on_disk_or_mmap(
     data: &[u8],
     expected: gix_hash::ObjectId,
     object_hash: gix_hash::Kind,
-    mut progress: impl Progress,
+    progress: &mut dyn Progress,
     should_interrupt: &AtomicBool,
 ) -> Result<gix_hash::ObjectId, checksum::Error> {
     let data_len_without_trailer = data.len() - object_hash.len_in_bytes();
@@ -41,7 +41,7 @@ pub fn checksum_on_disk_or_mmap(
         data_path,
         data_len_without_trailer,
         object_hash,
-        &mut progress,
+        progress,
         should_interrupt,
     ) {
         Ok(id) => id,

--- a/gix-pack/tests/Cargo.toml
+++ b/gix-pack/tests/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/Byron/gitoxide"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Please use `gix-<thiscrate>` instead ('git' -> 'gix')"
-edition = "2018"
+edition = "2021"
 rust-version = "1.65"
 
 [features]

--- a/gix-pack/tests/pack/bundle.rs
+++ b/gix-pack/tests/pack/bundle.rs
@@ -10,7 +10,7 @@ mod locate {
         let bundle = pack::Bundle::at(fixture_path(SMALL_PACK_INDEX), gix_hash::Kind::Sha1).expect("pack and idx");
         bundle
             .find(
-                hex_to_id(hex_id),
+                &hex_to_id(hex_id),
                 out,
                 &mut zlib::Inflate::default(),
                 &mut pack::cache::Never,
@@ -37,13 +37,13 @@ mod locate {
                 for entry in bundle.index.iter() {
                     let (obj, _location) = bundle
                         .find(
-                            entry.oid,
+                            &entry.oid,
                             &mut buf,
                             &mut zlib::Inflate::default(),
                             &mut pack::cache::Never,
                         )?
                         .expect("id present");
-                    obj.verify_checksum(entry.oid)?;
+                    obj.verify_checksum(&entry.oid)?;
                 }
             }
             Ok(())
@@ -165,10 +165,10 @@ mod write_to_directory {
         let pack_file = fs::File::open(fixture_path(pack_file))?;
         static SHOULD_INTERRUPT: AtomicBool = AtomicBool::new(false);
         pack::Bundle::write_to_directory_eagerly(
-            pack_file,
+            Box::new(pack_file),
             None,
             directory,
-            progress::Discard,
+            &mut progress::Discard,
             &SHOULD_INTERRUPT,
             None,
             pack::bundle::write::Options {

--- a/gix-pack/tests/pack/data/file.rs
+++ b/gix-pack/tests/pack/data/file.rs
@@ -26,7 +26,7 @@ mod method {
     fn verify_checksum() -> Result<(), Box<dyn std::error::Error>> {
         let p = pack_at(SMALL_PACK);
         assert_eq!(
-            p.verify_checksum(progress::Discard, &AtomicBool::new(false))?,
+            p.verify_checksum(&mut progress::Discard, &AtomicBool::new(false))?,
             p.checksum()
         );
         Ok(())
@@ -109,7 +109,7 @@ mod decode_entry {
             entry,
             &mut buf,
             &mut Default::default(),
-            resolve_with_panic,
+            &resolve_with_panic,
             &mut cache::Never,
         )
         .expect("valid offset provides valid entry");
@@ -160,7 +160,7 @@ mod resolve_header {
 
         let p = pack_at(SMALL_PACK);
         let entry = p.entry(offset);
-        p.decode_header(entry, &mut Default::default(), resolve_with_panic)
+        p.decode_header(entry, &mut Default::default(), &resolve_with_panic)
             .expect("valid offset provides valid entry")
     }
 }

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -264,7 +264,7 @@ fn traversals() -> crate::Result {
                     })))
                     .filter(|o| !o.is_null())
                     .map(Ok::<_, Infallible>),
-                progress::Discard,
+                &progress::Discard,
                 &AtomicBool::new(false),
                 count::objects::Options {
                     input_object_expansion: expansion_mode,

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, sync::atomic::AtomicBool};
+use std::sync::atomic::AtomicBool;
 
 use gix_features::{
     parallel::{reduce::Finalize, InOrderIter},
@@ -255,15 +255,17 @@ fn traversals() -> crate::Result {
             let deterministic_count_needs_single_thread = Some(1);
             let (counts, stats) = output::count::objects(
                 db.clone(),
-                commits
-                    .into_iter()
-                    .chain(std::iter::once(hex_to_id(if take.is_some() {
-                        "0000000000000000000000000000000000000000"
-                    } else {
-                        "e3fb53cbb4c346d48732a24f09cf445e49bc63d6"
-                    })))
-                    .filter(|o| !o.is_null())
-                    .map(Ok::<_, Infallible>),
+                Box::new(
+                    commits
+                        .into_iter()
+                        .chain(std::iter::once(hex_to_id(if take.is_some() {
+                            "0000000000000000000000000000000000000000"
+                        } else {
+                            "e3fb53cbb4c346d48732a24f09cf445e49bc63d6"
+                        })))
+                        .filter(|o| !o.is_null())
+                        .map(Ok),
+                ),
                 &progress::Discard,
                 &AtomicBool::new(false),
                 count::objects::Options {
@@ -274,7 +276,7 @@ fn traversals() -> crate::Result {
             )?;
             let actual_count = counts.iter().fold(ObjectCount::default(), |mut c, e| {
                 let mut buf = Vec::new();
-                if let Ok((obj, _location)) = db.find(e.id, &mut buf) {
+                if let Ok((obj, _location)) = db.find(&e.id, &mut buf) {
                     c.add(obj.kind);
                 }
                 c
@@ -289,7 +291,7 @@ fn traversals() -> crate::Result {
             let mut entries_iter = output::entry::iter_from_counts(
                 counts,
                 db.clone(),
-                progress::Discard,
+                Box::new(progress::Discard),
                 output::entry::iter_from_counts::Options {
                     allow_thin_pack,
                     ..Default::default()
@@ -348,9 +350,7 @@ fn write_and_verify(
     let (num_written_bytes, pack_hash) = {
         let num_entries = entries.len();
         let mut pack_writer = output::bytes::FromEntriesIter::new(
-            std::iter::once(Ok::<_, entry::iter_from_counts::Error<gix_odb::store::find::Error>>(
-                entries,
-            )),
+            std::iter::once(Ok::<_, entry::iter_from_counts::Error>(entries)),
             &mut pack_file,
             num_entries as u32,
             pack::data::Version::V2,
@@ -375,7 +375,7 @@ fn write_and_verify(
     );
     let pack = pack::data::File::at(&pack_file_path, gix_hash::Kind::Sha1)?;
     let should_interrupt = AtomicBool::new(false);
-    let hash = pack.verify_checksum(progress::Discard, &should_interrupt)?;
+    let hash = pack.verify_checksum(&mut progress::Discard, &should_interrupt)?;
     assert_eq!(
         hash, pack_hash,
         "the trailer of the pack matches the actually written trailer"
@@ -388,11 +388,11 @@ fn write_and_verify(
     let object_hash = gix_hash::Kind::Sha1; // TODO: parameterize this
     let bundle = pack::Bundle::at(
         pack::Bundle::write_to_directory(
-            std::io::BufReader::new(std::fs::File::open(pack_file_path)?),
+            &mut std::io::BufReader::new(std::fs::File::open(pack_file_path)?),
             Some(tmp_dir.path()),
-            progress::Discard,
+            &mut progress::Discard,
             &should_interrupt,
-            Some(Box::new(move |oid, buf| db.find(oid, buf).ok().map(|t| t.0))),
+            Some(Box::new(move |oid, buf| db.find(&oid, buf).ok().map(|t| t.0))),
             pack::bundle::write::Options::default(),
         )?
         .data_path
@@ -409,7 +409,7 @@ fn write_and_verify(
     // }
 
     bundle.verify_integrity(
-        progress::Discard,
+        &mut progress::Discard,
         &should_interrupt,
         gix_pack::index::verify::integrity::Options {
             verify_mode: pack::index::verify::Mode::HashCrc32DecodeEncode,

--- a/gix-pack/tests/pack/data/output/mod.rs
+++ b/gix-pack/tests/pack/data/output/mod.rs
@@ -32,7 +32,7 @@ fn db(kind: DbKind) -> crate::Result<gix_odb::HandleArc> {
         DeterministicGeneratedContentMultiIndex => "make_pack_gen_repo_multi_index.sh",
     };
     let path: PathBuf = crate::scripted_fixture_read_only(name)?.join(".git").join("objects");
-    gix_odb::Store::at_opts(path, Vec::new(), gix_odb::store::init::Options::default())
+    gix_odb::Store::at_opts(path, &mut None.into_iter(), gix_odb::store::init::Options::default())
         .map_err(Into::into)
         .map(|store| {
             let mut cache = Arc::new(store).to_cache_arc();

--- a/gix-pack/tests/pack/index.rs
+++ b/gix-pack/tests/pack/index.rs
@@ -39,7 +39,7 @@ mod version {
                     assert_eq!(entry.crc32, file.crc32_at_index(index));
 
                     let hex_len = (entry_index % object_hash.len_in_hex()).max(7);
-                    let prefix = gix_hash::Prefix::new(entry.oid, hex_len)?;
+                    let prefix = gix_hash::Prefix::new(&entry.oid, hex_len)?;
                     assert_eq!(
                         file.lookup_prefix(prefix, candidates.as_mut())
                             .expect("object exists")
@@ -73,7 +73,7 @@ mod version {
                     let id = gix_hash::ObjectId::from_hex(id)?;
                     assert_eq!(file.lookup(id), expected, "{assertion_message}");
                     assert_eq!(
-                        file.lookup_prefix(gix_hash::Prefix::new(id, hex_len)?, candidates.as_mut()),
+                        file.lookup_prefix(gix_hash::Prefix::new(&id, hex_len)?, candidates.as_mut()),
                         expected.map(Ok)
                     );
                     if let Some(candidates) = candidates {
@@ -92,7 +92,7 @@ mod version {
                     assert_eq!(entry.crc32, file.crc32_at_index(index), "{index} {entry:?}");
 
                     let hex_len = (entry_index % object_hash.len_in_hex()).max(7);
-                    let prefix = gix_hash::Prefix::new(entry.oid, hex_len)?;
+                    let prefix = gix_hash::Prefix::new(&entry.oid, hex_len)?;
                     assert_eq!(
                         file.lookup_prefix(prefix, candidates.as_mut())
                             .expect("object exists")
@@ -253,7 +253,7 @@ fn traverse_with_index_and_forward_ref_deltas() {
                 count.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, std::io::Error>(())
             },
-            progress::Discard,
+            &mut progress::Discard,
             &AtomicBool::new(false),
             index::traverse::with_index::Options::default(),
         )
@@ -381,7 +381,7 @@ fn pack_lookup() -> Result<(), Box<dyn std::error::Error>> {
                                 thread_limit: None
                             }
                         }),
-                        progress::Discard,
+                        &mut progress::Discard,
                         &AtomicBool::new(false)
                     )
                     .map(|o| (o.actual_index_checksum, o.pack_traverse_statistics))?,
@@ -478,7 +478,7 @@ fn iter() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(
             idx.verify_integrity(
                 None::<gix_pack::index::verify::PackContext<'_, fn() -> cache::Never>>,
-                progress::Discard,
+                &mut progress::Discard,
                 &AtomicBool::new(false)
             )
             .map(|o| (o.actual_index_checksum, o.pack_traverse_statistics))?,

--- a/gix-pack/tests/pack/mod.rs
+++ b/gix-pack/tests/pack/mod.rs
@@ -20,7 +20,7 @@ pub fn hex_to_id(hex: &str) -> ObjectId {
     ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
 }
 
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 #[cfg(not(windows))]
 pub fn fixup(v: Vec<u8>) -> Vec<u8> {

--- a/gix-pack/tests/pack/multi_index/access.rs
+++ b/gix-pack/tests/pack/multi_index/access.rs
@@ -7,7 +7,7 @@ use crate::hex_to_id;
 fn lookup_with_ambiguity() {
     let (file, _path) = multi_index();
     let oid = hex_to_id("cfc33fc40413fb3e30ff6b44d03fd8d071cb633b");
-    let prefix = gix_hash::Prefix::new(oid, 4).unwrap();
+    let prefix = gix_hash::Prefix::new(&oid, 4).unwrap();
     assert_eq!(
         file.lookup_prefix(prefix, None),
         Some(Err(())),
@@ -32,7 +32,7 @@ fn lookup_prefix() {
             let hex_len = (idx % file.object_hash().len_in_hex()).max(5);
             let hex_oid = entry.oid.to_hex_with_len(hex_len).to_string();
             assert_eq!(hex_oid.len(), hex_len);
-            let oid_prefix = gix_hash::Prefix::new(entry.oid, hex_len).unwrap();
+            let oid_prefix = gix_hash::Prefix::new(&entry.oid, hex_len).unwrap();
             let entry_index = file
                 .lookup_prefix(oid_prefix, candidates.as_mut())
                 .expect("object found")
@@ -49,7 +49,7 @@ fn lookup_prefix() {
 #[test]
 fn lookup_missing() {
     let (file, _path) = multi_index();
-    let prefix = gix_hash::Prefix::new(gix_hash::ObjectId::null(gix_hash::Kind::Sha1), 7).unwrap();
+    let prefix = gix_hash::Prefix::new(&gix_hash::ObjectId::null(gix_hash::Kind::Sha1), 7).unwrap();
     assert!(file.lookup_prefix(prefix, None).is_none());
 
     let mut candidates = 1..1;

--- a/gix-pack/tests/pack/multi_index/verify.rs
+++ b/gix-pack/tests/pack/multi_index/verify.rs
@@ -9,7 +9,7 @@ use crate::pack::multi_index::multi_index;
 fn checksum() -> crate::Result {
     let (file, _) = multi_index();
     assert_eq!(
-        file.verify_checksum(progress::Discard, &AtomicBool::new(false))?,
+        file.verify_checksum(&mut progress::Discard, &AtomicBool::new(false))?,
         file.checksum()
     );
     Ok(())
@@ -19,7 +19,7 @@ fn checksum() -> crate::Result {
 fn integrity() {
     let (file, _) = multi_index();
     let outcome = file
-        .verify_integrity(progress::Discard, &AtomicBool::new(false), Default::default())
+        .verify_integrity(&mut progress::Discard, &AtomicBool::new(false), Default::default())
         .unwrap();
     assert_eq!(outcome.actual_index_checksum, file.checksum());
     assert_eq!(

--- a/gix-pack/tests/pack/multi_index/write.rs
+++ b/gix-pack/tests/pack/multi_index/write.rs
@@ -24,7 +24,7 @@ fn from_paths() -> crate::Result {
     let outcome = gix_pack::multi_index::File::write_from_index_paths(
         input_indices.clone(),
         &mut out,
-        progress::Discard,
+        &mut progress::Discard,
         &AtomicBool::new(false),
         gix_pack::multi_index::write::Options {
             object_hash: gix_hash::Kind::Sha1,
@@ -56,13 +56,13 @@ fn from_paths() -> crate::Result {
     }
 
     assert_eq!(
-        file.verify_integrity(progress::Discard, &AtomicBool::new(false), Default::default())?
+        file.verify_integrity(&mut progress::Discard, &AtomicBool::new(false), Default::default())?
             .actual_index_checksum,
         outcome.multi_index_checksum
     );
 
-    let outcome = file.verify_integrity_fast(progress::Discard, &AtomicBool::new(false))?;
+    let outcome = file.verify_integrity_fast(&mut progress::Discard, &AtomicBool::new(false))?;
 
-    assert_eq!(outcome.0, file.checksum());
+    assert_eq!(outcome, file.checksum());
     Ok(())
 }

--- a/gix-path/src/convert.rs
+++ b/gix-path/src/convert.rs
@@ -249,14 +249,12 @@ pub fn to_windows_separators<'a>(path: impl Into<Cow<'a, BStr>>) -> Cow<'a, BStr
 /// as typical return value of `std::env::current_dir()`.
 /// As a `current_dir` like `/c` can be exhausted by paths like `../../r`, `None` will be returned to indicate the inability
 /// to produce a logically consistent path.
-pub fn normalize<'a>(path: impl Into<Cow<'a, Path>>, current_dir: impl AsRef<Path>) -> Option<Cow<'a, Path>> {
+pub fn normalize<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Option<Cow<'a, Path>> {
     use std::path::Component::ParentDir;
 
-    let path = path.into();
     if !path.components().any(|c| matches!(c, ParentDir)) {
         return Some(path);
     }
-    let current_dir = current_dir.as_ref();
     let mut current_dir_opt = Some(current_dir);
     let was_relative = path.is_relative();
     let components = path.components();

--- a/gix-path/src/realpath.rs
+++ b/gix-path/src/realpath.rs
@@ -31,19 +31,18 @@ pub(crate) mod function {
     ///
     /// If `path` is relative, the current working directory be used to make it absolute.
     pub fn realpath(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
+        let path = path.as_ref();
         let cwd = path
-            .as_ref()
             .is_relative()
             .then(std::env::current_dir)
             .unwrap_or_else(|| Ok(PathBuf::default()))
             .map_err(Error::CurrentWorkingDir)?;
-        realpath_opts(path, cwd, MAX_SYMLINKS)
+        realpath_opts(path, &cwd, MAX_SYMLINKS)
     }
 
     /// The same as [`realpath()`], but allow to configure `max_symlinks` to configure how many symbolic links we are going to follow.
     /// This serves to avoid running into cycles or doing unreasonable amounts of work.
-    pub fn realpath_opts(path: impl AsRef<Path>, cwd: impl AsRef<Path>, max_symlinks: u8) -> Result<PathBuf, Error> {
-        let path = path.as_ref();
+    pub fn realpath_opts(path: &Path, cwd: &Path, max_symlinks: u8) -> Result<PathBuf, Error> {
         if path.as_os_str().is_empty() {
             return Err(Error::EmptyPath);
         }

--- a/gix-pathspec/src/defaults.rs
+++ b/gix-pathspec/src/defaults.rs
@@ -28,7 +28,7 @@ impl Defaults {
     ///
     /// Instead of failing if `GIT_LITERAL_PATHSPECS` is used with glob globals, we ignore these. Also our implementation allows global
     /// `icase` settings in combination with this setting.
-    pub fn from_environment(mut var: impl FnMut(&str) -> Option<OsString>) -> Result<Self, from_environment::Error> {
+    pub fn from_environment(var: &mut dyn FnMut(&str) -> Option<OsString>) -> Result<Self, from_environment::Error> {
         let mut env_bool = |name: &str| -> Result<Option<bool>, gix_config_value::Error> {
             var(name)
                 .map(|val| gix_config_value::Boolean::try_from(val).map(|b| b.0))

--- a/gix-pathspec/src/pattern.rs
+++ b/gix-pathspec/src/pattern.rs
@@ -57,7 +57,7 @@ impl Pattern {
             (count > 0).then_some(count as usize).unwrap_or_default()
         }
 
-        let mut path = gix_path::from_bstr(self.path.as_ref());
+        let mut path = gix_path::from_bstr(self.path.as_bstr());
         let mut num_prefix_components = 0;
         let mut was_absolute = false;
         if gix_path::is_absolute(path.as_ref()) {
@@ -89,7 +89,7 @@ impl Pattern {
         }
 
         let assure_path_cannot_break_out_upwards = Path::new("");
-        let path = match gix_path::normalize(path.as_ref(), assure_path_cannot_break_out_upwards) {
+        let path = match gix_path::normalize(path.as_ref().into(), assure_path_cannot_break_out_upwards) {
             Some(path) => {
                 if was_absolute {
                     num_prefix_components = path.components().count().saturating_sub(

--- a/gix-pathspec/src/search/matching.rs
+++ b/gix-pathspec/src/search/matching.rs
@@ -23,13 +23,12 @@ impl Search {
     /// Higher-level crates should control this default case folding of pathspecs when instantiating them, which is when they can
     /// set it to match the repository setting for more natural behaviour when, for instance, adding files to a repository:
     /// as it stands, on a case-insensitive file system, `touch File && git add file` will not add the file, but also not error.
-    pub fn pattern_matching_relative_path<'a>(
+    pub fn pattern_matching_relative_path(
         &mut self,
-        relative_path: impl Into<&'a BStr>,
+        relative_path: &BStr,
         is_dir: Option<bool>,
-        mut attributes: impl FnMut(&BStr, Case, bool, &mut gix_attributes::search::Outcome) -> bool,
+        attributes: &mut dyn FnMut(&BStr, Case, bool, &mut gix_attributes::search::Outcome) -> bool,
     ) -> Option<Match<'_>> {
-        let relative_path = relative_path.into();
         let basename_not_important = None;
         if relative_path
             .get(..self.common_prefix_len)

--- a/gix-pathspec/tests/defaults.rs
+++ b/gix-pathspec/tests/defaults.rs
@@ -10,7 +10,7 @@ fn literal_only_combines_with_icase() -> gix_testtools::Result {
             .set("GIT_ICASE_PATHSPECS", "1")
             .set("GIT_NOGLOB_PATHSPECS", "yes");
         assert_eq!(
-            Defaults::from_environment(|n| std::env::var_os(n))?,
+            Defaults::from_environment(&mut |n| std::env::var_os(n))?,
             Defaults {
                 signature: MagicSignature::ICASE,
                 search_mode: SearchMode::Literal,
@@ -24,7 +24,7 @@ fn literal_only_combines_with_icase() -> gix_testtools::Result {
             .set("GIT_ICASE_PATHSPECS", "false")
             .set("GIT_GLOB_PATHSPECS", "yes");
         assert_eq!(
-            Defaults::from_environment(|n| std::env::var_os(n))?,
+            Defaults::from_environment(&mut |n| std::env::var_os(n))?,
             Defaults {
                 signature: MagicSignature::default(),
                 search_mode: SearchMode::Literal,
@@ -38,7 +38,7 @@ fn literal_only_combines_with_icase() -> gix_testtools::Result {
 #[serial]
 fn nothing_is_set_then_it_is_like_the_default_impl() -> gix_testtools::Result {
     assert_eq!(
-        Defaults::from_environment(|n| std::env::var_os(n))?,
+        Defaults::from_environment(&mut |n| std::env::var_os(n))?,
         Defaults::default()
     );
     Ok(())
@@ -51,7 +51,7 @@ fn glob_and_noglob_cause_error() -> gix_testtools::Result {
         .set("GIT_GLOB_PATHSPECS", "1")
         .set("GIT_NOGLOB_PATHSPECS", "yes");
     assert_eq!(
-        Defaults::from_environment(|n| std::env::var_os(n))
+        Defaults::from_environment(&mut |n| std::env::var_os(n))
             .unwrap_err()
             .to_string(),
         "Glob and no-glob settings are mutually exclusive"
@@ -67,7 +67,7 @@ fn noglob_works() -> gix_testtools::Result {
         .set("GIT_GLOB_PATHSPECS", "0")
         .set("GIT_NOGLOB_PATHSPECS", "true");
     assert_eq!(
-        Defaults::from_environment(|n| std::env::var_os(n))?,
+        Defaults::from_environment(&mut |n| std::env::var_os(n))?,
         Defaults {
             signature: MagicSignature::default(),
             search_mode: SearchMode::Literal,
@@ -83,7 +83,7 @@ fn noglob_works() -> gix_testtools::Result {
 fn glob_works() -> gix_testtools::Result {
     let _env = gix_testtools::Env::new().set("GIT_GLOB_PATHSPECS", "yes");
     assert_eq!(
-        Defaults::from_environment(|n| std::env::var_os(n))?,
+        Defaults::from_environment(&mut |n| std::env::var_os(n))?,
         Defaults {
             signature: MagicSignature::default(),
             search_mode: SearchMode::PathAwareGlob,

--- a/gix-pathspec/tests/search/mod.rs
+++ b/gix-pathspec/tests/search/mod.rs
@@ -10,7 +10,9 @@ fn no_pathspecs_match_everything() -> crate::Result {
     let mut search = gix_pathspec::Search::from_specs([], None, Path::new(""))?;
     assert_eq!(search.patterns().count(), 0, "nothing artificial is added");
     let m = search
-        .pattern_matching_relative_path("hello", None, |_, _, _, _| unreachable!("must not be called"))
+        .pattern_matching_relative_path("hello".into(), None, &mut |_, _, _, _| {
+            unreachable!("must not be called")
+        })
         .expect("matches");
     assert_eq!(m.pattern.prefix_directory(), "", "there is no prefix as none was given");
 
@@ -39,12 +41,14 @@ fn no_pathspecs_respect_prefix() -> crate::Result {
     );
     assert!(
         search
-            .pattern_matching_relative_path("hello", None, |_, _, _, _| unreachable!("must not be called"))
+            .pattern_matching_relative_path("hello".into(), None, &mut |_, _, _, _| unreachable!(
+                "must not be called"
+            ))
             .is_none(),
         "not the right prefix"
     );
     let m = search
-        .pattern_matching_relative_path("a/b", None, |_, _, _, _| unreachable!("must not be called"))
+        .pattern_matching_relative_path("a/b".into(), None, &mut |_, _, _, _| unreachable!("must not be called"))
         .expect("match");
     assert_eq!(
         m.pattern.prefix_directory(),
@@ -98,7 +102,7 @@ fn prefixes_are_always_case_insensitive() -> crate::Result {
             .iter()
             .filter(|relative_path| {
                 search
-                    .pattern_matching_relative_path(relative_path.as_str(), Some(false), |_, _, _, _| false)
+                    .pattern_matching_relative_path(relative_path.as_str().into(), Some(false), &mut |_, _, _, _| false)
                     .is_some()
             })
             .collect();
@@ -163,9 +167,9 @@ mod baseline {
                 .filter(|path| {
                     search
                         .pattern_matching_relative_path(
-                            path.as_str(),
+                            path.as_str().into(),
                             Some(items_are_dirs),
-                            |rela_path, case, is_dir, out| {
+                            &mut |rela_path, case, is_dir, out| {
                                 out.initialize(&collection);
                                 attrs.pattern_matching_relative_path(rela_path, case, Some(is_dir), out)
                             },

--- a/gix-protocol/src/fetch/delegate.rs
+++ b/gix-protocol/src/fetch/delegate.rs
@@ -183,7 +183,7 @@ mod blocking_io {
         ops::DerefMut,
     };
 
-    use gix_features::progress::Progress;
+    use gix_features::progress::NestedProgress;
 
     use crate::{
         fetch::{DelegateBlocking, Response},
@@ -207,7 +207,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl io::BufRead,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()>;
@@ -217,7 +217,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl BufRead,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {
@@ -229,7 +229,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl BufRead,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {
@@ -246,7 +246,7 @@ mod async_io {
 
     use async_trait::async_trait;
     use futures_io::AsyncBufRead;
-    use gix_features::progress::Progress;
+    use gix_features::progress::NestedProgress;
 
     use crate::{
         fetch::{DelegateBlocking, Response},
@@ -272,7 +272,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()>;
@@ -282,7 +282,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {
@@ -297,7 +297,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl Progress,
+            progress: impl NestedProgress,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {

--- a/gix-protocol/src/fetch/delegate.rs
+++ b/gix-protocol/src/fetch/delegate.rs
@@ -207,7 +207,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl io::BufRead,
-            progress: impl NestedProgress,
+            progress: impl NestedProgress + 'static,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()>;
@@ -217,7 +217,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl BufRead,
-            progress: impl NestedProgress,
+            progress: impl NestedProgress + 'static,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {
@@ -229,7 +229,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             input: impl BufRead,
-            progress: impl NestedProgress,
+            progress: impl NestedProgress + 'static,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {
@@ -272,7 +272,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl NestedProgress,
+            progress: impl NestedProgress + 'static,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()>;
@@ -282,7 +282,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl NestedProgress,
+            progress: impl NestedProgress + 'static,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {
@@ -297,7 +297,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             input: impl AsyncBufRead + Unpin + 'async_trait,
-            progress: impl NestedProgress,
+            progress: impl NestedProgress + 'static,
             refs: &[Ref],
             previous_response: &Response,
         ) -> io::Result<()> {

--- a/gix-protocol/src/fetch_fn.rs
+++ b/gix-protocol/src/fetch_fn.rs
@@ -59,7 +59,7 @@ where
     F: FnMut(credentials::helper::Action) -> credentials::protocol::Result,
     D: Delegate,
     T: client::Transport,
-    P: NestedProgress,
+    P: NestedProgress + 'static,
     P::SubProgress: 'static,
 {
     let crate::handshake::Outcome {

--- a/gix-protocol/src/fetch_fn.rs
+++ b/gix-protocol/src/fetch_fn.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use gix_features::progress::Progress;
+use gix_features::progress::NestedProgress;
 use gix_transport::client;
 use maybe_async::maybe_async;
 
@@ -59,7 +59,7 @@ where
     F: FnMut(credentials::helper::Action) -> credentials::protocol::Result,
     D: Delegate,
     T: client::Transport,
-    P: Progress,
+    P: NestedProgress,
     P::SubProgress: 'static,
 {
     let crate::handshake::Outcome {
@@ -136,7 +136,7 @@ where
         .await?;
         previous_response = if response.has_pack() {
             progress.step();
-            progress.set_name("receiving pack");
+            progress.set_name("receiving pack".into());
             if !sideband_all {
                 setup_remote_progress(&mut progress, &mut reader);
             }
@@ -159,7 +159,7 @@ where
 
 fn setup_remote_progress<P>(progress: &mut P, reader: &mut Box<dyn gix_transport::client::ExtendedBufRead + Unpin + '_>)
 where
-    P: Progress,
+    P: NestedProgress,
     P::SubProgress: 'static,
 {
     reader.set_progress_handler(Some(Box::new({

--- a/gix-protocol/src/handshake/function.rs
+++ b/gix-protocol/src/handshake/function.rs
@@ -24,7 +24,7 @@ where
 {
     let (server_protocol_version, refs, capabilities) = {
         progress.init(None, progress::steps());
-        progress.set_name("handshake");
+        progress.set_name("handshake".into());
         progress.step();
 
         let extra_parameters: Vec<_> = extra_parameters
@@ -43,13 +43,13 @@ where
             Err(client::Error::Io(ref err)) if err.kind() == std::io::ErrorKind::PermissionDenied => {
                 drop(result); // needed to workaround this: https://github.com/rust-lang/rust/issues/76149
                 let url = transport.to_url().into_owned();
-                progress.set_name("authentication");
+                progress.set_name("authentication".into());
                 let credentials::protocol::Outcome { identity, next } =
                     authenticate(credentials::helper::Action::get_for_url(url.clone()))?
                         .ok_or(Error::EmptyCredentials)?;
                 transport.set_identity(identity)?;
                 progress.step();
-                progress.set_name("handshake (authenticated)");
+                progress.set_name("handshake (authenticated)".into());
                 match transport.handshake(service, &extra_parameters).await {
                     Ok(v) => {
                         authenticate(next.store())?;

--- a/gix-protocol/src/ls_refs.rs
+++ b/gix-protocol/src/ls_refs.rs
@@ -86,7 +86,7 @@ pub(crate) mod function {
                 );
 
                 progress.step();
-                progress.set_name("list refs");
+                progress.set_name("list refs".into());
                 let mut remote_refs = transport
                     .invoke(
                         ls_refs.as_str(),

--- a/gix-protocol/tests/fetch/mod.rs
+++ b/gix-protocol/tests/fetch/mod.rs
@@ -150,9 +150,9 @@ impl fetch::DelegateBlocking for LsRemoteDelegate {
 
 #[cfg(feature = "blocking-client")]
 mod blocking_io {
+    use gix_features::progress::NestedProgress;
     use std::io;
 
-    use gix_features::progress::Progress;
     use gix_protocol::{fetch, fetch::Response, handshake, handshake::Ref};
 
     use crate::fetch::{CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
@@ -161,7 +161,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             mut input: impl io::BufRead,
-            _progress: impl Progress,
+            _progress: impl NestedProgress,
             _refs: &[Ref],
             _previous_response: &Response,
         ) -> io::Result<()> {
@@ -174,7 +174,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             mut input: impl io::BufRead,
-            _progress: impl Progress,
+            _progress: impl NestedProgress,
             _refs: &[Ref],
             response: &Response,
         ) -> io::Result<()> {
@@ -193,7 +193,7 @@ mod blocking_io {
         fn receive_pack(
             &mut self,
             _input: impl io::BufRead,
-            _progress: impl Progress,
+            _progress: impl NestedProgress,
             _refs: &[Ref],
             _previous_response: &Response,
         ) -> io::Result<()> {
@@ -208,7 +208,7 @@ mod async_io {
 
     use async_trait::async_trait;
     use futures_io::AsyncBufRead;
-    use gix_features::progress::Progress;
+    use gix_features::progress::NestedProgress;
     use gix_protocol::{fetch, fetch::Response, handshake, handshake::Ref};
 
     use crate::fetch::{CloneDelegate, CloneRefInWantDelegate, LsRemoteDelegate};
@@ -218,7 +218,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             mut input: impl AsyncBufRead + Unpin + 'async_trait,
-            _progress: impl Progress,
+            _progress: impl NestedProgress,
             _refs: &[Ref],
             _previous_response: &Response,
         ) -> io::Result<()> {
@@ -232,7 +232,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             mut input: impl AsyncBufRead + Unpin + 'async_trait,
-            _progress: impl Progress,
+            _progress: impl NestedProgress,
             _refs: &[Ref],
             response: &Response,
         ) -> io::Result<()> {
@@ -252,7 +252,7 @@ mod async_io {
         async fn receive_pack(
             &mut self,
             _input: impl AsyncBufRead + Unpin + 'async_trait,
-            _progress: impl Progress,
+            _progress: impl NestedProgress,
             _refs: &[Ref],
             _previous_response: &Response,
         ) -> io::Result<()> {

--- a/gix-ref/src/fullname.rs
+++ b/gix-ref/src/fullname.rs
@@ -134,7 +134,7 @@ impl FullNameRef {
             if shortened.starts_with_str("refs/") {
                 (Category::MainRef, shortened.as_bstr()).into()
             } else {
-                is_pseudo_ref(shortened).then(|| (Category::MainPseudoRef, shortened.as_bstr()))
+                is_pseudo_ref(shortened.into()).then(|| (Category::MainPseudoRef, shortened.as_bstr()))
             }
         } else if let Some(shortened_with_worktree_name) =
             name.strip_prefix(Category::LinkedPseudoRef { name: "".into() }.prefix().as_bytes())

--- a/gix-ref/src/name.rs
+++ b/gix-ref/src/name.rs
@@ -98,10 +98,10 @@ impl PartialNameRef {
 
 impl PartialName {
     /// Append the `component` to ourselves and validate the newly created partial path.
-    pub fn join(self, component: impl AsRef<[u8]>) -> Result<Self, Error> {
+    pub fn join(self, component: &BStr) -> Result<Self, Error> {
         let mut b = self.0;
         b.push_byte(b'/');
-        b.extend(component.as_ref());
+        b.extend(component.as_bytes());
         gix_validate::reference::name_partial(b.as_ref())?;
         Ok(PartialName(b))
     }
@@ -263,6 +263,6 @@ impl convert::TryFrom<BString> for PartialName {
 /// Note that this method is disagreeing with `gix_validate` as it allows dashes '-' for some reason.
 /// Since partial names cannot be created with dashes inside we adjusted this as it's probably unintended or git creates pseudo-refs
 /// which wouldn't pass its safety checks.
-pub(crate) fn is_pseudo_ref<'a>(name: impl Into<&'a BStr>) -> bool {
-    name.into().bytes().all(|b| b.is_ascii_uppercase() || b == b'_')
+pub(crate) fn is_pseudo_ref(name: &BStr) -> bool {
+    name.bytes().all(|b| b.is_ascii_uppercase() || b == b'_')
 }

--- a/gix-ref/src/namespace.rs
+++ b/gix-ref/src/namespace.rs
@@ -21,9 +21,8 @@ impl Namespace {
         gix_path::from_byte_slice(&self.0)
     }
     /// Append the given `prefix` to this namespace so it becomes usable for prefixed iteration.
-    pub fn into_namespaced_prefix(mut self, prefix: impl AsRef<Path>) -> PathBuf {
-        let path = prefix.as_ref();
-        let prefix = gix_path::into_bstr(path);
+    pub fn into_namespaced_prefix(mut self, prefix: &Path) -> PathBuf {
+        let prefix = gix_path::into_bstr(prefix);
         self.0.push_str(prefix.as_ref());
         gix_path::to_native_path_on_windows(self.0).into_owned()
     }

--- a/gix-ref/src/peel.rs
+++ b/gix-ref/src/peel.rs
@@ -1,8 +1,9 @@
 /// A function for use in [`crate::file::ReferenceExt::peel_to_id_in_place()`] to indicate no peeling should happen.
+#[allow(clippy::type_complexity)]
 pub fn none(
     _id: gix_hash::ObjectId,
     #[allow(clippy::ptr_arg)] _buf: &mut Vec<u8>,
-) -> Result<Option<(gix_object::Kind, &[u8])>, std::convert::Infallible> {
+) -> Result<Option<(gix_object::Kind, &[u8])>, Box<dyn std::error::Error + Send + Sync>> {
     Ok(Some((gix_object::Kind::Commit, &[])))
 }
 

--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -81,7 +81,7 @@ impl file::Store {
                 "remotes",
                 partial_name
                     .to_owned()
-                    .join("HEAD")
+                    .join("HEAD".into())
                     .expect("HEAD is valid name")
                     .as_ref(),
                 None,

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -33,9 +33,9 @@ mod write {
     /// Output
     impl Line {
         /// Serialize this instance to `out` in the git serialization format for ref log lines.
-        pub fn write_to(&self, mut out: impl io::Write) -> io::Result<()> {
+        pub fn write_to(&self, out: &mut dyn io::Write) -> io::Result<()> {
             write!(out, "{} {} ", self.previous_oid, self.new_oid)?;
-            self.signature.write_to(&mut out)?;
+            self.signature.write_to(out)?;
             writeln!(out, "\t{}", check_newlines(self.message.as_ref())?)
         }
     }

--- a/gix-ref/src/store/file/loose/iter.rs
+++ b/gix-ref/src/store/file/loose/iter.rs
@@ -13,10 +13,9 @@ pub(in crate::store_impl::file) struct SortedLoosePaths {
 }
 
 impl SortedLoosePaths {
-    pub fn at(path: impl AsRef<Path>, base: impl Into<PathBuf>, filename_prefix: Option<BString>) -> Self {
-        let path = path.as_ref();
+    pub fn at(path: &Path, base: PathBuf, filename_prefix: Option<BString>) -> Self {
         SortedLoosePaths {
-            base: base.into(),
+            base,
             filename_prefix,
             file_walk: path.is_dir().then(|| {
                 // serial iteration as we expect most refs in packed-refs anyway.
@@ -89,7 +88,7 @@ impl file::Store {
     /// Return an iterator over all loose references that start with the given `prefix`.
     ///
     /// Otherwise it's similar to [`loose_iter()`][file::Store::loose_iter()].
-    pub fn loose_iter_prefixed(&self, prefix: impl AsRef<Path>) -> std::io::Result<LooseThenPacked<'_, '_>> {
+    pub fn loose_iter_prefixed(&self, prefix: &Path) -> std::io::Result<LooseThenPacked<'_, '_>> {
         self.iter_prefixed_packed(prefix, None)
     }
 }

--- a/gix-ref/src/store/file/loose/mod.rs
+++ b/gix-ref/src/store/file/loose/mod.rs
@@ -33,9 +33,9 @@ mod init {
         /// Create a new instance at the given `git_dir`, which commonly is a standard git repository with a
         /// `refs/` subdirectory.
         /// The `object_hash` defines which kind of hash we should recognize.
-        pub fn at(git_dir: impl Into<PathBuf>, write_reflog: file::WriteReflog, object_hash: gix_hash::Kind) -> Self {
+        pub fn at(git_dir: PathBuf, write_reflog: file::WriteReflog, object_hash: gix_hash::Kind) -> Self {
             file::Store {
-                git_dir: git_dir.into(),
+                git_dir,
                 common_dir: None,
                 write_reflog,
                 namespace: None,
@@ -47,14 +47,14 @@ mod init {
         /// Like [`at()`][file::Store::at()], but for _linked_ work-trees which use `git_dir` as private ref store and `common_dir` for
         /// shared references.
         pub fn for_linked_worktree(
-            git_dir: impl Into<PathBuf>,
-            common_dir: impl Into<PathBuf>,
+            git_dir: PathBuf,
+            common_dir: PathBuf,
             write_reflog: file::WriteReflog,
             object_hash: gix_hash::Kind,
         ) -> Self {
             file::Store {
-                git_dir: git_dir.into(),
-                common_dir: Some(common_dir.into()),
+                git_dir,
+                common_dir: Some(common_dir),
                 write_reflog,
                 namespace: None,
                 packed: gix_fs::SharedFileSnapshotMut::new().into(),

--- a/gix-ref/src/store/file/loose/reflog.rs
+++ b/gix-ref/src/store/file/loose/reflog.rs
@@ -134,7 +134,7 @@ pub mod create_or_update {
                         Err(err) => {
                             // TODO: when Kind::IsADirectory becomes stable, use that.
                             if log_path.is_dir() {
-                                gix_tempfile::remove_dir::empty_depth_first(&log_path)
+                                gix_tempfile::remove_dir::empty_depth_first(log_path.clone())
                                     .and_then(|_| options.open(&log_path))
                                     .map(Some)
                                     .map_err(|_| Error::Append {

--- a/gix-ref/src/store/file/loose/reflog/create_or_update/tests.rs
+++ b/gix-ref/src/store/file/loose/reflog/create_or_update/tests.rs
@@ -17,7 +17,7 @@ fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
 
 fn empty_store(writemode: WriteReflog) -> Result<(TempDir, file::Store)> {
     let dir = TempDir::new()?;
-    let store = file::Store::at(dir.path(), writemode, gix_hash::Kind::Sha1);
+    let store = file::Store::at(dir.path().into(), writemode, gix_hash::Kind::Sha1);
     Ok((dir, store))
 }
 

--- a/gix-ref/src/store/general/init.rs
+++ b/gix-ref/src/store/general/init.rs
@@ -21,13 +21,8 @@ impl crate::Store {
     /// Create a new store at the given location, typically the `.git/` directory.
     ///
     /// `object_hash` defines the kind of hash to assume when dealing with refs.
-    pub fn at(
-        git_dir: impl Into<PathBuf>,
-        reflog_mode: WriteReflog,
-        object_hash: gix_hash::Kind,
-    ) -> Result<Self, Error> {
+    pub fn at(git_dir: PathBuf, reflog_mode: WriteReflog, object_hash: gix_hash::Kind) -> Result<Self, Error> {
         // for now, just try to read the directory - later we will do that naturally as we have to figure out if it's a ref-table or not.
-        let git_dir = git_dir.into();
         std::fs::read_dir(&git_dir)?;
         Ok(crate::Store {
             inner: crate::store::State::Loose {

--- a/gix-ref/src/store/packed/buffer.rs
+++ b/gix-ref/src/store/packed/buffer.rs
@@ -30,8 +30,7 @@ pub mod open {
         ///
         /// In order to allow fast lookups and optimizations, the contents of the packed refs must be sorted.
         /// If that's not the case, they will be sorted on the fly with the data being written into a memory buffer.
-        pub fn open(path: impl Into<PathBuf>, use_memory_map_if_larger_than_bytes: u64) -> Result<Self, Error> {
-            let path = path.into();
+        pub fn open(path: PathBuf, use_memory_map_if_larger_than_bytes: u64) -> Result<Self, Error> {
             let (backing, offset) = {
                 let backing = if std::fs::metadata(&path)?.len() <= use_memory_map_if_larger_than_bytes {
                     packed::Backing::InMemory(std::fs::read(&path)?)

--- a/gix-ref/src/store/packed/iter.rs
+++ b/gix-ref/src/store/packed/iter.rs
@@ -19,8 +19,7 @@ impl packed::Buffer {
     }
 
     /// Return an iterator yielding only references matching the given prefix, ordered by reference name.
-    pub fn iter_prefixed(&self, prefix: impl Into<BString>) -> Result<packed::Iter<'_>, packed::iter::Error> {
-        let prefix = prefix.into();
+    pub fn iter_prefixed(&self, prefix: BString) -> Result<packed::Iter<'_>, packed::iter::Error> {
         let first_record_with_prefix = self.binary_search_by(prefix.as_bstr()).unwrap_or_else(|(_, pos)| pos);
         packed::Iter::new_with_prefix(&self.as_ref()[first_record_with_prefix..], Some(prefix))
     }

--- a/gix-ref/src/store/packed/transaction.rs
+++ b/gix-ref/src/store/packed/transaction.rs
@@ -46,7 +46,7 @@ impl packed::Transaction {
     /// Prepare the transaction by checking all edits for applicability.
     pub fn prepare(
         mut self,
-        edits: impl IntoIterator<Item = RefEdit>,
+        edits: &mut dyn Iterator<Item = RefEdit>,
         find: &mut FindObjectFn<'_>,
     ) -> Result<Self, prepare::Error> {
         assert!(self.edits.is_none(), "BUG: cannot call prepare(…) more than once");
@@ -189,7 +189,7 @@ impl packed::Transaction {
     }
 }
 
-fn write_packed_ref(mut out: impl std::io::Write, pref: packed::Reference<'_>) -> std::io::Result<()> {
+fn write_packed_ref(out: &mut dyn std::io::Write, pref: packed::Reference<'_>) -> std::io::Result<()> {
     write!(out, "{} ", pref.target)?;
     out.write_all(pref.name.as_bstr())?;
     out.write_all(b"\n")?;
@@ -199,7 +199,7 @@ fn write_packed_ref(mut out: impl std::io::Write, pref: packed::Reference<'_>) -
     Ok(())
 }
 
-fn write_edit(mut out: impl std::io::Write, edit: &Edit, lines_written: &mut i32) -> std::io::Result<()> {
+fn write_edit(out: &mut dyn std::io::Write, edit: &Edit, lines_written: &mut i32) -> std::io::Result<()> {
     match edit.inner.change {
         Change::Delete { .. } => {}
         Change::Update {

--- a/gix-ref/src/transaction/ext.rs
+++ b/gix-ref/src/transaction/ext.rs
@@ -18,8 +18,8 @@ where
     /// Note no action is performed if deref isn't specified.
     fn extend_with_splits_of_symbolic_refs(
         &mut self,
-        find: impl FnMut(&PartialNameRef) -> Option<Target>,
-        make_entry: impl FnMut(usize, RefEdit) -> T,
+        find: &mut dyn FnMut(&PartialNameRef) -> Option<Target>,
+        make_entry: &mut dyn FnMut(usize, RefEdit) -> T,
     ) -> Result<(), std::io::Error>;
 
     /// All processing steps in one and in the correct order.
@@ -27,8 +27,8 @@ where
     /// Users call this to assure derefs are honored and duplicate checks are done.
     fn pre_process(
         &mut self,
-        find: impl FnMut(&PartialNameRef) -> Option<Target>,
-        make_entry: impl FnMut(usize, RefEdit) -> T,
+        find: &mut dyn FnMut(&PartialNameRef) -> Option<Target>,
+        make_entry: &mut dyn FnMut(usize, RefEdit) -> T,
     ) -> Result<(), std::io::Error> {
         self.extend_with_splits_of_symbolic_refs(find, make_entry)?;
         self.assure_one_name_has_one_edit().map_err(|name| {
@@ -55,8 +55,8 @@ where
 
     fn extend_with_splits_of_symbolic_refs(
         &mut self,
-        mut find: impl FnMut(&PartialNameRef) -> Option<Target>,
-        mut make_entry: impl FnMut(usize, RefEdit) -> E,
+        find: &mut dyn FnMut(&PartialNameRef) -> Option<Target>,
+        make_entry: &mut dyn FnMut(usize, RefEdit) -> E,
     ) -> Result<(), std::io::Error> {
         let mut new_edits = Vec::new();
         let mut first = 0;

--- a/gix-ref/tests/file/store/find.rs
+++ b/gix-ref/tests/file/store/find.rs
@@ -80,10 +80,10 @@ mod existing {
         store.find_loose(&name.to_full_name())?;
         store.find_loose(name.to_full_name().as_ref())?;
         store.find_loose(name.to_full_name().as_ref().as_partial_name())?;
-        store.find_loose(&PartialName::try_from(name.remote)?.join(name.branch)?)?;
-        store.find_loose(&PartialName::try_from("origin")?.join("main")?)?;
-        store.find_loose(&PartialName::try_from("origin")?.join(String::from("main"))?)?;
-        store.find_loose(&PartialName::try_from("origin")?.join("main")?)?;
+        store.find_loose(&PartialName::try_from(name.remote)?.join(name.branch.into())?)?;
+        store.find_loose(&PartialName::try_from("origin")?.join("main".into())?)?;
+        store.find_loose(&PartialName::try_from("origin")?.join(String::from("main").as_str().into())?)?;
+        store.find_loose(&PartialName::try_from("origin")?.join("main".into())?)?;
 
         Ok(())
     }

--- a/gix-ref/tests/file/store/iter.rs
+++ b/gix-ref/tests/file/store/iter.rs
@@ -61,7 +61,7 @@ mod with_namespace {
             packed
                 .as_ref()
                 .expect("present")
-                .iter_prefixed(ns_two.as_bstr())?
+                .iter_prefixed(ns_two.as_bstr().into())?
                 .map(Result::unwrap)
                 .map(|r| r.name.to_owned().into_inner())
                 .collect::<Vec<_>>(),
@@ -323,7 +323,7 @@ fn loose_iter_with_prefix_wont_allow_absolute_paths() -> crate::Result {
     #[cfg(windows)]
     let abs_path = "c:\\hello";
 
-    match store.loose_iter_prefixed(abs_path) {
+    match store.loose_iter_prefixed(abs_path.as_ref()) {
         Ok(_) => unreachable!("absolute paths aren't allowed"),
         Err(err) => assert_eq!(err.to_string(), "prefix must be a relative path, like 'refs/heads'"),
     }
@@ -335,7 +335,7 @@ fn loose_iter_with_prefix() -> crate::Result {
     let store = store()?;
 
     let actual = store
-        .loose_iter_prefixed("refs/heads/")?
+        .loose_iter_prefixed("refs/heads/".as_ref())?
         .collect::<Result<Vec<_>, _>>()
         .expect("no broken ref in this subset")
         .into_iter()
@@ -363,7 +363,7 @@ fn loose_iter_with_partial_prefix() -> crate::Result {
     let store = store()?;
 
     let actual = store
-        .loose_iter_prefixed("refs/heads/d")?
+        .loose_iter_prefixed("refs/heads/d".as_ref())?
         .collect::<Result<Vec<_>, _>>()
         .expect("no broken ref in this subset")
         .into_iter()
@@ -420,7 +420,7 @@ fn overlay_iter_with_prefix_wont_allow_absolute_paths() -> crate::Result {
     #[cfg(windows)]
     let abs_path = "c:\\hello";
 
-    match store.iter()?.prefixed(abs_path) {
+    match store.iter()?.prefixed(abs_path.as_ref()) {
         Ok(_) => unreachable!("absolute paths aren't allowed"),
         Err(err) => assert_eq!(err.to_string(), "prefix must be a relative path, like 'refs/heads'"),
     }
@@ -434,7 +434,7 @@ fn overlay_prefixed_iter() -> crate::Result {
     let store = store_at("make_packed_ref_repository_for_overlay.sh")?;
     let ref_names = store
         .iter()?
-        .prefixed("refs/heads")?
+        .prefixed("refs/heads".as_ref())?
         .map(|r| r.map(|r| (r.name.as_bstr().to_owned(), r.target)))
         .collect::<Result<Vec<_>, _>>()?;
     let c1 = hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03");
@@ -456,7 +456,7 @@ fn overlay_partial_prefix_iter() -> crate::Result {
     let store = store_at("make_packed_ref_repository_for_overlay.sh")?;
     let ref_names = store
         .iter()?
-        .prefixed("refs/heads/m")? // 'm' is partial
+        .prefixed("refs/heads/m".as_ref())? // 'm' is partial
         .map(|r| r.map(|r| (r.name.as_bstr().to_owned(), r.target)))
         .collect::<Result<Vec<_>, _>>()?;
     let c1 = hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03");

--- a/gix-ref/tests/file/transaction/mod.rs
+++ b/gix-ref/tests/file/transaction/mod.rs
@@ -24,7 +24,11 @@ pub(crate) mod prepare_and_commit {
 
     pub(crate) fn empty_store() -> crate::Result<(gix_testtools::tempfile::TempDir, file::Store)> {
         let dir = gix_testtools::tempfile::TempDir::new().unwrap();
-        let store = file::Store::at(dir.path(), gix_ref::store::WriteReflog::Normal, gix_hash::Kind::Sha1);
+        let store = file::Store::at(
+            dir.path().into(),
+            gix_ref::store::WriteReflog::Normal,
+            gix_hash::Kind::Sha1,
+        );
         Ok((dir, store))
     }
 

--- a/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -713,11 +713,7 @@ fn packed_refs_creation_with_packed_refs_mode_prune_removes_original_loose_refs(
     let edits = store
         .transaction()
         .packed_refs(PackedRefs::DeletionsAndNonSymbolicUpdatesRemoveLooseSourceReference(
-            Box::new(move |oid, buf| {
-                odb.try_find(oid, buf)
-                    .map(|obj| obj.map(|obj| obj.kind))
-                    .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
-            }),
+            Box::new(move |oid, buf| odb.try_find(&oid, buf).map(|obj| obj.map(|obj| obj.kind))),
         ))
         .prepare(
             store

--- a/gix-ref/tests/namespace/mod.rs
+++ b/gix-ref/tests/namespace/mod.rs
@@ -5,7 +5,7 @@ fn into_namespaced_prefix() {
     assert_eq!(
         gix_ref::namespace::expand("foo")
             .unwrap()
-            .into_namespaced_prefix("prefix"),
+            .into_namespaced_prefix("prefix".as_ref()),
         Path::new("refs").join("namespaces").join("foo").join("prefix")
     )
 }

--- a/gix-ref/tests/packed/iter.rs
+++ b/gix-ref/tests/packed/iter.rs
@@ -29,7 +29,7 @@ fn iter_prefix() -> crate::Result {
     let packed = store_with_packed_refs()?.open_packed_buffer()?.expect("packed-refs");
     assert_eq!(
         packed
-            .iter_prefixed("refs/heads/")?
+            .iter_prefixed("refs/heads/".into())?
             .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
         vec![
@@ -41,7 +41,7 @@ fn iter_prefix() -> crate::Result {
 
     assert_eq!(
         packed
-            .iter_prefixed("refs/heads/d")?
+            .iter_prefixed("refs/heads/d".into())?
             .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
         vec!["refs/heads/d1".as_bytes().as_bstr(), "refs/heads/dt1".into(),],
@@ -50,7 +50,7 @@ fn iter_prefix() -> crate::Result {
 
     assert_eq!(
         packed
-            .iter_prefixed("refs/remotes/")?
+            .iter_prefixed("refs/remotes/".into())?
             .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
         vec![
@@ -62,7 +62,7 @@ fn iter_prefix() -> crate::Result {
     let last_ref_in_file = "refs/tags/t1";
     assert_eq!(
         packed
-            .iter_prefixed(last_ref_in_file)?
+            .iter_prefixed(last_ref_in_file.into())?
             .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
         vec![last_ref_in_file.as_bytes().as_bstr()],
@@ -71,7 +71,7 @@ fn iter_prefix() -> crate::Result {
     let first_ref_in_file = "refs/d1";
     assert_eq!(
         packed
-            .iter_prefixed(first_ref_in_file)?
+            .iter_prefixed(first_ref_in_file.into())?
             .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
         vec![first_ref_in_file.as_bytes().as_bstr()],

--- a/gix-ref/tests/refs.rs
+++ b/gix-ref/tests/refs.rs
@@ -4,7 +4,7 @@ pub fn hex_to_id(hex: &str) -> ObjectId {
     ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
 }
 
-type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub use gix_testtools::Result;
 
 mod file;
 mod fullname;

--- a/gix-ref/tests/transaction/mod.rs
+++ b/gix-ref/tests/transaction/mod.rs
@@ -65,7 +65,7 @@ mod refedit_ext {
         ];
 
         let err = edits
-            .pre_process(|n| store.find_existing(n), |_, e| e)
+            .pre_process(&mut |n| store.find_existing(n), &mut |_, e| e)
             .expect_err("duplicate detected");
         assert_eq!(
             err.to_string(),
@@ -146,10 +146,9 @@ mod refedit_ext {
                 },
             ];
 
-            edits.extend_with_splits_of_symbolic_refs(
-                |n| store.find_existing(n),
-                |_, _| panic!("should not be called"),
-            )?;
+            edits.extend_with_splits_of_symbolic_refs(&mut |n| store.find_existing(n), &mut |_, _| {
+                panic!("should not be called")
+            })?;
             assert_eq!(edits.len(), 3, "no edit was added");
             assert!(
                 !find(&edits, "refs/heads/anything-but-not-symbolic").deref,
@@ -166,7 +165,7 @@ mod refedit_ext {
         fn empty_inputs_are_ok() -> crate::Result {
             let store = MockStore::default();
             Vec::<RefEdit>::new()
-                .extend_with_splits_of_symbolic_refs(|n| store.find_existing(n), |_, e| e)
+                .extend_with_splits_of_symbolic_refs(&mut |n| store.find_existing(n), &mut |_, e| e)
                 .map_err(Into::into)
         }
 
@@ -214,7 +213,7 @@ mod refedit_ext {
 
             let store = Cycler::default();
             let err = edits
-                .extend_with_splits_of_symbolic_refs(|n| store.find_existing(n), |_, e| e)
+                .extend_with_splits_of_symbolic_refs(&mut |n| store.find_existing(n), &mut |_, e| e)
                 .expect_err("cycle detected");
             assert_eq!(
                 err.to_string(),
@@ -283,13 +282,10 @@ mod refedit_ext {
             ];
 
             let mut indices = Vec::new();
-            edits.extend_with_splits_of_symbolic_refs(
-                |n| store.find_existing(n),
-                |idx, e| {
-                    indices.push(idx);
-                    e
-                },
-            )?;
+            edits.extend_with_splits_of_symbolic_refs(&mut |n| store.find_existing(n), &mut |idx, e| {
+                indices.push(idx);
+                e
+            })?;
             assert_eq!(
                 indices,
                 vec![0, 1, 2, 3],

--- a/gix-refspec/src/write.rs
+++ b/gix-refspec/src/write.rs
@@ -14,7 +14,7 @@ impl RefSpecRef<'_> {
     }
 
     /// Serialize ourselves in a parseable format to `out`.
-    pub fn write_to(&self, out: impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
         self.instruction().write_to(out)
     }
 }
@@ -28,7 +28,7 @@ impl Instruction<'_> {
     }
 
     /// Serialize ourselves in a parseable format to `out`.
-    pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
         match self {
             Instruction::Push(Push::Matching {
                 src,

--- a/gix-revision/src/describe.rs
+++ b/gix-revision/src/describe.rs
@@ -313,11 +313,11 @@ pub(crate) mod function {
         graph
             .insert_parents(
                 &commit,
-                |parent_id, parent_commit_date| {
+                &mut |parent_id, parent_commit_date| {
                     queue.insert(parent_commit_date as u32, parent_id);
                     commit_flags
                 },
-                |_parent_id, flags| *flags |= commit_flags,
+                &mut |_parent_id, flags| *flags |= commit_flags,
                 first_parent,
             )
             .map_err(|err| Error::InsertParentsToGraph { err, oid: commit })?;

--- a/gix-revision/tests/describe/mod.rs
+++ b/gix-revision/tests/describe/mod.rs
@@ -21,7 +21,7 @@ fn run_test(
     let commit_id = hex_to_id("01ec18a3ebf2855708ad3c9d244306bc1fae3e9b");
     for use_commitgraph in [false, true] {
         let cache = use_commitgraph
-            .then(|| gix_commitgraph::Graph::from_info_dir(store.store_ref().path().join("info")).ok())
+            .then(|| gix_commitgraph::Graph::from_info_dir(&store.store_ref().path().join("info")).ok())
             .flatten();
         let mut graph = gix_revision::Graph::new(
             |id, buf| {

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -13,7 +13,7 @@ pub struct Account {
 /// Returns true if the given `path` is owned by the user who is executing the current process.
 ///
 /// Note that this method is very specific to avoid having to deal with any operating system types.
-pub fn is_path_owned_by_current_user(path: impl AsRef<Path>) -> std::io::Result<bool> {
+pub fn is_path_owned_by_current_user(path: &Path) -> std::io::Result<bool> {
     impl_::is_path_owned_by_current_user(path)
 }
 
@@ -21,8 +21,8 @@ pub fn is_path_owned_by_current_user(path: impl AsRef<Path>) -> std::io::Result<
 mod impl_ {
     use std::path::Path;
 
-    pub fn is_path_owned_by_current_user(path: impl AsRef<Path>) -> std::io::Result<bool> {
-        fn owner_from_path(path: impl AsRef<Path>) -> std::io::Result<u32> {
+    pub fn is_path_owned_by_current_user(path: &Path) -> std::io::Result<bool> {
+        fn owner_from_path(path: &Path) -> std::io::Result<u32> {
             use std::os::unix::fs::MetadataExt;
             let meta = std::fs::symlink_metadata(path)?;
             Ok(meta.uid())
@@ -58,7 +58,7 @@ mod impl_ {
         std::io::Error::new(std::io::ErrorKind::Other, msg.into())
     }
 
-    pub fn is_path_owned_by_current_user(path: impl AsRef<Path>) -> std::io::Result<bool> {
+    pub fn is_path_owned_by_current_user(path: &Path) -> std::io::Result<bool> {
         use windows::{
             core::{Error, PCWSTR},
             Win32::{
@@ -78,7 +78,6 @@ mod impl_ {
 
         let mut err_msg = None;
         let mut is_owned = false;
-        let path = path.as_ref();
 
         if !path.exists() {
             return Err(std::io::Error::new(

--- a/gix-sec/src/trust.rs
+++ b/gix-sec/src/trust.rs
@@ -2,8 +2,8 @@ use crate::Trust;
 
 impl Trust {
     /// Derive `Full` trust if `path` is owned by the user executing the current process, or `Reduced` trust otherwise.
-    pub fn from_path_ownership(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
-        Ok(if crate::identity::is_path_owned_by_current_user(path.as_ref())? {
+    pub fn from_path_ownership(path: &std::path::Path) -> std::io::Result<Self> {
+        Ok(if crate::identity::is_path_owned_by_current_user(path)? {
             Trust::Full
         } else {
             Trust::Reduced

--- a/gix-sec/tests/identity/mod.rs
+++ b/gix-sec/tests/identity/mod.rs
@@ -3,7 +3,7 @@ fn is_path_owned_by_current_user() -> crate::Result {
     let dir = tempfile::tempdir()?;
     let file = dir.path().join("file");
     std::fs::write(&file, [])?;
-    assert!(gix_sec::identity::is_path_owned_by_current_user(file)?);
+    assert!(gix_sec::identity::is_path_owned_by_current_user(&file)?);
     assert!(gix_sec::identity::is_path_owned_by_current_user(dir.path())?);
     Ok(())
 }
@@ -12,6 +12,6 @@ fn is_path_owned_by_current_user() -> crate::Result {
 #[cfg(windows)]
 fn windows_home() -> crate::Result {
     let home = gix_path::env::home_dir().expect("home dir is available");
-    assert!(gix_sec::identity::is_path_owned_by_current_user(home)?);
+    assert!(gix_sec::identity::is_path_owned_by_current_user(&home)?);
     Ok(())
 }

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -41,7 +41,7 @@ fn fixture(name: &str, expected_status: &[(&BStr, Option<Change>, bool)]) {
         FastEq,
         |_, _| Ok::<_, std::convert::Infallible>(gix_object::BlobRef { data: &[] }),
         Options {
-            fs: gix_fs::Capabilities::probe(git_dir),
+            fs: gix_fs::Capabilities::probe(&git_dir),
             stat: TEST_OPTIONS,
             ..Options::default()
         },

--- a/gix-submodule/src/is_active_platform.rs
+++ b/gix-submodule/src/is_active_platform.rs
@@ -27,7 +27,7 @@ impl IsActivePlatform {
         &mut self,
         config: &gix_config::File<'static>,
         name: &BStr,
-        attributes: impl FnMut(
+        attributes: &mut dyn FnMut(
             &BStr,
             gix_pathspec::attributes::glob::pattern::Case,
             bool,

--- a/gix-submodule/src/lib.rs
+++ b/gix-submodule/src/lib.rs
@@ -66,7 +66,7 @@ impl File {
         for ((module_name, field), values) in values {
             if prev_name.map_or(true, |pn: &BStr| pn != module_name) {
                 config_to_append
-                    .new_section("submodule", Cow::Owned(module_name.to_owned()))
+                    .new_section("submodule", Some(Cow::Owned(module_name.to_owned())))
                     .expect("all names come from valid configuration, so remain valid");
                 prev_name = Some(module_name);
             }

--- a/gix-tempfile/src/forksafe.rs
+++ b/gix-tempfile/src/forksafe.rs
@@ -47,7 +47,11 @@ impl ForksafeTempfile {
             self
         }
     }
-    pub fn persist(mut self, path: impl AsRef<Path>) -> Result<Option<std::fs::File>, (std::io::Error, Self)> {
+    pub fn persist(self, path: impl AsRef<Path>) -> Result<Option<std::fs::File>, (std::io::Error, Self)> {
+        self.persist_inner(path.as_ref())
+    }
+
+    fn persist_inner(mut self, path: &Path) -> Result<Option<std::fs::File>, (std::io::Error, Self)> {
         match self.inner {
             TempfileOrTemppath::Tempfile(file) => match file.persist(path) {
                 Ok(file) => Ok(Some(file)),

--- a/gix-tempfile/src/handle.rs
+++ b/gix-tempfile/src/handle.rs
@@ -22,13 +22,7 @@ pub(crate) enum Mode {
 
 /// Utilities
 impl Handle<()> {
-    fn at_path(
-        path: impl AsRef<Path>,
-        directory: ContainingDirectory,
-        cleanup: AutoRemove,
-        mode: Mode,
-    ) -> io::Result<usize> {
-        let path = path.as_ref();
+    fn at_path(path: &Path, directory: ContainingDirectory, cleanup: AutoRemove, mode: Mode) -> io::Result<usize> {
         let tempfile = {
             let mut builder = tempfile::Builder::new();
             let dot_ext_storage;
@@ -50,12 +44,12 @@ impl Handle<()> {
     }
 
     fn new_writable_inner(
-        containing_directory: impl AsRef<Path>,
+        containing_directory: &Path,
         directory: ContainingDirectory,
         cleanup: AutoRemove,
         mode: Mode,
     ) -> io::Result<usize> {
-        let containing_directory = directory.resolve(containing_directory.as_ref())?;
+        let containing_directory = directory.resolve(containing_directory)?;
         let id = NEXT_MAP_INDEX.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         expect_none(REGISTRY.insert(
             id,
@@ -77,7 +71,7 @@ impl Handle<Closed> {
     /// intermediate directories will be removed.
     pub fn at(path: impl AsRef<Path>, directory: ContainingDirectory, cleanup: AutoRemove) -> io::Result<Self> {
         Ok(Handle {
-            id: Handle::<()>::at_path(path, directory, cleanup, Mode::Closed)?,
+            id: Handle::<()>::at_path(path.as_ref(), directory, cleanup, Mode::Closed)?,
             _marker: Default::default(),
         })
     }
@@ -100,7 +94,7 @@ impl Handle<Writable> {
     /// intermediate directories will be removed.
     pub fn at(path: impl AsRef<Path>, directory: ContainingDirectory, cleanup: AutoRemove) -> io::Result<Self> {
         Ok(Handle {
-            id: Handle::<()>::at_path(path, directory, cleanup, Mode::Writable)?,
+            id: Handle::<()>::at_path(path.as_ref(), directory, cleanup, Mode::Writable)?,
             _marker: Default::default(),
         })
     }
@@ -114,7 +108,7 @@ impl Handle<Writable> {
         cleanup: AutoRemove,
     ) -> io::Result<Self> {
         Ok(Handle {
-            id: Handle::<()>::new_writable_inner(containing_directory, directory, cleanup, Mode::Writable)?,
+            id: Handle::<()>::new_writable_inner(containing_directory.as_ref(), directory, cleanup, Mode::Writable)?,
             _marker: Default::default(),
         })
     }

--- a/gix-tempfile/src/lib.rs
+++ b/gix-tempfile/src/lib.rs
@@ -96,8 +96,8 @@ type HashMap<K, V> = hashmap::Concurrent<K, V>;
 
 pub use gix_fs::dir::{create as create_dir, remove as remove_dir};
 
-#[cfg(feature = "signals")]
 /// signal setup and reusable handlers.
+#[cfg(feature = "signals")]
 pub mod signal;
 
 mod forksafe;

--- a/gix-transport/src/client/blocking_io/http/curl/remote.rs
+++ b/gix-transport/src/client/blocking_io/http/curl/remote.rs
@@ -269,7 +269,7 @@ pub fn new() -> (
                 handler.send_data = Some(send);
                 let (send, receive_headers) = pipe::unidirectional(1);
                 handler.send_header = Some(send);
-                let (send_body, receive_body) = pipe::unidirectional(None);
+                let (send_body, receive_body) = pipe::unidirectional(0);
                 (receive_data, receive_headers, send_body, receive_body)
             };
 

--- a/gix-traverse/tests/traverse.rs
+++ b/gix-traverse/tests/traverse.rs
@@ -1,4 +1,4 @@
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+use gix_testtools::Result;
 
 fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
     gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")

--- a/gix-traverse/tests/tree/mod.rs
+++ b/gix-traverse/tests/tree/mod.rs
@@ -16,12 +16,12 @@ fn breadth_first_full_path() -> crate::Result<()> {
     let mut buf = Vec::new();
     let mut buf2 = Vec::new();
     let mut commit = db
-        .find_commit_iter(hex_to_id("85df34aa34848b8138b2b3dcff5fb5c2b734e0ce"), &mut buf)?
+        .find_commit_iter(&hex_to_id("85df34aa34848b8138b2b3dcff5fb5c2b734e0ce"), &mut buf)?
         .0;
     // Full paths - that's the default.
     let mut recorder = tree::Recorder::default();
     gix_traverse::tree::breadthfirst(
-        db.find_tree_iter(commit.tree_id().expect("a tree is available in a commit"), &mut buf2)?
+        db.find_tree_iter(&commit.tree_id().expect("a tree is available in a commit"), &mut buf2)?
             .0,
         tree::breadthfirst::State::default(),
         |oid, buf| db.find_tree_iter(oid, buf).ok().map(|t| t.0),
@@ -104,11 +104,11 @@ fn breadth_first_filename_only() -> crate::Result<()> {
     let mut buf = Vec::new();
     let mut buf2 = Vec::new();
     let mut commit = db
-        .find_commit_iter(hex_to_id("85df34aa34848b8138b2b3dcff5fb5c2b734e0ce"), &mut buf)?
+        .find_commit_iter(&hex_to_id("85df34aa34848b8138b2b3dcff5fb5c2b734e0ce"), &mut buf)?
         .0;
     let mut recorder = tree::Recorder::default().track_location(Some(Location::FileName));
     gix_traverse::tree::breadthfirst(
-        db.find_tree_iter(commit.tree_id().expect("a tree is available in a commit"), &mut buf2)?
+        db.find_tree_iter(&commit.tree_id().expect("a tree is available in a commit"), &mut buf2)?
             .0,
         tree::breadthfirst::State::default(),
         |oid, buf| db.find_tree_iter(oid, buf).ok().map(|t| t.0),
@@ -131,11 +131,11 @@ fn breadth_first_no_location() -> crate::Result<()> {
     let mut buf = Vec::new();
     let mut buf2 = Vec::new();
     let mut commit = db
-        .find_commit_iter(hex_to_id("85df34aa34848b8138b2b3dcff5fb5c2b734e0ce"), &mut buf)?
+        .find_commit_iter(&hex_to_id("85df34aa34848b8138b2b3dcff5fb5c2b734e0ce"), &mut buf)?
         .0;
     let mut recorder = tree::Recorder::default().track_location(None);
     gix_traverse::tree::breadthfirst(
-        db.find_tree_iter(commit.tree_id().expect("a tree is available in a commit"), &mut buf2)?
+        db.find_tree_iter(&commit.tree_id().expect("a tree is available in a commit"), &mut buf2)?
             .0,
         tree::breadthfirst::State::default(),
         |oid, buf| db.find_tree_iter(oid, buf).ok().map(|t| t.0),

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -1,4 +1,6 @@
 mod canonicalized {
+    use std::borrow::Cow;
+
     #[test]
     fn non_file_scheme_is_noop() -> crate::Result {
         let url = gix_url::parse("https://github.com/byron/gitoxide".into())?;
@@ -19,8 +21,11 @@ mod canonicalized {
     #[test]
     fn file_that_is_current_dir_is_absolutized() -> crate::Result {
         let url = gix_url::parse(".".into())?;
-        assert!(gix_path::from_bstr(url.path.as_ref()).is_relative());
-        assert!(gix_path::from_bstr(url.canonicalized(&std::env::current_dir()?)?.path.as_ref()).is_absolute());
+        assert!(gix_path::from_bstr(Cow::Borrowed(url.path.as_ref())).is_relative());
+        assert!(gix_path::from_bstr(Cow::Borrowed(
+            url.canonicalized(&std::env::current_dir()?)?.path.as_ref()
+        ))
+        .is_absolute());
         Ok(())
     }
 }

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -96,7 +96,7 @@ where
             let filtered = filters.convert_to_worktree(
                 obj.data,
                 entry_path,
-                |_, attrs| {
+                &mut |_, attrs| {
                     path_cache.matching_attributes(attrs);
                 },
                 filter_process_delay,

--- a/gix-worktree-state/src/checkout/function.rs
+++ b/gix-worktree-state/src/checkout/function.rs
@@ -89,18 +89,12 @@ where
         let mut delayed_filter_results = Vec::new();
         let mut out = chunk::process(
             entries_with_paths,
-            num_files.as_deref(),
-            num_bytes.as_deref(),
+            &num_files,
+            &num_bytes,
             &mut delayed_filter_results,
             &mut ctx,
         )?;
-        chunk::process_delayed_filter_results(
-            delayed_filter_results,
-            num_files.as_deref(),
-            num_bytes.as_deref(),
-            &mut out,
-            &mut ctx,
-        )?;
+        chunk::process_delayed_filter_results(delayed_filter_results, &num_files, &num_bytes, &mut out, &mut ctx)?;
         out
     } else {
         let entries_with_paths = interrupt::Iter::new(index.entries_mut_with_paths_in(paths), should_interrupt);
@@ -115,28 +109,20 @@ where
                 move |_| (Vec::new(), ctx)
             },
             |chunk, (delayed_filter_results, ctx)| {
-                chunk::process(
-                    chunk.into_iter(),
-                    num_files.as_deref(),
-                    num_bytes.as_deref(),
-                    delayed_filter_results,
-                    ctx,
-                )
+                chunk::process(chunk.into_iter(), &num_files, &num_bytes, delayed_filter_results, ctx)
             },
             |(delayed_filter_results, mut ctx)| {
                 let mut out = chunk::Outcome::default();
                 chunk::process_delayed_filter_results(
                     delayed_filter_results,
-                    num_files.as_deref(),
-                    num_bytes.as_deref(),
+                    &num_files,
+                    &num_bytes,
                     &mut out,
                     &mut ctx,
                 )?;
                 Ok(out)
             },
             chunk::Reduce {
-                files: num_files.is_none().then_some(files),
-                bytes: num_bytes.is_none().then_some(bytes),
                 aggregate: Default::default(),
                 marker: Default::default(),
             },
@@ -149,8 +135,8 @@ where
             entry_path,
             &mut errors,
             &mut collisions,
-            num_files.as_deref(),
-            num_bytes.as_deref(),
+            &num_files,
+            &num_bytes,
             &mut ctx,
         )?
         .as_bytes()

--- a/gix-worktree-state/src/checkout/function.rs
+++ b/gix-worktree-state/src/checkout/function.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use gix_features::{interrupt, parallel::in_parallel_with_finalize, progress::Progress};
+use gix_features::{interrupt, parallel::in_parallel_with_finalize};
 use gix_hash::oid;
 use gix_worktree::{stack, Stack};
 
@@ -21,8 +21,8 @@ pub fn checkout<Find, E>(
     index: &mut gix_index::State,
     dir: impl Into<std::path::PathBuf>,
     find: Find,
-    files: &mut impl Progress,
-    bytes: &mut impl Progress,
+    files: &dyn gix_features::progress::Count,
+    bytes: &dyn gix_features::progress::Count,
     should_interrupt: &AtomicBool,
     options: crate::checkout::Options,
 ) -> Result<crate::checkout::Outcome, crate::checkout::Error<E>>
@@ -42,8 +42,8 @@ fn checkout_inner<Find, E>(
     paths: &gix_index::PathStorage,
     dir: impl Into<std::path::PathBuf>,
     find: Find,
-    files: &mut impl Progress,
-    bytes: &mut impl Progress,
+    files: &dyn gix_features::progress::Count,
+    bytes: &dyn gix_features::progress::Count,
     should_interrupt: &AtomicBool,
     mut options: crate::checkout::Options,
 ) -> Result<crate::checkout::Outcome, crate::checkout::Error<E>>

--- a/gix-worktree-state/tests/state/checkout.rs
+++ b/gix-worktree-state/tests/state/checkout.rs
@@ -507,8 +507,8 @@ fn checkout_index_in_tmp_dir_opts(
                 Err(gix_odb::find::existing_object::Error::NotFound { oid: oid.to_owned() })
             }
         },
-        &mut progress::Discard,
-        &mut progress::Discard,
+        &progress::Discard,
+        &progress::Discard,
         &AtomicBool::default(),
         opts,
     )?;
@@ -521,7 +521,7 @@ fn stripped_prefix(prefix: impl AsRef<Path>, source_files: &[PathBuf]) -> Vec<&P
 
 fn probe_gitoxide_dir() -> crate::Result<gix_fs::Capabilities> {
     Ok(gix_fs::Capabilities::probe(
-        gix_discover::upwards(".")?
+        &gix_discover::upwards(".".as_ref())?
             .0
             .into_repository_and_work_tree_directories()
             .0,

--- a/gix-worktree-stream/src/from_tree/traverse.rs
+++ b/gix-worktree-stream/src/from_tree/traverse.rs
@@ -68,7 +68,7 @@ where
         let converted = self.pipeline.convert_to_worktree(
             &self.buf,
             self.path.as_ref(),
-            |a, b| {
+            &mut |a, b| {
                 (self.fetch_attributes)(a, entry.mode, b).ok();
             },
             gix_filter::driver::apply::Delay::Forbid,

--- a/gix-worktree/src/stack/mod.rs
+++ b/gix-worktree/src/stack/mod.rs
@@ -88,7 +88,7 @@ impl Stack {
         &mut self,
         relative: impl AsRef<Path>,
         is_dir: Option<bool>,
-        find: Find,
+        mut find: Find,
     ) -> std::io::Result<Platform<'_>>
     where
         Find: for<'a> FnMut(&oid, &'a mut Vec<u8>) -> Result<gix_object::BlobRef<'a>, E>,
@@ -100,11 +100,12 @@ impl Stack {
             buf: &mut self.buf,
             is_dir: is_dir.unwrap_or(false),
             id_mappings: &self.id_mappings,
-            find,
+            find: &mut |oid, buf| Ok(find(oid, buf).map_err(Box::new)?),
             case: self.case,
             statistics: &mut self.statistics,
         };
-        self.stack.make_relative_path_current(relative, &mut delegate)?;
+        self.stack
+            .make_relative_path_current(relative.as_ref(), &mut delegate)?;
         Ok(Platform { parent: self, is_dir })
     }
 

--- a/gix-worktree/src/stack/state/ignore.rs
+++ b/gix-worktree/src/stack/state/ignore.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use bstr::{BStr, ByteSlice};
 use gix_glob::pattern::Case;
 
+use crate::stack::delegate::FindFn;
 use crate::{
     stack::state::{Ignore, IgnoreMatchGroup},
     PathIdMapping,
@@ -156,21 +157,17 @@ impl Ignore {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn push_directory<Find, E>(
+    pub(crate) fn push_directory(
         &mut self,
         root: &Path,
         dir: &Path,
         rela_dir: &BStr,
         buf: &mut Vec<u8>,
         id_mappings: &[PathIdMapping],
-        mut find: Find,
+        find: &mut FindFn<'_>,
         case: Case,
         stats: &mut Statistics,
-    ) -> std::io::Result<()>
-    where
-        Find: for<'b> FnMut(&gix_hash::oid, &'b mut Vec<u8>) -> Result<gix_object::BlobRef<'b>, E>,
-        E: std::error::Error + Send + Sync + 'static,
-    {
+    ) -> std::io::Result<()> {
         self.matched_directory_patterns_stack
             .push(self.matching_exclude_pattern_no_dir(rela_dir, Some(true), case));
 

--- a/gix-worktree/tests/worktree/mod.rs
+++ b/gix-worktree/tests/worktree/mod.rs
@@ -2,7 +2,7 @@ use gix_hash::ObjectId;
 
 mod stack;
 
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub use gix_testtools::Result;
 
 pub fn hex_to_id(hex: &str) -> ObjectId {
     ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")

--- a/gix-worktree/tests/worktree/stack/ignore.rs
+++ b/gix-worktree/tests/worktree/stack/ignore.rs
@@ -94,7 +94,7 @@ fn check_against_baseline() -> crate::Result {
     let state = gix_worktree::stack::State::for_add(
         Default::default(),
         gix_worktree::stack::state::Ignore::new(
-            gix_ignore::Search::from_overrides(vec!["!force-include"]),
+            gix_ignore::Search::from_overrides(["!force-include"]),
             gix_ignore::Search::from_git_dir(&git_dir, Some(user_exclude_path), &mut buf)?,
             None,
             Source::WorktreeThenIdMappingIfNotSkipped,

--- a/gix-worktree/tests/worktree/stack/mod.rs
+++ b/gix-worktree/tests/worktree/stack/mod.rs
@@ -8,7 +8,7 @@ mod ignore;
 fn probe_case() -> crate::Result<Case> {
     Ok(
         if gix_fs::Capabilities::probe(
-            gix_discover::upwards(".")?
+            &gix_discover::upwards(".".as_ref())?
                 .0
                 .into_repository_and_work_tree_directories()
                 .0,

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -176,7 +176,7 @@ gix-protocol = { version = "^0.38.0", path = "../gix-protocol", optional = true 
 gix-transport = { version = "^0.35.0", path = "../gix-transport", optional = true }
 
 # Just to get the progress-tree feature
-prodash = { version = "25.0", optional = true, default-features = false, features = ["progress-tree"] }
+prodash = { version = "26.0", optional = true, default-features = false, features = ["progress-tree"] }
 once_cell = "1.14.0"
 signal-hook = { version = "0.3.9", default-features = false }
 thiserror = "1.0.26"

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -176,7 +176,7 @@ gix-protocol = { version = "^0.38.0", path = "../gix-protocol", optional = true 
 gix-transport = { version = "^0.35.0", path = "../gix-transport", optional = true }
 
 # Just to get the progress-tree feature
-prodash = { version = "26.0", optional = true, default-features = false, features = ["progress-tree"] }
+prodash = { version = "26.2", optional = true, default-features = false, features = ["progress-tree"] }
 once_cell = "1.14.0"
 signal-hook = { version = "0.3.9", default-features = false }
 thiserror = "1.0.26"

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -67,7 +67,7 @@ pub mod main_worktree {
         /// if the `head()` of the returned repository is not unborn.
         pub fn main_worktree(
             &mut self,
-            mut progress: impl crate::Progress,
+            mut progress: impl gix_features::progress::NestedProgress,
             should_interrupt: &AtomicBool,
         ) -> Result<(Repository, gix_worktree_state::checkout::Outcome), Error> {
             let _span = gix_trace::coarse!("gix::clone::PrepareCheckout::main_worktree()");

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -26,10 +26,7 @@ pub mod main_worktree {
         #[error(transparent)]
         CheckoutOptions(#[from] crate::config::checkout_options::Error),
         #[error(transparent)]
-        IndexCheckout(
-            #[from]
-            gix_worktree_state::checkout::Error<gix_odb::find::existing_object::Error<gix_odb::store::find::Error>>,
-        ),
+        IndexCheckout(#[from] gix_worktree_state::checkout::Error<gix_odb::find::existing_object::Error>),
         #[error("Failed to reopen object database as Arc (only if thread-safety wasn't compiled in)")]
         OpenArcOdb(#[from] std::io::Error),
         #[error("The HEAD reference could not be located")]
@@ -113,8 +110,8 @@ pub mod main_worktree {
                     let objects = repo.objects.clone().into_arc()?;
                     move |oid, buf| objects.find_blob(oid, buf)
                 },
-                &mut files,
-                &mut bytes,
+                &files,
+                &bytes,
                 should_interrupt,
                 opts,
             )?;

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -55,7 +55,7 @@ impl PrepareFetch {
         should_interrupt: &std::sync::atomic::AtomicBool,
     ) -> Result<(crate::Repository, crate::remote::fetch::Outcome), Error>
     where
-        P: crate::Progress,
+        P: crate::NestedProgress,
         P::SubProgress: 'static,
     {
         use crate::{bstr::ByteVec, remote, remote::fetch::RefLogMessage};
@@ -156,7 +156,7 @@ impl PrepareFetch {
         should_interrupt: &std::sync::atomic::AtomicBool,
     ) -> Result<(crate::clone::PrepareCheckout, crate::remote::fetch::Outcome), Error>
     where
-        P: crate::Progress,
+        P: crate::NestedProgress,
         P::SubProgress: 'static,
     {
         let (repo, fetch_outcome) = self.fetch_only(progress, should_interrupt)?;

--- a/gix/src/commit.rs
+++ b/gix/src/commit.rs
@@ -204,7 +204,7 @@ pub mod describe {
                         .try_find(id, buf)
                         .map(|r| r.and_then(gix_object::Data::try_into_commit_iter))
                 },
-                gix_commitgraph::Graph::from_info_dir(self.repo.objects.store_ref().path().join("info")).ok(),
+                gix_commitgraph::Graph::from_info_dir(self.repo.objects.store_ref().path().join("info").as_ref()).ok(),
             );
             let outcome = gix_revision::describe(
                 &self.id,

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -276,7 +276,7 @@ impl Cache {
     pub(crate) fn pathspec_defaults(
         &self,
     ) -> Result<gix_pathspec::Defaults, gix_pathspec::defaults::from_environment::Error> {
-        let res = gix_pathspec::Defaults::from_environment(|name| {
+        let res = gix_pathspec::Defaults::from_environment(&mut |name| {
             let key = [
                 &gitoxide::Pathspec::ICASE,
                 &gitoxide::Pathspec::GLOB,

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -72,7 +72,7 @@ impl Cache {
 
         let config = {
             let git_prefix = &git_prefix;
-            let metas = [
+            let mut metas = [
                 gix_config::source::Kind::GitInstallation,
                 gix_config::source::Kind::System,
                 gix_config::source::Kind::Global,
@@ -100,7 +100,7 @@ impl Cache {
 
             let err_on_nonexisting_paths = false;
             let mut globals = gix_config::File::from_paths_metadata_buf(
-                metas,
+                &mut metas,
                 &mut buf,
                 err_on_nonexisting_paths,
                 gix_config::file::init::Options {

--- a/gix/src/config/overrides.rs
+++ b/gix/src/config/overrides.rs
@@ -29,8 +29,12 @@ pub(crate) fn append(
         let mut tokens = key_value.splitn(2, |b| *b == b'=').map(ByteSlice::trim);
         let key = tokens.next().expect("always one value").as_bstr();
         let value = tokens.next();
-        let key = gix_config::parse::key(key.to_str().map_err(|_| Error::InvalidKey { input: key.into() })?)
-            .ok_or_else(|| Error::InvalidKey { input: key.into() })?;
+        let key = gix_config::parse::key(
+            key.to_str()
+                .map_err(|_| Error::InvalidKey { input: key.into() })?
+                .into(),
+        )
+        .ok_or_else(|| Error::InvalidKey { input: key.into() })?;
         let mut section = file.section_mut_or_create_new(key.section_name, key.subsection_name)?;
         let key =
             gix_config::parse::section::Key::try_from(key.value_name.to_owned()).map_err(|err| Error::SectionKey {

--- a/gix/src/config/snapshot/access.rs
+++ b/gix/src/config/snapshot/access.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 
 use gix_features::threading::OwnShared;
 
+use crate::bstr::ByteSlice;
 use crate::{
     bstr::{BStr, BString},
     config::{CommitAutoRollback, Snapshot, SnapshotMut},
@@ -58,7 +59,7 @@ impl<'repo> Snapshot<'repo> {
         &self,
         key: impl Into<&'a BStr>,
     ) -> Option<Result<Cow<'_, std::path::Path>, gix_config::path::interpolate::Error>> {
-        let key = gix_config::parse::key(key)?;
+        let key = gix_config::parse::key(key.into())?;
         self.repo
             .config
             .trusted_file_path(key.section_name, key.subsection_name, key.value_name)
@@ -134,7 +135,7 @@ impl<'repo> SnapshotMut<'repo> {
         let name = key
             .full_name(Some(subsection.into()))
             .expect("we know it needs a subsection");
-        let key = gix_config::parse::key(&**name).expect("statically known keys can always be parsed");
+        let key = gix_config::parse::key((**name).as_bstr()).expect("statically known keys can always be parsed");
         let current =
             self.config
                 .set_raw_value(key.section_name, key.subsection_name, key.value_name.to_owned(), value)?;

--- a/gix/src/create.rs
+++ b/gix/src/create.rs
@@ -232,7 +232,7 @@ pub fn into(
         } else {
             gix_discover::repository::Kind::WorkTree { linked_git_dir: None }
         },
-        std::env::current_dir()?,
+        &std::env::current_dir()?,
     )
     .expect("by now the `dot_git` dir is valid as we have accessed it"))
 }

--- a/gix/src/discover.rs
+++ b/gix/src/discover.rs
@@ -37,7 +37,7 @@ impl ThreadSafeRepository {
         trust_map: gix_sec::trust::Mapping<crate::open::Options>,
     ) -> Result<Self, Error> {
         let _span = gix_trace::coarse!("ThreadSafeRepository::discover()");
-        let (path, trust) = upwards_opts(directory, options)?;
+        let (path, trust) = upwards_opts(directory.as_ref(), options)?;
         let (git_dir, worktree_dir) = path.into_repository_and_work_tree_directories();
         let mut options = trust_map.into_value_by_level(trust);
         options.git_dir_trust = trust.into();

--- a/gix/src/filter.rs
+++ b/gix/src/filter.rs
@@ -147,15 +147,15 @@ impl<'repo> Pipeline<'repo> {
         Ok(self.inner.convert_to_git(
             src,
             rela_path,
-            |_, attrs| {
+            &mut |_, attrs| {
                 entry.matching_attributes(attrs);
             },
-            |rela_path, buf| -> Result<_, crate::object::find::Error> {
+            &mut |rela_path, buf| -> Result<_, gix_odb::find::Error> {
                 let entry = match index.entry_by_path(rela_path) {
                     None => return Ok(None),
                     Some(entry) => entry,
                 };
-                let obj = self.repo.objects.try_find(entry.id, buf)?;
+                let obj = self.repo.objects.try_find(&entry.id, buf)?;
                 Ok(obj.filter(|obj| obj.kind == gix_object::Kind::Blob).map(|_| ()))
             },
         )?)
@@ -181,7 +181,7 @@ impl<'repo> Pipeline<'repo> {
         Ok(self.inner.convert_to_worktree(
             src,
             rela_path,
-            |_, attrs| {
+            &mut |_, attrs| {
                 entry.matching_attributes(attrs);
             },
             can_delay,

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -83,7 +83,11 @@ pub use gix_credentials as credentials;
 pub use gix_date as date;
 pub use gix_features as features;
 use gix_features::threading::OwnShared;
-pub use gix_features::{parallel, progress::Progress, threading};
+pub use gix_features::{
+    parallel,
+    progress::{Count, NestedProgress, Progress},
+    threading,
+};
 pub use gix_fs as fs;
 pub use gix_glob as glob;
 pub use gix_hash as hash;

--- a/gix/src/object/errors.rs
+++ b/gix/src/object/errors.rs
@@ -18,17 +18,21 @@ pub mod conversion {
 ///
 pub mod find {
     /// Indicate that an error occurred when trying to find an object.
-    pub type Error = gix_odb::store::find::Error;
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct Error(#[from] pub gix_odb::find::Error);
 
     ///
     pub mod existing {
         /// An object could not be found in the database, or an error occurred when trying to obtain it.
-        pub type Error = gix_odb::find::existing::Error<gix_odb::store::find::Error>;
+        pub type Error = gix_odb::find::existing::Error;
     }
 }
 
 ///
 pub mod write {
     /// An error to indicate writing to the loose object store failed.
-    pub type Error = gix_odb::store::write::Error;
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct Error(#[from] pub gix_odb::find::Error);
 }

--- a/gix/src/object/tree/mod.rs
+++ b/gix/src/object/tree/mod.rs
@@ -71,7 +71,7 @@ impl<'repo> Tree<'repo> {
                         }));
                     } else {
                         let next_id = entry.oid.to_owned();
-                        let obj = self.repo.objects.find(next_id, buf)?;
+                        let obj = self.repo.objects.find(&next_id, buf)?;
                         if !obj.kind.is_tree() {
                             return Ok(None);
                         }
@@ -113,7 +113,7 @@ impl<'repo> Tree<'repo> {
                         }));
                     } else {
                         let next_id = entry.oid.to_owned();
-                        let obj = self.repo.objects.find(next_id, &mut self.data)?;
+                        let obj = self.repo.objects.find(&next_id, &mut self.data)?;
                         self.id = next_id;
                         if !obj.kind.is_tree() {
                             return Ok(None);

--- a/gix/src/pathspec.rs
+++ b/gix/src/pathspec.rs
@@ -104,8 +104,10 @@ impl<'repo> Pathspec<'repo> {
         relative_path: impl Into<&'a BStr>,
         is_dir: Option<bool>,
     ) -> Option<gix_pathspec::search::Match<'_>> {
-        self.search
-            .pattern_matching_relative_path(relative_path, is_dir, |relative_path, case, is_dir, out| {
+        self.search.pattern_matching_relative_path(
+            relative_path.into(),
+            is_dir,
+            &mut |relative_path, case, is_dir, out| {
                 let stack = self.stack.as_mut().expect("initialized in advance");
                 stack
                     .set_case(case)
@@ -113,7 +115,8 @@ impl<'repo> Pathspec<'repo> {
                         self.repo.objects.find_blob(id, buf)
                     })
                     .map_or(false, |platform| platform.matching_attributes(out))
-            })
+            },
+        )
     }
 
     /// The simplified version of [`pattern_matching_relative_path()`](Self::pattern_matching_relative_path()) which returns

--- a/gix/src/reference/iter.rs
+++ b/gix/src/reference/iter.rs
@@ -43,7 +43,7 @@ impl<'r> Platform<'r> {
     // TODO: Create a custom `Path` type that enforces the requirements of git naturally, this type is surprising possibly on windows
     //       and when not using a trailing '/' to signal directories.
     pub fn prefixed(&self, prefix: impl AsRef<Path>) -> Result<Iter<'_>, init::Error> {
-        Ok(Iter::new(self.repo, self.platform.prefixed(prefix)?))
+        Ok(Iter::new(self.repo, self.platform.prefixed(prefix.as_ref())?))
     }
 
     // TODO: tests
@@ -51,7 +51,7 @@ impl<'r> Platform<'r> {
     ///
     /// They are all prefixed with `refs/tags`.
     pub fn tags(&self) -> Result<Iter<'_>, init::Error> {
-        Ok(Iter::new(self.repo, self.platform.prefixed("refs/tags/")?))
+        Ok(Iter::new(self.repo, self.platform.prefixed("refs/tags/".as_ref())?))
     }
 
     // TODO: tests
@@ -59,7 +59,7 @@ impl<'r> Platform<'r> {
     ///
     /// They are all prefixed with `refs/heads`.
     pub fn local_branches(&self) -> Result<Iter<'_>, init::Error> {
-        Ok(Iter::new(self.repo, self.platform.prefixed("refs/heads/")?))
+        Ok(Iter::new(self.repo, self.platform.prefixed("refs/heads/".as_ref())?))
     }
 
     // TODO: tests
@@ -67,7 +67,7 @@ impl<'r> Platform<'r> {
     ///
     /// They are all prefixed with `refs/remotes`.
     pub fn remote_branches(&self) -> Result<Iter<'_>, init::Error> {
-        Ok(Iter::new(self.repo, self.platform.prefixed("refs/remotes/")?))
+        Ok(Iter::new(self.repo, self.platform.prefixed("refs/remotes/".as_ref())?))
     }
 }
 
@@ -95,10 +95,10 @@ impl<'r> Iterator for Iter<'r> {
                 .and_then(|mut r| {
                     if self.peel {
                         let handle = &self.repo;
-                        r.peel_to_id_in_place(&handle.refs, |oid, buf| {
+                        r.peel_to_id_in_place(&handle.refs, &mut |oid, buf| {
                             handle
                                 .objects
-                                .try_find(oid, buf)
+                                .try_find(oid.as_ref(), buf)
                                 .map(|po| po.map(|(o, _l)| (o.kind, o.data)))
                         })
                         .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>)

--- a/gix/src/reference/mod.rs
+++ b/gix/src/reference/mod.rs
@@ -70,9 +70,9 @@ impl<'repo> Reference<'repo> {
     /// This is useful to learn where this reference is ultimately pointing to.
     pub fn peel_to_id_in_place(&mut self) -> Result<Id<'repo>, peel::Error> {
         let repo = &self.repo;
-        let oid = self.inner.peel_to_id_in_place(&repo.refs, |oid, buf| {
+        let oid = self.inner.peel_to_id_in_place(&repo.refs, &mut |oid, buf| {
             repo.objects
-                .try_find(oid, buf)
+                .try_find(&oid, buf)
                 .map(|po| po.map(|(o, _l)| (o.kind, o.data)))
         })?;
         Ok(Id::from_id(oid, repo))

--- a/gix/src/remote/connect.rs
+++ b/gix/src/remote/connect.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::result_large_err)]
+
 use gix_protocol::transport::client::Transport;
+use std::borrow::Cow;
 
 use crate::{remote::Connection, Remote};
 
@@ -104,7 +106,7 @@ impl<'repo> Remote<'repo> {
     ) -> Result<(gix_url::Url, gix_protocol::transport::Protocol), Error> {
         fn sanitize(mut url: gix_url::Url) -> Result<gix_url::Url, Error> {
             if url.scheme == gix_url::Scheme::File {
-                let mut dir = gix_path::to_native_path_on_windows(url.path.as_ref());
+                let mut dir = gix_path::to_native_path_on_windows(Cow::Borrowed(url.path.as_ref()));
                 let kind = gix_discover::is_git(dir.as_ref())
                     .or_else(|_| {
                         dir.to_mut().push(gix_discover::DOT_GIT_DIR);
@@ -117,7 +119,7 @@ impl<'repo> Remote<'repo> {
                 let (git_dir, _work_dir) = gix_discover::repository::Path::from_dot_git_dir(
                     dir.clone().into_owned(),
                     kind,
-                    std::env::current_dir()?,
+                    &std::env::current_dir()?,
                 )
                 .ok_or_else(|| Error::InvalidRemoteRepositoryPath {
                     directory: dir.into_owned(),

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -23,7 +23,7 @@ use crate::{
             Shallow, Status,
         },
     },
-    Progress, Repository,
+    Repository,
 };
 
 impl<'remote, 'repo, T> Prepare<'remote, 'repo, T>
@@ -75,7 +75,7 @@ where
     #[gix_protocol::maybe_async::maybe_async]
     pub async fn receive<P>(mut self, mut progress: P, should_interrupt: &AtomicBool) -> Result<Outcome, Error>
     where
-        P: Progress,
+        P: gix_features::progress::NestedProgress,
         P::SubProgress: 'static,
     {
         let _span = gix_trace::coarse!("fetch::Prepare::receive()");
@@ -211,7 +211,7 @@ where
                     previous_response = Some(response);
                     if has_pack {
                         progress.step();
-                        progress.set_name("receiving pack");
+                        progress.set_name("receiving pack".into());
                         if !sideband_all {
                             setup_remote_progress(progress, &mut reader, should_interrupt);
                         }
@@ -377,7 +377,7 @@ fn setup_remote_progress<P>(
     reader: &mut Box<dyn gix_protocol::transport::client::ExtendedBufRead + Unpin + '_>,
     should_interrupt: &AtomicBool,
 ) where
-    P: Progress,
+    P: gix_features::progress::NestedProgress,
     P::SubProgress: 'static,
 {
     use gix_protocol::transport::client::ExtendedBufRead;

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -327,9 +327,8 @@ pub(crate) fn update(
                         fetch::WritePackedRefs::Only => {
                             gix_ref::file::transaction::PackedRefs::DeletionsAndNonSymbolicUpdatesRemoveLooseSourceReference(Box::new(|oid, buf| {
                                 repo.objects
-                                    .try_find(oid, buf)
+                                    .try_find(&oid, buf)
                                     .map(|obj| obj.map(|obj| obj.kind))
-                                    .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>)
                             }))},
                         fetch::WritePackedRefs::Never => gix_ref::file::transaction::PackedRefs::DeletionsOnly
                     }

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -191,7 +191,7 @@ mod update {
 
     #[test]
     fn checked_out_branches_in_worktrees_are_rejected_with_additional_information() -> Result {
-        let root = gix_path::realpath(gix_testtools::scripted_fixture_read_only_with_args(
+        let root = gix_path::realpath(&gix_testtools::scripted_fixture_read_only_with_args(
             "make_fetch_repos.sh",
             [base_repo_path()],
         )?)?;

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -114,7 +114,7 @@ impl crate::Repository {
         &self,
         mut stream: gix_worktree_stream::Stream,
         out: impl std::io::Write + std::io::Seek,
-        blobs: impl gix_features::progress::Progress,
+        blobs: impl gix_features::progress::Count,
         should_interrupt: &std::sync::atomic::AtomicBool,
         options: gix_archive::Options,
     ) -> Result<(), crate::repository::worktree_archive::Error> {

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -114,7 +114,7 @@ impl crate::Repository {
         &self,
         mut stream: gix_worktree_stream::Stream,
         out: impl std::io::Write + std::io::Seek,
-        mut blobs: impl gix_features::progress::Progress,
+        blobs: impl gix_features::progress::Progress,
         should_interrupt: &std::sync::atomic::AtomicBool,
         options: gix_archive::Options,
     ) -> Result<(), crate::repository::worktree_archive::Error> {

--- a/gix/src/revision/walk.rs
+++ b/gix/src/revision/walk.rs
@@ -188,7 +188,7 @@ impl<'repo> Platform<'repo> {
                                         return false;
                                     };
                                     if commits.binary_search(&id).is_ok() {
-                                        if let Ok(commit) = repo.objects.find_commit_iter(id, &mut buf) {
+                                        if let Ok(commit) = repo.objects.find_commit_iter(&id, &mut buf) {
                                             grafted_parents_to_skip.extend(commit.parent_ids());
                                             grafted_parents_to_skip.sort();
                                         }

--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -144,7 +144,7 @@ impl<'repo> Submodule<'repo> {
     pub fn is_active(&self) -> Result<bool, is_active::Error> {
         let (mut platform, mut attributes) = self.state.active_state_mut()?;
         let is_active = platform.is_active(&self.state.repo.config.resolved, self.name.as_ref(), {
-            |relative_path, case, is_dir, out| {
+            &mut |relative_path, case, is_dir, out| {
                 attributes
                     .set_case(case)
                     .at_entry(relative_path, Some(is_dir), |id, buf| {

--- a/gix/tests/clone/mod.rs
+++ b/gix/tests/clone/mod.rs
@@ -2,6 +2,7 @@ use crate::{remote, util::restricted};
 
 #[cfg(feature = "blocking-network-client")]
 mod blocking_io {
+    use std::borrow::Cow;
     use std::sync::atomic::AtomicBool;
 
     use gix::{
@@ -267,13 +268,13 @@ mod blocking_io {
             "fetch-tags are persisted via the 'tagOpt` key"
         );
         assert!(
-            gix::path::from_bstr(
+            gix::path::from_bstr(Cow::Borrowed(
                 remote
                     .url(gix::remote::Direction::Fetch)
                     .expect("present")
                     .path
                     .as_ref()
-            )
+            ))
             .is_absolute(),
             "file urls can't be relative paths"
         );

--- a/gix/tests/remote/fetch.rs
+++ b/gix/tests/remote/fetch.rs
@@ -84,6 +84,7 @@ mod blocking_and_async_io {
 
     #[test]
     #[cfg(feature = "blocking-network-client")]
+    #[allow(clippy::result_large_err)]
     fn collate_fetch_error() -> Result<(), gix::env::collate::fetch::Error<std::io::Error>> {
         let (repo, _tmp) = try_repo_rw("two-origins")?;
         let remote = repo

--- a/gix/tests/remote/save.rs
+++ b/gix/tests/remote/save.rs
@@ -22,7 +22,7 @@ mod save_to {
         let previous_remote_state = repo
             .config_snapshot()
             .plumbing()
-            .section_by_key("remote.origin")
+            .section_by_key("remote.origin".into())
             .expect("present")
             .to_bstring();
         let mut config = repo.config_snapshot().plumbing().clone();
@@ -33,7 +33,10 @@ mod save_to {
             "amount of remotes are unaltered"
         );
         assert_eq!(
-            config.section_by_key("remote.origin").expect("present").to_bstring(),
+            config
+                .section_by_key("remote.origin".into())
+                .expect("present")
+                .to_bstring(),
             previous_remote_state,
             "the serialization doesn't modify anything"
         );

--- a/gix/tests/repository/object.rs
+++ b/gix/tests/repository/object.rs
@@ -182,7 +182,7 @@ mod find {
 
         let mut buf = Vec::new();
         assert!(
-            repo.objects.try_find(empty_tree, &mut buf)?.is_none(),
+            repo.objects.try_find(&empty_tree, &mut buf)?.is_none(),
             "the lower level has no such special case so one can determine if this object exists or not"
         );
         Ok(())

--- a/gix/tests/repository/shallow.rs
+++ b/gix/tests/repository/shallow.rs
@@ -71,7 +71,8 @@ mod traverse {
     #[test]
     #[parallel]
     fn complex_graphs_can_be_iterated_despite_multiple_shallow_boundaries() -> crate::Result {
-        let base = gix_path::realpath(gix_testtools::scripted_fixture_read_only("make_remote_repos.sh")?.join("base"))?;
+        let base =
+            gix_path::realpath(&gix_testtools::scripted_fixture_read_only("make_remote_repos.sh")?.join("base"))?;
         let shallow_base = gix_testtools::scripted_fixture_read_only_with_args(
             "make_complex_shallow_repo.sh",
             Some(base.to_string_lossy()),

--- a/gix/tests/repository/worktree.rs
+++ b/gix/tests/repository/worktree.rs
@@ -50,7 +50,7 @@ mod with_core_worktree_config {
             } else {
                 assert_eq!(
                     repo.work_dir().unwrap(),
-                    gix_path::realpath(repo.git_dir().parent().unwrap().parent().unwrap().join("worktree"))?,
+                    gix_path::realpath(&repo.git_dir().parent().unwrap().parent().unwrap().join("worktree"))?,
                     "absolute workdirs are left untouched"
                 );
             }
@@ -147,6 +147,7 @@ struct Baseline<'a> {
 }
 
 mod baseline {
+    use std::borrow::Cow;
     use std::path::{Path, PathBuf};
 
     use gix::bstr::{BString, ByteSlice};
@@ -178,7 +179,7 @@ mod baseline {
         type Item = Worktree;
 
         fn next(&mut self) -> Option<Self::Item> {
-            let root = gix_path::from_bstr(fields(self.lines.next()?).1).into_owned();
+            let root = gix_path::from_bstr(Cow::Borrowed(fields(self.lines.next()?).1)).into_owned();
             let mut bare = false;
             let mut branch = None;
             let mut peeled = gix_hash::ObjectId::null(gix_hash::Kind::Sha1);

--- a/gix/tests/revision/spec/from_bytes/util.rs
+++ b/gix/tests/revision/spec/from_bytes/util.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use gix_object::{bstr, bstr::BStr};

--- a/gix/tests/util/mod.rs
+++ b/gix/tests/util/mod.rs
@@ -2,7 +2,7 @@
 use gix::{open, Repository, ThreadSafeRepository};
 use gix_testtools::tempfile;
 
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub use gix_testtools::Result;
 
 /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
 pub fn hex_to_id(hex: &str) -> gix_hash::ObjectId {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -350,7 +350,7 @@ mod clap {
     pub struct AsPathSpec;
 
     static PATHSPEC_DEFAULTS: once_cell::sync::Lazy<gix::pathspec::Defaults> = once_cell::sync::Lazy::new(|| {
-        gix::pathspec::Defaults::from_environment(|n| std::env::var_os(n)).unwrap_or_default()
+        gix::pathspec::Defaults::from_environment(&mut |n| std::env::var_os(n)).unwrap_or_default()
     });
 
     impl TypedValueParser for AsPathSpec {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -112,11 +112,11 @@ pub mod pretty {
                     let tree = tracing_forest::printer::Pretty.fmt(tree)?;
                     if reverse_lines {
                         for line in tree.lines().rev() {
-                            progress.info(line);
+                            progress.info(line.into());
                         }
                     } else {
                         for line in tree.lines() {
-                            progress.info(line);
+                            progress.info(line.into());
                         }
                     }
                     Ok(String::new())

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -34,7 +34,7 @@ pub use tempfile;
 ///
 /// }
 /// ```
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 /// A wrapper for a running git-daemon process which is killed automatically on drop.
 ///


### PR DESCRIPTION
Implement a proper worktree reset, eventually leading to a high-level reset similar to how git supports it.

### Facilitate compile time reduction

* [x] upgrade to latest `Prodash`
* [x] See if users of `Progress` can also use `Count` or `dyn Count`, or `dyn Progress`
* [x] review all crates for unnecessary usage of generics
* [ ] split `gix-pack` data-io off using feature toggles
* [ ] Add `gix` feature toggles: remote-connection, blob-diff, describe, attributes->worktree-checkout, attribute->pathspecs->submodules, mailmap
* [ ] **security**: assure we don't read outside of the repository when refs are `../../../`. Further, assure that we don't write such refs when receiving them from the server.

### Tasks

* [ ] upgrade to 
* [ ] worktree reset to match new index, with or without safety checks to prevent overwriting modified files or untracked files.
* [ ] figure out how this relates to the current `checkout()` method as technically that's a `reset --hard` with optional overwrite check. Could it be rolled into one, with pathspec support added?
* TBD

### Postponed

What follows is important for resets, but won't be needed for `cargo` worktree resets.

* [ ] insert entry into index
* [ ] traverse tree with pathspec matching and insert entry into index.

### Research

* How to integrate submodules
* How to deal with various modes like `merge` and `keep`? How to control `refresh`?
* Worthwhile to make explicit the difference between `git reset` and `git checkout` in terms of `HEAD` modifications. With the former changing `HEAD`s referent, and the latter changing `HEAD` itself.