### PR TITLE
Optimize `clone::PrepareCheckout::main_worktree``

### DIFF
--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -62,14 +62,14 @@ pub mod main_worktree {
         ///
         /// Note that this is a no-op if the remote was empty, leaving this repository empty as well. This can be validated by checking
         /// if the `head()` of the returned repository is not unborn.
-        pub fn main_worktree<P, SubP>(
+        pub fn main_worktree<P>(
             &mut self,
             mut progress: P,
             should_interrupt: &AtomicBool,
         ) -> Result<(Repository, gix_worktree_state::checkout::Outcome), Error>
         where
-            P: gix_features::progress::NestedProgress<SubProgress = SubP>,
-            SubP: gix_features::progress::NestedProgress + 'static,
+            P: gix_features::progress::NestedProgress,
+            P::SubProgress: gix_features::progress::NestedProgress + 'static,
         {
             self.main_worktree_inner(&mut progress, should_interrupt)
         }

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -62,9 +62,21 @@ pub mod main_worktree {
         ///
         /// Note that this is a no-op if the remote was empty, leaving this repository empty as well. This can be validated by checking
         /// if the `head()` of the returned repository is not unborn.
-        pub fn main_worktree(
+        pub fn main_worktree<P, SubP>(
             &mut self,
-            mut progress: impl gix_features::progress::NestedProgress,
+            mut progress: P,
+            should_interrupt: &AtomicBool,
+        ) -> Result<(Repository, gix_worktree_state::checkout::Outcome), Error>
+        where
+            P: gix_features::progress::NestedProgress<SubProgress = SubP>,
+            SubP: gix_features::progress::NestedProgress + 'static,
+        {
+            self.main_worktree_inner(&mut progress, should_interrupt)
+        }
+
+        fn main_worktree_inner(
+            &mut self,
+            progress: &mut dyn gix_features::progress::DynNestedProgress,
             should_interrupt: &AtomicBool,
         ) -> Result<(Repository, gix_worktree_state::checkout::Outcome), Error> {
             let _span = gix_trace::coarse!("gix::clone::PrepareCheckout::main_worktree()");
@@ -96,8 +108,8 @@ pub mod main_worktree {
                 .checkout_options(repo, gix_worktree::stack::state::attributes::Source::IdMapping)?;
             opts.destination_is_initially_empty = true;
 
-            let mut files = progress.add_child_with_id("checkout", ProgressId::CheckoutFiles.into());
-            let mut bytes = progress.add_child_with_id("writing", ProgressId::BytesWritten.into());
+            let mut files = progress.add_child_with_id("checkout".to_string(), ProgressId::CheckoutFiles.into());
+            let mut bytes = progress.add_child_with_id("writing".to_string(), ProgressId::BytesWritten.into());
 
             files.init(Some(index.entries().len()), crate::progress::count("files"));
             bytes.init(None, crate::progress::bytes());


### PR DESCRIPTION
Use `DynNestedProgress` instead of `NestedProgress`, although this also require `<P as NestedProgress>::SubProgress: 'static` which is a breaking change.

