### PR TITLE
yarn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteyarn"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7534301c0ea17abb4db06d75efc7b4b0fa360fce8e175a4330d721c71c942ff"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1342,7 @@ name = "gix-attributes"
 version = "0.18.0"
 dependencies = [
  "bstr",
+ "byteyarn",
  "document-features",
  "gix-fs 0.6.0",
  "gix-glob 0.12.0",
@@ -1343,7 +1350,6 @@ dependencies = [
  "gix-quote 0.4.7",
  "gix-testtools",
  "gix-trace 0.1.3",
- "kstring",
  "serde",
  "smallvec",
  "thiserror",
@@ -2962,7 +2968,6 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
 dependencies = [
- "serde",
  "static_assertions",
 ]
 

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde = ["dep:serde", "bstr/serde", "gix-glob/serde", "kstring/serde"]
+serde = ["dep:serde", "bstr/serde", "gix-glob/serde"]
 
 [dependencies]
 gix-path = { version = "^0.10.0", path = "../gix-path" }
@@ -24,7 +24,7 @@ gix-trace = { version = "^0.1.3", path = "../gix-trace" }
 
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
 smallvec = "1.10.0"
-kstring = "2.0.0"
+byteyarn = "0.2.3"
 unicode-bom = "2.0.2"
 thiserror = "1.0.26"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}

--- a/gix-attributes/src/lib.rs
+++ b/gix-attributes/src/lib.rs
@@ -8,8 +8,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
+use byteyarn::{Yarn, YarnRef};
 pub use gix_glob as glob;
-use kstring::{KString, KStringRef};
 
 mod assignment;
 ///
@@ -34,7 +34,6 @@ pub fn parse(bytes: &[u8]) -> parse::Lines<'_> {
 ///
 /// Note that this doesn't contain the name.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StateRef<'a> {
     /// The attribute is listed, or has the special value 'true'
     Set,
@@ -42,7 +41,6 @@ pub enum StateRef<'a> {
     Unset,
     /// The attribute is set to the given value, which followed the `=` sign.
     /// Note that values can be empty.
-    #[cfg_attr(feature = "serde", serde(borrow))]
     Value(state::ValueRef<'a>),
     /// The attribute isn't mentioned with a given path or is explicitly set to `Unspecified` using the `!` sign.
     Unspecified,
@@ -52,7 +50,6 @@ pub enum StateRef<'a> {
 ///
 /// Note that this doesn't contain the name.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum State {
     /// The attribute is listed, or has the special value 'true'
     Set,
@@ -67,16 +64,14 @@ pub enum State {
 
 /// Represents a validated attribute name
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Name(pub(crate) KString);
+pub struct Name(pub(crate) Yarn);
 
 /// Holds a validated attribute name as a reference
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]
-pub struct NameRef<'a>(KStringRef<'a>);
+pub struct NameRef<'a>(YarnRef<'a, str>);
 
 /// Name an attribute and describe it's assigned state.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Assignment {
     /// The validated name of the attribute.
     pub name: Name,

--- a/gix-attributes/src/name.rs
+++ b/gix-attributes/src/name.rs
@@ -1,12 +1,16 @@
 use bstr::{BStr, BString, ByteSlice};
-use kstring::KStringRef;
+use byteyarn::YarnRef;
 
 use crate::{Name, NameRef};
 
 impl<'a> NameRef<'a> {
     /// Turn this ref into its owned counterpart.
     pub fn to_owned(self) -> Name {
-        Name(self.0.into())
+        Name(
+            self.0
+                .immortalize()
+                .map_or_else(|| self.0.to_boxed_str().into(), YarnRef::to_box),
+        )
     }
 
     /// Return the inner `str`.
@@ -35,7 +39,7 @@ impl<'a> TryFrom<&'a BStr> for NameRef<'a> {
         }
 
         attr_valid(attr)
-            .then(|| NameRef(KStringRef::from_ref(attr.to_str().expect("no illformed utf8"))))
+            .then(|| NameRef(YarnRef::from(attr.to_str().expect("no illformed utf8"))))
             .ok_or_else(|| Error { attribute: attr.into() })
     }
 }

--- a/gix-attributes/src/parse.rs
+++ b/gix-attributes/src/parse.rs
@@ -1,13 +1,12 @@
 use std::borrow::Cow;
 
 use bstr::{BStr, ByteSlice};
-use kstring::KStringRef;
+use byteyarn::YarnRef;
 
 use crate::{name, AssignmentRef, Name, NameRef, StateRef};
 
 /// The kind of attribute that was parsed.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Kind {
     /// A pattern to match paths against
     Pattern(gix_glob::Pattern),
@@ -76,7 +75,7 @@ fn check_attr(attr: &BStr) -> Result<NameRef<'_>, name::Error> {
     }
 
     attr_valid(attr)
-        .then(|| NameRef(KStringRef::from_ref(attr.to_str().expect("no illformed utf8"))))
+        .then(|| NameRef(YarnRef::from(attr.to_str().expect("no illformed utf8"))))
         .ok_or_else(|| name::Error { attribute: attr.into() })
 }
 

--- a/gix-attributes/src/search/mod.rs
+++ b/gix-attributes/src/search/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use kstring::KString;
+use byteyarn::Yarn;
 use smallvec::SmallVec;
 
 use crate::{Assignment, AssignmentRef};
@@ -99,7 +99,7 @@ pub struct Outcome {
     /// A stack of attributes to use for processing attributes of matched patterns and for resolving their macros.
     attrs_stack: SmallVec<[(AttributeId, Assignment, Option<AttributeId>); 8]>,
     /// A set of attributes we should limit ourselves to, or empty if we should fill in all attributes, made of
-    selected: SmallVec<[(KString, Option<AttributeId>); AVERAGE_NUM_ATTRS]>,
+    selected: SmallVec<[(Yarn, Option<AttributeId>); AVERAGE_NUM_ATTRS]>,
     /// storage for all patterns we have matched so far (in order to avoid referencing them, we copy them, but only once).
     patterns: RefMap<gix_glob::Pattern>,
     /// storage for all assignments we have matched so far (in order to avoid referencing them, we copy them, but only once).
@@ -135,7 +135,7 @@ pub struct MetadataCollection {
     /// A mapping of an attribute or macro name to its order, that is the time when it was *first* seen.
     ///
     /// This is the inverse of the order attributes are searched.
-    name_to_meta: HashMap<KString, Metadata>,
+    name_to_meta: HashMap<Yarn, Metadata>,
 }
 
 /// Metadata associated with an attribute or macro name.

--- a/gix-attributes/src/state.rs
+++ b/gix-attributes/src/state.rs
@@ -1,29 +1,21 @@
 use bstr::{BStr, ByteSlice};
-use kstring::{KString, KStringRef};
+use byteyarn::{ByteYarn, YarnRef};
 
 use crate::{State, StateRef};
 
 /// A container to encapsulate a tightly packed and typically unallocated byte value that isn't necessarily UTF8 encoded.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Value(KString);
+pub struct Value(ByteYarn);
 
 /// A reference container to encapsulate a tightly packed and typically unallocated byte value that isn't necessarily UTF8 encoded.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ValueRef<'a>(#[cfg_attr(feature = "serde", serde(borrow))] KStringRef<'a>);
+pub struct ValueRef<'a>(YarnRef<'a, [u8]>);
 
 /// Lifecycle
 impl<'a> ValueRef<'a> {
     /// Keep `input` as our value.
     pub fn from_bytes(input: &'a [u8]) -> Self {
-        Self(KStringRef::from_ref(
-            // SAFETY: our API makes accessing that value as `str` impossible, so illformed UTF8 is never exposed as such.
-            #[allow(unsafe_code)]
-            unsafe {
-                std::str::from_utf8_unchecked(input)
-            },
-        ))
+        Self(YarnRef::from(input))
     }
 }
 
@@ -42,19 +34,25 @@ impl ValueRef<'_> {
 
 impl<'a> From<&'a str> for ValueRef<'a> {
     fn from(v: &'a str) -> Self {
-        ValueRef(v.into())
+        ValueRef(v.as_bytes().into())
     }
 }
 
 impl<'a> From<ValueRef<'a>> for Value {
     fn from(v: ValueRef<'a>) -> Self {
-        Value(v.0.into())
+        Value(
+            v.0.immortalize()
+                .map_or_else(|| v.0.to_boxed_bytes().into(), YarnRef::to_box),
+        )
     }
 }
 
 impl From<&str> for Value {
     fn from(v: &str) -> Self {
-        Value(KString::from_ref(v))
+        Value(
+            ByteYarn::inlined(v.as_bytes())
+                .unwrap_or_else(|| ByteYarn::from_boxed_bytes(v.as_bytes().to_vec().into_boxed_slice())),
+        )
     }
 }
 

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -270,7 +270,7 @@ fn given_attributes_are_made_available_in_given_order() -> crate::Result {
 fn size_of_outcome() {
     assert_eq!(
         std::mem::size_of::<Outcome>(),
-        904,
+        752,
         "it's quite big, shouldn't change without us noticing"
     )
 }


### PR DESCRIPTION
Yarn instead of `kstring`

This change reduces the size of the `gix_attributes::search::Outcome` structure by 25% and makes copying these strings cheaper, which improves performance measurably by 2% on attribute-heavy workloads.

```
WebKit ( main) via △ took 14s
❯ hyperfine 'gix index entries -i' '/Users/byron/dev/github.com/Byron/gitoxide/target/release/gix index entries -i' -N --warmup 1
Benchmark 1: gix index entries -i
  Time (mean ± σ):     645.1 ms ±   1.2 ms    [User: 623.3 ms, System: 19.6 ms]
  Range (min … max):   643.5 ms … 647.0 ms    10 runs

Benchmark 2: /Users/byron/dev/github.com/Byron/gitoxide/target/release/gix index entries -i
  Time (mean ± σ):     635.4 ms ±   1.2 ms    [User: 614.4 ms, System: 19.6 ms]
  Range (min … max):   633.6 ms … 636.9 ms    10 runs

Summary
  /Users/byron/dev/github.com/Byron/gitoxide/target/release/gix index entries -i ran
    1.02 ± 0.00 times faster than gix index entries -i
```

> [!NOTE]
> `gix-glob` seemed like another candidate, but it turned out that this made it 2% slower (so in total, 4%) than with just using a heap-allocated `BString`. This seems to be one of the trade-offs, fair enough.