### PR TITLE
better transport argument sanitization

### DIFF
--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -8,6 +8,8 @@ use crate::{client::blocking_io, Protocol};
 pub enum Error {
     #[error("The scheme in \"{}\" is not usable for an ssh connection", .0.to_bstring())]
     UnsupportedScheme(gix_url::Url),
+    #[error("Host name '{host}' could be mistaken for a command-line argument")]
+    AmbiguousHostName { host: String },
 }
 
 impl crate::IsSpuriousError for Error {}
@@ -37,12 +39,17 @@ pub mod invocation {
 
     /// The error returned when producing ssh invocation arguments based on a selected invocation kind.
     #[derive(Debug, thiserror::Error)]
-    #[error("The 'Simple' ssh variant doesn't support {function}")]
-    pub struct Error {
-        /// The simple command that should have been invoked.
-        pub command: OsString,
-        /// The function that was unsupported
-        pub function: &'static str,
+    #[allow(missing_docs)]
+    pub enum Error {
+        #[error("Host name '{host}' could be mistaken for a command-line argument")]
+        AmbiguousHostName { host: String },
+        #[error("The 'Simple' ssh variant doesn't support {function}")]
+        Unsupported {
+            /// The simple command that should have been invoked.
+            command: OsString,
+            /// The function that was unsupported
+            function: &'static str,
+        },
     }
 }
 
@@ -105,7 +112,9 @@ pub fn connect(
                 .stdin(Stdio::null())
                 .with_shell()
                 .arg("-G")
-                .arg(url.host().expect("always set for ssh urls")),
+                .arg(url.host_argument_safe().ok_or_else(|| Error::AmbiguousHostName {
+                    host: url.host().expect("set in ssh urls").into(),
+                })?),
         )
         .status()
         .ok()

--- a/gix-transport/src/client/git/mod.rs
+++ b/gix-transport/src/client/git/mod.rs
@@ -165,6 +165,21 @@ mod message {
                 "git-upload-pack hello\\world\0host=host:404\0"
             )
         }
+
+        #[test]
+        fn with_strange_host_and_port() {
+            assert_eq!(
+                git::message::connect(
+                    Service::UploadPack,
+                    Protocol::V1,
+                    b"--upload-pack=attack",
+                    Some(&("--proxy=other-attack".into(), Some(404))),
+                    &[]
+                ),
+                "git-upload-pack --upload-pack=attack\0host=--proxy=other-attack:404\0",
+                "we explicitly allow possible `-arg` arguments to be passed to the git daemon - the remote must protect against exploitation, we don't want to prevent legitimate cases"
+            )
+        }
     }
 }
 

--- a/gix-transport/src/client/non_io_types.rs
+++ b/gix-transport/src/client/non_io_types.rs
@@ -138,6 +138,8 @@ mod error {
         Http(#[from] HttpError),
         #[error(transparent)]
         SshInvocation(SshInvocationError),
+        #[error("The repository path '{path}' could be mistaken for a command-line argument")]
+        AmbiguousPath { path: BString },
     }
 
     impl crate::IsSpuriousError for Error {

--- a/gix-transport/src/lib.rs
+++ b/gix-transport/src/lib.rs
@@ -21,7 +21,6 @@ pub use gix_packetline as packetline;
 /// The version of the way client and server communicate.
 #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
 pub enum Protocol {
     /// Version 0 is like V1, but doesn't show capabilities at all, at least when hosted without `git-daemon`.
     V0 = 0,

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -48,6 +48,13 @@ pub struct Url {
     /// The port to use when connecting to a host. If `None`, standard ports depending on `scheme` will be used.
     pub port: Option<u16>,
     /// The path portion of the URL, usually the location of the git repository.
+    ///
+    /// # Security-Warning
+    ///
+    /// URLs allow paths to start with `-` which makes it possible to mask command-line arguments as path which then leads to
+    /// the invocation of programs from an attacker controlled URL. See https://secure.phabricator.com/T12961 for details.
+    ///
+    /// If this value is going to be used in a command-line application, call [Self::path_argument_safe()] instead.
     pub path: bstr::BString,
 }
 
@@ -123,9 +130,34 @@ impl Url {
         self.password.as_deref()
     }
     /// Returns the host mentioned in the url, if present.
+    ///
+    /// # Security-Warning
+    ///
+    /// URLs allow hosts to start with `-` which makes it possible to mask command-line arguments as host which then leads to
+    /// the invocation of programs from an attacker controlled URL. See https://secure.phabricator.com/T12961 for details.
+    ///
+    /// If this value is going to be used in a command-line application, call [Self::host_argument_safe()] instead.
     pub fn host(&self) -> Option<&str> {
         self.host.as_deref()
     }
+
+    /// Return the host of this URL if present *and* if it can't be mistaken for a command-line argument.
+    ///
+    /// Use this method if the host is going to be passed to a command-line application.
+    pub fn host_argument_safe(&self) -> Option<&str> {
+        self.host().filter(|host| !looks_like_argument(host.as_bytes()))
+    }
+
+    /// Return the path of this URL *and* if it can't be mistaken for a command-line argument.
+    /// Note that it always begins with a slash, which is ignored for this comparison.
+    ///
+    /// Use this method if the path is going to be passed to a command-line application.
+    pub fn path_argument_safe(&self) -> Option<&BStr> {
+        self.path
+            .get(1..)
+            .and_then(|truncated| (!looks_like_argument(truncated)).then_some(self.path.as_ref()))
+    }
+
     /// Returns true if the path portion of the url is `/`.
     pub fn path_is_root(&self) -> bool {
         self.path == "/"
@@ -144,6 +176,10 @@ impl Url {
             })
         })
     }
+}
+
+fn looks_like_argument(b: &[u8]) -> bool {
+    b.get(0) == Some(&b'-')
 }
 
 /// Transformation

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -52,7 +52,7 @@ pub struct Url {
     /// # Security-Warning
     ///
     /// URLs allow paths to start with `-` which makes it possible to mask command-line arguments as path which then leads to
-    /// the invocation of programs from an attacker controlled URL. See https://secure.phabricator.com/T12961 for details.
+    /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
     ///
     /// If this value is going to be used in a command-line application, call [Self::path_argument_safe()] instead.
     pub path: bstr::BString,
@@ -134,7 +134,7 @@ impl Url {
     /// # Security-Warning
     ///
     /// URLs allow hosts to start with `-` which makes it possible to mask command-line arguments as host which then leads to
-    /// the invocation of programs from an attacker controlled URL. See https://secure.phabricator.com/T12961 for details.
+    /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
     ///
     /// If this value is going to be used in a command-line application, call [Self::host_argument_safe()] instead.
     pub fn host(&self) -> Option<&str> {
@@ -179,7 +179,7 @@ impl Url {
 }
 
 fn looks_like_argument(b: &[u8]) -> bool {
-    b.get(0) == Some(&b'-')
+    b.first() == Some(&b'-')
 }
 
 /// Transformation

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -29,3 +29,23 @@ mod canonicalized {
         Ok(())
     }
 }
+
+#[test]
+fn host_argument_safe() -> crate::Result {
+    let url = gix_url::parse("ssh://-oProxyCommand=open$IFS-aCalculator/foo".into())?;
+    assert_eq!(url.host(), Some("-oProxyCommand=open$IFS-aCalculator"));
+    assert_eq!(url.host_argument_safe(), None);
+    assert_eq!(url.path, "/foo");
+    assert_eq!(url.path_argument_safe(), Some("/foo".into()));
+    Ok(())
+}
+
+#[test]
+fn path_argument_safe() -> crate::Result {
+    let url = gix_url::parse("ssh://foo/-oProxyCommand=open$IFS-aCalculator".into())?;
+    assert_eq!(url.host(), Some("foo"));
+    assert_eq!(url.host_argument_safe(), Some("foo"));
+    assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
+    assert_eq!(url.path_argument_safe(), None);
+    Ok(())
+}

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -345,6 +345,12 @@ title "gix commit-graph"
               }
             )
           )
+          (with "an ambiguous ssh host which could be mistaken for an argument"
+              it "fails without trying to pass it to command-line programs" && {
+                WITH_SNAPSHOT="$snapshot/fail-ambigous-host" \
+                expect_run $WITH_FAILURE "$exe_plumbing" free pack receive 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'
+              }
+          )
           fi
         )
         elif [[ "$kind" = "small" ]]; then
@@ -355,6 +361,17 @@ title "gix commit-graph"
         fi
       )
     )
+    if test "$kind" = "max" || test "$kind" = "max-pure"; then
+    (with "the 'clone' sub-command"
+        snapshot="$snapshot/clone"
+        (with "an ambiguous ssh host which could be mistaken for an argument"
+            it "fails without trying to pass it to command-line programs" && {
+              WITH_SNAPSHOT="$snapshot/fail-ambigous-host" \
+              expect_run $WITH_FAILURE "$exe_plumbing" clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'
+            }
+        )
+    )
+    fi
     (with "the 'index' sub-command"
       snapshot="$snapshot/index"
       title "gix free pack index create"

--- a/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambigous-host
+++ b/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambigous-host
@@ -1,0 +1,1 @@
+[2KError: Host name '-oProxyCommand=open$IFS-aCalculator' could be mistaken for a command-line argument

--- a/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambigous-host
+++ b/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambigous-host
@@ -1,0 +1,1 @@
+Error: Host name '-oProxyCommand=open$IFS-aCalculator' could be mistaken for a command-line argument


### PR DESCRIPTION
See https://secure.phabricator.com/T12961 for more details.


### Tasks

* [x] fix the issue for `ssh`
* [x] fix issue for `file` 
* ~~fix issue for submodules~~ - let's not assume a command-line will be invoked that needs protection, with `gix` one day this won't be the case and until then the call-site must protect itself.
* [x] add journey tests to assure we see an error message