### PR TITLE
fix pathspec handling for `gix attrs|excludes query`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Setup dependencies
       run:

--- a/gix-index/tests/index/access.rs
+++ b/gix-index/tests/index/access.rs
@@ -152,6 +152,16 @@ fn prefixed_entries() {
     check_prefix(&file, "x", &["x"]);
     check_prefix(&file, "b", &["b"]);
     check_prefix(&file, "c", &["c"]);
+
+    assert_eq!(
+        file.prefixed_entries_range("".into()),
+        Some(0..11),
+        "empty prefixes match everything"
+    );
+    assert!(
+        file.prefixed_entries_range("foo".into()).is_none(),
+        "there is no match for this prefix"
+    );
 }
 
 fn check_prefix(index: &gix_index::State, prefix: &str, expected: &[&str]) {

--- a/justfile
+++ b/justfile
@@ -13,7 +13,11 @@ alias nt := nextest
 test: clippy check doc unit-tests journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
 # run all tests, without clippy, including journey tests, try building docs (and clear target on CI)
-ci-test: check doc unit-tests clear-target journey-tests-pure journey-tests-small journey-tests-async journey-tests
+ci-test: check doc clear-target unit-tests ci-journey-tests
+
+# run all journey tests, but assure these are running after `cargo clean` (and workaround a just-issue of deduplicating targets)
+ci-journey-tests:
+    just clear-target journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
 clear-target:
     cargo clean

--- a/tests/snapshots/panic-behaviour/expected-failure
+++ b/tests/snapshots/panic-behaviour/expected-failure
@@ -1,2 +1,3 @@
-thread 'main' panicked at 'something went very wrong', src/porcelain/main.rs:41:42
+thread 'main' panicked at src/porcelain/main.rs:41:42:
+something went very wrong
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/snapshots/panic-behaviour/expected-failure-in-thread
+++ b/tests/snapshots/panic-behaviour/expected-failure-in-thread
@@ -1,3 +1,4 @@
-thread 'main' panicked at 'something went very wrong', src/porcelain/main.rs:41:42
+thread 'main' panicked at src/porcelain/main.rs:41:42:
+something went very wrong
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 [2K

--- a/tests/snapshots/panic-behaviour/expected-failure-in-thread-with-progress
+++ b/tests/snapshots/panic-behaviour/expected-failure-in-thread-with-progress
@@ -1,3 +1,4 @@
-[?1049h[?25lthread '<unnamed>' panicked at 'something went very wrong', src/porcelain/main.rs:41:42
+[?1049h[?25lthread '<unnamed>' panicked at src/porcelain/main.rs:41:42:
+something went very wrong
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 [?25h[?1049l


### PR DESCRIPTION
- assure a prefixed entries range is never empty.
- fix: `gix exclude query` now also displays paths that don't match existing index entries.
- fix: `gix attrs query` now shows attributes even for paths that aren't already tracked
