### PR TITLE
gix attrs/exclude query now with directory support

### DIFF
--- a/gitoxide-core/src/repository/attributes/query.rs
+++ b/gitoxide-core/src/repository/attributes/query.rs
@@ -83,11 +83,18 @@ pub(crate) mod function {
                             .adjust_for_bare(repo.is_bare()),
                     )?;
                     for pattern in pathspec.search().patterns() {
-                        let entry = cache.at_entry(pattern.path(), Some(false))?;
+                        let path = pattern.path();
+                        let entry = cache.at_entry(
+                            path,
+                            pattern
+                                .signature
+                                .contains(gix::pathspec::MagicSignature::MUST_BE_DIR)
+                                .into(),
+                        )?;
                         if !entry.matching_attributes(&mut matches) {
                             continue;
                         }
-                        print_match(&matches, pattern.path(), &mut out)?;
+                        print_match(&matches, path, &mut out)?;
                     }
                 }
             }

--- a/gitoxide-core/src/repository/exclude.rs
+++ b/gitoxide-core/src/repository/exclude.rs
@@ -88,11 +88,18 @@ pub fn query(
                         .adjust_for_bare(repo.is_bare()),
                 )?;
                 for pattern in pathspec.search().patterns() {
-                    let entry = cache.at_entry(pattern.path(), None)?;
+                    let path = pattern.path();
+                    let entry = cache.at_entry(
+                        path,
+                        pattern
+                            .signature
+                            .contains(gix::pathspec::MagicSignature::MUST_BE_DIR)
+                            .into(),
+                    )?;
                     let match_ = entry
                         .matching_exclude_pattern()
                         .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                    print_match(match_, pattern.path(), &mut out)?;
+                    print_match(match_, path, &mut out)?;
                 }
             }
         }


### PR DESCRIPTION
Patterns exist that end in a trailing slash and that will naturally match these now, and
`git` can do the same.
