### PR TITLE
fix: set binary name for completions

### DIFF
--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1221,13 +1221,17 @@ pub fn main() -> Result<()> {
         },
         Subcommands::Completions { shell, out_dir } => {
             let mut app = Args::command();
+
+            let bin_name = "gix";
+            app.set_bin_name(bin_name);
+
             let shell = shell
                 .or_else(clap_complete::Shell::from_env)
                 .ok_or_else(|| anyhow!("The shell could not be derived from the environment"))?;
             if let Some(out_dir) = out_dir {
-                clap_complete::generate_to(shell, &mut app, env!("CARGO_PKG_NAME"), &out_dir)?;
+                clap_complete::generate_to(shell, &mut app, bin_name, &out_dir)?;
             } else {
-                clap_complete::generate(shell, &mut app, env!("CARGO_PKG_NAME"), &mut std::io::stdout());
+                clap_complete::generate(shell, &mut app, bin_name, &mut std::io::stdout());
             }
             Ok(())
         }


### PR DESCRIPTION
Closes #1060 

```bash
shauh@specialist gitoxide 🦀±|fix_completion-bin-name ✗|→ source <(cargo run -- completions)
   Compiling gitoxide v0.31.1 (/home/shauh/gitoxide)
    Finished dev [unoptimized + debuginfo] target(s) in 13.11s
     Running `target/debug/gix completions`
shauh@specialist gitoxide 🦀±|fix_completion-bin-name ✗|→ gix
-r                    -f                    --threads             --strict              --version             commit                clone                 index                 corpus
-c                    -h                    --verbose             --progress-keep-open  archive               verify                mailmap               submodule             free
-t                    -V                    --trace               --format              commit-graph          revision              remote                config-tree           completions
-v                    --repository          --no-verbose          --object-hash         odb                   credential            attributes            status                help
-s                    --config              --progress            --help                tree                  fetch                 exclude               config
shauh@specialist gitoxide 🦀±|fix_completion-bin-name ✗|→ gix
```
