### PR TITLE
handle discovery of split worktrees

### DIFF
--- a/gitoxide-core/src/discover.rs
+++ b/gitoxide-core/src/discover.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+
+pub fn discover(repo: &Path, mut out: impl std::io::Write) -> anyhow::Result<()> {
+    let mut has_err = false;
+    writeln!(out, "open (strict) {}:", repo.display())?;
+    has_err |= print_result(
+        &mut out,
+        gix::open_opts(repo, gix::open::Options::default().strict_config(true)),
+    )?;
+
+    if has_err {
+        writeln!(out, "open (lenient) {}:", repo.display())?;
+        has_err |= print_result(
+            &mut out,
+            gix::open_opts(repo, gix::open::Options::default().strict_config(false)),
+        )?;
+    }
+
+    writeln!(out)?;
+    writeln!(out, "discover from {}:", repo.display())?;
+    has_err |= print_result(&mut out, gix::discover(repo))?;
+
+    writeln!(out)?;
+    writeln!(out, "discover (plumbing) from {}:", repo.display())?;
+    has_err |= print_result(&mut out, gix::discover::upwards(repo))?;
+
+    if has_err {
+        writeln!(out)?;
+        anyhow::bail!("At least one operation failed")
+    }
+
+    Ok(())
+}
+
+fn print_result<T, E>(mut out: impl std::io::Write, res: Result<T, E>) -> std::io::Result<bool>
+where
+    T: std::fmt::Debug,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let mut has_err = false;
+    let to_print = match res {
+        Ok(good) => {
+            format!("{good:#?}")
+        }
+        Err(err) => {
+            has_err = true;
+            format!("{:?}", anyhow::Error::from(err))
+        }
+    };
+    indent(&mut out, to_print)?;
+    Ok(has_err)
+}
+
+fn indent(mut out: impl std::io::Write, msg: impl Into<String>) -> std::io::Result<()> {
+    for line in msg.into().lines() {
+        writeln!(out, "\t{line}")?;
+    }
+    Ok(())
+}

--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -79,5 +79,8 @@ pub mod pack;
 pub mod query;
 pub mod repository;
 
+mod discover;
+pub use discover::discover;
+
 #[cfg(all(feature = "async-client", feature = "blocking-client"))]
 compile_error!("Cannot set both 'blocking-client' and 'async-client' features as they are mutually exclusive");

--- a/gix-discover/src/lib.rs
+++ b/gix-discover/src/lib.rs
@@ -37,7 +37,7 @@ pub mod is_git {
         GitFile(#[from] crate::path::from_gitdir_file::Error),
         #[error("Could not retrieve metadata of \"{path}\"")]
         Metadata { source: std::io::Error, path: PathBuf },
-        #[error("The repository's config file doesn't exist or didn't have a 'bare' configuration")]
+        #[error("The repository's config file doesn't exist or didn't have a 'bare' configuration or contained core.worktree without value")]
         Inconclusive,
     }
 }

--- a/gix-discover/src/repository.rs
+++ b/gix-discover/src/repository.rs
@@ -78,7 +78,7 @@ mod path {
                         Path::WorkTree(work_dir)
                     }
                 },
-                Kind::Bare => Path::Repository(dir),
+                Kind::PossiblyBare => Path::Repository(dir),
             }
             .into()
         }
@@ -89,7 +89,7 @@ mod path {
                     linked_git_dir: Some(git_dir.to_owned()),
                 },
                 Path::WorkTree(_) => Kind::WorkTree { linked_git_dir: None },
-                Path::Repository(_) => Kind::Bare,
+                Path::Repository(_) => Kind::PossiblyBare,
             }
         }
 
@@ -110,7 +110,11 @@ pub enum Kind {
     /// A bare repository does not have a work tree, that is files on disk beyond the `git` repository itself.
     ///
     /// Note that this is merely a guess at this point as we didn't read the configuration yet.
-    Bare,
+    ///
+    /// Also note that due to optimizing for performance and *just* making an educated *guess in some situations*,
+    /// we may consider a non-bare repository bare if it it doesn't have an index yet due to be freshly initialized.
+    /// The caller is has to handle this, typically by reading the configuration.
+    PossiblyBare,
     /// A `git` repository along with checked out files in a work tree.
     WorkTree {
         /// If set, this is the git dir associated with this _linked_ worktree.
@@ -135,6 +139,6 @@ pub enum Kind {
 impl Kind {
     /// Returns true if this is a bare repository, one without a work tree.
     pub fn is_bare(&self) -> bool {
-        matches!(self, Kind::Bare)
+        matches!(self, Kind::PossiblyBare)
     }
 }

--- a/gix-discover/tests/fixtures/make_basic_repo.sh
+++ b/gix-discover/tests/fixtures/make_basic_repo.sh
@@ -70,3 +70,25 @@ git init non-bare-without-index
   git commit -m "init"
   rm .git/index
 )
+
+git --git-dir=repo-with-worktree-in-config-unborn-no-worktreedir --work-tree=does-not-exist-yet init
+worktree=repo-with-worktree-in-config-unborn-worktree
+git --git-dir=repo-with-worktree-in-config-unborn --work-tree=$worktree init && mkdir $worktree
+
+repo=repo-with-worktree-in-config-unborn-empty-worktreedir
+git --git-dir=$repo --work-tree="." init
+touch $repo/index
+git -C $repo config core.worktree ''
+
+repo=repo-with-worktree-in-config-unborn-worktreedir-missing-value
+git --git-dir=$repo init
+touch $repo/index
+echo "    worktree" >> $repo/config
+
+worktree=repo-with-worktree-in-config-worktree
+git --git-dir=repo-with-worktree-in-config --work-tree=$worktree init
+mkdir $worktree && touch $worktree/file
+(cd repo-with-worktree-in-config
+  git add file
+  git commit -m "make sure na index exists"
+)

--- a/gix-discover/tests/is_git/mod.rs
+++ b/gix-discover/tests/is_git/mod.rs
@@ -45,7 +45,7 @@ fn missing_configuration_file_is_not_a_dealbreaker_in_bare_repo() -> crate::Resu
     for name in ["bare-no-config-after-init.git", "bare-no-config.git"] {
         let repo = repo_path()?.join(name);
         let kind = gix_discover::is_git(&repo)?;
-        assert_eq!(kind, gix_discover::repository::Kind::Bare);
+        assert_eq!(kind, gix_discover::repository::Kind::PossiblyBare);
     }
     Ok(())
 }
@@ -54,7 +54,7 @@ fn missing_configuration_file_is_not_a_dealbreaker_in_bare_repo() -> crate::Resu
 fn bare_repo_with_index_file_looks_still_looks_like_bare() -> crate::Result {
     let repo = repo_path()?.join("bare-with-index.git");
     let kind = gix_discover::is_git(&repo)?;
-    assert_eq!(kind, gix_discover::repository::Kind::Bare);
+    assert_eq!(kind, gix_discover::repository::Kind::PossiblyBare);
     Ok(())
 }
 
@@ -63,7 +63,7 @@ fn bare_repo_with_index_file_looks_still_looks_like_bare_if_it_was_renamed() -> 
     for repo_name in ["bare-with-index-bare", "bare-with-index-no-config-bare"] {
         let repo = repo_path()?.join(repo_name);
         let kind = gix_discover::is_git(&repo)?;
-        assert_eq!(kind, gix_discover::repository::Kind::Bare);
+        assert_eq!(kind, gix_discover::repository::Kind::PossiblyBare);
     }
     Ok(())
 }
@@ -82,6 +82,27 @@ fn missing_configuration_file_is_not_a_dealbreaker_in_nonbare_repo() -> crate::R
         let repo = repo_path()?.join(name);
         let kind = gix_discover::is_git(&repo)?;
         assert_eq!(kind, gix_discover::repository::Kind::WorkTree { linked_git_dir: None });
+    }
+    Ok(())
+}
+
+#[test]
+fn split_worktree_using_configuration() -> crate::Result {
+    for name in [
+        "repo-with-worktree-in-config",
+        "repo-with-worktree-in-config-unborn",
+        "repo-with-worktree-in-config-unborn-no-worktreedir",
+        "repo-with-worktree-in-config-unborn-empty-worktreedir",
+        "repo-with-worktree-in-config-unborn-worktreedir-missing-value",
+    ] {
+        let repo = repo_path()?.join(name);
+        let kind = gix_discover::is_git(&repo)?;
+        assert_eq!(
+            kind,
+            gix_discover::repository::Kind::PossiblyBare,
+            "{name}: we think these are bare as we don't read the configuration in this case - \
+            a shortcoming to favor performance which still comes out correct in `gix`"
+        );
     }
     Ok(())
 }

--- a/gix-discover/tests/isolated.rs
+++ b/gix-discover/tests/isolated.rs
@@ -12,7 +12,7 @@ fn upwards_bare_repo_with_index() -> gix_testtools::Result {
     let (repo_path, _trust) = gix_discover::upwards(".".as_ref())?;
     assert_eq!(
         repo_path.kind(),
-        gix_discover::repository::Kind::Bare,
+        gix_discover::repository::Kind::PossiblyBare,
         "bare stays bare, even with index, as it resolves the path as needed in this special case"
     );
     Ok(())
@@ -25,7 +25,7 @@ fn in_cwd_upwards_bare_repo_without_index() -> gix_testtools::Result {
 
     let _keep = gix_testtools::set_current_dir(repo.join("bare.git"))?;
     let (repo_path, _trust) = gix_discover::upwards(".".as_ref())?;
-    assert_eq!(repo_path.kind(), gix_discover::repository::Kind::Bare);
+    assert_eq!(repo_path.kind(), gix_discover::repository::Kind::PossiblyBare);
     Ok(())
 }
 

--- a/gix-discover/tests/upwards/mod.rs
+++ b/gix-discover/tests/upwards/mod.rs
@@ -17,7 +17,7 @@ fn from_bare_git_dir() -> crate::Result {
     let dir = repo_path()?.join("bare.git");
     let (path, trust) = gix_discover::upwards(&dir)?;
     assert_eq!(path.as_ref(), dir, "the bare .git dir is directly returned");
-    assert_eq!(path.kind(), Kind::Bare);
+    assert_eq!(path.kind(), Kind::PossiblyBare);
     assert_eq!(trust, expected_trust());
     Ok(())
 }
@@ -27,7 +27,7 @@ fn from_bare_with_index() -> crate::Result {
     let dir = repo_path()?.join("bare-with-index.git");
     let (path, trust) = gix_discover::upwards(&dir)?;
     assert_eq!(path.as_ref(), dir, "the bare .git dir is directly returned");
-    assert_eq!(path.kind(), Kind::Bare);
+    assert_eq!(path.kind(), Kind::PossiblyBare);
     assert_eq!(trust, expected_trust());
     Ok(())
 }
@@ -48,7 +48,7 @@ fn from_bare_git_dir_without_config_file() -> crate::Result {
         let dir = repo_path()?.join(name);
         let (path, trust) = gix_discover::upwards(&dir)?;
         assert_eq!(path.as_ref(), dir, "the bare .git dir is directly returned");
-        assert_eq!(path.kind(), Kind::Bare);
+        assert_eq!(path.kind(), Kind::PossiblyBare);
         assert_eq!(trust, expected_trust());
     }
     Ok(())
@@ -64,7 +64,7 @@ fn from_inside_bare_git_dir() -> crate::Result {
         git_dir,
         "the bare .git dir is found while traversing upwards"
     );
-    assert_eq!(path.kind(), Kind::Bare);
+    assert_eq!(path.kind(), Kind::PossiblyBare);
     assert_eq!(trust, expected_trust());
     Ok(())
 }

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -91,8 +91,11 @@ pub enum Error {
     ResolveIncludes(#[from] gix_config::file::includes::Error),
     #[error(transparent)]
     FromEnv(#[from] gix_config::file::init::from_env::Error),
-    #[error(transparent)]
-    PathInterpolation(#[from] gix_config::path::interpolate::Error),
+    #[error("The path {path:?} at the 'core.worktree' configuration could not be interpolated")]
+    PathInterpolation {
+        path: BString,
+        source: gix_config::path::interpolate::Error,
+    },
     #[error("{source:?} configuration overrides at open or init time could not be applied.")]
     ConfigOverrides {
         #[source]

--- a/gix/src/create.rs
+++ b/gix/src/create.rs
@@ -230,7 +230,7 @@ pub fn into(
     Ok(gix_discover::repository::Path::from_dot_git_dir(
         dot_git,
         if bare {
-            gix_discover::repository::Kind::Bare
+            gix_discover::repository::Kind::PossiblyBare
         } else {
             gix_discover::repository::Kind::WorkTree { linked_git_dir: None }
         },

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -237,9 +237,13 @@ impl ThreadSafeRepository {
                 .resolved
                 .path_filter("core", None, Core::WORKTREE.name, &mut filter_config_section)
             {
+                let wt_clone = wt.clone();
                 let wt_path = wt
                     .interpolate(interpolate_context(git_install_dir.as_deref(), home.as_deref()))
-                    .map_err(config::Error::PathInterpolation)?;
+                    .map_err(|err| config::Error::PathInterpolation {
+                        path: wt_clone.value.into_owned(),
+                        source: err,
+                    })?;
                 worktree_dir = gix_path::normalize(git_dir.join(wt_path).into(), current_dir).map(Cow::into_owned);
                 #[allow(unused_variables)]
                 if let Some(worktree_path) = worktree_dir.as_deref().filter(|wtd| !wtd.is_dir()) {

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -240,10 +240,20 @@ impl ThreadSafeRepository {
                 let wt_path = wt
                     .interpolate(interpolate_context(git_install_dir.as_deref(), home.as_deref()))
                     .map_err(config::Error::PathInterpolation)?;
-                worktree_dir = {
-                    gix_path::normalize(git_dir.join(wt_path).into(), current_dir)
-                        .and_then(|wt| wt.as_ref().is_dir().then(|| wt.into_owned()))
+                worktree_dir = gix_path::normalize(git_dir.join(wt_path).into(), current_dir).map(Cow::into_owned);
+                #[allow(unused_variables)]
+                if let Some(worktree_path) = worktree_dir.as_deref().filter(|wtd| !wtd.is_dir()) {
+                    gix_trace::warn!("The configured worktree path '{}' is not a directory or doesn't exist - `core.worktree` may be misleading", worktree_path.display());
                 }
+            } else if !config.lenient_config
+                && config
+                    .resolved
+                    .boolean_filter("core", None, Core::WORKTREE.name, &mut filter_config_section)
+                    .is_some()
+            {
+                return Err(Error::from(config::Error::ConfigTypedString(
+                    config::key::GenericErrorWithValue::from(&Core::WORKTREE),
+                )));
             }
         }
 

--- a/gix/src/repository/kind.rs
+++ b/gix/src/repository/kind.rs
@@ -13,7 +13,7 @@ impl From<gix_discover::repository::Kind> for Kind {
             gix_discover::repository::Kind::Submodule { .. } | gix_discover::repository::Kind::SubmoduleGitDir => {
                 Kind::WorkTree { is_linked: false }
             }
-            gix_discover::repository::Kind::Bare => Kind::Bare,
+            gix_discover::repository::Kind::PossiblyBare => Kind::Bare,
             gix_discover::repository::Kind::WorkTreeGitDir { .. } => Kind::WorkTree { is_linked: true },
             gix_discover::repository::Kind::WorkTree { linked_git_dir } => Kind::WorkTree {
                 is_linked: linked_git_dir.is_some(),

--- a/gix/tests/fixtures/make_worktree_repo.sh
+++ b/gix/tests/fixtures/make_worktree_repo.sh
@@ -17,18 +17,42 @@ mkdir repo
   git commit -q -am c2
 )
 
-if [ "$bare" == "bare" ]; then
+(if [ "$bare" == "bare" ]; then
   git clone --bare --shared repo repo.git
   cd repo.git
 else
   cd repo
 fi
 
-git worktree add ../wt-a
-git worktree add ../prev/wt-a HEAD~1
-git worktree add ../wt-b HEAD~1
-git worktree add ../wt-a/nested-wt-b HEAD~1
-git worktree add --lock ../wt-c-locked
-git worktree add ../wt-deleted && rm -Rf ../wt-deleted
+  git worktree add ../wt-a
+  git worktree add ../prev/wt-a HEAD~1
+  git worktree add ../wt-b HEAD~1
+  git worktree add ../wt-a/nested-wt-b HEAD~1
+  git worktree add --lock ../wt-c-locked
+  git worktree add ../wt-deleted && rm -Rf ../wt-deleted
 
-git worktree list --porcelain > ../worktree-list.baseline
+  git worktree list --porcelain > ../worktree-list.baseline
+)
+
+
+git --git-dir=repo-with-worktree-in-config-unborn-no-worktreedir --work-tree=does-not-exist-yet init
+worktree=repo-with-worktree-in-config-unborn-worktree
+git --git-dir=repo-with-worktree-in-config-unborn --work-tree=$worktree init && mkdir $worktree
+
+repo=repo-with-worktree-in-config-unborn-empty-worktreedir
+git --git-dir=$repo --work-tree="." init
+git -C $repo config core.worktree ''
+
+repo=repo-with-worktree-in-config-unborn-worktreedir-missing-value
+git --git-dir=$repo init
+touch $repo/index
+git -C $repo config core.bare false
+echo "    worktree" >> $repo/config
+
+worktree=repo-with-worktree-in-config-worktree
+git --git-dir=repo-with-worktree-in-config --work-tree=$worktree init
+mkdir $worktree && touch $worktree/file
+(cd repo-with-worktree-in-config
+  git add file
+  git commit -m "make sure na index exists"
+)

--- a/gix/tests/repository/open.rs
+++ b/gix/tests/repository/open.rs
@@ -1,4 +1,5 @@
 use crate::util::named_subrepo_opts;
+use std::error::Error;
 
 #[test]
 fn bare_repo_with_index() -> crate::Result {
@@ -23,6 +24,59 @@ fn none_bare_repo_without_index() -> crate::Result {
     )?;
     assert!(!repo.is_bare(), "worktree isn't dependent on an index file");
     assert!(repo.worktree().is_some());
+    Ok(())
+}
+
+#[test]
+fn non_bare_split_worktree() -> crate::Result {
+    for (name, worktree_exists) in [
+        ("repo-with-worktree-in-config-unborn-no-worktreedir", false),
+        ("repo-with-worktree-in-config-unborn", true),
+        ("repo-with-worktree-in-config", true),
+    ] {
+        let repo = named_subrepo_opts("make_worktree_repo.sh", name, gix::open::Options::isolated())?;
+        assert!(repo.git_dir().is_dir());
+        assert!(
+            !repo.is_bare(),
+            "worktree is actually configured, and it's non-bare by configuration"
+        );
+        assert_eq!(
+            repo.work_dir().expect("worktree is configured").is_dir(),
+            worktree_exists
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn non_bare_split_worktree_invalid_worktree_path_boolean() -> crate::Result {
+    let err = named_subrepo_opts(
+        "make_worktree_repo.sh",
+        "repo-with-worktree-in-config-unborn-worktreedir-missing-value",
+        gix::open::Options::isolated().strict_config(true),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.source().expect("present").to_string(),
+        "The key \"core.worktree\" (possibly from GIT_WORK_TREE) was invalid",
+        "in strict mode, we fail just like git does"
+    );
+    Ok(())
+}
+
+#[test]
+fn non_bare_split_worktree_invalid_worktree_path_empty() -> crate::Result {
+    // "repo-with-worktree-in-config-unborn-worktreedir-missing-value",
+    let err = named_subrepo_opts(
+        "make_worktree_repo.sh",
+        "repo-with-worktree-in-config-unborn-empty-worktreedir",
+        gix::open::Options::isolated(),
+    )
+    .unwrap_err();
+    assert!(
+            matches!(err, gix::open::Error::Config(gix::config::Error::PathInterpolation(_))),
+            "DEVIATION: could not read path at core.worktree as empty is always invalid, git tries to use an empty path, even though it's better to reject it"
+        );
     Ok(())
 }
 

--- a/gix/tests/repository/open.rs
+++ b/gix/tests/repository/open.rs
@@ -74,7 +74,7 @@ fn non_bare_split_worktree_invalid_worktree_path_empty() -> crate::Result {
     )
     .unwrap_err();
     assert!(
-            matches!(err, gix::open::Error::Config(gix::config::Error::PathInterpolation(_))),
+            matches!(err, gix::open::Error::Config(gix::config::Error::PathInterpolation{..})),
             "DEVIATION: could not read path at core.worktree as empty is always invalid, git tries to use an empty path, even though it's better to reject it"
         );
     Ok(())

--- a/gix/tests/repository/worktree.rs
+++ b/gix/tests/repository/worktree.rs
@@ -91,10 +91,10 @@ mod with_core_worktree_config {
             "git can't chdir into missing worktrees, has no error handling there"
         );
 
-        assert_eq!(
-            repo.work_dir(),
-            repo.git_dir().parent(),
-            "we just ignore missing configured worktree dirs and fall back to the default one"
+        assert!(
+            !repo.work_dir().expect("configured").exists(),
+            "non-existing or invalid worktrees (this one is a file) are taken verbatim and \
+            may lead to errors later - just like in `git` and we explicitly do not try to be smart about it"
         )
     }
 
@@ -103,11 +103,11 @@ mod with_core_worktree_config {
         let repo = repo("relative-worktree-file");
         assert_eq!(count_deleted(repo.git_dir()), 0, "git can't chdir into a file");
 
-        assert_eq!(
-            repo.work_dir(),
-            repo.git_dir().parent(),
-            "we just ignore missing configured worktree dirs and fall back to the default one"
-        )
+        assert!(
+            repo.work_dir().expect("configured").is_file(),
+            "non-existing or invalid worktrees (this one is a file) are taken verbatim and \
+            may lead to errors later - just like in `git` and we explicitly do not try to be smart about it"
+        );
     }
 
     #[test]

--- a/gix/tests/submodule/mod.rs
+++ b/gix/tests/submodule/mod.rs
@@ -1,6 +1,10 @@
 pub fn repo(name: &str) -> crate::Result<gix::Repository> {
     use crate::util::named_subrepo_opts;
-    named_subrepo_opts("make_submodules.sh", name, gix::open::Options::isolated())
+    Ok(named_subrepo_opts(
+        "make_submodules.sh",
+        name,
+        gix::open::Options::isolated(),
+    )?)
 }
 
 mod open {

--- a/gix/tests/util/mod.rs
+++ b/gix/tests/util/mod.rs
@@ -34,8 +34,12 @@ pub fn named_repo(name: &str) -> Result<Repository> {
     Ok(ThreadSafeRepository::open_opts(repo_path, restricted())?.to_thread_local())
 }
 
-pub fn named_subrepo_opts(fixture: &str, name: &str, opts: open::Options) -> Result<Repository> {
-    let repo_path = gix_testtools::scripted_fixture_read_only(fixture)?.join(name);
+pub fn named_subrepo_opts(
+    fixture: &str,
+    name: &str,
+    opts: open::Options,
+) -> std::result::Result<Repository, gix::open::Error> {
+    let repo_path = gix_testtools::scripted_fixture_read_only(fixture).unwrap().join(name);
     Ok(ThreadSafeRepository::open_opts(repo_path, opts)?.to_thread_local())
 }
 

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -72,6 +72,7 @@ pub fn main() -> Result<()> {
     let object_hash = args.object_hash;
     let config = args.config;
     let repository = args.repository;
+    let repository_path = repository.clone();
     enum Mode {
         Strict,
         StrictWithGitInstallConfig,
@@ -449,6 +450,15 @@ pub fn main() -> Result<()> {
         )
         .map(|_| ()),
         Subcommands::Free(subcommands) => match subcommands {
+            free::Subcommands::Discover => prepare_and_run(
+                "discover",
+                trace,
+                verbose,
+                progress,
+                progress_keep_open,
+                None,
+                move |_progress, out, _err| core::discover(&repository_path, out),
+            ),
             free::Subcommands::CommitGraph(cmd) => match cmd {
                 free::commitgraph::Subcommands::Verify { path, statistics } => prepare_and_run(
                     "commitgraph-verify",

--- a/src/plumbing/options/free.rs
+++ b/src/plumbing/options/free.rs
@@ -14,6 +14,8 @@ pub enum Subcommands {
     Pack(pack::Subcommands),
     /// Subcommands for interacting with a worktree index, typically at .git/index
     Index(index::Platform),
+    /// Show information about repository discovery and when opening a repository at the current path.
+    Discover,
 }
 
 ///


### PR DESCRIPTION
Triggered by https://github.com/gitpython-developers/GitPython/issues/1710 .

### Tasks

* [x] validate that both split-worktree scenarios are handled in `gix` correctly (unborn, born)
* [x] `gix discover` - a high-level command command to obtain information about `gix-discover` information 
