### PR TITLE
Allow changing URL password

### DIFF
--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -124,6 +124,13 @@ impl Url {
         self.user = user;
         prev
     }
+
+    /// Set the given `password`, or unset it with `None`. Return the previous value.
+    pub fn set_password(&mut self, password: Option<String>) -> Option<String> {
+        let prev = self.password.take();
+        self.password = password;
+        prev
+    }
 }
 
 /// Builder


### PR DESCRIPTION
When a GitHub app wants to clone a private repo, it is required to pass the access token as a part of the URL https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation :unamused: . A `gix-url` user may want to use `Url` to store the validared Url internally, but the access token is retrieved at runtime, so such an application will want to clone the Url and set the password just before fetching the private repo.