### PR TITLE
trace packetlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,7 @@ dependencies = [
  "gix-hash 0.13.1",
  "gix-odb",
  "gix-pack",
+ "gix-trace 0.1.3",
  "maybe-async",
  "pin-project-lite",
  "serde",
@@ -2012,6 +2013,7 @@ dependencies = [
  "bstr",
  "document-features",
  "faster-hex",
+ "gix-trace 0.1.3",
  "serde",
  "thiserror",
 ]

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -116,6 +116,7 @@ impl<W> protocol::fetch::DelegateBlocking for CloneDelegate<W> {
 mod blocking_io {
     use std::{io, io::BufRead, path::PathBuf};
 
+    use gix::config::tree::Key;
     use gix::{
         bstr::BString,
         protocol,
@@ -180,6 +181,12 @@ mod blocking_io {
             progress,
             protocol::FetchConnection::TerminateOnSuccessfulCompletion,
             gix::env::agent(),
+            std::env::var_os(
+                gix::config::tree::Gitoxide::TRACE_PACKET
+                    .environment_override()
+                    .expect("set"),
+            )
+            .is_some(),
         )?;
         Ok(())
     }
@@ -196,6 +203,7 @@ mod async_io {
 
     use async_trait::async_trait;
     use futures_io::AsyncBufRead;
+    use gix::config::tree::Key;
     use gix::{
         bstr::{BString, ByteSlice},
         odb::pack,
@@ -264,6 +272,12 @@ mod async_io {
                 progress,
                 protocol::FetchConnection::TerminateOnSuccessfulCompletion,
                 gix::env::agent(),
+                std::env::var_os(
+                    gix::config::tree::Gitoxide::TRACE_PACKET
+                        .environment_override()
+                        .expect("set"),
+                )
+                .is_some(),
             ))
         })
         .await?;

--- a/gix-filter/src/driver/process/client.rs
+++ b/gix-filter/src/driver/process/client.rs
@@ -76,6 +76,7 @@ impl Client {
         let mut input = gix_packetline::StreamingPeekableIter::new(
             process.stdout.take().expect("configured stdout when spawning"),
             &[gix_packetline::PacketLineRef::Flush],
+            false, /* packet tracing */
         );
         let mut read = input.as_read();
         let mut buf = String::new();

--- a/gix-filter/src/driver/process/server.rs
+++ b/gix-filter/src/driver/process/server.rs
@@ -63,8 +63,11 @@ impl Server {
         pick_version: &mut dyn FnMut(&[usize]) -> Option<usize>,
         available_capabilities: &[&str],
     ) -> Result<Self, handshake::Error> {
-        let mut input =
-            gix_packetline::StreamingPeekableIter::new(stdin.lock(), &[gix_packetline::PacketLineRef::Flush]);
+        let mut input = gix_packetline::StreamingPeekableIter::new(
+            stdin.lock(),
+            &[gix_packetline::PacketLineRef::Flush],
+            false, /* packet tracing */
+        );
         let mut read = input.as_read();
         let mut buf = String::new();
         read.read_line_to_string(&mut buf)?;

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -24,6 +24,8 @@ blocking-io = []
 serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
+gix-trace = { version = "^0.1.3", path = "../gix-trace" }
+
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"]}
 thiserror = "1.0.34"
 faster-hex = "0.8.0"

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -39,6 +39,8 @@ path = "tests/blocking-packetline.rs"
 required-features = ["blocking-io", "maybe-async/is_sync"]
 
 [dependencies]
+gix-trace = { version = "^0.1.3", path = "../gix-trace" }
+
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"]}
 thiserror = "1.0.34"
 faster-hex = "0.8.0"

--- a/gix-packetline/src/lib.rs
+++ b/gix-packetline/src/lib.rs
@@ -91,6 +91,8 @@ pub struct StreamingPeekableIter<T> {
     delimiters: &'static [PacketLineRef<'static>],
     is_done: bool,
     stopped_at: Option<PacketLineRef<'static>>,
+    #[cfg_attr(all(not(feature = "async-io"), not(feature = "blocking-io")), allow(dead_code))]
+    trace: bool,
 }
 
 /// Utilities to help decoding packet lines

--- a/gix-packetline/src/read/mod.rs
+++ b/gix-packetline/src/read/mod.rs
@@ -43,7 +43,8 @@ pub use error::Error;
 
 impl<T> StreamingPeekableIter<T> {
     /// Return a new instance from `read` which will stop decoding packet lines when receiving one of the given `delimiters`.
-    pub fn new(read: T, delimiters: &'static [PacketLineRef<'static>]) -> Self {
+    /// If `trace` is `true`, all packetlines received or sent will be passed to the facilities of the `gix-trace` crate.
+    pub fn new(read: T, delimiters: &'static [PacketLineRef<'static>], trace: bool) -> Self {
         StreamingPeekableIter {
             read,
             #[cfg(any(feature = "blocking-io", feature = "async-io"))]
@@ -53,6 +54,7 @@ impl<T> StreamingPeekableIter<T> {
             fail_on_err_lines: false,
             is_done: false,
             stopped_at: None,
+            trace,
         }
     }
 

--- a/gix-packetline/src/read/sidebands/async_io.rs
+++ b/gix-packetline/src/read/sidebands/async_io.rs
@@ -80,12 +80,12 @@ mod tests {
     /// We want to declare items containing pointers of `StreamingPeekableIter` `Send` as well, so it must be `Send` itself.
     #[test]
     fn streaming_peekable_iter_is_send() {
-        receiver(StreamingPeekableIter::new(Vec::<u8>::new(), &[]));
+        receiver(StreamingPeekableIter::new(Vec::<u8>::new(), &[], false));
     }
 
     #[test]
     fn state_is_send() {
-        let mut s = StreamingPeekableIter::new(Vec::<u8>::new(), &[]);
+        let mut s = StreamingPeekableIter::new(Vec::<u8>::new(), &[], false);
         receiver(State::Idle { parent: Some(&mut s) });
     }
 }

--- a/gix-packetline/tests/read/mod.rs
+++ b/gix-packetline/tests/read/mod.rs
@@ -20,7 +20,7 @@ pub mod streaming_peek_iter {
 
     #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
     async fn peek_follows_read_line_delimiter_logic() -> crate::Result {
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&b"0005a00000005b"[..], &[PacketLineRef::Flush]);
+        let mut rd = gix_packetline::StreamingPeekableIter::new(&b"0005a00000005b"[..], &[PacketLineRef::Flush], false);
         let res = rd.peek_line().await;
         assert_eq!(res.expect("line")??, PacketLineRef::Data(b"a"));
         rd.read_line().await;
@@ -46,7 +46,8 @@ pub mod streaming_peek_iter {
 
     #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
     async fn peek_follows_read_line_err_logic() -> crate::Result {
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&b"0005a0009ERR e0000"[..], &[PacketLineRef::Flush]);
+        let mut rd =
+            gix_packetline::StreamingPeekableIter::new(&b"0005a0009ERR e0000"[..], &[PacketLineRef::Flush], false);
         rd.fail_on_err_lines(true);
         let res = rd.peek_line().await;
         assert_eq!(res.expect("line")??, PacketLineRef::Data(b"a"));
@@ -73,7 +74,8 @@ pub mod streaming_peek_iter {
 
     #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
     async fn peek_non_data() -> crate::Result {
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&b"000000010002"[..], &[PacketLineRef::ResponseEnd]);
+        let mut rd =
+            gix_packetline::StreamingPeekableIter::new(&b"000000010002"[..], &[PacketLineRef::ResponseEnd], false);
         let res = rd.read_line().await;
         assert_eq!(res.expect("line")??, PacketLineRef::Flush);
         let res = rd.read_line().await;
@@ -100,7 +102,7 @@ pub mod streaming_peek_iter {
     #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
     async fn fail_on_err_lines() -> crate::Result {
         let input = b"00010009ERR e0002";
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&input[..], &[]);
+        let mut rd = gix_packetline::StreamingPeekableIter::new(&input[..], &[], false);
         let res = rd.read_line().await;
         assert_eq!(res.expect("line")??, PacketLineRef::Delimiter);
         let res = rd.read_line().await;
@@ -110,7 +112,7 @@ pub mod streaming_peek_iter {
             "by default no special handling"
         );
 
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&input[..], &[]);
+        let mut rd = gix_packetline::StreamingPeekableIter::new(&input[..], &[], false);
         rd.fail_on_err_lines(true);
         let res = rd.read_line().await;
         assert_eq!(res.expect("line")??, PacketLineRef::Delimiter);
@@ -138,7 +140,7 @@ pub mod streaming_peek_iter {
     #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
     async fn peek() -> crate::Result {
         let bytes = fixture_bytes("v1/fetch/01-many-refs.response");
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&bytes[..], &[PacketLineRef::Flush]);
+        let mut rd = gix_packetline::StreamingPeekableIter::new(&bytes[..], &[PacketLineRef::Flush], false);
         let res = rd.peek_line().await;
         assert_eq!(res.expect("line")??, first_line(), "peek returns first line");
         let res = rd.peek_line().await;
@@ -175,7 +177,7 @@ pub mod streaming_peek_iter {
     async fn read_from_file_and_reader_advancement() -> crate::Result {
         let mut bytes = fixture_bytes("v1/fetch/01-many-refs.response");
         bytes.extend(fixture_bytes("v1/fetch/01-many-refs.response"));
-        let mut rd = gix_packetline::StreamingPeekableIter::new(&bytes[..], &[PacketLineRef::Flush]);
+        let mut rd = gix_packetline::StreamingPeekableIter::new(&bytes[..], &[PacketLineRef::Flush], false);
         let res = rd.read_line().await;
         assert_eq!(res.expect("line")??, first_line());
         let res = exhaust(&mut rd).await;

--- a/gix-protocol/src/fetch/arguments/async_io.rs
+++ b/gix-protocol/src/fetch/arguments/async_io.rs
@@ -19,8 +19,11 @@ impl Arguments {
                     transport.connection_persists_across_multiple_requests(),
                     add_done_argument,
                 )?;
-                let mut line_writer =
-                    transport.request(client::WriteMode::OneLfTerminatedLinePerWriteCall, on_into_read)?;
+                let mut line_writer = transport.request(
+                    client::WriteMode::OneLfTerminatedLinePerWriteCall,
+                    on_into_read,
+                    self.trace,
+                )?;
                 let had_args = !self.args.is_empty();
                 for arg in self.args.drain(..) {
                     line_writer.write_all(&arg).await?;
@@ -47,6 +50,7 @@ impl Arguments {
                         Command::Fetch.as_str(),
                         self.features.iter().filter(|(_, v)| v.is_some()).cloned(),
                         Some(std::mem::replace(&mut self.args, retained_state).into_iter()),
+                        self.trace,
                     )
                     .await
             }

--- a/gix-protocol/src/fetch/arguments/blocking_io.rs
+++ b/gix-protocol/src/fetch/arguments/blocking_io.rs
@@ -20,8 +20,11 @@ impl Arguments {
                     transport.connection_persists_across_multiple_requests(),
                     add_done_argument,
                 )?;
-                let mut line_writer =
-                    transport.request(client::WriteMode::OneLfTerminatedLinePerWriteCall, on_into_read)?;
+                let mut line_writer = transport.request(
+                    client::WriteMode::OneLfTerminatedLinePerWriteCall,
+                    on_into_read,
+                    self.trace,
+                )?;
                 let had_args = !self.args.is_empty();
                 for arg in self.args.drain(..) {
                     line_writer.write_all(&arg)?;
@@ -47,6 +50,7 @@ impl Arguments {
                     Command::Fetch.as_str(),
                     self.features.iter().filter(|(_, v)| v.is_some()).cloned(),
                     Some(std::mem::replace(&mut self.args, retained_state).into_iter()),
+                    self.trace,
                 )
             }
         }

--- a/gix-protocol/src/fetch/arguments/mod.rs
+++ b/gix-protocol/src/fetch/arguments/mod.rs
@@ -23,6 +23,8 @@ pub struct Arguments {
     features_for_first_want: Option<Vec<String>>,
     #[cfg(any(feature = "async-client", feature = "blocking-client"))]
     version: gix_transport::Protocol,
+
+    trace: bool,
 }
 
 impl Arguments {
@@ -194,8 +196,9 @@ impl Arguments {
     }
     /// Create a new instance to help setting up arguments to send to the server as part of a `fetch` operation
     /// for which `features` are the available and configured features to use.
+    /// If `trace` is `true`, all packetlines received or sent will be passed to the facilities of the `gix-trace` crate.
     #[cfg(any(feature = "async-client", feature = "blocking-client"))]
-    pub fn new(version: gix_transport::Protocol, features: Vec<crate::command::Feature>) -> Self {
+    pub fn new(version: gix_transport::Protocol, features: Vec<crate::command::Feature>, trace: bool) -> Self {
         use crate::Command;
         let has = |name: &str| features.iter().any(|f| f.0 == name);
         let filter = has("filter");
@@ -242,6 +245,7 @@ impl Arguments {
             ref_in_want,
             deepen_since,
             features_for_first_want,
+            trace,
         }
     }
 }

--- a/gix-protocol/src/fetch/tests.rs
+++ b/gix-protocol/src/fetch/tests.rs
@@ -6,11 +6,11 @@ mod arguments {
     use crate::fetch;
 
     fn arguments_v1(features: impl IntoIterator<Item = &'static str>) -> fetch::Arguments {
-        fetch::Arguments::new(Protocol::V1, features.into_iter().map(|n| (n, None)).collect())
+        fetch::Arguments::new(Protocol::V1, features.into_iter().map(|n| (n, None)).collect(), false)
     }
 
     fn arguments_v2(features: impl IntoIterator<Item = &'static str>) -> fetch::Arguments {
-        fetch::Arguments::new(Protocol::V2, features.into_iter().map(|n| (n, None)).collect())
+        fetch::Arguments::new(Protocol::V2, features.into_iter().map(|n| (n, None)).collect(), false)
     }
 
     struct Transport<T> {
@@ -40,8 +40,9 @@ mod arguments {
                 &mut self,
                 write_mode: WriteMode,
                 on_into_read: MessageKind,
+                trace: bool,
             ) -> Result<RequestWriter<'_>, Error> {
-                self.inner.request(write_mode, on_into_read)
+                self.inner.request(write_mode, on_into_read, trace)
             }
 
             fn to_url(&self) -> Cow<'_, BStr> {
@@ -97,8 +98,9 @@ mod arguments {
                 &mut self,
                 write_mode: WriteMode,
                 on_into_read: MessageKind,
+                trace: bool,
             ) -> Result<RequestWriter<'_>, Error> {
-                self.inner.request(write_mode, on_into_read)
+                self.inner.request(write_mode, on_into_read, trace)
             }
 
             fn to_url(&self) -> Cow<'_, BStr> {
@@ -145,6 +147,7 @@ mod arguments {
                 b"does/not/matter".as_bstr().to_owned(),
                 None::<(&str, _)>,
                 gix_transport::client::git::ConnectMode::Process, // avoid header to be sent
+                false,
             ),
             stateful,
         }

--- a/gix-protocol/src/handshake/function.rs
+++ b/gix-protocol/src/handshake/function.rs
@@ -22,6 +22,7 @@ where
     AuthFn: FnMut(credentials::helper::Action) -> credentials::protocol::Result,
     T: client::Transport,
 {
+    let _span = gix_features::trace::detail!("gix_protocol::handshake()", service = ?service, extra_parameters = ?extra_parameters);
     let (server_protocol_version, refs, capabilities) = {
         progress.init(None, progress::steps());
         progress.set_name("handshake".into());

--- a/gix-protocol/src/util.rs
+++ b/gix-protocol/src/util.rs
@@ -8,10 +8,12 @@ pub fn agent(name: impl Into<String>) -> String {
 }
 
 /// Send a message to indicate the remote side that there is nothing more to expect from us, indicating a graceful shutdown.
+/// If `trace` is `true`, all packetlines received or sent will be passed to the facilities of the `gix-trace` crate.
 #[cfg(any(feature = "blocking-client", feature = "async-client"))]
 #[maybe_async::maybe_async]
 pub async fn indicate_end_of_interaction(
     mut transport: impl gix_transport::client::Transport,
+    trace: bool,
 ) -> Result<(), gix_transport::client::Error> {
     // An empty request marks the (early) end of the interaction. Only relevant in stateful transports though.
     if transport.connection_persists_across_multiple_requests() {
@@ -19,6 +21,7 @@ pub async fn indicate_end_of_interaction(
             .request(
                 gix_transport::client::WriteMode::Binary,
                 gix_transport::client::MessageKind::Flush,
+                trace,
             )?
             .into_read()
             .await?;

--- a/gix-protocol/tests/fetch/mod.rs
+++ b/gix-protocol/tests/fetch/mod.rs
@@ -280,6 +280,7 @@ pub fn transport<W: futures_io::AsyncWrite + Unpin>(
         b"does/not/matter".as_bstr().to_owned(),
         None::<(&str, _)>,
         mode,
+        false,
     )
 }
 
@@ -298,6 +299,7 @@ pub fn transport<W: std::io::Write>(
         b"does/not/matter".as_bstr().to_owned(),
         None::<(&str, _)>,
         mode,
+        false,
     )
 }
 

--- a/gix-protocol/tests/fetch/response.rs
+++ b/gix-protocol/tests/fetch/response.rs
@@ -3,7 +3,7 @@ use crate::fetch::Cursor;
 fn mock_reader(path: &str) -> gix_packetline::StreamingPeekableIter<Cursor> {
     use crate::fixture_bytes;
     let buf = fixture_bytes(path);
-    gix_packetline::StreamingPeekableIter::new(Cursor::new(buf), &[gix_packetline::PacketLineRef::Flush])
+    gix_packetline::StreamingPeekableIter::new(Cursor::new(buf), &[gix_packetline::PacketLineRef::Flush], false)
 }
 
 fn id(hex: &str) -> gix_hash::ObjectId {
@@ -149,7 +149,11 @@ mod v1 {
         #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
         async fn all() -> crate::Result {
             let (caps, _) = Capabilities::from_bytes(&b"7814e8a05a59c0cf5fb186661d1551c75d1299b5 HEAD\0multi_ack thin-pack filter side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed symref=HEAD:refs/heads/master object-format=sha1 agent=git/2.28.0"[..])?;
-            let mut args = fetch::Arguments::new(Protocol::V1, Command::Fetch.default_features(Protocol::V1, &caps));
+            let mut args = fetch::Arguments::new(
+                Protocol::V1,
+                Command::Fetch.default_features(Protocol::V1, &caps),
+                false,
+            );
             assert!(
                 args.is_stateless(true /* transport is stateless */),
                 "V1 is stateless if the transport is connection oriented"
@@ -378,7 +382,11 @@ mod v2 {
         #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
         async fn all() -> crate::Result {
             let (caps, _) = Capabilities::from_bytes(&b"7814e8a05a59c0cf5fb186661d1551c75d1299b5 HEAD\0multi_ack thin-pack filter side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed symref=HEAD:refs/heads/master object-format=sha1 agent=git/2.28.0"[..])?;
-            let mut args = fetch::Arguments::new(Protocol::V2, Command::Fetch.default_features(Protocol::V1, &caps));
+            let mut args = fetch::Arguments::new(
+                Protocol::V2,
+                Command::Fetch.default_features(Protocol::V1, &caps),
+                false,
+            );
             assert!(args.can_use_shallow());
             assert!(args.can_use_deepen());
             assert!(args.can_use_deepen_not());

--- a/gix-protocol/tests/fetch/v1.rs
+++ b/gix-protocol/tests/fetch/v1.rs
@@ -26,6 +26,7 @@ async fn clone() -> crate::Result {
             progress::Discard,
             FetchConnection::TerminateOnSuccessfulCompletion,
             "agent",
+            false,
         )
         .await?;
         assert_eq!(dlg.pack_bytes, 876, "{fixture}: It be able to read pack bytes");
@@ -49,6 +50,7 @@ async fn clone_empty_with_capabilities() -> crate::Result {
         progress::Discard,
         FetchConnection::TerminateOnSuccessfulCompletion,
         "agent",
+        false,
     )
     .await?;
     assert_eq!(dlg.pack_bytes, 0, "there is no pack");
@@ -72,6 +74,7 @@ async fn ls_remote() -> crate::Result {
         progress::Discard,
         FetchConnection::AllowReuse,
         "agent",
+        false,
     )
     .await?;
 
@@ -115,6 +118,7 @@ async fn ls_remote_handshake_failure_due_to_downgrade() -> crate::Result {
         progress::Discard,
         FetchConnection::AllowReuse,
         "agent",
+        false,
     )
     .await
     .expect("V1 is OK for this transport");

--- a/gix-protocol/tests/fetch/v2.rs
+++ b/gix-protocol/tests/fetch/v2.rs
@@ -26,6 +26,7 @@ async fn clone_abort_prep() -> crate::Result {
         progress::Discard,
         FetchConnection::TerminateOnSuccessfulCompletion,
         "agent",
+        false,
     )
     .await
     .expect_err("fetch aborted");
@@ -72,6 +73,7 @@ async fn ls_remote() -> crate::Result {
         progress::Discard,
         FetchConnection::AllowReuse,
         "agent",
+        false,
     )
     .await?;
 
@@ -127,6 +129,7 @@ async fn ls_remote_abort_in_prep_ls_refs() -> crate::Result {
         progress::Discard,
         FetchConnection::AllowReuse,
         "agent",
+        false,
     )
     .await
     .expect_err("ls-refs preparation is aborted");
@@ -168,6 +171,7 @@ async fn ref_in_want() -> crate::Result {
         progress::Discard,
         FetchConnection::TerminateOnSuccessfulCompletion,
         "agent",
+        false,
     )
     .await?;
 

--- a/gix-transport/src/client/async_io/connect.rs
+++ b/gix-transport/src/client/async_io/connect.rs
@@ -36,6 +36,7 @@ pub(crate) mod function {
                         url.port,
                         path,
                         options.version,
+                        options.trace,
                     )
                     .await
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,

--- a/gix-transport/src/client/blocking_io/connect.rs
+++ b/gix-transport/src/client/blocking_io/connect.rs
@@ -30,12 +30,12 @@ pub(crate) mod function {
                     });
                 }
                 Box::new(
-                    crate::client::blocking_io::file::connect(url.path, options.version)
+                    crate::client::blocking_io::file::connect(url.path, options.version, options.trace)
                         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
                 )
             }
             gix_url::Scheme::Ssh => Box::new({
-                crate::client::blocking_io::ssh::connect(url, options.version, options.ssh)
+                crate::client::blocking_io::ssh::connect(url, options.version, options.ssh, options.trace)
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
             }),
             gix_url::Scheme::Git => {
@@ -52,6 +52,7 @@ pub(crate) mod function {
                         path,
                         options.version,
                         url.port,
+                        options.trace,
                     )
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
                 })
@@ -60,7 +61,7 @@ pub(crate) mod function {
             gix_url::Scheme::Https | gix_url::Scheme::Http => return Err(Error::CompiledWithoutHttp(url.scheme)),
             #[cfg(any(feature = "http-client-curl", feature = "http-client-reqwest"))]
             gix_url::Scheme::Https | gix_url::Scheme::Http => {
-                Box::new(crate::client::http::connect(url, options.version))
+                Box::new(crate::client::http::connect(url, options.version, options.trace))
             }
         })
     }

--- a/gix-transport/src/client/blocking_io/request.rs
+++ b/gix-transport/src/client/blocking_io/request.rs
@@ -10,10 +10,16 @@ pub struct RequestWriter<'a> {
     on_into_read: MessageKind,
     writer: gix_packetline::Writer<Box<dyn io::Write + 'a>>,
     reader: Box<dyn ExtendedBufRead + Unpin + 'a>,
+    trace: bool,
 }
 
 impl<'a> io::Write for RequestWriter<'a> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        #[allow(unused_imports)]
+        if self.trace {
+            use bstr::ByteSlice;
+            gix_features::trace::trace!(">> {}", buf.as_bstr());
+        }
         self.writer.write(buf)
     }
 
@@ -27,11 +33,13 @@ impl<'a> RequestWriter<'a> {
     /// Create a new instance from a `writer` (commonly a socket), a `reader` into which to transform once the
     /// writes are finished, along with configuration for the `write_mode` and information about which message to write
     /// when this instance is converted into a `reader` to read the request's response.
+    /// If `trace` is true, `gix_trace` will be used on every written message or data.
     pub fn new_from_bufread<W: io::Write + 'a>(
         writer: W,
         reader: Box<dyn ExtendedBufRead + Unpin + 'a>,
         write_mode: WriteMode,
         on_into_read: MessageKind,
+        trace: bool,
     ) -> Self {
         let mut writer = gix_packetline::Writer::new(Box::new(writer) as Box<dyn io::Write>);
         match write_mode {
@@ -42,16 +50,39 @@ impl<'a> RequestWriter<'a> {
             on_into_read,
             writer,
             reader,
+            trace,
         }
     }
 
     /// Write the given message as packet line.
     pub fn write_message(&mut self, message: MessageKind) -> io::Result<()> {
         match message {
-            MessageKind::Flush => gix_packetline::PacketLineRef::Flush.write_to(self.writer.inner_mut()),
-            MessageKind::Delimiter => gix_packetline::PacketLineRef::Delimiter.write_to(self.writer.inner_mut()),
-            MessageKind::ResponseEnd => gix_packetline::PacketLineRef::ResponseEnd.write_to(self.writer.inner_mut()),
-            MessageKind::Text(t) => gix_packetline::TextRef::from(t).write_to(self.writer.inner_mut()),
+            MessageKind::Flush => {
+                if self.trace {
+                    gix_features::trace::trace!(">> FLUSH");
+                }
+                gix_packetline::PacketLineRef::Flush.write_to(self.writer.inner_mut())
+            }
+            MessageKind::Delimiter => {
+                if self.trace {
+                    gix_features::trace::trace!(">> DELIM");
+                }
+                gix_packetline::PacketLineRef::Delimiter.write_to(self.writer.inner_mut())
+            }
+            MessageKind::ResponseEnd => {
+                if self.trace {
+                    gix_features::trace::trace!(">> RESPONSE_END");
+                }
+                gix_packetline::PacketLineRef::ResponseEnd.write_to(self.writer.inner_mut())
+            }
+            MessageKind::Text(t) => {
+                #[allow(unused_variables, unused_imports)]
+                if self.trace {
+                    use bstr::ByteSlice;
+                    gix_features::trace::trace!(">> {}", t.as_bstr());
+                }
+                gix_packetline::TextRef::from(t).write_to(self.writer.inner_mut())
+            }
         }
         .map(|_| ())
     }

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -93,11 +93,13 @@ pub mod connect {
 ///
 /// The `desired_version` is the preferred protocol version when establishing the connection, but note that it can be
 /// downgraded by servers not supporting it.
+/// If `trace` is `true`, all packetlines received or sent will be passed to the facilities of the `gix-trace` crate.
 #[allow(clippy::result_large_err)]
 pub fn connect(
     url: gix_url::Url,
     desired_version: Protocol,
     options: connect::Options,
+    trace: bool,
 ) -> Result<blocking_io::file::SpawnProcessOnDemand, Error> {
     if url.scheme != gix_url::Scheme::Ssh || url.host().is_none() {
         return Err(Error::UnsupportedScheme(url));
@@ -134,6 +136,7 @@ pub fn connect(
         kind,
         options.disallow_shell,
         desired_version,
+        trace,
     ))
 }
 

--- a/gix-transport/src/client/blocking_io/traits.rs
+++ b/gix-transport/src/client/blocking_io/traits.rs
@@ -66,12 +66,15 @@ impl<T: Transport + ?Sized> Transport for &mut T {
 pub trait TransportV2Ext {
     /// Invoke a protocol V2 style `command` with given `capabilities` and optional command specific `arguments`.
     /// The `capabilities` were communicated during the handshake.
+    /// If `trace` is `true`, then all packetlines written and received will be traced using facilities provided by the `gix_trace` crate.
+    ///
     /// _Note:_ panics if [handshake][Transport::handshake()] wasn't performed beforehand.
     fn invoke<'a>(
         &mut self,
         command: &str,
         capabilities: impl Iterator<Item = (&'a str, Option<impl AsRef<str>>)> + 'a,
         arguments: Option<impl Iterator<Item = bstr::BString>>,
+        trace: bool,
     ) -> Result<Box<dyn ExtendedBufRead + Unpin + '_>, Error>;
 }
 
@@ -81,8 +84,9 @@ impl<T: Transport> TransportV2Ext for T {
         command: &str,
         capabilities: impl Iterator<Item = (&'a str, Option<impl AsRef<str>>)> + 'a,
         arguments: Option<impl Iterator<Item = BString>>,
+        trace: bool,
     ) -> Result<Box<dyn ExtendedBufRead + Unpin + '_>, Error> {
-        let mut writer = self.request(WriteMode::OneLfTerminatedLinePerWriteCall, MessageKind::Flush)?;
+        let mut writer = self.request(WriteMode::OneLfTerminatedLinePerWriteCall, MessageKind::Flush, trace)?;
         writer.write_all(format!("command={command}").as_bytes())?;
         for (name, value) in capabilities {
             match value {

--- a/gix-transport/src/client/non_io_types.rs
+++ b/gix-transport/src/client/non_io_types.rs
@@ -40,6 +40,8 @@ pub(crate) mod connect {
         #[cfg(feature = "blocking-client")]
         /// Options to use if the scheme of the URL is `ssh`.
         pub ssh: crate::client::ssh::connect::Options,
+        /// If `true`, all packetlines received or sent will be passed to the facilities of the `gix-trace` crate.
+        pub trace: bool,
     }
 
     /// The error used in [`connect()`][crate::connect()].

--- a/gix-transport/src/client/traits.rs
+++ b/gix-transport/src/client/traits.rs
@@ -26,8 +26,14 @@ pub trait TransportWithoutIO {
     /// to support the task at hand.
     /// `write_mode` determines how calls to the `write(…)` method are interpreted, and `on_into_read` determines
     /// which message to write when the writer is turned into the response reader using [`into_read()`][RequestWriter::into_read()].
+    /// If `trace` is `true`, then all packetlines written and received will be traced using facilities provided by the `gix_trace` crate.
     #[cfg(any(feature = "blocking-client", feature = "async-client"))]
-    fn request(&mut self, write_mode: WriteMode, on_into_read: MessageKind) -> Result<RequestWriter<'_>, Error>;
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, Error>;
 
     /// Returns the canonical URL pointing to the destination of this transport.
     fn to_url(&self) -> Cow<'_, BStr>;
@@ -66,8 +72,13 @@ impl<T: TransportWithoutIO + ?Sized> TransportWithoutIO for Box<T> {
     }
 
     #[cfg(any(feature = "blocking-client", feature = "async-client"))]
-    fn request(&mut self, write_mode: WriteMode, on_into_read: MessageKind) -> Result<RequestWriter<'_>, Error> {
-        self.deref_mut().request(write_mode, on_into_read)
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, Error> {
+        self.deref_mut().request(write_mode, on_into_read, trace)
     }
 
     fn to_url(&self) -> Cow<'_, BStr> {
@@ -93,8 +104,13 @@ impl<T: TransportWithoutIO + ?Sized> TransportWithoutIO for &mut T {
     }
 
     #[cfg(any(feature = "blocking-client", feature = "async-client"))]
-    fn request(&mut self, write_mode: WriteMode, on_into_read: MessageKind) -> Result<RequestWriter<'_>, Error> {
-        self.deref_mut().request(write_mode, on_into_read)
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, Error> {
+        self.deref_mut().request(write_mode, on_into_read, trace)
     }
 
     fn to_url(&self) -> Cow<'_, BStr> {

--- a/gix-transport/tests/client/blocking_io/http/mock.rs
+++ b/gix-transport/tests/client/blocking_io/http/mock.rs
@@ -105,7 +105,7 @@ pub fn serve_and_connect(
         &server.addr.port(),
         path
     );
-    let client = gix_transport::client::http::connect(url_str.as_str().try_into()?, version);
+    let client = gix_transport::client::http::connect(url_str.as_str().try_into()?, version, false);
     assert_eq!(url_str, client.to_url().as_ref());
     Ok((server, client))
 }

--- a/gix-transport/tests/client/capabilities.rs
+++ b/gix-transport/tests/client/capabilities.rs
@@ -55,7 +55,7 @@ async fn from_lines_with_version_detection_v0() -> crate::Result {
     let mut buf = Vec::<u8>::new();
     gix_packetline::encode::flush_to_write(&mut buf).await?;
     let mut stream =
-        gix_packetline::StreamingPeekableIter::new(buf.as_slice(), &[gix_packetline::PacketLineRef::Flush]);
+        gix_packetline::StreamingPeekableIter::new(buf.as_slice(), &[gix_packetline::PacketLineRef::Flush], false);
     let caps = Capabilities::from_lines_with_version_detection(&mut stream)
         .await
         .expect("we can parse V0 as very special case, useful for testing stateful connections in other crates")

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -28,6 +28,7 @@ async fn handshake_v1_and_request() -> crate::Result {
         "/foo.git",
         Some(("example.org", None)),
         git::ConnectMode::Daemon,
+        false,
     );
     assert!(
         c.connection_persists_across_multiple_requests(),
@@ -86,7 +87,7 @@ async fn handshake_v1_and_request() -> crate::Result {
     );
     drop(res);
 
-    let writer = c.request(client::WriteMode::Binary, client::MessageKind::Flush)?;
+    let writer = c.request(client::WriteMode::Binary, client::MessageKind::Flush, false)?;
     let nak_line = writer
         .into_read()
         .await?
@@ -99,6 +100,7 @@ async fn handshake_v1_and_request() -> crate::Result {
     let mut writer = c.request(
         client::WriteMode::OneLfTerminatedLinePerWriteCall,
         client::MessageKind::Text(b"done"),
+        false,
     )?;
 
     writer.write_all(b"hello").await?;
@@ -158,9 +160,10 @@ async fn push_v1_simulated() -> crate::Result {
         "/foo.git",
         Some(("example.org", None)),
         git::ConnectMode::Process,
+        false,
     );
 
-    let mut writer = c.request(client::WriteMode::Binary, client::MessageKind::Flush)?;
+    let mut writer = c.request(client::WriteMode::Binary, client::MessageKind::Flush, false)?;
     let expected = fixture_bytes("v1/push.request");
     writer.write_all(b"7c09ba0c4c3680af369bda4fc8e3c58d3fccdc76 32690d87d3943c7c0dda81246d0cde344ca7e633 refs/heads/main\0 report-status-v2 side-band-64k object-format=sha1 agent=git/2.37.1.(Apple.Git-137.1)").await?;
     writer.write_message(client::MessageKind::Flush).await?;
@@ -223,6 +226,7 @@ async fn handshake_v1_process_mode() -> crate::Result {
         "/foo.git",
         Some(("example.org", None)),
         git::ConnectMode::Process,
+        false,
     );
     c.handshake(Service::UploadPack, &[]).await?;
 
@@ -245,6 +249,7 @@ async fn handshake_v2_downgrade_to_v1() -> crate::Result {
         "/bar.git",
         Some(("example.org", None)),
         git::ConnectMode::Daemon,
+        false,
     );
     let res = c.handshake(Service::UploadPack, &[]).await?;
     assert_eq!(res.actual_protocol, Protocol::V1);
@@ -291,6 +296,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
         "/bar.git",
         Some(("example.org", None)),
         git::ConnectMode::Daemon,
+        false,
     );
     assert!(
         c.connection_persists_across_multiple_requests(),
@@ -337,6 +343,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
                 .iter()
                 .map(|s| s.as_bytes().as_bstr().to_owned()),
             ),
+            false,
         )
         .await?;
 
@@ -375,6 +382,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
                 .iter()
                 .map(|s| s.as_bytes().as_bstr().to_owned()),
             ),
+            false,
         )
         .await?;
 

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -54,6 +54,17 @@ impl Cache {
         ("agent", Some(gix_protocol::agent(agent).into()))
     }
 
+    /// Return `true` if packet-tracing is enabled. Lenient and defaults to `false`.
+    #[cfg(any(feature = "async-network-client", feature = "blocking-network-client"))]
+    pub(crate) fn trace_packet(&self) -> bool {
+        use crate::config::tree::Section;
+        use config::tree::Gitoxide;
+        self.resolved
+            .boolean(Gitoxide.name(), None, Gitoxide::TRACE_PACKET.name())
+            .and_then(Result::ok)
+            .unwrap_or_default()
+    }
+
     pub(crate) fn personas(&self) -> &identity::Personas {
         self.personas
             .get_or_init(|| identity::Personas::from_config_and_env(&self.resolved))

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -4,6 +4,7 @@ use std::{borrow::Cow, ffi::OsString};
 use gix_sec::Permission;
 
 use super::{interpolate_context, util, Error, StageOne};
+use crate::config::tree::Gitoxide;
 use crate::{
     bstr::BString,
     config,
@@ -336,6 +337,15 @@ fn apply_environment_overrides(
                     (env(key), key.name)
                 },
             ][..],
+        ),
+        (
+            "gitoxide",
+            None,
+            git_prefix,
+            &[{
+                let key = &Gitoxide::TRACE_PACKET;
+                (env(key), key.name)
+            }],
         ),
         (
             "gitoxide",

--- a/gix/src/config/tree/sections/gitoxide.rs
+++ b/gix/src/config/tree/sections/gitoxide.rs
@@ -31,6 +31,9 @@ impl Gitoxide {
     pub const USER_AGENT: keys::Any = keys::Any::new("userAgent", &config::Tree::GITOXIDE).with_note(
         "The user agent presented on the git protocol layer, serving as fallback for when no `http.userAgent` is set",
     );
+    /// The `gitoxide.tracePacket` Key.
+    pub const TRACE_PACKET: keys::Boolean = keys::Boolean::new_boolean("tracePacket", &config::Tree::GITOXIDE)
+        .with_environment_override("GIX_TRACE_PACKET");
 }
 
 impl Section for Gitoxide {
@@ -39,7 +42,7 @@ impl Section for Gitoxide {
     }
 
     fn keys(&self) -> &[&dyn Key] {
-        &[&Self::USER_AGENT]
+        &[&Self::USER_AGENT, &Self::TRACE_PACKET]
     }
 
     fn sub_sections(&self) -> &[&dyn Section] {

--- a/gix/src/remote/connect.rs
+++ b/gix/src/remote/connect.rs
@@ -57,11 +57,13 @@ impl<'repo> Remote<'repo> {
     where
         T: Transport,
     {
+        let trace = self.repo.config.trace_packet();
         Connection {
             remote: self,
             authenticate: None,
             transport_options: None,
             transport,
+            trace,
         }
     }
 
@@ -91,6 +93,7 @@ impl<'repo> Remote<'repo> {
                     .then(|| self.repo.ssh_connect_options())
                     .transpose()?
                     .unwrap_or_default(),
+                trace: self.repo.config.trace_packet(),
             },
         )
         .await?;

--- a/gix/src/remote/connection/fetch/mod.rs
+++ b/gix/src/remote/connection/fetch/mod.rs
@@ -281,12 +281,13 @@ where
                 //       connection in an async context.
                 gix_protocol::futures_lite::future::block_on(gix_protocol::indicate_end_of_interaction(
                     &mut con.transport,
+                    con.trace,
                 ))
                 .ok();
             }
             #[cfg(not(feature = "async-network-client"))]
             {
-                gix_protocol::indicate_end_of_interaction(&mut con.transport).ok();
+                gix_protocol::indicate_end_of_interaction(&mut con.transport, con.trace).ok();
             }
         }
     }

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -104,7 +104,7 @@ where
 
         gix_protocol::fetch::Response::check_required_features(protocol_version, &fetch_features)?;
         let sideband_all = fetch_features.iter().any(|(n, _)| *n == "sideband-all");
-        let mut arguments = gix_protocol::fetch::Arguments::new(protocol_version, fetch_features);
+        let mut arguments = gix_protocol::fetch::Arguments::new(protocol_version, fetch_features, con.trace);
         if matches!(con.remote.fetch_tags, crate::remote::fetch::Tags::Included) {
             if !arguments.can_use_include_tag() {
                 return Err(Error::MissingServerFeature {
@@ -158,7 +158,9 @@ where
         let mut previous_response = None::<gix_protocol::fetch::Response>;
         let (mut write_pack_bundle, negotiate) = match &action {
             negotiate::Action::NoChange | negotiate::Action::SkipToRefUpdate => {
-                gix_protocol::indicate_end_of_interaction(&mut con.transport).await.ok();
+                gix_protocol::indicate_end_of_interaction(&mut con.transport, con.trace)
+                    .await
+                    .ok();
                 (None, None)
             }
             negotiate::Action::MustNegotiate {
@@ -209,7 +211,9 @@ where
                             is_done
                         }
                         Err(err) => {
-                            gix_protocol::indicate_end_of_interaction(&mut con.transport).await.ok();
+                            gix_protocol::indicate_end_of_interaction(&mut con.transport, con.trace)
+                                .await
+                                .ok();
                             return Err(err.into());
                         }
                     };
@@ -287,7 +291,9 @@ where
                 drop(reader);
 
                 if matches!(protocol_version, gix_protocol::transport::Protocol::V2) {
-                    gix_protocol::indicate_end_of_interaction(&mut con.transport).await.ok();
+                    gix_protocol::indicate_end_of_interaction(&mut con.transport, con.trace)
+                        .await
+                        .ok();
                 }
 
                 if let Some(shallow_lock) = shallow_lock {

--- a/gix/src/remote/connection/mod.rs
+++ b/gix/src/remote/connection/mod.rs
@@ -17,6 +17,7 @@ pub struct Connection<'a, 'repo, T> {
     pub(crate) authenticate: Option<AuthenticateFn<'a>>,
     pub(crate) transport_options: Option<Box<dyn std::any::Any>>,
     pub(crate) transport: T,
+    pub(crate) trace: bool,
 }
 
 mod access;

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -31,6 +31,7 @@ pub mod async_util {
 
     pub fn prepare(
         verbose: bool,
+        trace: bool,
         name: &str,
         range: impl Into<Option<ProgressRange>>,
     ) -> (
@@ -41,7 +42,7 @@ pub mod async_util {
         shared::init_env_logger();
 
         if verbose {
-            let progress = shared::progress_tree();
+            let progress = shared::progress_tree(trace);
             let sub_progress = progress.add_child(name);
             let ui_handle = shared::setup_line_renderer_range(&progress, range.into().unwrap_or(STANDARD_RANGE));
             (Some(ui_handle), Some(sub_progress).into())
@@ -416,6 +417,7 @@ pub fn main() -> Result<()> {
                     {
                         let (_handle, progress) = async_util::prepare(
                             auto_verbose,
+                            trace,
                             "remote-refs",
                             Some(core::repository::remote::refs::PROGRESS_RANGE),
                         );
@@ -626,7 +628,7 @@ pub fn main() -> Result<()> {
                     refs_directory,
                 } => {
                     let (_handle, progress) =
-                        async_util::prepare(verbose, "pack-receive", core::pack::receive::PROGRESS_RANGE);
+                        async_util::prepare(verbose, trace, "pack-receive", core::pack::receive::PROGRESS_RANGE);
                     let fut = core::pack::receive(
                         protocol,
                         &url,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -83,8 +83,15 @@ pub fn main() -> Result<()> {
 
     let repository = {
         let config = config.clone();
-        move |mode: Mode| -> Result<gix::Repository> {
+        move |mut mode: Mode| -> Result<gix::Repository> {
             let mut mapping: gix::sec::trust::Mapping<gix::open::Options> = Default::default();
+            if !config.is_empty() {
+                mode = match mode {
+                    Mode::Lenient => Mode::Strict,
+                    Mode::LenientWithGitInstallConfig => Mode::StrictWithGitInstallConfig,
+                    _ => mode,
+                };
+            }
             let strict_toggle = matches!(mode, Mode::Strict | Mode::StrictWithGitInstallConfig) || args.strict;
             mapping.full = mapping.full.strict_config(strict_toggle);
             mapping.reduced = mapping.reduced.strict_config(strict_toggle);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -20,9 +20,9 @@ pub fn init_env_logger() {
 }
 
 #[cfg(feature = "prodash-render-line")]
-pub fn progress_tree() -> std::sync::Arc<prodash::tree::Root> {
+pub fn progress_tree(trace: bool) -> std::sync::Arc<prodash::tree::Root> {
     prodash::tree::root::Options {
-        message_buffer_capacity: 200,
+        message_buffer_capacity: if trace { 10_000 } else { 200 },
         ..Default::default()
     }
     .into()
@@ -55,7 +55,7 @@ pub mod pretty {
     #[cfg(feature = "small")]
     pub fn prepare_and_run<T>(
         name: &str,
-        _trace: bool,
+        trace: bool,
         verbose: bool,
         progress: bool,
         #[cfg_attr(not(feature = "prodash-render-tui"), allow(unused_variables))] progress_keep_open: bool,
@@ -77,7 +77,7 @@ pub mod pretty {
                 run(progress::DoOrDiscard::from(None), &mut stdout_lock, &mut stderr_lock)
             }
             (true, false) => {
-                let progress = crate::shared::progress_tree();
+                let progress = crate::shared::progress_tree(trace);
                 let sub_progress = progress.add_child(name);
 
                 use crate::shared::{self, STANDARD_RANGE};
@@ -157,7 +157,7 @@ pub mod pretty {
             }
             (true, false) => {
                 use crate::shared::{self, STANDARD_RANGE};
-                let progress = shared::progress_tree();
+                let progress = shared::progress_tree(trace);
                 let sub_progress = progress.add_child(name);
                 init_tracing(trace, false, &progress)?;
 


### PR DESCRIPTION
Related to #1061 

The difficulty here is to make that configurable without the primary use of environment variables so that a flag can be passed down from the porcelain to plumbing.
