### PR TITLE
add version information to dev-dependencies of gix-command

### DIFF
--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -15,4 +15,4 @@ doctest = false
 bstr = { version = "1.5.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-gix-testtools = { path = "../tests/tools" }
+gix-testtools = { path = "../tests/tools", version = "0.13.0" }


### PR DESCRIPTION
The published crate is missing the dev-dependencies: https://docs.rs/crate/gix-command/0.2.10/source/Cargo.toml

Which makes it harder to run the unittests for the crate when we package it for Debian.

This is the change that removes the dependencies: https://github.com/rust-lang/cargo/pull/7333 