### PR TITLE
Add feature to allow using rustls without trust-dns

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -124,8 +124,10 @@ blocking-http-transport-curl = ["blocking-network-client", "gix-transport/http-c
 blocking-http-transport-curl-rustls = ["blocking-http-transport-curl", "dep:curl-for-configuration-only", "curl-for-configuration-only?/rustls"]
 ## Stacks with `blocking-network-client` to provide support for HTTP/S using **reqwest**, and implies blocking networking as a whole, making the `https://` transport avaialble.
 blocking-http-transport-reqwest = ["blocking-network-client", "gix-transport/http-client-reqwest"]
-## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `rustls` crate.
+## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `rustls` crate. Enables `trust-dns` on `reqwest`.
 blocking-http-transport-reqwest-rust-tls = ["blocking-http-transport-reqwest", "reqwest-for-configuration-only/rustls-tls", "reqwest-for-configuration-only/trust-dns"]
+## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `rustls` crate. 
+blocking-http-transport-reqwest-rust-tls-no-trust-dns = ["blocking-http-transport-reqwest", "reqwest-for-configuration-only/rustls-tls"]
 ## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `native-tls` crate.
 blocking-http-transport-reqwest-native-tls = ["blocking-http-transport-reqwest", "reqwest-for-configuration-only/default-tls" ]
 


### PR DESCRIPTION
Using `gitoxide` with bloop, we have observed that putting a laptop to sleep and waking it up often causes intermittent network errors. Using `trust-dns`, the DNS lookups never seem to recover, while using `hyper` directly works.

There's a related issue in [`reqwest`](https://github.com/seanmonstar/reqwest/pull/437) which seems to also point in this direction, and my own testing confirms disabling `trust-dns` resolves this issue.

It would be helpful to include this feature in the mainline repository so we aren't forced to use a fork or other workarounds.