### PR TITLE
fix: prevent underflows while trying to `abs()` very large numbers.

### DIFF
--- a/gix-date/src/time/write.rs
+++ b/gix-date/src/time/write.rs
@@ -23,8 +23,8 @@ impl Time {
 
         const ZERO: &[u8; 1] = b"0";
 
-        const SECONDS_PER_HOUR: i32 = 60 * 60;
-        let offset = self.offset.abs();
+        const SECONDS_PER_HOUR: u32 = 60 * 60;
+        let offset = self.offset.unsigned_abs();
         let hours = offset / SECONDS_PER_HOUR;
         assert!(hours < 25, "offset is more than a day: {hours}");
         let minutes = (offset - (hours * SECONDS_PER_HOUR)) / 60;

--- a/gix-revision/src/spec/parse/function.rs
+++ b/gix-revision/src/spec/parse/function.rs
@@ -422,7 +422,7 @@ where
                 if n < 0 {
                     if name.is_empty() {
                         delegate
-                            .nth_checked_out_branch(n.abs().try_into().expect("non-negative isize fits usize"))
+                            .nth_checked_out_branch(n.unsigned_abs())
                             .ok_or(Error::Delegate)?;
                     } else {
                         return Err(Error::RefnameNeedsPositiveReflogEntries { nav: nav.into() });

--- a/gix-revision/tests/spec/parse/anchor/at_symbol.rs
+++ b/gix-revision/tests/spec/parse/anchor/at_symbol.rs
@@ -11,6 +11,13 @@ fn braces_must_be_closed() {
 }
 
 #[test]
+#[cfg_attr(target_pointer_width = "32", ignore = "Only works this way on 64 bit systems")]
+fn fuzzed() {
+    let rec = parse("@{-9223372036854775808}");
+    assert_eq!(rec.nth_checked_out_branch, [Some(9223372036854775808), None]);
+}
+
+#[test]
 fn reflog_by_entry_for_current_branch() {
     for (spec, expected_entry) in [("@{0}", 0), ("@{42}", 42), ("@{00100}", 100)] {
         let rec = parse(spec);


### PR DESCRIPTION
For example, "@{-9223372036854775808}" could trigger a panic previously.
