### PR TITLE
Bug template includes question about Git behavior

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,10 @@ body:
       description: Describe what should happen.
   - type: textarea
     attributes:
+      label: Git behavior
+      description: Describe what Git does under similar circumstances.
+  - type: textarea
+    attributes:
       label: Steps to reproduce 🕹
       description: Describe how we can reproduce the behaviour.
       placeholder: |


### PR DESCRIPTION
I'm getting embarrassed by all the times Byron has to remind me to include Git behavior in issues, so here's a template field to remind me :smile: 

Seriously though, it is often useful to have the official client's behavior as a baseline when considering bugs.