### PR TITLE
feat: add the `gitoxide.credentials.terminalPrompt` key to represent the GIT_TERMINAL_PROMPT (#1090)

### DIFF
--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -387,6 +387,15 @@ fn apply_environment_overrides(
         ),
         (
             "gitoxide",
+            Some(Cow::Borrowed("credentials".into())),
+            git_prefix,
+            &[{
+                let key = &gitoxide::Credentials::TERMINAL_PROMPT;
+                (env(key), key.name)
+            }],
+        ),
+        (
+            "gitoxide",
             Some(Cow::Borrowed("committer".into())),
             identity,
             &[

--- a/gix/src/config/tree/sections/gitoxide.rs
+++ b/gix/src/config/tree/sections/gitoxide.rs
@@ -14,6 +14,8 @@ impl Gitoxide {
     pub const COMMIT: Commit = Commit;
     /// The `gitoxide.committer` section.
     pub const COMMITTER: Committer = Committer;
+    /// The `gitoxide.credentials` section.
+    pub const CREDENTIALS: Credentials = Credentials;
     /// The `gitoxide.http` section.
     pub const HTTP: Http = Http;
     /// The `gitoxide.https` section.
@@ -427,6 +429,30 @@ mod subsections {
         }
     }
 
+    /// The `credentials` sub-section.
+    #[derive(Copy, Clone, Default)]
+    pub struct Credentials;
+    impl Credentials {
+        /// The `gitoxide.credentials.terminalPrompt` key.
+        pub const TERMINAL_PROMPT: keys::Boolean = keys::Boolean::new_boolean("terminalPrompt", &Gitoxide::CREDENTIALS)
+            .with_note("This is a custom addition to provide an alternative to the respective environment variable.")
+            .with_environment_override("GIT_TERMINAL_PROMPT");
+    }
+
+    impl Section for Credentials {
+        fn name(&self) -> &str {
+            "credentials"
+        }
+
+        fn keys(&self) -> &[&dyn Key] {
+            &[&Self::TERMINAL_PROMPT]
+        }
+
+        fn parent(&self) -> Option<&dyn Section> {
+            Some(&Tree::GITOXIDE)
+        }
+    }
+
     /// The `commit` sub-section.
     #[derive(Copy, Clone, Default)]
     pub struct Commit;
@@ -454,7 +480,7 @@ mod subsections {
         }
     }
 }
-pub use subsections::{Allow, Author, Commit, Committer, Core, Http, Https, Objects, Pathspec, Ssh, User};
+pub use subsections::{Allow, Author, Commit, Committer, Core, Credentials, Http, Https, Objects, Pathspec, Ssh, User};
 
 pub mod validate {
     use std::error::Error;

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -48,6 +48,7 @@ mod with_overrides {
             .set("GIT_GLOB_PATHSPECS", "pathspecs-glob")
             .set("GIT_NOGLOB_PATHSPECS", "pathspecs-noglob")
             .set("GIT_ICASE_PATHSPECS", "pathspecs-icase")
+            .set("GIT_TERMINAL_PROMPT", "42")
             .set("GIT_SHALLOW_FILE", "shallow-file-env");
         let mut opts = gix::open::Options::isolated()
             .cli_overrides([
@@ -234,6 +235,7 @@ mod with_overrides {
             ("gitoxide.pathspec.glob", "pathspecs-glob"),
             ("gitoxide.pathspec.noglob", "pathspecs-noglob"),
             ("gitoxide.pathspec.literal", "pathspecs-literal"),
+            ("gitoxide.credentials.terminalPrompt", "42"),
         ] {
             assert_eq!(
                 config


### PR DESCRIPTION
That way, it's easy to control the usage of terminals without using and environment.
