### PR TITLE
drop "MIT License" line from LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,3 @@
-MIT License
-
 Copyright (c) 2018-2021 Sebastian Thiel, and [contributors](https://github.com/byron/gitoxide/contributors).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Since jj now uses gitoxide, I need to import many gitoxide crates into Google's source control system. The automation at Google doesn't like the "MIT License" line at the beginning of the LICENSE-MIT file. AFAICT, the automation is correct in thinking that the line is not supposed to be there.

