### PR TITLE
fix: Allow multiple packs to be received one after another. (#972)

### DIFF
--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -281,10 +281,19 @@ where
                         })),
                         options,
                     )?;
+                    // Assure the final flush packet is consumed.
+                    #[cfg(feature = "async-network-client")]
+                    let has_read_to_end = { rd.get_ref().stopped_at().is_some() };
+                    #[cfg(not(feature = "async-network-client"))]
+                    let has_read_to_end = { rd.stopped_at().is_some() };
+                    if !has_read_to_end {
+                        std::io::copy(&mut rd, &mut std::io::sink()).unwrap();
+                    }
                     #[cfg(feature = "async-network-client")]
                     {
                         reader = rd.into_inner();
                     }
+
                     #[cfg(not(feature = "async-network-client"))]
                     {
                         reader = rd;


### PR DESCRIPTION
Previously it would be difficult to perform another fetch operation on the
same connection as the final flush packet after a pack wouldn't be consumed.

This has now been mitigated by consuming it in the one place where knoweldge
about this specialty exists.
