### PR TITLE
Make gix crates ready for automatic cfg checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,29 +173,6 @@ jobs:
           # than allows is no problem either if it comes to that.
           just check-size || true
   
-  lint-nightly:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: clippy,rustfmt
-      - uses: extractions/setup-just@v1
-      - name: Run cargo check -Zcheck-cfg
-        if: '!cancelled()'
-        run: cargo check -Zcheck-cfg
-      - name: Run cargo clippy
-        if: '!cancelled()'
-        run: just clippy -D warnings
-      - name: Run cargo doc
-        if: '!cancelled()'
-        run: just doc
-      - name: Run cargo fmt
-        if: '!cancelled()'
-        run: cargo fmt --all -- --check
-
   cargo-deny:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,29 @@ jobs:
           # Let's not fail CI for this, it will fail locally often enough, and a crate a little bigger
           # than allows is no problem either if it comes to that.
           just check-size || true
+  
+  lint-nightly:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: clippy,rustfmt
+      - uses: extractions/setup-just@v1
+      - name: Run cargo check -Zcheck-cfg
+        if: '!cancelled()'
+        run: cargo check -Zcheck-cfg
+      - name: Run cargo clippy
+        if: '!cancelled()'
+        run: just clippy -D warnings
+      - name: Run cargo doc
+        if: '!cancelled()'
+        run: just doc
+      - name: Run cargo fmt
+        if: '!cancelled()'
+        run: cargo fmt --all -- --check
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ name = "gix-fs"
 version = "0.8.0"
 dependencies = [
  "gix-features 0.36.0",
+ "serde",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,4 +302,3 @@ prodash = { version = "26.2.2", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["document-features", "max"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -93,4 +93,3 @@ document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["document-features", "blocking-client", "organize", "estimate-hours", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -22,10 +22,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(feature = "async-client", allow(unused))]
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -37,4 +37,3 @@ gix-hash = { path = "../gix-hash" }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-actor/src/lib.rs
+++ b/gix-actor/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -53,4 +53,3 @@ gix-filter = { path = "../gix-filter"}
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-archive/src/lib.rs
+++ b/gix-archive/src/lib.rs
@@ -9,10 +9,10 @@
 //! ## Feature Flags
 //! All features are related to which container formats are available.
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms, missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -37,5 +37,4 @@ gix-fs = { path = "../gix-fs" }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 features = ["document-features"]

--- a/gix-attributes/src/lib.rs
+++ b/gix-attributes/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub use gix_glob as glob;

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -36,4 +36,3 @@ gix-date = { path = "../gix-date" }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-commitgraph/src/lib.rs
+++ b/gix-commitgraph/src/lib.rs
@@ -9,10 +9,10 @@
 //! Eventually, git will merge these files together as the number of files grows.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::path::Path;

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -32,4 +32,3 @@ libc = "0.2"
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-config-value/src/lib.rs
+++ b/gix-config-value/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// The error returned when any config value couldn't be instantiated due to malformed input.

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -46,4 +46,3 @@ path = "./benches/large_config_file.rs"
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-config/src/lib.rs
+++ b/gix-config/src/lib.rs
@@ -31,10 +31,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 pub mod file;

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -40,4 +40,3 @@ gix-sec = { path = "../gix-sec" }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-credentials/src/lib.rs
+++ b/gix-credentials/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -33,4 +33,3 @@ gix-hash = { path = "../gix-hash" }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-date/src/lib.rs
+++ b/gix-date/src/lib.rs
@@ -3,10 +3,10 @@
 //! Note that this is not a general purpose time library.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -37,4 +37,3 @@ document-features = { version = "0.2.0", optional = true }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-diff/src/lib.rs
+++ b/gix-diff/src/lib.rs
@@ -1,10 +1,10 @@
 //! Algorithms for diffing various git object types and for generating patches, highly optimized for performance.
 //! ## Feature Flags
 #![cfg_attr(
-feature = "document-features",
-cfg_attr(doc, doc = ::document_features::document_features!())
+all(doc, feature = "document-features"),
+doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -159,4 +159,3 @@ sha1 = { version = "0.10.0", optional = true, features = ["asm"] }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-features/src/lib.rs
+++ b/gix-features/src/lib.rs
@@ -8,10 +8,10 @@
 //! counterparts with higher performance.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -12,8 +12,13 @@ include = ["src/**/*", "LICENSE-*"]
 [lib]
 doctest = false
 
+[features]
+## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+serde = ["dep:serde"]
+
 [dependencies]
 gix-features = { version = "^0.36.0", path = "../gix-features" }
+serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -31,4 +31,3 @@ gix-testtools = { path = "../tests/tools"}
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-glob/src/lib.rs
+++ b/gix-glob/src/lib.rs
@@ -1,10 +1,10 @@
 //! Provide glob [`Patterns`][Pattern] for matching against paths or anything else.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -31,4 +31,3 @@ gix-features = { path = "../gix-features", features = ["rustsha1"] }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-hash/src/lib.rs
+++ b/gix-hash/src/lib.rs
@@ -3,10 +3,10 @@
 //! These are provided in [borrowed versions][oid] as well as an [owned one][ObjectId].
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 #[path = "oid.rs"]

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -32,5 +32,4 @@ gix-fs = { path = "../gix-fs" }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 features = ["document-features"]

--- a/gix-ignore/src/lib.rs
+++ b/gix-ignore/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -47,4 +47,3 @@ libc = { version = "0.2.149" }
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-index/src/lib.rs
+++ b/gix-index/src/lib.rs
@@ -1,9 +1,9 @@
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(unsafe_code, missing_docs, rust_2018_idioms)]
 
 use std::{ops::Range, path::PathBuf};

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -31,4 +31,3 @@ gix-testtools = { path = "../tests/tools"}
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-mailmap/src/lib.rs
+++ b/gix-mailmap/src/lib.rs
@@ -2,10 +2,10 @@
 //! using an [accelerated data-structure][Snapshot].
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -52,5 +52,4 @@ gix-testtools = { path = "../tests/tools"}
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]
 

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -2,10 +2,10 @@
 //! as well as [mutable versions][Object] of these. Both types of objects can be encoded.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -44,4 +44,3 @@ document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -9,10 +9,10 @@
 //! * multiple loose objects and pack locations as gathered from `alternates` files.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::{

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -66,4 +66,3 @@ gix-testtools = { path = "../tests/tools"}
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features", "pack-cache-lru-dynamic", "object-cache-dynamic", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-pack/src/lib.rs
+++ b/gix-pack/src/lib.rs
@@ -12,10 +12,10 @@
 //! in order to decompress packs in parallel and without any waste.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -19,6 +19,9 @@ default = ["blocking-io"]
 ## If set, all IO will become blocking. The same types will be used preventing side-by-side usage of blocking and non-blocking IO.
 blocking-io = []
 
+## DO NOT USE, use instead directly gix-packetline
+async-io = []
+
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "bstr/serde"]

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -35,4 +35,3 @@ document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["document-features", "blocking-io", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -61,4 +61,3 @@ maybe-async = "0.2.6"
 
 [package.metadata.docs.rs]
 features = ["document-features", "blocking-io", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-packetline/src/lib.rs
+++ b/gix-packetline/src/lib.rs
@@ -3,10 +3,10 @@
 //! For reading the packet line format use the [`StreamingPeekableIter`], and for writing the [`Writer`].
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, all(doc, feature = "document-features")),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 const U16_HEX_BYTES: usize = 4;

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -67,4 +67,3 @@ gix-testtools = { path = "../tests/tools" }
 
 [package.metadata.docs.rs]
 features = ["blocking-client", "document-features", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-protocol/src/lib.rs
+++ b/gix-protocol/src/lib.rs
@@ -4,10 +4,10 @@
 //! the actual client implementation.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// A selector for V2 commands to invoke on the server for purpose of pre-invocation validation.

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -45,4 +45,3 @@ gix-testtools = { path = "../tests/tools" }
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-ref/src/lib.rs
+++ b/gix-ref/src/lib.rs
@@ -17,10 +17,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::borrow::Cow;

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -42,4 +42,3 @@ gix-commitgraph = { path = "../gix-commitgraph" }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-revision/src/lib.rs
+++ b/gix-revision/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -41,4 +41,3 @@ tempfile = "3.3.0"
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-sec/src/lib.rs
+++ b/gix-sec/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 // `unsafe_code` not forbidden because we need to interact with the libc
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 

--- a/gix-tempfile/Cargo.toml
+++ b/gix-tempfile/Cargo.toml
@@ -54,5 +54,4 @@ libc = { version = "0.2.98", default-features = false }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]
 

--- a/gix-tempfile/src/lib.rs
+++ b/gix-tempfile/src/lib.rs
@@ -28,10 +28,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 use std::{

--- a/gix-trace/Cargo.toml
+++ b/gix-trace/Cargo.toml
@@ -36,4 +36,3 @@ document-features = { version = "0.2.0", optional = true }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-trace/src/lib.rs
+++ b/gix-trace/src/lib.rs
@@ -5,10 +5,10 @@
 //! Crates that use `gix-features` should use `gix_features::trace`, and those who don't can use `gix_trace` directly.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 /// The level at which the tracing item should be created.

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -95,4 +95,3 @@ blocking = "1.0.2"
 
 [package.metadata.docs.rs]
 features = ["http-client-curl", "document-features", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-transport/src/lib.rs
+++ b/gix-transport/src/lib.rs
@@ -4,10 +4,10 @@
 //! All git transports are supported, including `ssh`, `git`, `http` and `https`, as well as local repository paths.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -35,4 +35,3 @@ gix-testtools = { path = "../tests/tools" }
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -1,10 +1,10 @@
 //! A library implementing a URL for use in git with access to its special capabilities.
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms, missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -38,4 +38,3 @@ document-features = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["document-features", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix-worktree/src/lib.rs
+++ b/gix-worktree/src/lib.rs
@@ -4,10 +4,10 @@
 //!
 //! ## Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 use bstr::BString;
 pub use gix_glob;

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -301,4 +301,3 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 
 [package.metadata.docs.rs]
 features = ["document-features", "max-performance", "blocking-network-client", "blocking-http-transport-curl", "serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -82,10 +82,10 @@
 //!
 //! ### Feature Flags
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 #![allow(clippy::result_large_err)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@
 //! Feature configuration can be complex and this document seeks to provide an overview.
 //!
 #![cfg_attr(
-    feature = "document-features",
-    cfg_attr(doc, doc = ::document_features::document_features!())
+    all(doc, feature = "document-features"),
+    doc = ::document_features::document_features!()
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(rust_2018_idioms)]
 #![allow(missing_docs)]
 #![forbid(unsafe_code)]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -270,28 +270,6 @@ pub fn setup_line_renderer_range(
     )
 }
 
-#[cfg(all(feature = "lean-cli", not(feature = "pretty-cli")))]
-pub fn from_env<T: argh::TopLevelCommand>() -> T {
-    static VERSION: &str = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
-    let strings: Vec<String> = std::env::args().collect();
-    let strs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
-    T::from_args(&[strs[0]], &strs[1..]).unwrap_or_else(|early_exit| {
-        // This allows us to make subcommands mandatory,
-        // and trigger a helpful message unless --version is specified
-        if let Some(arg) = std::env::args().nth(1) {
-            if arg == "--version" {
-                println!("{}", VERSION);
-                std::process::exit(0);
-            }
-        }
-        println!("{}", early_exit.output);
-        std::process::exit(match early_exit.status {
-            Ok(()) => 0,
-            Err(()) => 1,
-        })
-    })
-}
-
 mod clap {
     use std::{ffi::OsStr, str::FromStr};
 


### PR DESCRIPTION
This PR makes the necessary changes to make gitoxide crates ready for `-Zcheck-cfg` (automatic cfgs checking) being enabled by default.

 - It first removes all the `--cfg docsrs` and `#[cfg_attr(docsrs, ...)]` which are an anti-pattern and simply use the already existing feature `document-features`.
 - It also add a missing `serde` feature in `gix-fs` and remove a dead code from the now non-existing `lean-cli` feature.
 - I also added the `async-io` feature to `gix-packetline-blocking` since being a symlink to `gix-packetline` it needs to have all the feature of the former.
   Maybe instead of adding the `async-io` feature we could allow the lint for `gix-packetline-blocking`?
 - And finally it adds a new CI job `lint-nightly` to run nightly tools, in particular `cargo check -Zcheck-cfg`.