### PR TITLE
filter improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "gix-actor 0.28.0",
  "gix-archive",
  "gix-attributes 0.20.0",
+ "gix-command",
  "gix-commitgraph",
  "gix-config",
  "gix-credentials",

--- a/gix-archive/tests/archive.rs
+++ b/gix-archive/tests/archive.rs
@@ -303,6 +303,6 @@ mod from_tree {
     }
 
     fn noop_pipeline() -> gix_filter::Pipeline {
-        gix_filter::Pipeline::new(&Default::default(), Default::default())
+        gix_filter::Pipeline::new(&Default::default(), Default::default(), Default::default())
     }
 }

--- a/gix-filter/src/driver/apply.rs
+++ b/gix-filter/src/driver/apply.rs
@@ -63,6 +63,7 @@ pub struct Context<'a, 'b> {
     pub blob: Option<gix_hash::ObjectId>,
 }
 
+/// Apply operations to filter programs.
 impl State {
     /// Apply `operation` of `driver` to the bytes read from `src` and return a reader to immediately consume the output
     /// produced by the filter. `rela_path` is the repo-relative path of the entry to handle.

--- a/gix-filter/src/driver/delayed.rs
+++ b/gix-filter/src/driver/delayed.rs
@@ -45,6 +45,7 @@ pub mod fetch {
     }
 }
 
+/// Operations related to delayed filtering.
 impl State {
     /// Return a list of delayed paths for `process` that can then be obtained with [`fetch_delayed()`][Self::fetch_delayed()].
     ///

--- a/gix-filter/src/driver/mod.rs
+++ b/gix-filter/src/driver/mod.rs
@@ -70,12 +70,27 @@ pub struct State {
     /// Note that these processes are expected to shut-down once their stdin/stdout are dropped, so nothing else
     /// needs to be done to clean them up after drop.
     running: HashMap<BString, process::Client>,
+
+    /// The context to pass to spawned filter programs.
+    pub context: gix_command::Context,
+}
+
+/// Initialization
+impl State {
+    /// Create a new instance using `context` to inform launched processes about their environment.
+    pub fn new(context: gix_command::Context) -> Self {
+        Self {
+            running: Default::default(),
+            context,
+        }
+    }
 }
 
 impl Clone for State {
     fn clone(&self) -> Self {
         State {
             running: Default::default(),
+            context: self.context.clone(),
         }
     }
 }

--- a/gix-filter/src/driver/process/client.rs
+++ b/gix-filter/src/driver/process/client.rs
@@ -185,8 +185,8 @@ impl Client {
         self.send_command_and_meta(command, meta)?;
         while let Some(data) = self.out.read_line() {
             let line = data??;
-            if let Some(line) = line.as_bstr() {
-                inspect_line(line);
+            if let Some(line) = line.as_text() {
+                inspect_line(line.as_bstr());
             }
         }
         self.out.reset_with(&[gix_packetline::PacketLineRef::Flush]);

--- a/gix-filter/src/pipeline/mod.rs
+++ b/gix-filter/src/pipeline/mod.rs
@@ -52,18 +52,22 @@ const ATTRS: [&str; 6] = ["crlf", "ident", "filter", "eol", "text", "working-tre
 
 /// Lifecycle
 impl Pipeline {
-    /// Create a new pipeline with configured `drivers` (which should be considered safe to invoke) as well as a way to initialize
-    /// our attributes with `collection`.
+    /// Create a new pipeline with configured `drivers` (which should be considered safe to invoke) with `context` as well as
+    /// a way to initialize our attributes with `collection`.
     /// `eol_config` serves as fallback to understand how to convert line endings if no line-ending attributes are present.
     /// `crlf_roundtrip_check` corresponds to the git-configuration of `core.safecrlf`.
     /// `object_hash` is relevant for the `ident` filter.
-    pub fn new(collection: &gix_attributes::search::MetadataCollection, options: Options) -> Self {
+    pub fn new(
+        collection: &gix_attributes::search::MetadataCollection,
+        context: gix_command::Context,
+        options: Options,
+    ) -> Self {
         let mut attrs = gix_attributes::search::Outcome::default();
         attrs.initialize_with_selection(collection, ATTRS);
         Pipeline {
             attrs,
             context: Context::default(),
-            processes: driver::State::default(),
+            processes: driver::State::new(context),
             options,
             bufs: Default::default(),
         }
@@ -80,7 +84,7 @@ impl Pipeline {
 impl Default for Pipeline {
     fn default() -> Self {
         let collection = Default::default();
-        Pipeline::new(&collection, Default::default())
+        Pipeline::new(&collection, Default::default(), Default::default())
     }
 }
 

--- a/gix-filter/tests/pipeline/mod.rs
+++ b/gix-filter/tests/pipeline/mod.rs
@@ -59,6 +59,7 @@ fn pipeline(
     let (drivers, encodings_with_roundtrip_check, crlf_roundtrip_check, eol_config) = init();
     let pipe = gix_filter::Pipeline::new(
         cache.attributes_collection(),
+        Default::default(),
         gix_filter::pipeline::Options {
             drivers,
             eol_config,

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -262,6 +262,7 @@ mod from_tree {
     fn mutating_pipeline(driver: bool) -> gix_filter::Pipeline {
         gix_filter::Pipeline::new(
             &Default::default(),
+            Default::default(),
             gix_filter::pipeline::Options {
                 drivers: if driver { vec![driver_with_process()] } else { vec![] },
                 eol_config: gix_filter::eol::Configuration {

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -81,7 +81,7 @@ worktree-mutation = ["attributes", "dep:gix-worktree-state"]
 excludes = ["dep:gix-ignore", "dep:gix-worktree", "index"]
 
 ## Query attributes and excludes. Enables access to pathspecs, worktree checkouts, filter-pipelines and submodules.
-attributes = ["excludes", "dep:gix-filter", "dep:gix-pathspec", "dep:gix-attributes", "dep:gix-submodule", "gix-worktree?/attributes"]
+attributes = ["excludes", "dep:gix-filter", "dep:gix-pathspec", "dep:gix-attributes", "dep:gix-submodule", "gix-worktree?/attributes", "dep:gix-command"]
 
 ## Add support for mailmaps, as way of determining the final name of commmiters and authors.
 mailmap = ["dep:gix-mailmap"]
@@ -254,6 +254,7 @@ gix-commitgraph = { version = "^0.22.0", path = "../gix-commitgraph" }
 gix-pathspec = { version = "^0.4.0", path = "../gix-pathspec", optional = true }
 gix-submodule = { version = "^0.5.0", path = "../gix-submodule", optional = true }
 gix-status = { version = "^0.2.0", path = "../gix-status", optional = true }
+gix-command = { version = "^0.2.10", path = "../gix-command", optional = true }
 
 gix-worktree-stream = { version = "^0.6.0", path = "../gix-worktree-stream", optional = true }
 gix-archive = { version = "^0.6.0", path = "../gix-archive", default-features = false, optional = true }

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -197,7 +197,11 @@ impl Cache {
         let capabilities = self.fs_capabilities()?;
         let filters = {
             let collection = Default::default();
-            let mut filters = gix_filter::Pipeline::new(&collection, crate::filter::Pipeline::options(repo)?);
+            let mut filters = gix_filter::Pipeline::new(
+                &collection,
+                repo.command_context()?,
+                crate::filter::Pipeline::options(repo)?,
+            );
             if let Ok(mut head) = repo.head() {
                 let ctx = filters.driver_context_mut();
                 ctx.ref_name = head.referent_name().map(|name| name.as_bstr().to_owned());

--- a/gix/src/config/cache/util.rs
+++ b/gix/src/config/cache/util.rs
@@ -55,6 +55,18 @@ pub(crate) fn query_refupdates(
         .map_err(Into::into)
 }
 
+pub(crate) fn query_refs_namespace(
+    config: &gix_config::File<'static>,
+    lenient_config: bool,
+) -> Result<Option<gix_ref::Namespace>, config::refs_namespace::Error> {
+    let key = "gitoxide.core.refsNamespace";
+    config
+        .string_by_key(key)
+        .map(|ns| gitoxide::Core::REFS_NAMESPACE.try_into_refs_namespace(ns))
+        .transpose()
+        .with_leniency(lenient_config)
+}
+
 pub(crate) fn reflog_or_default(
     config_reflog: Option<gix_ref::store::WriteReflog>,
     has_worktree: bool,

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -76,6 +76,8 @@ pub enum Error {
     ConfigUnsigned(#[from] unsigned_integer::Error),
     #[error(transparent)]
     ConfigTypedString(#[from] key::GenericErrorWithValue),
+    #[error(transparent)]
+    RefsNamespace(#[from] refs_namespace::Error),
     #[error("Cannot handle objects formatted as {:?}", .name)]
     UnsupportedObjectFormat { name: BString },
     #[error(transparent)]
@@ -168,9 +170,9 @@ pub mod command_context {
     #[allow(missing_docs)]
     pub enum Error {
         #[error(transparent)]
-        PathSpec(#[from] gix_pathspec::defaults::from_environment::Error),
-        #[error(transparent)]
         Boolean(#[from] config::boolean::Error),
+        #[error(transparent)]
+        ParseBool(#[from] gix_config::value::Error),
     }
 }
 
@@ -431,6 +433,12 @@ pub mod refspec {
 }
 
 ///
+pub mod refs_namespace {
+    /// The error produced when failing to parse a refspec from the configuration.
+    pub type Error = super::key::Error<gix_validate::reference::name::Error, 'v', 'i'>;
+}
+
+///
 pub mod ssl_version {
     /// The error produced when failing to parse a refspec from the configuration.
     pub type Error = super::key::Error<std::convert::Infallible, 's', 'i'>;
@@ -526,6 +534,8 @@ pub(crate) struct Cache {
     pub use_multi_pack_index: bool,
     /// The representation of `core.logallrefupdates`, or `None` if the variable wasn't set.
     pub reflog: Option<gix_ref::store::WriteReflog>,
+    /// The representation of `gitoxide.core.refsNamespace`, or `None` if the variable wasn't set.
+    pub refs_namespace: Option<gix_ref::Namespace>,
     /// The configured user agent for presentation to servers.
     pub(crate) user_agent: OnceCell<String>,
     /// identities for later use, lazy initialization.

--- a/gix/src/filter.rs
+++ b/gix/src/filter.rs
@@ -32,6 +32,8 @@ pub mod pipeline {
                 name: BString,
                 source: gix_config::value::Error,
             },
+            #[error(transparent)]
+            CommandContext(#[from] config::command_context::Error),
         }
     }
 
@@ -111,7 +113,11 @@ impl<'repo> Pipeline<'repo> {
     /// Create a new instance by extracting all necessary information and configuration from a `repo` along with `cache` for accessing
     /// attributes. The `index` is used for some filters which may access it under very specific circumstances.
     pub fn new(repo: &'repo Repository, cache: gix_worktree::Stack) -> Result<Self, pipeline::options::Error> {
-        let pipeline = gix_filter::Pipeline::new(cache.attributes_collection(), Self::options(repo)?);
+        let pipeline = gix_filter::Pipeline::new(
+            cache.attributes_collection(),
+            repo.command_context()?,
+            Self::options(repo)?,
+        );
         Ok(Pipeline {
             inner: pipeline,
             cache,

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -273,6 +273,7 @@ impl ThreadSafeRepository {
         }
 
         refs.write_reflog = config::cache::util::reflog_or_default(config.reflog, worktree_dir.is_some());
+        refs.namespace = config.refs_namespace.clone();
         let replacements = replacement_objects_refs_prefix(&config.resolved, lenient_config, filter_config_section)?
             .and_then(|prefix| {
                 let _span = gix_trace::detail!("find replacement objects");

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -8,7 +8,7 @@ use super::{Error, Options};
 use crate::{
     config,
     config::{
-        cache::{interpolate_context, util::ApplyLeniency},
+        cache::interpolate_context,
         tree::{gitoxide, Core, Key, Safe},
     },
     open::Permissions,
@@ -324,11 +324,7 @@ fn replacement_objects_refs_prefix(
     lenient: bool,
     mut filter_config_section: fn(&gix_config::file::Metadata) -> bool,
 ) -> Result<Option<PathBuf>, Error> {
-    let is_disabled = config
-        .boolean_filter_by_key("core.useReplaceRefs", &mut filter_config_section)
-        .map(|b| Core::USE_REPLACE_REFS.enrich_error(b))
-        .transpose()
-        .with_leniency(lenient)
+    let is_disabled = config::shared::is_replace_refs_enabled(config, lenient, filter_config_section)
         .map_err(config::Error::ConfigBoolean)?
         .unwrap_or(true);
 

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -79,6 +79,26 @@ impl crate::Repository {
         Ok(opts)
     }
 
+    /// Return the context to be passed to any spawned program that is supposed to interact with the repository, like
+    /// hooks or filters.
+    #[cfg(feature = "attributes")]
+    pub fn command_context(&self) -> Result<gix_command::Context, config::command_context::Error> {
+        Ok(gix_command::Context {
+            git_dir: self.git_dir().to_owned().into(),
+            worktree_dir: self.work_dir().map(ToOwned::to_owned),
+            no_replace_objects: config::shared::is_replace_refs_enabled(
+                &self.config.resolved,
+                self.config.lenient_config,
+                self.filter_config_section(),
+            )?
+            .map(|enabled| !enabled),
+            ref_namespace: None,
+            literal_pathspecs: None,
+            glob_pathspecs: None,
+            icase_pathspecs: None,
+        })
+    }
+
     /// The kind of object hash the repository is configured to use.
     pub fn object_hash(&self) -> gix_hash::Kind {
         self.config.object_hash

--- a/gix/src/repository/mod.rs
+++ b/gix/src/repository/mod.rs
@@ -124,6 +124,8 @@ pub mod worktree_stream {
         AttributesCache(#[from] crate::config::attribute_stack::Error),
         #[error(transparent)]
         FilterPipeline(#[from] crate::filter::pipeline::options::Error),
+        #[error(transparent)]
+        CommandContext(#[from] crate::config::command_context::Error),
         #[error("Needed {id} to be a tree to turn into a workspace stream, got {actual}")]
         NotATree {
             id: gix_hash::ObjectId,

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -79,8 +79,11 @@ impl crate::Repository {
         let mut cache = self
             .attributes_only(&index, gix_worktree::stack::state::attributes::Source::IdMapping)?
             .detach();
-        let pipeline =
-            gix_filter::Pipeline::new(cache.attributes_collection(), crate::filter::Pipeline::options(self)?);
+        let pipeline = gix_filter::Pipeline::new(
+            cache.attributes_collection(),
+            self.command_context()?,
+            crate::filter::Pipeline::options(self)?,
+        );
         let objects = self.objects.clone().into_arc().expect("TBD error handling");
         let stream = gix_worktree_stream::from_tree(
             id,

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -49,7 +49,8 @@ mod with_overrides {
             .set("GIT_NOGLOB_PATHSPECS", "pathspecs-noglob")
             .set("GIT_ICASE_PATHSPECS", "pathspecs-icase")
             .set("GIT_TERMINAL_PROMPT", "42")
-            .set("GIT_SHALLOW_FILE", "shallow-file-env");
+            .set("GIT_SHALLOW_FILE", "shallow-file-env")
+            .set("GIT_NAMESPACE", "namespace-env");
         let mut opts = gix::open::Options::isolated()
             .cli_overrides([
                 "http.userAgent=agent-from-cli",
@@ -62,6 +63,7 @@ mod with_overrides {
                 "gitoxide.ssh.commandWithoutShellFallback=ssh-command-fallback-cli",
                 "gitoxide.http.proxyAuthMethod=proxy-auth-method-cli",
                 "gitoxide.core.shallowFile=shallow-file-cli",
+                "gitoxide.core.refsNamespace=namespace-cli",
             ])
             .config_overrides([
                 "http.userAgent=agent-from-api",
@@ -74,6 +76,7 @@ mod with_overrides {
                 "gitoxide.ssh.commandWithoutShellFallback=ssh-command-fallback-api",
                 "gitoxide.http.proxyAuthMethod=proxy-auth-method-api",
                 "gitoxide.core.shallowFile=shallow-file-api",
+                "gitoxide.core.refsNamespace=namespace-api",
             ]);
         opts.permissions.env.git_prefix = Permission::Allow;
         opts.permissions.env.http_transport = Permission::Allow;
@@ -94,6 +97,16 @@ mod with_overrides {
                 cow_bstr("shallow-file-cli"),
                 cow_bstr("shallow-file-api"),
                 cow_bstr("shallow-file-env")
+            ]
+        );
+        assert_eq!(
+            config
+                .strings_by_key("gitoxide.core.refsNamespace")
+                .expect("at least one value"),
+            [
+                cow_bstr("namespace-cli"),
+                cow_bstr("namespace-api"),
+                cow_bstr("namespace-env")
             ]
         );
         assert_eq!(


### PR DESCRIPTION
Related to #1129.

### Tasks

* [x] fix bug around delayed filters.
* [x] assure spawned filters at least get the GIT_DIR set along with the current working 
* [x] figure out the protocol issue



<details>

#### Log

```
Downloading fixtures/1diff.png (26 KB)==   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===]
Downloading fixtures/6b.png (72 KB)========================================================================>----------------------------------------------------------------------------------------------]
Downloading fixtures/5diff.png (4.1 KB)==   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ===   ==]
Downloading fixtures/6empty.png (32 KB)
Downloading fixtures/1a.png (31 KB)
Downloading fixtures/4b.png (268 KB)
Downloading fixtures/3b.png (28 KB)
Downloading fixtures/3diff.png (16 KB)
Downloading fixtures/2a.png (33 KB)
Downloading fixtures/2b.png (35 KB)
Error downloading object: fixtures/5diff.png (414e99e): Smudge error: Error downloading fixtures/5diff.png (414e99e56bd063388081ede7cf5fa514b8fb7d058bcb8389b2a26800d0b0fc0c): [414e99e56bd063388081ede7cf5fa514b8fb7d058bcb8389b2a26800d0b0fc0c] Object does not exist on the server: [404] Object does not exist on the server
Error downloading object: fixtures/4b.png (ea0ec4a): Smudge error: Error downloading fixtures/4b.png (ea0ec4a7dadd57613b37a43942fc711db46625ba9956afc822ea3b7f03249c33): [ea0ec4a7dadd57613b37a43942fc711db46625ba9956afc822ea3b7f03249c33] Object does not exist on the server: [404] Object does not exist on the server
Error downloading object: fixtures/1a.png (b90f2c0): Smudge error: Error downloading fixtures/1a.png (b90f2c0ea9e2f768835dcc03a1f4a4526550d0267be38d87900f4cb2250a6581): [b90f2c0ea9e2f768835dcc03a1f4a4526550d0267be38d87900f4cb2250a6581] Object does not exist on the server: [404] Object does not exist on the server
Error downloading object: fixtures/6empty.png (c0e3c42): Smudge error: Error downloading fixtures/6empty.png (c0e3c42822835b005bf55d2d0ea5c9e7d87dabe4eb006e56a0d76440adef00fe): [c0e3c42822835b005bf55d2d0ea5c9e7d87dabe4eb006e56a0d76440adef00fe] Object does not exist on the server: [404] Object does not exist on the server

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.434234.log'.
Use `git lfs logs last` to view the log.

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.434205.log'.
Use `git lfs logs last` to view the log.

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.434201.log'.
Use `git lfs logs last` to view the log.

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.435485.log'.
Use `git lfs logs last` to view the log.
Error downloading object: fixtures/3b.png (5ca514b): Smudge error: Error downloading fixtures/3b.png (5ca514be867312f2486fd59b4e192e7dccff5f1621620f4e0c9e05144080f6b2): [5ca514be867312f2486fd59b4e192e7dccff5f1621620f4e0c9e05144080f6b2] Object does not exist on the server: [404] Object does not exist on the server
Error downloading object: fixtures/1diff.png (ad5bba0): Smudge error: Error downloading fixtures/1diff.png (ad5bba061619792a6efb6264fb426cdcc684694f5b9be80cf898bf3f9d651519): [ad5bba061619792a6efb6264fb426cdcc684694f5b9be80cf898bf3f9d651519] Object does not exist on the server: [404] Object does not exist on the server
Error downloading object: fixtures/6b.png (12edb43): Smudge error: Error downloading fixtures/6b.png (12edb432045427d11a039ef48e3254fdcbe7d14e2602d6b2c38972579f56eae6): [12edb432045427d11a039ef48e3254fdcbe7d14e2602d6b2c38972579f56eae6] Object does not exist on the server: [404] Object does not exist on the server

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.446265.log'.
Use `git lfs logs last` to view the log.

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.446292.log'.
Use `git lfs logs last` to view the log.

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.447406.log'.
Use `git lfs logs last` to view the log.
Error downloading object: fixtures/2b.png (f0c1978): Smudge error: Error downloading fixtures/2b.png (f0c1978598423a43defb3cd7c253123f860a6b531c77f81e88e199c913fcd618): [f0c1978598423a43defb3cd7c253123f860a6b531c77f81e88e199c913fcd618] Object does not exist on the server: [404] Object does not exist on the server

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.457443.log'.
Use `git lfs logs last` to view the log.
Error downloading object: fixtures/2a.png (4462106): Smudge error: Error downloading fixtures/2a.png (4462106013f6bd57d670ec9115e6413683905976d5234f0b8efa5f1ab4691bf6): [4462106013f6bd57d670ec9115e6413683905976d5234f0b8efa5f1ab4691bf6] Object does not exist on the server: [404] Object does not exist on the server
Error downloading object: fixtures/3diff.png (718af0d): Smudge error: Error downloading fixtures/3diff.png (718af0d67fc57ed46608a7ac694ac43822a8e43f97e57552ff003dd16260bfa3): [718af0d67fc57ed46608a7ac694ac43822a8e43f97e57552ff003dd16260bfa3] Object does not exist on the server: [404] Object does not exist on the server

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.461343.log'.
Use `git lfs logs last` to view the log.

Errors logged to '/Users/byron/dev/github.com/Byron/gitoxide/.git/lfs/logs/20231125T091640.46221.log'.
Use `git lfs logs last` to view the log.
Error: IO error while writing blob or reading file metadata or changing filetype

Caused by:
    failed to fill whole buffer
```

</details>
