### PR TITLE
test size_of_sha1 reports wrong size on i386

### DIFF
--- a/gix-features/tests/hash.rs
+++ b/gix-features/tests/hash.rs
@@ -6,14 +6,8 @@ fn size_of_sha1() {
     assert_eq!(std::mem::size_of::<Sha1>(), 96)
 }
 
-#[cfg(all(feature = "fast-sha1", target_arch = "x86"))]
+#[cfg(feature = "fast-sha1")]
 #[test]
 fn size_of_sha1() {
-    assert_eq!(std::mem::size_of::<Sha1>(), 96)
-}
-
-#[cfg(all(feature = "fast-sha1", not(target_arch = "x86")))]
-#[test]
-fn size_of_sha1() {
-    assert_eq!(std::mem::size_of::<Sha1>(), 104)
+    assert_eq!(std::mem::size_of::<Sha1>(), if cfg!(target_arch = "x86") { 96 } else { 104 })
 }

--- a/gix-features/tests/hash.rs
+++ b/gix-features/tests/hash.rs
@@ -6,7 +6,13 @@ fn size_of_sha1() {
     assert_eq!(std::mem::size_of::<Sha1>(), 96)
 }
 
-#[cfg(feature = "fast-sha1")]
+#[cfg(all(feature = "fast-sha1", target_arch = "x86"))]
+#[test]
+fn size_of_sha1() {
+    assert_eq!(std::mem::size_of::<Sha1>(), 96)
+}
+
+#[cfg(all(feature = "fast-sha1", not(target_arch = "x86")))]
 #[test]
 fn size_of_sha1() {
     assert_eq!(std::mem::size_of::<Sha1>(), 104)


### PR DESCRIPTION
Build failure:

```
159s 
159s running 1 test
159s test size_of_sha1 ... FAILED
159s 
159s failures:
159s 
159s ---- size_of_sha1 stdout ----
159s thread 'size_of_sha1' panicked at 'assertion failed: `(left == right)`
159s   left: `96`,
159s  right: `104`', tests/hash.rs:12:5
159s stack backtrace:
159s    0: rust_begin_unwind
159s              at /usr/src/rustc-1.70.0/library/std/src/panicking.rs:578:5
159s    1: core::panicking::panic_fmt
159s              at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:67:14
159s    2: core::panicking::assert_failed_inner
159s    3: core::panicking::assert_failed
159s              at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:228:5
159s    4: hash::size_of_sha1
159s              at ./tests/hash.rs:12:5
159s    5: hash::size_of_sha1::{{closure}}
159s              at ./tests/hash.rs:11:19
159s    6: core::ops::function::FnOnce::call_once
159s              at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
159s    7: core::ops::function::FnOnce::call_once
159s              at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
159s note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
159s 
159s 
159s failures:
159s     size_of_sha1
```

From: https://ci.debian.net/data/autopkgtest/testing/i386/r/rust-gix-features/40167696/log.gz

Can be reproduced with `cargo test --all-features`

I'm far from certain that this is the correct fix, as this more documents the size differences on the different architectures.