### PR TITLE
gix-status improvements 

### DIFF
--- a/crate-status.md
+++ b/crate-status.md
@@ -43,6 +43,7 @@ The top-level crate that acts as hub to all functionality provided by the `gix-*
         * [x] support for `GIT_CEILING_DIRECTORIES` environment variable
         * [ ] handle other non-discovery modes and provide control over environment variable usage required in applications
     * [x] rev-parse
+       - [ ] handle relative paths as relative to working directory
     * [x] rev-walk
         * [x] include tips
         * [ ] exclude commits

--- a/gitoxide-core/src/repository/revision/resolve.rs
+++ b/gitoxide-core/src/repository/revision/resolve.rs
@@ -5,6 +5,7 @@ pub struct Options {
     pub explain: bool,
     pub cat_file: bool,
     pub tree_mode: TreeMode,
+    pub blob_format: BlobFormat,
 }
 
 pub enum TreeMode {
@@ -12,13 +13,24 @@ pub enum TreeMode {
     Pretty,
 }
 
+#[derive(Copy, Clone)]
+pub enum BlobFormat {
+    Git,
+    Worktree,
+    Diff,
+    DiffOrGit,
+}
+
 pub(crate) mod function {
     use std::ffi::OsString;
 
-    use anyhow::Context;
+    use anyhow::{anyhow, Context};
+    use gix::diff::blob::ResourceKind;
+    use gix::filter::plumbing::driver::apply::Delay;
     use gix::revision::Spec;
 
     use super::Options;
+    use crate::repository::revision::resolve::BlobFormat;
     use crate::{
         repository::{revision, revision::resolve::TreeMode},
         OutputFormat,
@@ -33,9 +45,26 @@ pub(crate) mod function {
             explain,
             cat_file,
             tree_mode,
+            blob_format,
         }: Options,
     ) -> anyhow::Result<()> {
         repo.object_cache_size_if_unset(1024 * 1024);
+        let mut cache = (!matches!(blob_format, BlobFormat::Git))
+            .then(|| {
+                repo.diff_resource_cache(
+                    match blob_format {
+                        BlobFormat::Git => {
+                            unreachable!("checked before")
+                        }
+                        BlobFormat::Worktree | BlobFormat::Diff => {
+                            gix::diff::blob::pipeline::Mode::ToWorktreeAndBinaryToText
+                        }
+                        BlobFormat::DiffOrGit => gix::diff::blob::pipeline::Mode::ToGitUnlessBinaryToTextIsPresent,
+                    },
+                    Default::default(),
+                )
+            })
+            .transpose()?;
 
         match format {
             OutputFormat::Human => {
@@ -46,7 +75,7 @@ pub(crate) mod function {
                     let spec = gix::path::os_str_into_bstr(&spec)?;
                     let spec = repo.rev_parse(spec)?;
                     if cat_file {
-                        return display_object(spec, tree_mode, out);
+                        return display_object(&repo, spec, tree_mode, cache.as_mut().map(|c| (blob_format, c)), out);
                     }
                     writeln!(out, "{spec}", spec = spec.detach())?;
                 }
@@ -73,16 +102,51 @@ pub(crate) mod function {
         Ok(())
     }
 
-    fn display_object(spec: Spec<'_>, tree_mode: TreeMode, mut out: impl std::io::Write) -> anyhow::Result<()> {
+    fn display_object(
+        repo: &gix::Repository,
+        spec: Spec<'_>,
+        tree_mode: TreeMode,
+        cache: Option<(BlobFormat, &mut gix::diff::blob::Platform)>,
+        mut out: impl std::io::Write,
+    ) -> anyhow::Result<()> {
         let id = spec.single().context("rev-spec must resolve to a single object")?;
-        let object = id.object()?;
-        match object.kind {
+        let header = id.header()?;
+        match header.kind() {
             gix::object::Kind::Tree if matches!(tree_mode, TreeMode::Pretty) => {
-                for entry in object.into_tree().iter() {
+                for entry in id.object()?.into_tree().iter() {
                     writeln!(out, "{}", entry?)?;
                 }
             }
-            _ => out.write_all(&object.data)?,
+            gix::object::Kind::Blob if cache.is_some() && spec.path_and_mode().is_some() => {
+                let (path, mode) = spec.path_and_mode().expect("is present");
+                let is_dir = Some(mode.is_tree());
+                match cache.expect("is some") {
+                    (BlobFormat::Git, _) => unreachable!("no need for a cache when querying object db"),
+                    (BlobFormat::Worktree, cache) => {
+                        let platform = cache.attr_stack.at_entry(path, is_dir, &repo.objects)?;
+                        let object = id.object()?;
+                        let mut converted = cache.filter.worktree_filter.convert_to_worktree(
+                            &object.data,
+                            path,
+                            &mut |_path, attrs| {
+                                let _ = platform.matching_attributes(attrs);
+                            },
+                            Delay::Forbid,
+                        )?;
+                        std::io::copy(&mut converted, &mut out)?;
+                    }
+                    (BlobFormat::Diff | BlobFormat::DiffOrGit, cache) => {
+                        cache.set_resource(id.detach(), mode.kind(), path, ResourceKind::OldOrSource, &repo.objects)?;
+                        let resource = cache.resource(ResourceKind::OldOrSource).expect("just set");
+                        let data = resource
+                            .data
+                            .as_slice()
+                            .ok_or_else(|| anyhow!("Binary data at {} cannot be diffed", path))?;
+                        out.write_all(data)?;
+                    }
+                }
+            }
+            _ => out.write_all(&id.object()?.data)?,
         }
         Ok(())
     }

--- a/gix-index/src/entry/mod.rs
+++ b/gix-index/src/entry/mod.rs
@@ -18,9 +18,9 @@ mod write;
 
 use bitflags::bitflags;
 
-// TODO: we essentially treat this as an enum withj the only exception being
-// that `FILE_EXECUTABLE.contains(FILE)` works might want to turn this into an
-// enum proper
+// TODO: we essentially treat this as an enum with the only exception being
+//      that `FILE_EXECUTABLE.contains(FILE)` works might want to turn this into an
+//      enum proper
 bitflags! {
     /// The kind of file of an entry.
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/gix-index/src/entry/mode.rs
+++ b/gix-index/src/entry/mode.rs
@@ -11,6 +11,12 @@ impl Mode {
         *self == Self::DIR | Self::SYMLINK
     }
 
+    /// Convert this instance to a tree's entry mode, or return `None` if for some
+    /// and unexpected reason the bitflags don't resemble any known entry-mode.
+    pub fn to_tree_entry_mode(&self) -> Option<gix_object::tree::EntryMode> {
+        gix_object::tree::EntryMode::try_from(self.bits()).ok()
+    }
+
     /// Compares this mode to the file system version ([`std::fs::symlink_metadata`])
     /// and returns the change needed to update this mode to match the file.
     ///

--- a/gix/src/ext/rev_spec.rs
+++ b/gix/src/ext/rev_spec.rs
@@ -12,6 +12,7 @@ impl RevSpecExt for gix_revision::Spec {
     fn attach(self, repo: &crate::Repository) -> crate::revision::Spec<'_> {
         crate::revision::Spec {
             inner: self,
+            path: None,
             first_ref: None,
             second_ref: None,
             repo,

--- a/gix/src/revision/mod.rs
+++ b/gix/src/revision/mod.rs
@@ -7,6 +7,7 @@ pub use gix_revision as plumbing;
 
 ///
 pub mod walk;
+use crate::bstr::BString;
 pub use walk::iter::Walk;
 
 ///
@@ -22,6 +23,8 @@ pub mod spec;
 #[cfg(feature = "revision")]
 pub struct Spec<'repo> {
     pub(crate) inner: gix_revision::Spec,
+    /// The path we encountered in the revspec, like `@:<path>` or `@..@~1:<path>`.
+    pub(crate) path: Option<(BString, gix_object::tree::EntryMode)>,
     /// The first name of a reference as seen while parsing a `RevSpec`, for completeness.
     pub(crate) first_ref: Option<gix_ref::Reference>,
     /// The second name of a reference as seen while parsing a `RevSpec`, for completeness.

--- a/gix/src/revision/spec/mod.rs
+++ b/gix/src/revision/spec/mod.rs
@@ -1,3 +1,4 @@
+use crate::bstr::BStr;
 use crate::{ext::ReferenceExt, revision::Spec, Id, Reference};
 
 ///
@@ -37,6 +38,7 @@ impl<'repo> Spec<'repo> {
     pub fn from_id(id: Id<'repo>) -> Self {
         Spec {
             inner: gix_revision::Spec::Include(id.inner),
+            path: None,
             repo: id.repo,
             first_ref: None,
             second_ref: None,
@@ -60,6 +62,13 @@ impl<'repo> Spec<'repo> {
             self.first_ref.map(|r| r.attach(repo)),
             self.second_ref.map(|r| r.attach(repo)),
         )
+    }
+
+    /// Return the path encountered in specs like `@:<path>` or `:<path>`, along with the kind of object it represents.
+    ///
+    /// Note that there can only be one as paths always terminates further revspec parsing.
+    pub fn path_and_mode(&self) -> Option<(&BStr, gix_object::tree::EntryMode)> {
+        self.path.as_ref().map(|(p, mode)| (p.as_ref(), *mode))
     }
 
     /// Return the name of the first reference we encountered while resolving the rev-spec, or `None` if a short hash

--- a/gix/src/revision/spec/parse/delegate/mod.rs
+++ b/gix/src/revision/spec/parse/delegate/mod.rs
@@ -17,6 +17,7 @@ impl<'repo> Delegate<'repo> {
         Delegate {
             refs: Default::default(),
             objs: Default::default(),
+            paths: Default::default(),
             ambiguous_objects: Default::default(),
             idx: 0,
             kind: None,
@@ -100,6 +101,7 @@ impl<'repo> Delegate<'repo> {
 
         let range = zero_or_one_objects_or_ambiguity_err(self.objs, self.prefix, self.err, self.repo)?;
         Ok(crate::revision::Spec {
+            path: self.paths[0].take().or(self.paths[1].take()),
             first_ref: self.refs[0].take(),
             second_ref: self.refs[1].take(),
             inner: kind_to_spec(self.kind, range)?,

--- a/gix/src/revision/spec/parse/mod.rs
+++ b/gix/src/revision/spec/parse/mod.rs
@@ -7,6 +7,7 @@ use gix_revision::spec::parse;
 use crate::{bstr::BStr, revision::Spec, Repository};
 
 mod types;
+use crate::bstr::BString;
 pub use types::{Error, ObjectKindHint, Options, RefsHint};
 
 ///
@@ -45,6 +46,9 @@ impl<'repo> Spec<'repo> {
 struct Delegate<'repo> {
     refs: [Option<gix_ref::Reference>; 2],
     objs: [Option<HashSet<ObjectId>>; 2],
+    /// Path specified like `@:<path>` or `:<path>` for later use when looking up specs.
+    /// Note that it terminates spec parsing, so it's either `0` or `1`, never both.
+    paths: [Option<(BString, gix_object::tree::EntryMode)>; 2],
     /// The originally encountered ambiguous objects for potential later use in errors.
     ambiguous_objects: [Option<HashSet<ObjectId>>; 2],
     idx: usize,

--- a/gix/tests/revision/spec/from_bytes/ambiguous.rs
+++ b/gix/tests/revision/spec/from_bytes/ambiguous.rs
@@ -106,10 +106,15 @@ fn blob_and_tree_can_be_disambiguated_by_type() {
 #[test]
 fn trees_can_be_disambiguated_by_blob_access() {
     let repo = repo("ambiguous_blob_tree_commit").unwrap();
+    let actual = parse_spec_better_than_baseline("0000000000:a0blgqsjc", &repo).unwrap();
     assert_eq!(
-        parse_spec_better_than_baseline("0000000000:a0blgqsjc", &repo).unwrap(),
+        actual,
         Spec::from_id(hex_to_id("0000000000b36b6aa7ea4b75318ed078f55505c3").attach(&repo)),
         "we can disambiguate by providing a path, but git cannot"
+    );
+    assert_eq!(
+        actual.path_and_mode().expect("set"),
+        ("a0blgqsjc".into(), gix_object::tree::EntryKind::Blob.into())
     );
 }
 

--- a/gix/tests/revision/spec/from_bytes/mod.rs
+++ b/gix/tests/revision/spec/from_bytes/mod.rs
@@ -43,9 +43,15 @@ mod index {
     #[test]
     fn at_stage() {
         let repo = repo("complex_graph").unwrap();
+        let actual = parse_spec(":file", &repo).unwrap();
         assert_eq!(
-            parse_spec(":file", &repo).unwrap(),
+            actual,
             Spec::from_id(hex_to_id("fe27474251f7f8368742f01fbd3bd5666b630a82").attach(&repo))
+        );
+        assert_eq!(
+            actual.path_and_mode().expect("set"),
+            ("file".into(), gix_object::tree::EntryKind::Blob.into()),
+            "index paths (that are present) are captured"
         );
 
         assert_eq!(
@@ -116,9 +122,15 @@ fn bad_objects_are_valid_until_they_are_actually_read_from_the_odb() {
 #[test]
 fn access_blob_through_tree() {
     let repo = repo("ambiguous_blob_tree_commit").unwrap();
+    let actual = parse_spec("0000000000cdc:a0blgqsjc", &repo).unwrap();
     assert_eq!(
-        parse_spec("0000000000cdc:a0blgqsjc", &repo).unwrap(),
+        actual,
         Spec::from_id(hex_to_id("0000000000b36b6aa7ea4b75318ed078f55505c3").attach(&repo))
+    );
+    assert_eq!(
+        actual.path_and_mode().expect("set"),
+        ("a0blgqsjc".into(), gix_object::tree::EntryKind::Blob.into()),
+        "we capture tree-paths"
     );
 
     assert_eq!(

--- a/gix/tests/revision/spec/from_bytes/peel.rs
+++ b/gix/tests/revision/spec/from_bytes/peel.rs
@@ -21,5 +21,7 @@ fn peel_to_object() {
 #[test]
 fn trailing_colon_is_equivalent_to_peel_to_tree() {
     let repo = &repo("complex_graph").unwrap();
-    assert_eq!(parse_spec("@^{tree}", repo).unwrap(), parse_spec("@:", repo).unwrap());
+    let empty_path = parse_spec("@:", repo).unwrap();
+    assert_eq!(parse_spec("@^{tree}", repo).unwrap(), empty_path);
+    assert_eq!(empty_path.path_and_mode(), None, "empty tree paths are ignored");
 }

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -926,6 +926,7 @@ pub fn main() -> Result<()> {
                 explain,
                 cat_file,
                 tree_mode,
+                blob_format,
             } => prepare_and_run(
                 "revision-parse",
                 trace,
@@ -942,10 +943,24 @@ pub fn main() -> Result<()> {
                             format,
                             explain,
                             cat_file,
-                            tree_mode: match tree_mode.unwrap_or_default() {
+                            tree_mode: match tree_mode {
                                 revision::resolve::TreeMode::Raw => core::repository::revision::resolve::TreeMode::Raw,
                                 revision::resolve::TreeMode::Pretty => {
                                     core::repository::revision::resolve::TreeMode::Pretty
+                                }
+                            },
+                            blob_format: match blob_format {
+                                revision::resolve::BlobFormat::Git => {
+                                    core::repository::revision::resolve::BlobFormat::Git
+                                }
+                                revision::resolve::BlobFormat::Worktree => {
+                                    core::repository::revision::resolve::BlobFormat::Worktree
+                                }
+                                revision::resolve::BlobFormat::Diff => {
+                                    core::repository::revision::resolve::BlobFormat::Diff
+                                }
+                                revision::resolve::BlobFormat::DiffOrGit => {
+                                    core::repository::revision::resolve::BlobFormat::DiffOrGit
                                 }
                             },
                         },

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -614,6 +614,19 @@ pub mod revision {
             #[default]
             Pretty,
         }
+
+        #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]
+        pub enum BlobFormat {
+            /// The version stored in the Git Object Database.
+            #[default]
+            Git,
+            /// The version that would be checked out into the worktree, including filters.
+            Worktree,
+            /// The version that would be diffed (Worktree + Text-Conversion)
+            Diff,
+            /// The version that would be diffed if there is a text-conversion, or the one stored in Git otherwise.
+            DiffOrGit,
+        }
     }
     #[derive(Debug, clap::Subcommand)]
     #[clap(visible_alias = "rev", visible_alias = "r")]
@@ -645,8 +658,12 @@ pub mod revision {
             /// Show the first resulting object similar to how `git cat-file` would, but don't show the resolved spec.
             #[clap(short = 'c', long, conflicts_with = "explain")]
             cat_file: bool,
-            #[clap(short = 't', long)]
-            tree_mode: Option<resolve::TreeMode>,
+            /// How to display blobs.
+            #[clap(short = 'b', long, default_value = "git")]
+            blob_format: resolve::BlobFormat,
+            /// How to display trees as obtained with `@:dirname` or `@^{tree}`.
+            #[clap(short = 't', long, default_value = "pretty")]
+            tree_mode: resolve::TreeMode,
             /// rev-specs like `@`, `@~1` or `HEAD^2`.
             #[clap(required = true)]
             specs: Vec<std::ffi::OsString>,


### PR DESCRIPTION
Based on #1106

----

### diff-correctness → `gix-status` → gix reset

----

Improve `gix status` to the point where it's suitable for use in `reset` functinoality.
Leads to a proper worktree reset implementation, eventually leading to a high-level reset similar to how git supports it.

### Architecture

The reason this PR deals quite a bit with `gix status` is that for a safe implementation of `reset()` we need to be sure that the files we *would* want to touch don't don't carry modifications or are untracked files. In order to know what would need to be done, we have to diff the `current-index with target-index`. The set of files to touch can then be used to lookup information provided by `git-status`, like worktree modifications, index modifications, and untracked files, to know if we can proceed or not. Here is also where the reset-modes would affect the outcome, i.e. what to change and how.

This is a very modular approach which facilitates testing and understanding of what otherwise would be a very complex algorithm. Having a set of changes as output also allows to one day parallelize applying these changes.

This leaves us in a situation where the current `checkout()` implementation wants to become a fastpath for situations where the reset involves an empty tree as source (i.e. create everything and overwrite local changes).

On the way to `reset()` it's a valid choice to warm up more with the matter by improving on the current `gix status` implementation and assure correctness of what's there, which currently doesn't seem to be the case in comparison. Further, implementing `gix status` similarly to `git status ` should be made possible.


### Gix Status

* [x] fun: a way to apply filters in `cat-file` equivalent, and possibly `textconv` conversions just like in `git cat-file.
* [ ] a way to obtain untracked files to learn if changes can be made.
    - Integrate with the untracked-file extension and provide a way to update it.
* [ ] Integrate untracked and ignored files with rename tracking of index-worktree diffs
* [ ] status in `gix` crate with index-worktree
* [ ] diff index with index to learn what we would want to do in the worktree, or alternatively, 
      diff tree with index (with reverse-diff functionality to simulate diff of index with tree), for better performance as it 
      would avoid having to allocate a whole index even though we are only interested in a diff.
     - *Must include rename tracking*.
* [ ] how to make diff results available from status with all transformations applied, to allow user to obtain diffs of any kind?

### Next PR: Reset

* [ ] `reset()` that checks if it's allowed to perform a worktree modification is allowed, or if an entry should be skipped. *That way we can postpone safety checks like --hard*

### Postponed

What follows is important for resets, but won't be needed for `cargo` worktree resets.

* [ ] `gix status` with actual submodule support - needs `status` in `gix` (crate) effectively
* [ ] `gix status` with actual conflict support

### Research
 
* Ignored files are considered expandable and can be overwritten on reset
* How to integrate submodules - probably easy to answer once `gix status` can deal a little better with submodules. Even though in this case a lot of submodule-related information is needed for a complete reset, probably only doable by a higher-level caller which orchestrates it.
* How to deal with various modes like `merge` and `keep`? How to control `refresh`? Maybe partial (only the files we touch), and full, to also update the files we don't touch as part of status? Maybe it's part of status if that is run before.
* Worthwhile to make explicit the difference between `git reset` and `git checkout` in terms of `HEAD` modifications. With the former changing `HEAD`s referent, and the latter changing `HEAD` itself.
* figure out how this relates to the current `checkout()` method as technically that's a `reset --hard` with optional overwrite check. Could it be rolled into one, with pathspec support added? 
   - just keep them separate until it's clear that `reset()` performs just as well, which is unlikely as there is more overhead. But maybe it's not worth to maintain two versions over it. But if so, one should probably rename it.
* for `git status`: what about rename tracking? It's available for tree-diffs and quite complex on its own. Probably only needs HEAD-vs-index rename tracking. No, also can have worktree rename tracking, even though it's hard to imagine how this can be fast unless it's tightly integrated with untracked-files handling. This screams for a generalization of the tracking code though as the testing and implementation is complex, but *should* be generalisable.


