### PR TITLE
Recommend just over make in README.md and COLLABORATING.md

### DIFF
--- a/COLLABORATING.md
+++ b/COLLABORATING.md
@@ -10,7 +10,7 @@
      - …if collaboration on a feature and prior feedback is desired
    - **feel free to use the [project-board] to organize your issues, PRs or cards**
 - **`main` must never be broken or show warnings**
-   - An easy way to achieve this is to run `make tests check-size` before pushing or `make tests check-size && git push`.
+   - An easy way to achieve this is to run `just test check-size` before pushing or `just check-size && git push`.
    - If you're unsure about remembering to do this, we suggest using a pre-commit git hook.
 - **if `main` breaks on CI** _which can happen nonetheless_…
     - …and you _do know_ the cause, please fix it immediately. If necessary by reverting the offending commit until a more durable fix is possible.

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ If what you have seen so far sparked your interest to contribute, then let us sa
 > ❗️Note❗️: For cloning, `gix-lfs` needs to be locally installed or the checkout will fail. `git lfs install` must have been called once, followed
   by `git lfs pull` to replace the `lfs`-pointer files.
 
-We recommend running `make tests check-size` during the development process to assure CI is green before pushing.
+We recommend running `just test check-size` during the development process to assure CI is green before pushing.
 
 A backlog for work ready to be picked up is [available in the Project's Kanban board][project-board], which contains instructions on how 
 to pick a task. If it's empty or you have other questions, feel free to [start a discussion][discussions] or reach out to @Byron [privately][keybase].


### PR DESCRIPTION
Because the current makefile no longer support the mentioned args.

Side note:
I am not sure if check-size should be also still recommended because it fails on my device with:

```
  in gix-diff   →       Error: The actual estimated package size of 31.4 KB exceeded the limit of 15.0 KB by 16.4 KB
error: Recipe `check-size` failed on line 218 with exit code 1
```

But I assume it works on the CICD or maybe it is not executed.

Another side note:
index::file::read::sparse_checkout_non_sparse_index test fails which I had to ignore. I made sure to use git-lfs but maybe it is something related to my specific setup. So I will simply add #[ignore] to it locally. (All other tests work when I ignore it)

Here is the error:
```
---- index::file::read::sparse_checkout_non_sparse_index stdout ----
thread 'index::file::read::sparse_checkout_non_sparse_index' panicked at gix-index/tests/index/file/read.rs:267:13:
assertion `left == right` failed
  left: Flags(EXTENDED | SKIP_WORKTREE)
 right: Flags(0x0)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    index::file::read::sparse_checkout_non_sparse_index
```
