### PR TITLE
Remove unsafe transmute of should_interrupt

### DIFF
--- a/gix-protocol/src/fetch/arguments/async_io.rs
+++ b/gix-protocol/src/fetch/arguments/async_io.rs
@@ -9,7 +9,7 @@ impl Arguments {
         &mut self,
         transport: &'a mut T,
         add_done_argument: bool,
-    ) -> Result<Box<dyn client::ExtendedBufRead + Unpin + 'a>, client::Error> {
+    ) -> Result<Box<dyn client::ExtendedBufRead<'a> + Unpin + 'a>, client::Error> {
         if self.haves.is_empty() {
             assert!(add_done_argument, "If there are no haves, is_done must be true.");
         }

--- a/gix-protocol/src/fetch/arguments/blocking_io.rs
+++ b/gix-protocol/src/fetch/arguments/blocking_io.rs
@@ -10,7 +10,7 @@ impl Arguments {
         &mut self,
         transport: &'a mut T,
         add_done_argument: bool,
-    ) -> Result<Box<dyn client::ExtendedBufRead + Unpin + 'a>, client::Error> {
+    ) -> Result<Box<dyn client::ExtendedBufRead<'a> + Unpin + 'a>, client::Error> {
         if self.haves.is_empty() {
             assert!(add_done_argument, "If there are no haves, is_done must be true.");
         }

--- a/gix-protocol/src/fetch/response/async_io.rs
+++ b/gix-protocol/src/fetch/response/async_io.rs
@@ -10,7 +10,7 @@ use crate::fetch::{
 
 async fn parse_v2_section<T>(
     line: &mut String,
-    reader: &mut (impl client::ExtendedBufRead + Unpin),
+    reader: &mut (impl client::ExtendedBufRead<'_> + Unpin),
     res: &mut Vec<T>,
     parse: impl Fn(&str) -> Result<T, response::Error>,
 ) -> Result<bool, response::Error> {
@@ -44,7 +44,7 @@ impl Response {
     /// that `git` has to use to predict how many acks are supposed to be read. We also genuinely hope that this covers it all….
     pub async fn from_line_reader(
         version: Protocol,
-        reader: &mut (impl client::ExtendedBufRead + Unpin),
+        reader: &mut (impl client::ExtendedBufRead<'_> + Unpin),
         client_expects_pack: bool,
         wants_to_negotiate: bool,
     ) -> Result<Response, response::Error> {

--- a/gix-protocol/src/fetch/response/blocking_io.rs
+++ b/gix-protocol/src/fetch/response/blocking_io.rs
@@ -8,9 +8,9 @@ use crate::fetch::{
     Response,
 };
 
-fn parse_v2_section<T>(
+fn parse_v2_section<'a, T>(
     line: &mut String,
-    reader: &mut impl client::ExtendedBufRead,
+    reader: &mut impl client::ExtendedBufRead<'a>,
     res: &mut Vec<T>,
     parse: impl Fn(&str) -> Result<T, response::Error>,
 ) -> Result<bool, response::Error> {
@@ -42,9 +42,9 @@ impl Response {
     /// is to predict how to parse V1 output only, and neither `client_expects_pack` nor `wants_to_negotiate` are relevant for V2.
     /// This ugliness is in place to avoid having to resort to an [an even more complex ugliness](https://github.com/git/git/blob/9e49351c3060e1fa6e0d2de64505b7becf157f28/fetch-pack.c#L583-L594)
     /// that `git` has to use to predict how many acks are supposed to be read. We also genuinely hope that this covers it all….
-    pub fn from_line_reader(
+    pub fn from_line_reader<'a>(
         version: Protocol,
-        reader: &mut impl client::ExtendedBufRead,
+        reader: &mut impl client::ExtendedBufRead<'a>,
         client_expects_pack: bool,
         wants_to_negotiate: bool,
     ) -> Result<Response, response::Error> {

--- a/gix-protocol/src/fetch_fn.rs
+++ b/gix-protocol/src/fetch_fn.rs
@@ -165,8 +165,10 @@ where
     Ok(())
 }
 
-fn setup_remote_progress<P>(progress: &mut P, reader: &mut Box<dyn gix_transport::client::ExtendedBufRead + Unpin + '_>)
-where
+fn setup_remote_progress<P>(
+    progress: &mut P,
+    reader: &mut Box<dyn gix_transport::client::ExtendedBufRead<'_> + Unpin + '_>,
+) where
     P: NestedProgress,
     P::SubProgress: 'static,
 {
@@ -176,5 +178,5 @@ where
             crate::RemoteProgress::translate_to_progress(is_err, data, &mut remote_progress);
             gix_transport::packetline::read::ProgressAction::Continue
         }
-    }) as gix_transport::client::HandleProgress));
+    }) as gix_transport::client::HandleProgress<'_>));
 }

--- a/gix-transport/src/client/async_io/bufread_ext.rs
+++ b/gix-transport/src/client/async_io/bufread_ext.rs
@@ -15,7 +15,7 @@ use crate::{
 /// A function `f(is_error, text)` receiving progress or error information.
 /// As it is not a future itself, it must not block. If IO is performed within the function, be sure to spawn
 /// it onto an executor.
-pub type HandleProgress = Box<dyn FnMut(bool, &[u8]) -> ProgressAction>;
+pub type HandleProgress<'a> = Box<dyn FnMut(bool, &[u8]) -> ProgressAction + 'a>;
 
 /// This trait exists to get a version of a `gix_packetline::Provider` without type parameters,
 /// but leave support for reading lines directly without forcing them through `String`.
@@ -44,11 +44,11 @@ pub trait ReadlineBufRead: AsyncBufRead {
 
 /// Provide even more access to the underlying packet reader.
 #[async_trait(?Send)]
-pub trait ExtendedBufRead: ReadlineBufRead {
+pub trait ExtendedBufRead<'a>: ReadlineBufRead {
     /// Set the handler to which progress will be delivered.
     ///
     /// Note that this is only possible if packet lines are sent in side band mode.
-    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress>);
+    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>);
     /// Peek the next data packet line. Maybe None if the next line is a packet we stop at, queryable using
     /// [`stopped_at()`][ExtendedBufRead::stopped_at()].
     async fn peek_data_line(&mut self) -> Option<io::Result<Result<&[u8], Error>>>;
@@ -70,8 +70,8 @@ impl<'a, T: ReadlineBufRead + ?Sized + 'a + Unpin> ReadlineBufRead for Box<T> {
 }
 
 #[async_trait(?Send)]
-impl<'a, T: ExtendedBufRead + ?Sized + 'a + Unpin> ExtendedBufRead for Box<T> {
-    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress>) {
+impl<'a, T: ExtendedBufRead<'a> + ?Sized + 'a + Unpin> ExtendedBufRead<'a> for Box<T> {
+    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>) {
         self.deref_mut().set_progress_handler(handle_progress)
     }
 
@@ -101,7 +101,7 @@ impl<T: AsyncRead + Unpin> ReadlineBufRead
 }
 
 #[async_trait(?Send)]
-impl<'a, T: AsyncRead + Unpin> ReadlineBufRead for gix_packetline::read::WithSidebands<'a, T, HandleProgress> {
+impl<'a, T: AsyncRead + Unpin> ReadlineBufRead for gix_packetline::read::WithSidebands<'a, T, HandleProgress<'a>> {
     async fn readline(&mut self) -> Option<io::Result<Result<PacketLineRef<'_>, gix_packetline::decode::Error>>> {
         self.read_data_line().await
     }
@@ -111,8 +111,8 @@ impl<'a, T: AsyncRead + Unpin> ReadlineBufRead for gix_packetline::read::WithSid
 }
 
 #[async_trait(?Send)]
-impl<'a, T: AsyncRead + Unpin> ExtendedBufRead for gix_packetline::read::WithSidebands<'a, T, HandleProgress> {
-    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress>) {
+impl<'a, T: AsyncRead + Unpin> ExtendedBufRead<'a> for gix_packetline::read::WithSidebands<'a, T, HandleProgress<'a>> {
+    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>) {
         self.set_progress_handler(handle_progress)
     }
     async fn peek_data_line(&mut self) -> Option<io::Result<Result<&[u8], Error>>> {

--- a/gix-transport/src/client/async_io/traits.rs
+++ b/gix-transport/src/client/async_io/traits.rs
@@ -82,7 +82,7 @@ pub trait TransportV2Ext {
         capabilities: impl Iterator<Item = (&'a str, Option<impl AsRef<str>>)> + 'a,
         arguments: Option<impl Iterator<Item = bstr::BString> + 'a>,
         trace: bool,
-    ) -> Result<Box<dyn ExtendedBufRead + Unpin + '_>, Error>;
+    ) -> Result<Box<dyn ExtendedBufRead<'_> + Unpin + '_>, Error>;
 }
 
 #[async_trait(?Send)]
@@ -93,7 +93,7 @@ impl<T: Transport> TransportV2Ext for T {
         capabilities: impl Iterator<Item = (&'a str, Option<impl AsRef<str>>)> + 'a,
         arguments: Option<impl Iterator<Item = BString> + 'a>,
         trace: bool,
-    ) -> Result<Box<dyn ExtendedBufRead + Unpin + '_>, Error> {
+    ) -> Result<Box<dyn ExtendedBufRead<'_> + Unpin + '_>, Error> {
         let mut writer = self.request(WriteMode::OneLfTerminatedLinePerWriteCall, MessageKind::Flush, trace)?;
         writer.write_all(format!("command={command}").as_bytes()).await?;
         for (name, value) in capabilities {

--- a/gix-transport/src/client/blocking_io/http/mod.rs
+++ b/gix-transport/src/client/blocking_io/http/mod.rs
@@ -516,8 +516,8 @@ impl<H: Http, B: ReadlineBufRead + Unpin> ReadlineBufRead for HeadersThenBody<H,
     }
 }
 
-impl<H: Http, B: ExtendedBufRead + Unpin> ExtendedBufRead for HeadersThenBody<H, B> {
-    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress>) {
+impl<'a, H: Http, B: ExtendedBufRead<'a> + Unpin> ExtendedBufRead<'a> for HeadersThenBody<H, B> {
+    fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>) {
         self.body.set_progress_handler(handle_progress)
     }
 

--- a/gix-transport/src/client/blocking_io/request.rs
+++ b/gix-transport/src/client/blocking_io/request.rs
@@ -8,7 +8,7 @@ use crate::client::{ExtendedBufRead, MessageKind, WriteMode};
 pub struct RequestWriter<'a> {
     on_into_read: MessageKind,
     writer: gix_packetline::Writer<Box<dyn io::Write + 'a>>,
-    reader: Box<dyn ExtendedBufRead + Unpin + 'a>,
+    reader: Box<dyn ExtendedBufRead<'a> + Unpin + 'a>,
     trace: bool,
 }
 
@@ -35,7 +35,7 @@ impl<'a> RequestWriter<'a> {
     /// If `trace` is true, `gix_trace` will be used on every written message or data.
     pub fn new_from_bufread<W: io::Write + 'a>(
         writer: W,
-        reader: Box<dyn ExtendedBufRead + Unpin + 'a>,
+        reader: Box<dyn ExtendedBufRead<'a> + Unpin + 'a>,
         write_mode: WriteMode,
         on_into_read: MessageKind,
         trace: bool,
@@ -89,7 +89,7 @@ impl<'a> RequestWriter<'a> {
     /// Discard the ability to write and turn this instance into the reader for obtaining the other side's response.
     ///
     /// Doing so will also write the message type this instance was initialized with.
-    pub fn into_read(mut self) -> std::io::Result<Box<dyn ExtendedBufRead + Unpin + 'a>> {
+    pub fn into_read(mut self) -> std::io::Result<Box<dyn ExtendedBufRead<'a> + Unpin + 'a>> {
         self.write_message(self.on_into_read)?;
         self.writer.inner_mut().flush()?;
         Ok(self.reader)
@@ -105,7 +105,7 @@ impl<'a> RequestWriter<'a> {
     /// It's of utmost importance to drop the request writer before reading the response as these might be inter-dependent, depending on
     /// the underlying transport mechanism. Failure to do so may result in a deadlock depending on how the write and read mechanism
     /// is implemented.
-    pub fn into_parts(self) -> (Box<dyn io::Write + 'a>, Box<dyn ExtendedBufRead + Unpin + 'a>) {
+    pub fn into_parts(self) -> (Box<dyn io::Write + 'a>, Box<dyn ExtendedBufRead<'a> + Unpin + 'a>) {
         (self.writer.into_inner(), self.reader)
     }
 }

--- a/gix-transport/src/client/blocking_io/traits.rs
+++ b/gix-transport/src/client/blocking_io/traits.rs
@@ -75,7 +75,7 @@ pub trait TransportV2Ext {
         capabilities: impl Iterator<Item = (&'a str, Option<impl AsRef<str>>)> + 'a,
         arguments: Option<impl Iterator<Item = bstr::BString>>,
         trace: bool,
-    ) -> Result<Box<dyn ExtendedBufRead + Unpin + '_>, Error>;
+    ) -> Result<Box<dyn ExtendedBufRead<'_> + Unpin + '_>, Error>;
 }
 
 impl<T: Transport> TransportV2Ext for T {
@@ -85,7 +85,7 @@ impl<T: Transport> TransportV2Ext for T {
         capabilities: impl Iterator<Item = (&'a str, Option<impl AsRef<str>>)> + 'a,
         arguments: Option<impl Iterator<Item = BString>>,
         trace: bool,
-    ) -> Result<Box<dyn ExtendedBufRead + Unpin + '_>, Error> {
+    ) -> Result<Box<dyn ExtendedBufRead<'_> + Unpin + '_>, Error> {
         let mut writer = self.request(WriteMode::OneLfTerminatedLinePerWriteCall, MessageKind::Flush, trace)?;
         writer.write_all(format!("command={command}").as_bytes())?;
         for (name, value) in capabilities {


### PR DESCRIPTION
Adds a lifetime to the `ExtendedBufRead` trait to specify how long the callback provided must live.

cc @manishearth