### PR TITLE
Add config section for mailmap

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -84,7 +84,7 @@ excludes = ["dep:gix-ignore", "dep:gix-worktree", "index"]
 attributes = ["excludes", "dep:gix-filter", "dep:gix-pathspec", "dep:gix-attributes", "dep:gix-submodule", "gix-worktree?/attributes", "dep:gix-command"]
 
 ## Add support for mailmaps, as way of determining the final name of commmiters and authors.
-mailmap = ["dep:gix-mailmap"]
+mailmap = ["dep:gix-mailmap", "revision"]
 
 ## Make revspec parsing possible, as well describing revision.
 revision = ["gix-revision/describe", "index"]

--- a/gix/src/config/snapshot/access.rs
+++ b/gix/src/config/snapshot/access.rs
@@ -51,7 +51,7 @@ impl<'repo> Snapshot<'repo> {
     ///
     /// Note that this method takes the most recent value at `key` even if it is from a file with reduced trust.
     #[momo]
-    pub fn string<'a>(&self, key: impl Into<&'a BStr>) -> Option<Cow<'_, BStr>> {
+    pub fn string<'a>(&self, key: impl Into<&'a BStr>) -> Option<Cow<'repo, BStr>> {
         self.repo.config.resolved.string_by_key(key)
     }
 
@@ -62,7 +62,7 @@ impl<'repo> Snapshot<'repo> {
     pub fn trusted_path<'a>(
         &self,
         key: impl Into<&'a BStr>,
-    ) -> Option<Result<Cow<'_, std::path::Path>, gix_config::path::interpolate::Error>> {
+    ) -> Option<Result<Cow<'repo, std::path::Path>, gix_config::path::interpolate::Error>> {
         let key = gix_config::parse::key(key.into())?;
         self.repo
             .config

--- a/gix/src/config/tree/mod.rs
+++ b/gix/src/config/tree/mod.rs
@@ -45,6 +45,8 @@ pub(crate) mod root {
         pub const INDEX: sections::Index = sections::Index;
         /// The `init` section.
         pub const INIT: sections::Init = sections::Init;
+        /// The `mailmap` section.
+        pub const MAILMAP: sections::Mailmap = sections::Mailmap;
         /// The `pack` section.
         pub const PACK: sections::Pack = sections::Pack;
         /// The `protocol` section.
@@ -78,6 +80,7 @@ pub(crate) mod root {
                 &Self::HTTP,
                 &Self::INDEX,
                 &Self::INIT,
+                &Self::MAILMAP,
                 &Self::PACK,
                 &Self::PROTOCOL,
                 &Self::REMOTE,
@@ -93,8 +96,8 @@ pub(crate) mod root {
 mod sections;
 pub use sections::{
     branch, checkout, core, credential, extensions, fetch, gitoxide, http, index, protocol, remote, ssh, Author,
-    Branch, Checkout, Clone, Committer, Core, Credential, Extensions, Fetch, Gitoxide, Http, Index, Init, Pack,
-    Protocol, Remote, Safe, Ssh, Url, User,
+    Branch, Checkout, Clone, Committer, Core, Credential, Extensions, Fetch, Gitoxide, Http, Index, Init, Mailmap,
+    Pack, Protocol, Remote, Safe, Ssh, Url, User,
 };
 #[cfg(feature = "blob-diff")]
 pub use sections::{diff, Diff};

--- a/gix/src/config/tree/sections/mailmap.rs
+++ b/gix/src/config/tree/sections/mailmap.rs
@@ -1,0 +1,21 @@
+use crate::config::{
+    tree::{keys, Key, Mailmap, Section},
+    Tree,
+};
+
+impl Mailmap {
+    /// The `mailmap.blob` key
+    pub const BLOB: keys::Any = keys::Any::new("blob", &Tree::MAILMAP);
+    /// The `mailmap.file` key
+    pub const FILE: keys::Any = keys::Any::new("file", &Tree::MAILMAP);
+}
+
+impl Section for Mailmap {
+    fn name(&self) -> &str {
+        "mailmap"
+    }
+
+    fn keys(&self) -> &[&dyn Key] {
+        &[&Self::BLOB, &Self::FILE]
+    }
+}

--- a/gix/src/config/tree/sections/mailmap.rs
+++ b/gix/src/config/tree/sections/mailmap.rs
@@ -5,9 +5,9 @@ use crate::config::{
 
 impl Mailmap {
     /// The `mailmap.blob` key
-    pub const BLOB: keys::Any = keys::Any::new("blob", &Tree::MAILMAP);
+    pub const BLOB: keys::String = keys::String::new_string("blob", &Tree::MAILMAP);
     /// The `mailmap.file` key
-    pub const FILE: keys::Any = keys::Any::new("file", &Tree::MAILMAP);
+    pub const FILE: keys::Path = keys::Path::new_path("file", &Tree::MAILMAP);
 }
 
 impl Section for Mailmap {

--- a/gix/src/config/tree/sections/mod.rs
+++ b/gix/src/config/tree/sections/mod.rs
@@ -72,6 +72,10 @@ pub mod index;
 pub struct Init;
 mod init;
 
+#[derive(Copy, Clone, Default)]
+pub struct Mailmap;
+mod mailmap;
+
 /// The `pack` top-level section.
 #[derive(Copy, Clone, Default)]
 pub struct Pack;

--- a/gix/src/mailmap.rs
+++ b/gix/src/mailmap.rs
@@ -9,7 +9,7 @@ pub mod load {
         #[error("The mailmap file declared in `mailmap.file` could not be read")]
         Io(#[from] std::io::Error),
         #[error("The configured mailmap.blob could not be parsed")]
-        BlobSpec(#[from] gix_hash::decode::Error),
+        BlobSpec(#[from] crate::revision::spec::parse::single::Error),
         #[error(transparent)]
         PathInterpolate(#[from] gix_config::path::interpolate::Error),
         #[error("Could not find object configured in `mailmap.blob`")]


### PR DESCRIPTION
While working with #1125, I noticed that there were no config tree constants for `mailmap.{blob,file}`. This PR adds those keys. They will later be put to use in https://github.com/Byron/gitoxide/blob/58ed530da0eed05b6b5b97d4941a53e06b679918/gix/src/repository/mailmap.rs#L30 and following.
