### PR TITLE
fix: NetBSD doesn't have `st_mtime_nsec` and `st_ctime_nsec`

### DIFF
--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -56,7 +56,10 @@ impl Metadata {
         {
             Some(system_time_from_secs_nanos(
                 self.0.st_mtime.try_into().ok()?,
+                #[cfg(not(target_os = "netbsd"))]
                 self.0.st_mtime_nsec.try_into().ok()?,
+                #[cfg(target_os = "netbsd")]
+                self.0.st_mtimensec.try_into().ok()?,
             ))
         }
         #[cfg(windows)]
@@ -72,7 +75,10 @@ impl Metadata {
         {
             Some(system_time_from_secs_nanos(
                 self.0.st_ctime.try_into().ok()?,
+                #[cfg(not(target_os = "netbsd"))]
                 self.0.st_ctime_nsec.try_into().ok()?,
+                #[cfg(target_os = "netbsd")]
+                self.0.st_ctimensec.try_into().ok()?,
             ))
         }
         #[cfg(windows)]


### PR DESCRIPTION
fix: NetBSD doesn't have `st_mtime_nsec` and `st_ctime_nsec`

It has `st_mtimensec` and `st_ctimensec` instead.

* https://man.netbsd.org/NetBSD-8.0/stat.2
* https://docs.rs/libc/0.2/x86_64-unknown-netbsd/libc/struct.stat.html#structfield.st_mtimensec
* https://docs.rs/libc/0.2/aarch64-unknown-netbsd/libc/struct.stat.html#structfield.st_mtimensec
* https://docs.rs/libc/0.2/x86_64-unknown-netbsd/libc/struct.stat.html#structfield.st_ctimensec
* https://docs.rs/libc/0.2/aarch64-unknown-netbsd/libc/struct.stat.html#structfield.st_ctimensec


This blocks `cargo` submodule sync in rust-lang/rust btw: <https://github.com/rust-lang/rust/pull/118765#issuecomment-1848579803>

