### PR TITLE
allow organize to move repositories into a child directory of their current location

### DIFF
--- a/tests/journey/ein.sh
+++ b/tests/journey/ein.sh
@@ -139,6 +139,24 @@ title "Porcelain ${kind}"
                 expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
               }
             )
+
+            (with "--execute with move into subdirectory of itself"
+              (cd example.com
+                rm -Rf a-repo-with-extension origin-and-fork
+                mv one-origin ../
+                cd ..
+                rmdir example.com && mv one-origin example.com
+              )
+              it "succeeds" && {
+                WITH_SNAPSHOT="$snapshot/execute-success-new-root" \
+                expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
+              }
+
+              it "does alter the directory structure as these are already in place" && {
+                WITH_SNAPSHOT="$snapshot/directory-structure-after-organize-to-new-root" \
+                expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 -type d | sort'
+              }
+            )
           )
           if test "$kind" != "max-pure"; then
           (with "running with no further arguments"

--- a/tests/snapshots/porcelain/tool/organize/directory-structure-after-organize-to-new-root
+++ b/tests/snapshots/porcelain/tool/organize/directory-structure-after-organize-to-new-root
@@ -1,0 +1,8 @@
+.
+./dir
+./example.com
+./example.com/one-origin
+./no-origin
+./no-origin/.git
+./special-origin
+./special-origin/.git


### PR DESCRIPTION
I've run into a situation, where I had cloned a repo into a location and the canonicalized destination was a subpath of that location. `ein tool organize --execute` was unhappy about that:

```
~/dev 
❯ ein t organize --execute
 10:00:35 organize Moving ./example.org/foo to /path/to/destination/example.org/foo/foo
 10:00:35 organize Error when handling directory "./example.org/foo": Invalid argument (os error 22)
Error: Failed to handle 1 repositories
```

This patch moves directories twice, allowing for things like this to work out just fine:

```
~/dev 
❯ ein t organize --execute
 10:04:41 organize Moving ./example.org/foo to /path/to/destination/example.org/foo/foo
 ```
