### PR TITLE
Add `core.editor` key

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -61,6 +61,9 @@ comfort = ["gix-features/progress-unit-bytes", "gix-features/progress-unit-human
 #! A component is a distinct feature which may be comprised of one or more methods around a particular topic.
 #! Providers of libraries should only activate the components they need.
 
+## Provide a top-level `command` module that helps with spawning commands similarly to `git`.
+command = ["dep:gix-command"]
+
 ## Obtain information similar to `git status`.
 status = ["gix-status"]
 
@@ -81,7 +84,7 @@ worktree-mutation = ["attributes", "dep:gix-worktree-state"]
 excludes = ["dep:gix-ignore", "dep:gix-worktree", "index"]
 
 ## Query attributes and excludes. Enables access to pathspecs, worktree checkouts, filter-pipelines and submodules.
-attributes = ["excludes", "dep:gix-filter", "dep:gix-pathspec", "dep:gix-attributes", "dep:gix-submodule", "gix-worktree?/attributes", "dep:gix-command"]
+attributes = ["excludes", "dep:gix-filter", "dep:gix-pathspec", "dep:gix-attributes", "dep:gix-submodule", "gix-worktree?/attributes", "command"]
 
 ## Add support for mailmaps, as way of determining the final name of commmiters and authors.
 mailmap = ["dep:gix-mailmap", "revision"]

--- a/gix/src/config/tree/keys.rs
+++ b/gix/src/config/tree/keys.rs
@@ -165,9 +165,19 @@ pub type RemoteName = Any<validate::RemoteName>;
 pub type Boolean = Any<validate::Boolean>;
 
 /// A key that represents an executable program, shell script or shell commands.
+///
+/// Once obtained with [trusted_program()](crate::config::Snapshot::trusted_program())
+/// one can run it with [command::prepare()](gix_command::prepare), possibly after
+/// [obtaining](crate::Repository::command_context) and [setting](gix_command::Prepare::with_context)
+/// a git [command context](gix_command::Context) (depending on the commands needs).
 pub type Program = Any<validate::Program>;
 
 /// A key that represents an executable program as identified by name or path.
+///
+/// Once obtained with [trusted_program()](crate::config::Snapshot::trusted_program())
+/// one can run it with [command::prepare()](gix_command::prepare), possibly after
+/// [obtaining](crate::Repository::command_context) and [setting](gix_command::Prepare::with_context)
+/// a git [command context](gix_command::Context) (depending on the commands needs).
 pub type Executable = Any<validate::Executable>;
 
 /// A key that represents a path (to a resource).

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -22,6 +22,8 @@ impl Core {
     /// The `core.disambiguate` key.
     pub const DISAMBIGUATE: Disambiguate =
         Disambiguate::new_with_validate("disambiguate", &config::Tree::CORE, validate::Disambiguate);
+    /// The `core.editor` key.
+    pub const EDITOR: keys::Executable = keys::Executable::new_executable("editor", &config::Tree::CORE);
     /// The `core.fileMode` key.
     pub const FILE_MODE: keys::Boolean = keys::Boolean::new_boolean("fileMode", &config::Tree::CORE);
     /// The `core.ignoreCase` key.
@@ -102,6 +104,7 @@ impl Section for Core {
             &Self::CHECK_STAT,
             &Self::DELTA_BASE_CACHE_LIMIT,
             &Self::DISAMBIGUATE,
+            &Self::EDITOR,
             &Self::FILE_MODE,
             &Self::IGNORE_CASE,
             &Self::FILES_REF_LOCK_TIMEOUT,

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -23,7 +23,7 @@ impl Core {
     pub const DISAMBIGUATE: Disambiguate =
         Disambiguate::new_with_validate("disambiguate", &config::Tree::CORE, validate::Disambiguate);
     /// The `core.editor` key.
-    pub const EDITOR: keys::Executable = keys::Executable::new_executable("editor", &config::Tree::CORE);
+    pub const EDITOR: keys::Program = keys::Program::new_program("editor", &config::Tree::CORE);
     /// The `core.fileMode` key.
     pub const FILE_MODE: keys::Boolean = keys::Boolean::new_boolean("fileMode", &config::Tree::CORE);
     /// The `core.ignoreCase` key.
@@ -60,10 +60,10 @@ impl Core {
         .with_environment_override("GIT_ASKPASS")
         .with_note("fallback is 'SSH_ASKPASS'");
     /// The `core.excludesFile` key.
-    pub const EXCLUDES_FILE: keys::Executable = keys::Executable::new_executable("excludesFile", &config::Tree::CORE);
+    pub const EXCLUDES_FILE: keys::Path = keys::Path::new_path("excludesFile", &config::Tree::CORE);
     /// The `core.attributesFile` key.
-    pub const ATTRIBUTES_FILE: keys::Executable =
-        keys::Executable::new_executable("attributesFile", &config::Tree::CORE)
+    pub const ATTRIBUTES_FILE: keys::Path =
+        keys::Path::new_path("attributesFile", &config::Tree::CORE)
             .with_deviation("for checkout - it's already queried but needs building of attributes group, and of course support during checkout");
     /// The `core.sshCommand` key.
     pub const SSH_COMMAND: keys::Executable = keys::Executable::new_executable("sshCommand", &config::Tree::CORE)

--- a/gix/src/config/tree/sections/diff.rs
+++ b/gix/src/config/tree/sections/diff.rs
@@ -19,10 +19,10 @@ impl Diff {
     pub const RENAMES: Renames = Renames::new_renames("renames", &config::Tree::DIFF);
 
     /// The `diff.<driver>.command` key.
-    pub const DRIVER_COMMAND: keys::String = keys::String::new_string("command", &config::Tree::DIFF)
+    pub const DRIVER_COMMAND: keys::Program = keys::Program::new_program("command", &config::Tree::DIFF)
         .with_subsection_requirement(Some(SubSectionRequirement::Parameter("driver")));
     /// The `diff.<driver>.textconv` key.
-    pub const DRIVER_TEXTCONV: keys::String = keys::String::new_string("textconv", &config::Tree::DIFF)
+    pub const DRIVER_TEXTCONV: keys::Program = keys::Program::new_program("textconv", &config::Tree::DIFF)
         .with_subsection_requirement(Some(SubSectionRequirement::Parameter("driver")));
     /// The `diff.<driver>.algorithm` key.
     pub const DRIVER_ALGORITHM: Algorithm =

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -95,6 +95,8 @@
 pub use gix_actor as actor;
 #[cfg(feature = "attributes")]
 pub use gix_attributes as attrs;
+#[cfg(feature = "command")]
+pub use gix_command as command;
 pub use gix_commitgraph as commitgraph;
 #[cfg(feature = "credentials")]
 pub use gix_credentials as credentials;


### PR DESCRIPTION
Happy to adjust based on feedback, I wanted to add a feature to https://github.com/danobi/prr/pull/36 where we would use `$EDITOR` as a fallback, and use `core.editor` as the primary source, to match expectations with [`git` itself](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_editor), but the field isn't (yet) supported here, so this PR adds the `core.editor` field, I hope.

There is a test failing, but it seems like an unrelated failure, and it might be my local setup interfering, as it's about `file::init::comfort::from_git_dir`, so I want to open the PR to let the CI take a shot at it.

Looking forward to your feedback, feel free to edit and adjust as you see fit.