### PR TITLE
Remove reset of `match_ceiling_dir_or_error` in `apply_environment()`

### DIFF
--- a/gix-discover/src/upwards/types.rs
+++ b/gix-discover/src/upwards/types.rs
@@ -87,16 +87,12 @@ impl Options<'_> {
     ///
     /// Note that `GIT_DISCOVERY_ACROSS_FILESYSTEM` for `cross_fs` is **not** read,
     /// as it requires parsing of `git-config` style boolean values.
-    ///
-    /// In addition, this function disables `match_ceiling_dir_or_error` to allow
-    /// discovery if an outside environment variable sets non-matching ceiling directories.
     // TODO: test
     pub fn apply_environment(mut self) -> Self {
         let name = "GIT_CEILING_DIRECTORIES";
         if let Some(ceiling_dirs) = env::var_os(name) {
             self.ceiling_dirs = parse_ceiling_dirs(&ceiling_dirs);
         }
-        self.match_ceiling_dir_or_error = false;
         self
     }
 }


### PR DESCRIPTION
In https://github.com/Byron/gitoxide/pull/721, this reset was added which makes using
[ThreadSafeRepository::discover_with_environment_overrides_opts]( https://github.com/Byron/gitoxide/blob/f7adf97bc6aa2bf82f906c4463b1cbb3f9cddae3/gix/src/discover.rs#L67) inconvenient.

If the old behaviour of `match_ceiling_dir_or_error = false` desired, then it can be achieved by
setting it on `options` just before calling `apply_environment()`.

The inverse is not true, and `ThreadSafeRepository::discover_with_environment_overrides_opts`
cannot enable this flag because `apply_environment` overrides it.

I am not sure if this change is the best approach to accomplish what I need.
Let me know if you think it is better to change `discover_with_environment_overrides_opts`
so that `options` parameter is used as override instead of default.
