### PR TITLE
fix: use correct fields for ctime and mtime on AIX

### DIFF
--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -55,11 +55,16 @@ impl Metadata {
         #[cfg(not(windows))]
         {
             Some(system_time_from_secs_nanos(
+                #[cfg(not(target_os = "aix"))]
                 self.0.st_mtime.try_into().ok()?,
-                #[cfg(not(target_os = "netbsd"))]
+                #[cfg(target_os = "aix")]
+                self.0.st_mtim.tv_sec.try_into().ok()?,
+                #[cfg(not(any(target_os = "netbsd", target_os = "aix")))]
                 self.0.st_mtime_nsec.try_into().ok()?,
                 #[cfg(target_os = "netbsd")]
                 self.0.st_mtimensec.try_into().ok()?,
+                #[cfg(target_os = "aix")]
+                self.0.st_mtim.tv_nsec.try_into().ok()?,
             ))
         }
         #[cfg(windows)]
@@ -74,11 +79,16 @@ impl Metadata {
         #[cfg(not(windows))]
         {
             Some(system_time_from_secs_nanos(
+                #[cfg(not(target_os = "aix"))]
                 self.0.st_ctime.try_into().ok()?,
-                #[cfg(not(target_os = "netbsd"))]
+                #[cfg(target_os = "aix")]
+                self.0.st_ctim.tv_sec.try_into().ok()?,
+                #[cfg(not(any(target_os = "netbsd", target_os = "aix")))]
                 self.0.st_ctime_nsec.try_into().ok()?,
                 #[cfg(target_os = "netbsd")]
                 self.0.st_ctimensec.try_into().ok()?,
+                #[cfg(target_os = "aix")]
+                self.0.st_ctim.tv_nsec.try_into().ok()?,
             ))
         }
         #[cfg(windows)]


### PR DESCRIPTION
On AIX, ctime and mtime are structs containing seconds and nanoseconds.

Reference: https://github.com/rust-lang/libc/blob/f05d6a35b25288b143241ebb6b4b071618945431/src/unix/aix/powerpc64.rs#L63
