### PR TITLE
Give the CI fuzzer more time

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,7 +15,7 @@ jobs:
      with:
        oss-fuzz-project-name: 'gitoxide'
        language: rust
-       fuzz-seconds: 600
+       fuzz-seconds: 840
    - name: Upload Crash
      uses: actions/upload-artifact@v3
      if: failure() && steps.build.outcome == 'success'


### PR DESCRIPTION
Currently the CI fuzzer isn't on the critical path to completion. So we can extend the amount of fuzzing time without impacting the critical path.