### PR TITLE
msrv of 1.65 in crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,11 +2957,11 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "archive generation from of a worktree stream"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project dealing .gitattributes files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-bitmap/Cargo.toml
+++ b/gix-bitmap/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated implementing the standard git bitmap format"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 exclude = ["CHANGELOG.md"]
 
 [lib]

--- a/gix-chunk/Cargo.toml
+++ b/gix-chunk/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://github.com/git/git/blob/seen/Documentation/technical/ch
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project handling internal git command execution"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/lib.rs", "LICENSE-*"]
 
 [lib]

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -8,7 +8,7 @@ description = "Read-only access to the git commitgraph file format"
 authors = ["Conor Davis <gitoxide@conor.fastmail.fm>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project providing git-config value parsing"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 keywords = ["git-config", "git", "config", "gitoxide"]
 categories = ["config", "parser-implementations"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [features]

--- a/gix-config/tests/Cargo.toml
+++ b/gix-config/tests/Cargo.toml
@@ -6,7 +6,7 @@ description = "Tests for the gix-config crate"
 license = "MIT OR Apache-2.0"
 authors = ["Edward Shen <code@eddie.sh>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 publish = false
 
 

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to interact with git credentials helpers"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project parsing dates the way git does"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -7,7 +7,7 @@ description = "Calculate differences between various git objects"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [features]

--- a/gix-diff/tests/Cargo.toml
+++ b/gix-diff/tests/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Tests for the gix-diff crate"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[test]]
 doctest = false

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -7,7 +7,7 @@ description = "Discover git repositories and check if a directory is a git repos
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.37.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fetchhead/Cargo.toml
+++ b/gix-fetchhead/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to read and write .git/FETCH_HEAD"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing git filters"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate providing file system specific utilities to `gitoxide`"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fsck/Cargo.toml
+++ b/gix-fsck/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Verifies the connectivity and validity of objects in the database"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with pattern matching"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-hashtable/Cargo.toml
+++ b/gix-hashtable/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate that provides hashtable based data structures optimized t
 authors = ["Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project dealing .gitignore files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -7,7 +7,7 @@ description = "A work-in-progress crate of the gitoxide project dedicated implem
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 

--- a/gix-index/tests/Cargo.toml
+++ b/gix-index/tests/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Integration tests for gix-index"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[test]]
 name = "integrate"

--- a/gix-lfs/Cargo.toml
+++ b/gix-lfs/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with handling git large file support"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-lock/Cargo.toml
+++ b/gix-lock/Cargo.toml
@@ -7,7 +7,7 @@ description = "A git-style lock-file implementation"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-macros/Cargo.toml
+++ b/gix-macros/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 proc_macro = true

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for parsing mailmap files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing negotiation algorithms"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-note/Cargo.toml
+++ b/gix-note/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with git notes"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Implements various git object databases"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-odb/tests/Cargo.toml
+++ b/gix-odb/tests/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Tests for gix-odb with feature-toggle support"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 publish = false
 
 [features]

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Implements git packs and related data structures"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-pack/tests/Cargo.toml
+++ b/gix-pack/tests/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Please use `gix-<thiscrate>` instead ('git' -> 'gix')"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [features]
 gix-features-parallel = ["gix-features/parallel"]

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -7,7 +7,7 @@ description = "A duplicate of `gix-packetline` with the `blocking-io` feature pr
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project implementing the pkt-line seriali
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0.26"
 once_cell = "1.17.1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-home = "0.5.4"
+home = "0.5.5"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project dealing paths and their conversio
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing magical pathspecs"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [lib]

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project for handling prompts in the termi
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project for implementing git protocols"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "!**/tests/**/*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-quote/Cargo.toml
+++ b/gix-quote/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with various quotations used by git"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-rebase/Cargo.toml
+++ b/gix-rebase/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing rebases"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate to handle git references"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-ref/tests/Cargo.toml
+++ b/gix-ref/tests/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Test the gix-ref crate with feature toggles"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [features]
 gix-features-parallel = ["gix-features/parallel"] # test sorted parallel loose file traversal

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project for parsing and representing refs
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project dealing with finding names for re
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-revwalk/Cargo.toml
+++ b/gix-revwalk/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate providing utilities for walking the revision graph"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project providing a shared trust model"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-sequencer/Cargo.toml
+++ b/gix-sequencer/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project handling sequences of human-aided operations"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project dealing with 'git status'-like fu
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>", "Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-status/tests/Cargo.toml
+++ b/gix-status/tests/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate to drive gix-status tests with different features"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>", "Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
 publish = false
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[test]]
 name = "worktree"

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing git submodules"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-tempfile/Cargo.toml
+++ b/gix-tempfile/Cargo.toml
@@ -7,7 +7,7 @@ description = "A tempfile implementation with a global registry to assure cleanu
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[example]]
 name = "delete-tempfiles-on-sigterm"

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A tool like `tig`, but minimal, fast and efficient"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-trace/Cargo.toml
+++ b/gix-trace/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.5"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project dedicated to implementing the git
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-traverse/tests/Cargo.toml
+++ b/gix-traverse/tests/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Integration tests for the gix-traverse crate"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[test]]
 name ="test"

--- a/gix-tui/Cargo.toml
+++ b/gix-tui/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated to a terminal user interface to interact with git repositories"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[bin]]
 name = "gixi"

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.114", optional = true, default-features = false, featur
 thiserror = "1.0.32"
 url = "2.5.0"
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
-home = "0.5.3"
+home = "0.5.5"
 
 document-features = { version = "0.2.0", optional = true }
 

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project implementing parsing and serializ
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "tests/baseline/**/*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate with `gitoxide` utilities that don't need feature toggles"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-validate/Cargo.toml
+++ b/gix-validate/Cargo.toml
@@ -7,7 +7,7 @@ description = "Validation functions for various kinds of names in git"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project implementing setting the worktree
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-worktree-state/tests/Cargo.toml
+++ b/gix-worktree-state/tests/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate for running tests with feature toggles on gix-worktree-st
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.70"
+rust-version = "1.65"
 
 [[test]]
 name = "worktree"

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "generate a byte-stream from a git-tree"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate of the gitoxide project for shared worktree related types
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/gix-worktree/tests/Cargo.toml
+++ b/gix-worktree/tests/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate for testing the gix-worktree crate with feature toggles"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 publish = false
 
 [[test]]

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.57.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.65"
 
 [lib]
 doctest = false


### PR DESCRIPTION
- chore: change `rust-version` manifest field back to 1.65.
- virtually downgrade `home` to pass MRSV checks
