### PR TITLE
optimize gix-config fuzzer performance

### DIFF
--- a/gix-config/fuzz/fuzz_targets/fuzz_file.rs
+++ b/gix-config/fuzz/fuzz_targets/fuzz_file.rs
@@ -4,103 +4,58 @@ use anyhow::Result;
 
 use bstr::{BStr, BString};
 
-use gix_config::{
-    file::{init::Options, Metadata},
-    File,
-};
+use gix_config::file::{init::Options, Metadata};
 use libfuzzer_sys::fuzz_target;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::hint::black_box;
 use std::str;
 
-fn fuzz_immutable(file: &File, section_name: &str, subsection_name: &Option<BString>, key: &str) {
-    // Can't use the map here is the borrow checker chucks a flip converting between
-    // &Option<BString> and Option<&BStr>.
-    let subsection_name: Option<&BStr> = if let Some(n) = subsection_name {
-        Some(n.as_ref())
-    } else {
-        None
-    };
-    // Singular strings.
-    _ = black_box(file.string(section_name, subsection_name, key));
-    _ = black_box(file.string_by_key(key));
-    _ = black_box(file.string_filter(section_name, subsection_name, key, &mut |_| false));
-    _ = black_box(file.string_filter_by_key(key, &mut |_| false));
-
-    // Plural strings.
-    _ = black_box(file.strings(section_name, subsection_name, key));
-    _ = black_box(file.strings_by_key(key));
-    _ = black_box(file.strings_filter(section_name, subsection_name, key, &mut |_| false));
-    _ = black_box(file.strings_filter_by_key(key, &mut |_| false));
-
-    // Singular path.
-    _ = black_box(file.path(section_name, subsection_name, key));
-    _ = black_box(file.path_by_key(key));
-    _ = black_box(file.path_filter(section_name, subsection_name, key, &mut |_| false));
-    _ = black_box(file.path_filter_by_key(key, &mut |_| false));
-
-    // Singular bool.
-    _ = black_box(file.boolean(section_name, subsection_name, key));
-    _ = black_box(file.boolean_by_key(key));
-    _ = black_box(file.boolean_filter(section_name, subsection_name, key, &mut |_| false));
-    _ = black_box(file.boolean_filter_by_key(key, &mut |_| false));
-    // NOTE: no plural bool.
-
-    // Singular integer.
-    _ = black_box(file.integer(section_name, subsection_name, key));
-    _ = black_box(file.integer_by_key(key));
-    _ = black_box(file.integer_filter(section_name, subsection_name, key, &mut |_| false));
-    _ = black_box(file.integer_filter_by_key(key, &mut |_| false));
-
-    // Plural integers.
-    _ = black_box(file.integers(section_name, subsection_name, key));
-    _ = black_box(file.integers_by_key(key));
-    _ = black_box(file.integers_filter(section_name, subsection_name, key, &mut |_| false));
-    _ = black_box(file.integers_filter_by_key(key, &mut |_| false));
-
-    // Sections and frontmatter.
-    _ = black_box(file.sections_and_ids().count());
-    _ = black_box(file.sections_and_postmatter().count());
-    _ = black_box(file.sections_by_name("section").map(|x| x.count()));
-    _ = black_box(file.frontmatter());
+fn fuzz_immutable_section(section: &gix_config::file::Section<'_>, buf: &mut Vec<u8>) {
+    for key in section.keys() {
+        let _ = black_box(section.value(key));
+    }
+    buf.clear();
+    let _ = black_box(section.write_to(buf));
 }
 
-fn fuzz_mutable(file: &mut File, section_name: &str, subsection_name: &Option<BString>, key: &str) -> Result<()> {
-    // TODO: It might make sense to make fuzzed modifications.
-
-    // Can't use the map here is the borrow checker chucks a flip converting between
-    // &Option<BString> and Option<&BStr>.
-    let subsection_name: Option<&BStr> = if let Some(n) = subsection_name {
-        Some(n.as_ref())
-    } else {
-        None
-    };
+fn fuzz_mutable_section(
+    file: &mut gix_config::File<'_>,
+    section_name: &str,
+    subsection_name: Option<BString>,
+) -> Result<()> {
+    use bstr::ByteSlice;
+    let subsection_name: Option<&BStr> = subsection_name.as_ref().map(|b| (**b).as_bstr());
 
     // Mutate section.
     let section_id = {
         let mut section = file.section_mut(section_name, subsection_name)?;
-        section.push_newline();
-        section.set(key.to_string().try_into()?, BStr::new("Set value"));
-        section.push_newline();
-        let kv_pair = section.pop().map(|(key, value)| (key.to_owned(), value.to_owned()));
+        let key = section.keys().next().cloned();
+
+        if let Some(key) = key {
+            section.push_newline();
+            section.set(key, BStr::new("Set value"));
+            section.push_newline();
+        }
+        let kv_pair = section.pop().map(|(key, value)| (key.to_owned(), value));
         if let Some((key, value)) = kv_pair {
             section.push_with_comment(key, Some(&value), "Popped");
+        } else {
+            section.push("new-implicit".try_into()?, None);
+            section.push("new".try_into()?, Some("value".into()));
         }
         section.id()
     };
 
-    _ = black_box(file.section_mut_by_key(key));
     _ = black_box(file.section_mut_by_id(section_id));
 
     let new_section_name = section_name.to_string() + "_new";
     _ = black_box(file.section_mut_or_create_new(&new_section_name, subsection_name));
-    _ = black_box(file.section_mut_or_create_new_filter(&new_section_name, subsection_name, &mut |_| false));
 
-    _ = black_box(file.section_mut_filter(section_name, subsection_name, &mut |_| false));
-    _ = black_box(file.section_mut_filter_by_key(key, &mut |_| false));
     if let Some(removed_section) = file.remove_section(&new_section_name, subsection_name) {
         _ = black_box(file.push_section(removed_section));
     }
+
     _ = black_box(file.new_section(Cow::Owned(new_section_name.clone()), None));
     let renamed_section_name = section_name.to_string() + "_renamed";
     let renamed_subsection_name: Option<Cow<'_, BStr>> =
@@ -120,57 +75,41 @@ fn fuzz_mutable(file: &mut File, section_name: &str, subsection_name: &Option<BS
         &mut |_| false,
     ));
 
-    // Singular raw.
-    _ = black_box(
-        file.raw_value_mut(section_name, subsection_name, key)?
-            .set_string("raw_values"),
-    );
-
-    // Plural raw.
-    _ = black_box(file.raw_values_mut(section_name, subsection_name, key)?.len());
     Ok(())
 }
 
 fn fuzz(input: &[u8]) -> Result<()> {
     let meta = Metadata::default();
     let options = Options::default();
-    let file = File::from_bytes_no_includes(input, meta.clone(), options.clone())?;
+    let file = gix_config::File::from_bytes_no_includes(input, meta.clone(), options)?;
 
-    let section_triples: Vec<_> = file
-        .sections()
-        .flat_map(|sec| {
-            sec.keys().map(|key| {
-                let section_name = str::from_utf8(sec.header().name()).unwrap();
-                let subsection_name = sec.header().subsection_name();
-                let key = str::from_utf8(&key).unwrap();
-                return (
-                    section_name.to_owned(),
-                    subsection_name.map(|x| x.to_owned()),
-                    key.to_owned(),
-                );
-            })
-        })
-        .collect();
+    // Sections and frontmatter.
+    _ = black_box(file.sections_and_ids().count());
+    _ = black_box(file.sections_and_postmatter().count());
+    _ = black_box(file.sections_by_name("section").map(std::iter::Iterator::count));
+    _ = black_box(file.frontmatter());
 
-    for section_triple in section_triples.iter() {
-        let (section_name, subsection_name, key) = section_triple;
-        black_box(fuzz_immutable(&file, &section_name, &subsection_name, &key));
+    let mut buf = Vec::new();
+    let mut sections = Vec::new();
+    for section in file.sections() {
+        fuzz_immutable_section(section, &mut buf);
+
+        let header = section.header();
+        let section_name = str::from_utf8(header.name()).unwrap();
+        let subsection_name = header.subsection_name().map(std::borrow::ToOwned::to_owned);
+        sections.push((section_name, subsection_name));
     }
 
     let mut mutated_file = file.clone();
-
-    for section_triple in section_triples.iter() {
-        let (section_name, subsection_name, key) = section_triple;
-        _ = black_box(fuzz_mutable(&mut mutated_file, &section_name, &subsection_name, &key));
+    for (section_name, subsection_name) in sections.into_iter() {
+        let _ = black_box(fuzz_mutable_section(&mut mutated_file, section_name, subsection_name));
     }
 
     _ = black_box(mutated_file.append(file));
-
-    let roundtrip_as_string: Vec<u8> = mutated_file.to_bstring().into();
-    _ = black_box(File::from_bytes_no_includes(
-        &roundtrip_as_string,
-        meta.clone(),
-        options.clone(),
+    _ = black_box(gix_config::File::from_bytes_no_includes(
+        &mutated_file.to_bstring(),
+        meta,
+        options,
     )?);
 
     Ok(())


### PR DESCRIPTION
The fuzzer came up with a configuration file that has 50k sections.

Doing all these accesses to the configuration in Debug mode was slow enough for the
program to be considered stalled.

Now the fuzz-test focusses on much less of the API and limits itself to not necessarily
processing everything, which reduces the release runtime from 11 minutes to 2 seconds.
