### PR TITLE
make ItemSliceSync::get_mut() check that the index is in range

### DIFF
--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -57,7 +57,6 @@ mod node {
         /// Children are `Node`s referring to pack entries whose base object is this pack entry.
         pub fn into_child_iter(self) -> impl Iterator<Item = Node<'a, T>> + 'a {
             let children = self.child_items;
-            // SAFETY: The index is a valid index into the children array.
             // SAFETY: The resulting mutable pointer cannot be yielded by any other node.
             #[allow(unsafe_code)]
             self.item.children.iter().map(move |&index| Node {

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -57,6 +57,7 @@ mod node {
         /// Children are `Node`s referring to pack entries whose base object is this pack entry.
         pub fn into_child_iter(self) -> impl Iterator<Item = Node<'a, T>> + 'a {
             let children = self.child_items;
+            // SAFETY: The index is a valid index into the children array.
             // SAFETY: The resulting mutable pointer cannot be yielded by any other node.
             #[allow(unsafe_code)]
             self.item.children.iter().map(move |&index| Node {

--- a/gix-pack/src/cache/delta/traverse/util.rs
+++ b/gix-pack/src/cache/delta/traverse/util.rs
@@ -5,6 +5,7 @@ where
     T: Send,
 {
     items: *mut T,
+    len: usize,
     phantom: PhantomData<&'a T>,
 }
 
@@ -15,13 +16,18 @@ where
     pub fn new(items: &'a mut [T]) -> Self {
         ItemSliceSync {
             items: items.as_mut_ptr(),
+            len: items.len(),
             phantom: PhantomData,
         }
     }
 
-    /// SAFETY: The index must point into the slice and must not be reused concurrently.
+    // SAFETY: The index must not be reused concurrently
     #[allow(unsafe_code)]
     pub unsafe fn get_mut(&self, index: usize) -> &'a mut T {
+        if index >= self.len {
+            panic!("index out of bounds: the len is {} but the index is {index}", self.len);
+        }
+        // SAFETY: The index is within the slice
         // SAFETY: The children array is alive by the 'a lifetime.
         unsafe { &mut *self.items.add(index) }
     }

--- a/gix-pack/src/cache/delta/traverse/util.rs
+++ b/gix-pack/src/cache/delta/traverse/util.rs
@@ -5,6 +5,7 @@ where
     T: Send,
 {
     items: *mut T,
+    #[cfg(debug_assertions)]
     len: usize,
     phantom: PhantomData<&'a T>,
 }
@@ -16,14 +17,16 @@ where
     pub fn new(items: &'a mut [T]) -> Self {
         ItemSliceSync {
             items: items.as_mut_ptr(),
+            #[cfg(debug_assertions)]
             len: items.len(),
             phantom: PhantomData,
         }
     }
 
-    // SAFETY: The index must not be reused concurrently
+    // SAFETY: The index must point into the slice and must not be reused concurrently.
     #[allow(unsafe_code)]
     pub unsafe fn get_mut(&self, index: usize) -> &'a mut T {
+        #[cfg(debug_assertions)]
         if index >= self.len {
             panic!("index out of bounds: the len is {} but the index is {index}", self.len);
         }


### PR DESCRIPTION
This removes some of the unsafety from
ItemSliceSync::get_mut(). There's still the unsafety that the caller needs to make sure a single index is not used concurrently.

