### PR TITLE
RFC: remove "Copyright Sebastian Thiel ..." from LICENSE files

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -176,8 +176,6 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2018-2021 Sebastian Thiel, and [contributors](https://github.com/byron/gitoxide/contributors)
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,3 @@
-Copyright (c) 2018-2021 Sebastian Thiel, and [contributors](https://github.com/byron/gitoxide/contributors).
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
The "Copyright Sebastian Thiel ..." line in the LICENSE files confuse our tooling and reviewers at Google, making it take longer than necessary to import new versions of Gitoxide into our monorepo. IIUC, the copyright is supposed to go in each source code file instead. Maybe it will become necessary to move it out of the LICENSE file as soon as the project decides to copy/vendor some code from somewhere else anwyay, because then we probably can't claim copyright for the entire repo? I'm not a lawyer and far from an export on this.

If we remove the copyright line from the LICENSE files, does that mean that we should add them in each source file? I think I've heard that that's not necessary because the information about who wrote the code is available in the commit log..

