### PR TITLE
Add `cargo-binstall` support for gitoxide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,3 +308,7 @@ faster-hex = { version = "0.9.0" }
 
 [package.metadata.docs.rs]
 features = ["document-features", "max"]
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/gitoxide-max-pure-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "gitoxide-max-pure-v{ version }-{ target }/{ bin }{ binary-ext }"

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ Our [stability guide] helps to judge how much churn can be expected when dependi
 
 ### Download a Binary Release
 
-Using `cargo quickinstall`, one is able to fetch [binary releases][releases]. You can install it via `cargo install cargo-quickinstall`, assuming 
+Using `cargo binstall`, one is able to fetch [binary releases][releases]. You can install it via `cargo install cargo-quickinstall`, assuming 
 the [rust toolchain][rustup] is present.
 
-Then install gitoxide with `cargo quickinstall gitoxide`.
+Then install gitoxide with `cargo binstall gitoxide`.
 
 See the [releases section][releases] for manual installation and various alternative builds that are _slimmer_ or _smaller_, depending
 on your needs, for _Linux_, _MacOS_ and _Windows_.


### PR DESCRIPTION
So that `cargo-binstall` can download official pre-built binaries from the github release.

Tested locally using `cargo binstall --manifest-path Cargo.toml gitoxide --force --strategies crate-meta-data`

