### PR TITLE
Make cargo-binstall instructions consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Our [stability guide] helps to judge how much churn can be expected when dependi
 
 ### Download a Binary Release
 
-Using `cargo binstall`, one is able to fetch [binary releases][releases]. You can install it via `cargo install cargo-quickinstall`, assuming 
+Using `cargo binstall`, one is able to fetch [binary releases][releases]. You can install it via `cargo install cargo-binstall`, assuming 
 the [rust toolchain][rustup] is present.
 
 Then install gitoxide with `cargo binstall gitoxide`.


### PR DESCRIPTION
Small change to make cargo-binstall instructions consistent after adding them in #1239.
(Following the instructions I was confused and actually checked whether cargo-quickinstall installs cargo-binstall...)