### PR TITLE
Fix stat on files with timestamps before the epoch

### DIFF
--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -186,6 +186,11 @@ impl Metadata {
 }
 
 #[cfg(not(windows))]
-fn system_time_from_secs_nanos(secs: u64, nanos: u32) -> SystemTime {
-    std::time::UNIX_EPOCH + std::time::Duration::new(secs, nanos)
+fn system_time_from_secs_nanos(secs: i64, nanos: u32) -> SystemTime {
+    let d = std::time::Duration::new(secs.abs_diff(0), nanos);
+    if secs < 0 {
+        std::time::UNIX_EPOCH - d
+    } else {
+        std::time::UNIX_EPOCH + d
+    }
 }

--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -66,10 +66,11 @@ impl Metadata {
             #[cfg(target_os = "aix")]
             let nanoseconds = self.0.st_mtim.tv_nsec;
 
-            Some(system_time_from_secs_nanos(
-                seconds.try_into().ok()?,
-                nanoseconds.try_into().ok()?,
-            ))
+            // All operating systems treat the seconds as offset from unix epoch, hence it must
+            // be signed in order to deal with dates before epoch.
+            // Rustix seems to think this value is u64, but we fix it here for now.
+            let seconds = seconds as i64;
+            system_time_from_secs_nanos(seconds, nanoseconds.try_into().ok()?)
         }
         #[cfg(windows)]
         self.0.modified().ok()
@@ -94,10 +95,11 @@ impl Metadata {
             #[cfg(target_os = "aix")]
             let nanoseconds = self.0.st_ctim.tv_nsec;
 
-            Some(system_time_from_secs_nanos(
-                seconds.try_into().ok()?,
-                nanoseconds.try_into().ok()?,
-            ))
+            // All operating systems treat the seconds as offset from unix epoch, hence it must
+            // be signed in order to deal with dates before epoch.
+            // Rustix seems to think this value is u64, but we fix it here for now.
+            let seconds = seconds as i64;
+            system_time_from_secs_nanos(seconds, nanoseconds.try_into().ok()?)
         }
         #[cfg(windows)]
         self.0.created().ok()
@@ -186,11 +188,30 @@ impl Metadata {
 }
 
 #[cfg(not(windows))]
-fn system_time_from_secs_nanos(secs: i64, nanos: u32) -> SystemTime {
-    let d = std::time::Duration::new(secs.abs_diff(0), nanos);
-    if secs < 0 {
+fn system_time_from_secs_nanos(secs: i64, nanos: i32) -> Option<SystemTime> {
+    // Copied from https://github.com/rust-lang/rust at a8ece1190bf6b340175bc5b688e52bd29924f483, MIT licensed, and adapted.
+    // On Apple OS, dates before epoch are represented differently than on other
+    // Unix platforms: e.g. 1/10th of a second before epoch is represented as `seconds=-1`
+    // and `nanoseconds=100_000_000` on other platforms, but is `seconds=0` and
+    // `nanoseconds=-900_000_000` on Apple OS.
+    //
+    // To compensate, we first detect this special case by checking if both
+    // seconds and nanoseconds are in range, and then correct the value for seconds
+    // and nanoseconds to match the common unix representation.
+    //
+    // Please note that Apple OS nonetheless accepts the standard unix format when
+    // setting file times, which makes this compensation round-trippable and generally
+    // transparent.
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    let (secs, nanos) = if (secs <= 0 && secs > i64::MIN) && (nanos < 0 && nanos > -1_000_000_000) {
+        (secs - 1, nanos + 1_000_000_000)
+    } else {
+        (secs, nanos)
+    };
+    let d = std::time::Duration::new(secs.abs_diff(0), nanos.try_into().ok()?);
+    Some(if secs < 0 {
         std::time::UNIX_EPOCH - d
     } else {
         std::time::UNIX_EPOCH + d
-    }
+    })
 }

--- a/gix-index/tests/fixtures/file_metadata.sh
+++ b/gix-index/tests/fixtures/file_metadata.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# The largest-possible date for Ext4, nanos are special there, but ont usually on other filesystems
+touch -d "2446-05-10 22:38:55.111111111" future
+# The smallest-possible date for Ext4, nanos are special there, but ont usually on other filesystems
+touch -d "1901-12-13 20:45:52.222222222" past

--- a/gix-index/tests/fixtures/generated-archives/.gitignore
+++ b/gix-index/tests/fixtures/generated-archives/.gitignore
@@ -1,0 +1,1 @@
+file_metadata.tar.xz

--- a/gix-index/tests/index/fs.rs
+++ b/gix-index/tests/index/fs.rs
@@ -1,0 +1,18 @@
+mod metadata {
+    use gix_index::fs::Metadata;
+
+    #[test]
+    fn from_path_no_follow() -> crate::Result {
+        let root = gix_testtools::scripted_fixture_read_only_standalone("file_metadata.sh")?;
+
+        // For now, don't assert on the values of the metadata as these depends on the filesystem,
+        // which might truncate it, or fail entirely.
+        for filename in ["future", "past"] {
+            let meta = Metadata::from_path_no_follow(&root.join(filename))?;
+            assert!(meta.created().is_some());
+            assert!(meta.modified().is_some());
+            assert_eq!(meta.len(), 0);
+        }
+        Ok(())
+    }
+}

--- a/gix-index/tests/index/mod.rs
+++ b/gix-index/tests/index/mod.rs
@@ -5,6 +5,7 @@ use gix_hash::ObjectId;
 mod access;
 mod entry;
 mod file;
+mod fs;
 mod init;
 
 pub fn hex_to_id(hex: &str) -> ObjectId {


### PR DESCRIPTION
stat converted the seconds to a `u64` before converting them to
SystemTime. This would cause timestamps before the epoch to wrap around
to timestamps near `u64::MAX`.

Instead, pass the seconds as an i64. Convert it to SystemTime by
computing an absolute Duration and then adding or subtracting as
appropriate.
