### PR TITLE
Disable faster-hex's default `serde` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ members = [
 [workspace.dependencies]
 prodash = { version = "28.0.0", default-features = false }
 futures-lite = { version = "2.1.0", default-features = false, features = ["std"] }
-faster-hex = { version = "0.9.0" }
+faster-hex = { version = "0.9.0", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["document-features", "max"]


### PR DESCRIPTION
faster-hex has a default-enabled `serde` feature, but gitoxide doesn't
use that functionality. Disable that feature, so that builds of gitoxide
that otherwise disable serde don't end up pulling it in anyway.
