### PR TITLE
fuzz fix

### DIFF
--- a/gix-config/fuzz/fuzz_targets/fuzz_file.rs
+++ b/gix-config/fuzz/fuzz_targets/fuzz_file.rs
@@ -7,13 +7,20 @@ use bstr::{BStr, BString};
 use gix_config::file::{init::Options, Metadata};
 use libfuzzer_sys::fuzz_target;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::hint::black_box;
 use std::str;
 
 fn fuzz_immutable_section(section: &gix_config::file::Section<'_>, buf: &mut Vec<u8>) {
+    for (key, value) in section.body().clone() {
+        let _ = black_box((key, value));
+    }
+    let mut seen = BTreeSet::new();
     for key in section.keys() {
-        let _ = black_box(section.value(key));
+        if seen.insert(key) {
+            let _ = black_box(section.values(key.as_ref()));
+        }
     }
     buf.clear();
     let _ = black_box(section.write_to(buf));


### PR DESCRIPTION
Previously the fuzzer would create a section with 15k keys
which all were `n`. The first `n` has a 136kb sized value
which triggers an expensive normalization.

All other `n` are empty, but previously caused accessing the
long value again which is the first `n` it finds.

Now we iterate values, and keep track of previous ones when
doing multi-value access, which seems like a good test to
have.
