### PR TITLE
Update to Winnow 0.5.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,7 +3054,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -5519,9 +5519,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.31"
+version = "0.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a4882e6b134d6c28953a387571f1acdd3496830d5e36c5e3a1075580ea641c"
+checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
 dependencies = [
  "memchr",
 ]

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.8.3", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-winnow = { version = "0.5.24", features = ["simd"] }
+winnow = { version = "0.5.36", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -7,7 +7,7 @@ pub(crate) mod function {
         error::{AddContext, ParserError, StrContext},
         prelude::*,
         stream::AsChar,
-        token::{take, take_until0, take_while},
+        token::{take, take_until, take_while},
     };
 
     use crate::{IdentityRef, SignatureRef};
@@ -22,7 +22,7 @@ pub(crate) mod function {
             identity,
             b" ",
             (
-                terminated(take_until0(SPACE), take(1usize))
+                terminated(take_until(0.., SPACE), take(1usize))
                     .verify_map(|v| btoi::<SecondsSinceUnixEpoch>(v).ok())
                     .context(StrContext::Expected("<timestamp>".into())),
                 alt((
@@ -60,8 +60,8 @@ pub(crate) mod function {
         i: &mut &'a [u8],
     ) -> PResult<IdentityRef<'a>, E> {
         (
-            terminated(take_until0(&b" <"[..]), take(2usize)).context(StrContext::Expected("<name>".into())),
-            terminated(take_until0(&b">"[..]), take(1usize)).context(StrContext::Expected("<email>".into())),
+            terminated(take_until(0.., &b" <"[..]), take(2usize)).context(StrContext::Expected("<name>".into())),
+            terminated(take_until(0.., &b">"[..]), take(1usize)).context(StrContext::Expected("<email>".into())),
         )
             .map(|(name, email): (&[u8], &[u8])| IdentityRef {
                 name: name.as_bstr(),

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -24,7 +24,7 @@ gix-sec = { version = "^0.10.4", path = "../gix-sec" }
 gix-ref = { version = "^0.41.0", path = "../gix-ref" }
 gix-glob = { version = "^0.16.0", path = "../gix-glob" }
 
-winnow = { version = "0.5.24", features = ["simd"] }
+winnow = { version = "0.5.36", features = ["simd"] }
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.24", features = ["simd"] }
+winnow = { version = "0.5.36", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -4,7 +4,7 @@ use winnow::{
     combinator::{eof, rest, separated_pair, terminated},
     error::{ErrorKind, ParserError},
     prelude::*,
-    token::take_until1,
+    token::take_until,
 };
 
 use crate::{
@@ -33,7 +33,7 @@ pub struct TrailerRef<'a> {
 
 fn parse_single_line_trailer<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(&'a BStr, &'a BStr), E> {
     *i = i.trim_end();
-    let (token, value) = separated_pair(take_until1(b":".as_ref()), b": ", rest).parse_next(i)?;
+    let (token, value) = separated_pair(take_until(1.., b":".as_ref()), b": ", rest).parse_next(i)?;
 
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
         Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Fail).cut())

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -3,7 +3,7 @@ use winnow::{
     combinator::{preceded, repeat, terminated},
     error::{AddContext, ParserError, StrContext},
     prelude::*,
-    token::{take_till, take_until0, take_while},
+    token::{take_till, take_until, take_while},
     Parser,
 };
 
@@ -21,7 +21,7 @@ pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddCont
         (
             take_till(1.., NL),
             NL,
-            repeat(1.., terminated((SPACE, take_until0(NL)), NL)).map(|()| ()),
+            repeat(1.., terminated((SPACE, take_until(0.., NL)), NL)).map(|()| ()),
         )
             .recognize()
             .map(|o: &[u8]| {

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -3,7 +3,7 @@ use winnow::{
     error::{AddContext, ParserError, StrContext},
     prelude::*,
     stream::AsChar,
-    token::{take_until0, take_while},
+    token::{take_until, take_while},
 };
 
 use crate::{parse, parse::NL, BStr, ByteSlice, TagRef};
@@ -47,12 +47,12 @@ pub fn message<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(&'a B
         NL,
         alt((
             (
-                take_until0(PGP_SIGNATURE_BEGIN),
+                take_until(0.., PGP_SIGNATURE_BEGIN),
                 preceded(
                     NL,
                     (
                         &PGP_SIGNATURE_BEGIN[1..],
-                        take_until0(PGP_SIGNATURE_END),
+                        take_until(0.., PGP_SIGNATURE_END),
                         PGP_SIGNATURE_END,
                         rest,
                     )

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -49,7 +49,7 @@ gix-credentials = { version = "^0.24.0", path = "../gix-credentials" }
 thiserror = "1.0.32"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.24", features = ["simd"] }
+winnow = { version = "0.5.36", features = ["simd"] }
 btoi = "0.4.2"
 
 # for async-client

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -32,7 +32,7 @@ gix-lock = { version = "^13.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^13.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-winnow = { version = "0.5.24", features = ["simd"] }
+winnow = { version = "0.5.36", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.26"
 gix-fs = { version = "^0.10.0", path = "../../gix-fs" }
 gix-tempfile = { version = "^13.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-winnow = { version = "0.5.24", features = ["simd"] }
+winnow = { version = "0.5.36", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"


### PR DESCRIPTION
This resolves a couple of deprecations.  I'm thinking of doing 0.6 soon and I expect this to be the end of the deprecations that will happen in the lead up.  So for people on 0.5.36 with all deprecations resolved, i expect it to be a trivial version bump to 0.6 for most people.