### PR TITLE
Remove Rustix special-cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
  "futures-lite 2.1.0",
  "parking",
  "polling 3.3.1",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -1998,7 +1998,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2 0.9.3",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "serde",
  "smallvec",
  "thiserror",
@@ -2316,7 +2316,7 @@ dependencies = [
  "gix-config-value",
  "gix-testtools",
  "parking_lot",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "serial_test",
  "thiserror",
 ]
@@ -3198,7 +3198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -3294,9 +3294,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3832,7 +3832,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4182,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -4672,7 +4672,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -4691,7 +4691,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -5544,7 +5544,7 @@ checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.12",
- "rustix 0.38.28",
+ "rustix 0.38.31",
 ]
 
 [[package]]

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -42,7 +42,7 @@ bitflags = "2"
 document-features = { version = "0.2.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.20", default-features = false, features = ["std", "fs"] }
+rustix = { version = "0.38.31", default-features = false, features = ["std", "fs"] }
 libc = { version = "0.2.149" }
 
 [package.metadata.docs.rs]

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0.32"
 parking_lot = "0.12.1"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.38.4", features = ["termios"] }
+rustix = { version = "0.38.31", features = ["termios"] }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools"}


### PR DESCRIPTION
Fixes #1269

> [!WARNING]
> Blocked on https://github.com/bytecodealliance/rustix/pull/999#issuecomment-1925203175

### Tasks

* [x] update Rustix
* [ ] use `StatExt` trait

