### PR TITLE
Gracefully handle OOM during decoding of pack entries

### DIFF
--- a/gix-diff/src/blob/pipeline.rs
+++ b/gix-diff/src/blob/pipeline.rs
@@ -112,6 +112,8 @@ impl Mode {
 
 ///
 pub mod convert_to_diffable {
+    use std::collections::TryReserveError;
+
     use bstr::BString;
     use gix_object::tree::EntryKind;
 
@@ -147,6 +149,15 @@ pub mod convert_to_diffable {
         ConvertToWorktree(#[from] gix_filter::pipeline::convert::to_worktree::Error),
         #[error(transparent)]
         ConvertToGit(#[from] gix_filter::pipeline::convert::to_git::Error),
+        #[error("Memory allocation failed")]
+        OutOfMemory,
+    }
+
+    impl From<TryReserveError> for Error {
+        #[cold]
+        fn from(_: TryReserveError) -> Self {
+            Self::OutOfMemory
+        }
     }
 }
 
@@ -339,8 +350,9 @@ impl Pipeline {
                                                         })?;
                                                     }
                                                     ToGitOutcome::Buffer(buf) => {
-                                                        out.resize(buf.len(), 0);
-                                                        out.copy_from_slice(buf);
+                                                        out.clear();
+                                                        out.try_reserve(buf.len())?;
+                                                        out.extend_from_slice(buf);
                                                     }
                                                 }
                                             } else {
@@ -452,8 +464,9 @@ impl Pipeline {
                                     match res {
                                         ToWorktreeOutcome::Unchanged(_) => {}
                                         ToWorktreeOutcome::Buffer(src) => {
-                                            out.resize(src.len(), 0);
-                                            out.copy_from_slice(src);
+                                            out.clear();
+                                            out.try_reserve(src.len())?;
+                                            out.extend_from_slice(src);
                                         }
                                         ToWorktreeOutcome::Process(MaybeDelayed::Immediate(mut stream)) => {
                                             std::io::copy(&mut stream, out).map_err(|err| {

--- a/gix-diff/src/blob/pipeline.rs
+++ b/gix-diff/src/blob/pipeline.rs
@@ -150,14 +150,7 @@ pub mod convert_to_diffable {
         #[error(transparent)]
         ConvertToGit(#[from] gix_filter::pipeline::convert::to_git::Error),
         #[error("Memory allocation failed")]
-        OutOfMemory,
-    }
-
-    impl From<TryReserveError> for Error {
-        #[cold]
-        fn from(_: TryReserveError) -> Self {
-            Self::OutOfMemory
-        }
+        OutOfMemory(#[from] TryReserveError),
     }
 }
 

--- a/gix-diff/tests/diff.rs
+++ b/gix-diff/tests/diff.rs
@@ -35,8 +35,8 @@ mod util {
         fn try_find<'a>(&self, id: &oid, buffer: &'a mut Vec<u8>) -> Result<Option<gix_object::Data<'a>>, Error> {
             match self.data_by_id.get(&id.to_owned()) {
                 Some(data) => {
-                    buffer.resize(data.len(), 0);
-                    buffer.copy_from_slice(data);
+                    buffer.clear();
+                    buffer.extend_from_slice(data);
                     Ok(Some(gix_object::Data {
                         kind: gix_object::Kind::Blob,
                         data: buffer.as_slice(),

--- a/gix-filter/src/eol/convert_to_git.rs
+++ b/gix-filter/src/eol/convert_to_git.rs
@@ -34,6 +34,8 @@ pub enum Error {
     RoundTrip { msg: &'static str, path: PathBuf },
     #[error("Could not obtain index object to check line endings for")]
     FetchObjectFromIndex(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("Could not allocate buffer")]
+    OutOfMemory(#[from] std::collections::TryReserveError),
 }
 
 /// A function that writes a buffer like `fn(&mut buf)` with by tes of an object in the index that is the one that should be converted.
@@ -145,7 +147,7 @@ pub(crate) mod function {
             return Ok(false);
         }
 
-        clear_and_set_capacity(buf, src.len() - stats.crlf);
+        clear_and_set_capacity(buf, src.len() - stats.crlf)?;
         if stats.lone_cr == 0 {
             buf.extend(src.iter().filter(|b| **b != b'\r'));
         } else {

--- a/gix-filter/src/eol/convert_to_worktree.rs
+++ b/gix-filter/src/eol/convert_to_worktree.rs
@@ -7,16 +7,21 @@ use crate::{
 
 /// Convert all `\n` in `src` to `crlf` if `digest` and `config` indicate it, returning `true` if `buf` holds the result, or `false`
 /// if no change was made after all.
-pub fn convert_to_worktree(src: &[u8], digest: AttributesDigest, buf: &mut Vec<u8>, config: Configuration) -> bool {
+pub fn convert_to_worktree(
+    src: &[u8],
+    digest: AttributesDigest,
+    buf: &mut Vec<u8>,
+    config: Configuration,
+) -> Result<bool, std::collections::TryReserveError> {
     if src.is_empty() || digest.to_eol(config) != Some(Mode::CrLf) {
-        return false;
+        return Ok(false);
     }
     let stats = Stats::from_bytes(src);
     if !stats.will_convert_lf_to_crlf(digest, config) {
-        return false;
+        return Ok(false);
     }
 
-    clear_and_set_capacity(buf, src.len() + stats.lone_lf);
+    clear_and_set_capacity(buf, src.len() + stats.lone_lf)?;
 
     let mut ofs = 0;
     while let Some(pos) = src[ofs..].find_byteset(b"\r\n") {
@@ -39,5 +44,5 @@ pub fn convert_to_worktree(src: &[u8], digest: AttributesDigest, buf: &mut Vec<u
         }
     }
     buf.push_str(&src[ofs..]);
-    true
+    Ok(true)
 }

--- a/gix-filter/src/lib.rs
+++ b/gix-filter/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Driver {
 fn clear_and_set_capacity(buf: &mut Vec<u8>, cap: usize) {
     buf.clear();
     if buf.capacity() < cap {
-        buf.reserve(cap);
-        assert!(buf.capacity() >= cap, "{} >= {}", buf.capacity(), cap);
+        buf.try_reserve(cap).expect("OOM");
+        debug_assert!(buf.capacity() >= cap, "{} >= {}", buf.capacity(), cap);
     }
 }

--- a/gix-filter/src/lib.rs
+++ b/gix-filter/src/lib.rs
@@ -73,10 +73,11 @@ pub struct Driver {
     pub required: bool,
 }
 
-fn clear_and_set_capacity(buf: &mut Vec<u8>, cap: usize) {
+fn clear_and_set_capacity(buf: &mut Vec<u8>, cap: usize) -> Result<(), std::collections::TryReserveError> {
     buf.clear();
     if buf.capacity() < cap {
-        buf.try_reserve(cap).expect("memory allocation succeeds");
+        buf.try_reserve(cap)?;
         debug_assert!(buf.capacity() >= cap, "{} >= {}", buf.capacity(), cap);
     }
+    Ok(())
 }

--- a/gix-filter/src/lib.rs
+++ b/gix-filter/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Driver {
 fn clear_and_set_capacity(buf: &mut Vec<u8>, cap: usize) {
     buf.clear();
     if buf.capacity() < cap {
-        buf.try_reserve(cap).expect("OOM");
+        buf.try_reserve(cap).expect("memory allocation succeeds");
         debug_assert!(buf.capacity() >= cap, "{} >= {}", buf.capacity(), cap);
     }
 }

--- a/gix-filter/tests/eol/convert_to_worktree.rs
+++ b/gix-filter/tests/eol/convert_to_worktree.rs
@@ -5,20 +5,21 @@ use gix_filter::{
 };
 
 #[test]
-fn no_conversion_if_attribute_digest_does_not_allow_it() {
+fn no_conversion_if_attribute_digest_does_not_allow_it() -> crate::Result {
     let mut buf = Vec::new();
     for digest in [
         AttributesDigest::Binary,
         AttributesDigest::TextInput,
         AttributesDigest::TextAutoInput,
     ] {
-        let changed = eol::convert_to_worktree(b"hi\nho", digest, &mut buf, Default::default());
+        let changed = eol::convert_to_worktree(b"hi\nho", digest, &mut buf, Default::default())?;
         assert!(!changed, "the digest doesn't allow for CRLF changes");
     }
+    Ok(())
 }
 
 #[test]
-fn no_conversion_if_configuration_does_not_allow_it() {
+fn no_conversion_if_configuration_does_not_allow_it() -> crate::Result {
     let mut buf = Vec::new();
     for digest in [AttributesDigest::Text, AttributesDigest::TextAuto] {
         for config in [
@@ -31,14 +32,15 @@ fn no_conversion_if_configuration_does_not_allow_it() {
                 eol: Some(Mode::Lf),
             },
         ] {
-            let changed = eol::convert_to_worktree(b"hi\nho", digest, &mut buf, config);
+            let changed = eol::convert_to_worktree(b"hi\nho", digest, &mut buf, config)?;
             assert!(!changed, "the configuration doesn't allow for changes");
         }
     }
+    Ok(())
 }
 
 #[test]
-fn no_conversion_if_nothing_to_do() {
+fn no_conversion_if_nothing_to_do() -> crate::Result {
     let mut buf = Vec::new();
     for (input, digest, msg) in [
         (
@@ -62,36 +64,39 @@ fn no_conversion_if_nothing_to_do() {
             "designated binary is never handled",
         ),
     ] {
-        let changed = eol::convert_to_worktree(input, digest, &mut buf, Default::default());
+        let changed = eol::convert_to_worktree(input, digest, &mut buf, Default::default())?;
         assert!(!changed, "{msg}");
     }
+    Ok(())
 }
 
 #[test]
-fn each_nl_is_replaced_with_crnl() {
+fn each_nl_is_replaced_with_crnl() -> crate::Result {
     let mut buf = Vec::new();
     let changed = eol::convert_to_worktree(
         b"hi\n\nho\nend",
         AttributesDigest::TextCrlf,
         &mut buf,
         Default::default(),
-    );
+    )?;
     assert!(
         changed,
         "the buffer has to be changed as it is explicitly demanded and has newlines to convert"
     );
     assert_eq!(buf.as_bstr(), "hi\r\n\r\nho\r\nend");
+    Ok(())
 }
 
 #[test]
-fn existing_crnl_are_not_replaced_for_safety_nor_are_lone_cr() {
+fn existing_crnl_are_not_replaced_for_safety_nor_are_lone_cr() -> crate::Result {
     let mut buf = Vec::new();
     let changed = eol::convert_to_worktree(
         b"hi\r\n\nho\r\nend\r",
         AttributesDigest::TextCrlf,
         &mut buf,
         Default::default(),
-    );
+    )?;
     assert!(changed);
     assert_eq!(buf.as_bstr(), "hi\r\n\r\nho\r\nend\r");
+    Ok(())
 }

--- a/gix-filter/tests/ident/mod.rs
+++ b/gix-filter/tests/ident/mod.rs
@@ -2,60 +2,66 @@ mod undo {
     use bstr::{ByteSlice, B};
 
     #[test]
-    fn no_id_changes_nothing() {
+    fn no_id_changes_nothing() -> crate::Result {
         let mut buf = Vec::new();
-        let changed = gix_filter::ident::undo(B("hello"), &mut buf);
+        let changed = gix_filter::ident::undo(B("hello"), &mut buf)?;
         assert!(!changed, "the buffer is not touched");
         assert_eq!(buf.len(), 0);
+        Ok(())
     }
 
     #[test]
-    fn empty() {
+    fn empty() -> crate::Result {
         let mut buf = Vec::new();
         assert!(
-            !gix_filter::ident::undo(B(""), &mut buf),
+            !gix_filter::ident::undo(B(""), &mut buf)?,
             "nothing to be done in empty buffer"
         );
+        Ok(())
     }
 
     #[test]
-    fn nothing_if_newline_between_dollars() {
+    fn nothing_if_newline_between_dollars() -> crate::Result {
         let mut buf = Vec::new();
-        assert!(!gix_filter::ident::undo(B(" $Id: \n$"), &mut buf));
+        assert!(!gix_filter::ident::undo(B(" $Id: \n$"), &mut buf)?);
         assert_eq!(buf.len(), 0);
+        Ok(())
     }
 
     #[test]
-    fn nothing_if_it_is_not_id() {
+    fn nothing_if_it_is_not_id() -> crate::Result {
         let mut buf = Vec::new();
         assert!(
-            !gix_filter::ident::undo(B(" $id: something$"), &mut buf),
+            !gix_filter::ident::undo(B(" $id: something$"), &mut buf)?,
             "it's matching case-sensitively"
         );
         assert_eq!(buf.len(), 0);
+        Ok(())
     }
 
     #[test]
-    fn anything_between_dollar_id_dollar() {
+    fn anything_between_dollar_id_dollar() -> crate::Result {
         let mut buf = Vec::new();
-        assert!(gix_filter::ident::undo(B(" $Id: something$\nhello"), &mut buf));
+        assert!(gix_filter::ident::undo(B(" $Id: something$\nhello"), &mut buf)?);
         assert_eq!(buf.as_bstr(), " $Id$\nhello");
+        Ok(())
     }
 
     #[test]
-    fn multiple() {
+    fn multiple() -> crate::Result {
         let mut buf = Vec::new();
         assert!(gix_filter::ident::undo(
             B("$Id: a\n$ $Id: something$\nhello$Id: hex$\nlast $Id:other$\n$Id: \n$"),
             &mut buf
-        ));
+        )?);
         assert_eq!(buf.as_bstr(), "$Id: a\n$ $Id$\nhello$Id$\nlast $Id$\n$Id: \n$");
 
         assert!(gix_filter::ident::undo(
             B("$Id: a\n$$Id:$$Id: hex$\n$Id:other$$Id: $end"),
             &mut buf
-        ));
+        )?);
         assert_eq!(buf.as_bstr(), "$Id: a\n$$Id$$Id$\n$Id$$Id$end");
+        Ok(())
     }
 }
 
@@ -64,7 +70,7 @@ mod apply {
     use gix_filter::ident;
 
     #[test]
-    fn no_change() {
+    fn no_change() -> crate::Result {
         let mut buf = Vec::new();
         for input_no_match in [
             "",
@@ -72,40 +78,43 @@ mod apply {
             "$ID$ case sensitive matching",
             "$Id: expanded is ignored$",
         ] {
-            let changed = ident::apply(input_no_match.as_bytes(), gix_hash::Kind::Sha1, &mut buf);
+            let changed = ident::apply(input_no_match.as_bytes(), gix_hash::Kind::Sha1, &mut buf)?;
             assert!(!changed, "no substitution happens, nothing to do");
             assert_eq!(buf.len(), 0);
         }
+        Ok(())
     }
 
     #[test]
-    fn simple() {
+    fn simple() -> crate::Result {
         let mut buf = Vec::new();
         assert!(
-            ident::apply(B("$Id$"), gix_hash::Kind::Sha1, &mut buf),
+            ident::apply(B("$Id$"), gix_hash::Kind::Sha1, &mut buf)?,
             "a change happens"
         );
         assert_eq!(buf.as_bstr(), "$Id: b3f5ebfb5843bc43ceecff6d4f26bb37c615beb1$");
 
-        assert!(ident::apply(B("$Id$ $Id$ foo"), gix_hash::Kind::Sha1, &mut buf));
+        assert!(ident::apply(B("$Id$ $Id$ foo"), gix_hash::Kind::Sha1, &mut buf)?);
         assert_eq!(
             buf.as_bstr(),
             "$Id: e230cff7a9624f59eaa28bfb97602c3a03651a49$ $Id: e230cff7a9624f59eaa28bfb97602c3a03651a49$ foo"
         );
+        Ok(())
     }
 
     #[test]
-    fn round_trips() {
+    fn round_trips() -> crate::Result {
         let mut buf = Vec::new();
         for input in [
             "hi\n$Id$\nho\n\t$Id$$Id$$Id$",
             "$Id$",
             "$Id$ and one more $Id$ and done",
         ] {
-            let changed = ident::apply(B(input), gix_hash::Kind::Sha1, &mut buf);
+            let changed = ident::apply(B(input), gix_hash::Kind::Sha1, &mut buf)?;
             assert!(changed, "the input was rewritten");
-            assert!(ident::undo(&buf.clone(), &mut buf), "undo does something as well");
+            assert!(ident::undo(&buf.clone(), &mut buf)?, "undo does something as well");
             assert_eq!(buf.as_bstr(), input, "the filter can be undone perfectly");
         }
+        Ok(())
     }
 }

--- a/gix-pack/src/cache/lru.rs
+++ b/gix-pack/src/cache/lru.rs
@@ -2,11 +2,10 @@ use super::DecodeEntry;
 
 #[cfg(feature = "pack-cache-lru-dynamic")]
 mod memory {
-    use std::num::NonZeroUsize;
-
-    use clru::WeightScale;
-
     use super::DecodeEntry;
+    use crate::set_vec_to_slice;
+    use clru::WeightScale;
+    use std::num::NonZeroUsize;
 
     struct Entry {
         data: Vec<u8>,
@@ -48,18 +47,13 @@ mod memory {
     impl DecodeEntry for MemoryCappedHashmap {
         fn put(&mut self, pack_id: u32, offset: u64, data: &[u8], kind: gix_object::Kind, compressed_size: usize) {
             self.debug.put();
+            let Ok(data) = set_vec_to_slice(self.free_list.pop().unwrap_or_default(), data) else {
+                return;
+            };
             let res = self.inner.put_with_weight(
                 (pack_id, offset),
                 Entry {
-                    data: self.free_list.pop().map_or_else(
-                        || Vec::from(data),
-                        |mut v| {
-                            v.clear();
-                            v.resize(data.len(), 0);
-                            v.copy_from_slice(data);
-                            v
-                        },
-                    ),
+                    data,
                     kind,
                     compressed_size,
                 },
@@ -72,10 +66,9 @@ mod memory {
         }
 
         fn get(&mut self, pack_id: u32, offset: u64, out: &mut Vec<u8>) -> Option<(gix_object::Kind, usize)> {
-            let res = self.inner.get(&(pack_id, offset)).map(|e| {
-                out.resize(e.data.len(), 0);
-                out.copy_from_slice(&e.data);
-                (e.kind, e.compressed_size)
+            let res = self.inner.get(&(pack_id, offset)).and_then(|e| {
+                set_vec_to_slice(out, &e.data).ok()?;
+                Some((e.kind, e.compressed_size))
             });
             if res.is_some() {
                 self.debug.hit()
@@ -93,6 +86,7 @@ pub use memory::MemoryCappedHashmap;
 #[cfg(feature = "pack-cache-lru-static")]
 mod _static {
     use super::DecodeEntry;
+    use crate::set_vec_to_slice;
     struct Entry {
         pack_id: u32,
         offset: u64,
@@ -154,33 +148,28 @@ mod _static {
                 }
             }
             self.debug.put();
-            let (prev_cap, cur_cap);
+            let mut v = std::mem::take(&mut self.last_evicted);
+            self.mem_used -= v.capacity();
+            if set_vec_to_slice(&mut v, data).is_err() {
+                return;
+            }
+            self.mem_used += v.capacity();
             if let Some(previous) = self.inner.insert(Entry {
                 offset,
                 pack_id,
-                data: {
-                    let mut v = std::mem::take(&mut self.last_evicted);
-                    prev_cap = v.capacity();
-                    v.clear();
-                    v.resize(data.len(), 0);
-                    v.copy_from_slice(data);
-                    cur_cap = v.capacity();
-                    v
-                },
+                data: v,
                 kind,
                 compressed_size,
             }) {
                 // No need to adjust capacity as we already counted it.
                 self.last_evicted = previous.data;
             }
-            self.mem_used = self.mem_used + cur_cap - prev_cap;
         }
 
         fn get(&mut self, pack_id: u32, offset: u64, out: &mut Vec<u8>) -> Option<(gix_object::Kind, usize)> {
             let res = self.inner.lookup(|e: &mut Entry| {
                 if e.pack_id == pack_id && e.offset == offset {
-                    out.resize(e.data.len(), 0);
-                    out.copy_from_slice(&e.data);
+                    set_vec_to_slice(&mut *out, &e.data).ok()?;
                     Some((e.kind, e.compressed_size))
                 } else {
                     None

--- a/gix-pack/src/cache/mod.rs
+++ b/gix-pack/src/cache/mod.rs
@@ -53,3 +53,19 @@ pub mod object;
 
 ///
 pub(crate) mod delta;
+
+/// Replaces content of the given `Vec` with the slice. The vec will have the same length
+/// as the slice. The vec can be either `&mut Vec` or `Vec`.
+/// Returns `None` if no memory could be allocated.
+#[cfg(any(
+    feature = "pack-cache-lru-static",
+    feature = "pack-cache-lru-dynamic",
+    feature = "object-cache-dynamic"
+))]
+fn set_vec_to_slice<V: std::borrow::BorrowMut<Vec<u8>>>(mut vec: V, source: &[u8]) -> Option<V> {
+    let out = vec.borrow_mut();
+    out.clear();
+    out.try_reserve(source.len()).ok()?;
+    out.extend_from_slice(source);
+    Some(vec)
+}

--- a/gix-pack/src/cache/object.rs
+++ b/gix-pack/src/cache/object.rs
@@ -4,11 +4,9 @@ use crate::cache;
 
 #[cfg(feature = "object-cache-dynamic")]
 mod memory {
-    use std::num::NonZeroUsize;
-
+    use crate::{cache, set_vec_to_slice};
     use clru::WeightScale;
-
-    use crate::cache;
+    use std::num::NonZeroUsize;
 
     struct Entry {
         data: Vec<u8>,
@@ -56,21 +54,10 @@ mod memory {
         /// Put the object going by `id` of `kind` with `data` into the cache.
         fn put(&mut self, id: gix_hash::ObjectId, kind: gix_object::Kind, data: &[u8]) {
             self.debug.put();
-            let res = self.inner.put_with_weight(
-                id,
-                Entry {
-                    data: self.free_list.pop().map_or_else(
-                        || Vec::from(data),
-                        |mut v| {
-                            v.clear();
-                            v.resize(data.len(), 0);
-                            v.copy_from_slice(data);
-                            v
-                        },
-                    ),
-                    kind,
-                },
-            );
+            let Ok(data) = set_vec_to_slice(self.free_list.pop().unwrap_or_default(), data) else {
+                return;
+            };
+            let res = self.inner.put_with_weight(id, Entry { data, kind });
             match res {
                 Ok(Some(previous_entry)) => self.free_list.push(previous_entry.data),
                 Ok(None) => {}
@@ -80,10 +67,9 @@ mod memory {
 
         /// Try to retrieve the object named `id` and place its data into `out` if available and return `Some(kind)` if found.
         fn get(&mut self, id: &gix_hash::ObjectId, out: &mut Vec<u8>) -> Option<gix_object::Kind> {
-            let res = self.inner.get(id).map(|e| {
-                out.resize(e.data.len(), 0);
-                out.copy_from_slice(&e.data);
-                e.kind
+            let res = self.inner.get(id).and_then(|e| {
+                set_vec_to_slice(out, &e.data).ok()?;
+                Some(e.kind)
             });
             if res.is_some() {
                 self.debug.hit()

--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -178,8 +178,9 @@ impl File {
         match entry.header {
             Tree | Blob | Commit | Tag => {
                 let size: usize = entry.decompressed_size.try_into().map_err(|_| Error::OutOfMemory)?;
-                out.clear();
-                out.try_reserve(size)?;
+                if let Some(additional) = size.checked_sub(out.len()) {
+                    out.try_reserve(additional)?;
+                }
                 out.resize(size, 0);
                 self.decompress_entry(&entry, inflate, out.as_mut_slice())
                     .map(|consumed_input| {

--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -177,13 +177,10 @@ impl File {
         use crate::data::entry::Header::*;
         match entry.header {
             Tree | Blob | Commit | Tag => {
-                out.resize(
-                    entry
-                        .decompressed_size
-                        .try_into()
-                        .expect("size representable by machine"),
-                    0,
-                );
+                let size: usize = entry.decompressed_size.try_into().map_err(|_| Error::OutOfMemory)?;
+                out.clear();
+                out.try_reserve(size)?;
+                out.resize(size, 0);
                 self.decompress_entry(&entry, inflate, out.as_mut_slice())
                     .map(|consumed_input| {
                         Outcome::from_object_entry(
@@ -280,12 +277,14 @@ impl File {
         let chain_len = chain.len();
         let (first_buffer_end, second_buffer_end) = {
             let delta_start = base_buffer_size.unwrap_or(0);
-            out.resize(delta_start + total_delta_data_size, 0);
 
             let delta_range = Range {
                 start: delta_start,
                 end: delta_start + total_delta_data_size,
             };
+            out.try_reserve(delta_range.end.saturating_sub(out.len()))?;
+            out.resize(delta_range.end, 0);
+
             let mut instructions = &mut out[delta_range.clone()];
             let mut relative_delta_start = 0;
             let mut biggest_result_size = 0;
@@ -321,12 +320,12 @@ impl File {
             // Now we can produce a buffer like this
             // [<biggest-result-buffer, possibly filled with resolved base object data>]<biggest-result-buffer><delta-1..delta-n>
             // from [<possibly resolved base object>]<delta-1..delta-n>...
-            let biggest_result_size: usize = biggest_result_size
-                .try_into()
-                .expect("biggest result size small enough to fit into usize");
+            let biggest_result_size: usize = biggest_result_size.try_into().map_err(|_| Error::OutOfMemory)?;
             let first_buffer_size = biggest_result_size;
             let second_buffer_size = first_buffer_size;
-            out.resize(first_buffer_size + second_buffer_size + total_delta_data_size, 0);
+            let out_size = first_buffer_size + second_buffer_size + total_delta_data_size;
+            out.try_reserve(out_size.saturating_sub(out.len()))?;
+            out.resize(out_size, 0);
 
             // Now 'rescue' the deltas, because in the next step we possibly overwrite that portion
             // of memory with the base object (in the majority of cases)
@@ -400,7 +399,8 @@ impl File {
             // this seems inverted, but remember: we swapped the buffers on the last iteration
             target_buf[..last_result_size].copy_from_slice(&source_buf[..last_result_size]);
         }
-        out.resize(last_result_size, 0);
+        debug_assert!(out.len() >= last_result_size);
+        out.truncate(last_result_size);
 
         let object_kind = object_kind.expect("a base object as root of any delta chain that we are here to resolve");
         let consumed_input = consumed_input.expect("at least one decompressed delta object");

--- a/gix-pack/src/data/file/decode/mod.rs
+++ b/gix-pack/src/data/file/decode/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::TryReserveError;
+
 ///
 pub mod entry;
 ///
@@ -13,4 +15,13 @@ pub enum Error {
     ZlibInflate(#[from] gix_features::zlib::inflate::Error),
     #[error("A delta chain could not be followed as the ref base with id {0} could not be found")]
     DeltaBaseUnresolved(gix_hash::ObjectId),
+    #[error("Entry too large to fit in memory")]
+    OutOfMemory,
+}
+
+impl From<TryReserveError> for Error {
+    #[cold]
+    fn from(_: TryReserveError) -> Self {
+        Self::OutOfMemory
+    }
 }

--- a/gix-pack/src/lib.rs
+++ b/gix-pack/src/lib.rs
@@ -71,3 +71,16 @@ fn read_u32(b: &[u8]) -> u32 {
 fn read_u64(b: &[u8]) -> u64 {
     u64::from_be_bytes(b.try_into().unwrap())
 }
+
+use std::borrow::BorrowMut;
+use std::collections::TryReserveError;
+
+/// Replaces content of the given `Vec` with the slice. The vec will have the same length
+/// as the slice. The vec can be either `&mut Vec` or `Vec`.
+fn set_vec_to_slice<V: BorrowMut<Vec<u8>>>(mut vec: V, source: &[u8]) -> Result<V, TryReserveError> {
+    let out = vec.borrow_mut();
+    out.clear();
+    out.try_reserve(source.len())?;
+    out.extend_from_slice(source);
+    Ok(vec)
+}

--- a/gix-pack/src/lib.rs
+++ b/gix-pack/src/lib.rs
@@ -71,16 +71,3 @@ fn read_u32(b: &[u8]) -> u32 {
 fn read_u64(b: &[u8]) -> u64 {
     u64::from_be_bytes(b.try_into().unwrap())
 }
-
-use std::borrow::BorrowMut;
-use std::collections::TryReserveError;
-
-/// Replaces content of the given `Vec` with the slice. The vec will have the same length
-/// as the slice. The vec can be either `&mut Vec` or `Vec`.
-fn set_vec_to_slice<V: BorrowMut<Vec<u8>>>(mut vec: V, source: &[u8]) -> Result<V, TryReserveError> {
-    let out = vec.borrow_mut();
-    out.clear();
-    out.try_reserve(source.len())?;
-    out.extend_from_slice(source);
-    Ok(vec)
-}


### PR DESCRIPTION
`gix_pack::data::file::decode::entry::<impl gix_pack::data::File>::decode_entry` is causing an out-of-memory error for me.

I'm scanning github.com/rust-lang/crates.io-index using [crates_io_index.crates_parallel()](https://docs.rs/crates-index/latest/crates_index/struct.GitIndex.html#method.crates_parallel).
Unfortunately I can't reliably reproduce it, and the stack trace ends with rayon worker.

I've added a bunch of `try_reserve()` to make the error less crashy. I realize it may be treating only the symptom.

<details>

```text
thread '<unnamed>' panicked at library/std/src/alloc.rs:354:9:
memory allocation of 24781832 bytes failed
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: std::alloc::default_alloc_error_hook
   3: std::alloc::rust_oom
   4: ___rg_oom
   5: alloc::alloc::handle_alloc_error
   6: alloc::raw_vec::RawVec<T,A>::reserve::do_reserve_and_handle
   7: alloc::vec::Vec<T,A>::resize
   8: gix_pack::data::file::decode::entry::<impl gix_pack::data::File>::decode_entry
   9: gix_odb::store_impls::dynamic::find::<impl gix_odb::store_impls::dynamic::Handle<S>>::try_find_cached_inner
  10: gix_odb::store_impls::dynamic::find::<impl gix_pack::find_traits::Find for gix_odb::store_impls::dynamic::Handle<S>>::try_find_cached
  11: gix_odb::cache::impls::<impl gix_pack::find_traits::Find for gix_odb::Cache<S>>::try_find_cached
  12: gix_odb::cache::impls::<impl gix_object::traits::find::Find for gix_odb::Cache<S>>::try_find
  13: gix::repository::object::<impl gix::types::Repository>::_find_object_inner_generated_by_gix_macro_momo
  14: gix::repository::object::<impl gix::types::Repository>::find_object
  15: <crates_index::git::impl_::CratesTreesToBlobs as core::iter::traits::iterator::Iterator>::next
  16: <crates_index::git::impl_::Crates as core::iter::traits::iterator::Iterator>::next
  17: alloc::vec::Vec<T,A>::extend_desugared
  18: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
  19: core::ops::function::impls::<impl core::ops::function::Fn<A> for &F>::call
  20: rayon::iter::plumbing::Folder::consume_iter
  21: rayon::iter::plumbing::bridge_producer_consumer::helper
```
</details>