### PR TITLE
Use chunks_exact where possible

### DIFF
--- a/gix-commitgraph/src/file/access.rs
+++ b/gix-commitgraph/src/file/access.rs
@@ -57,7 +57,7 @@ impl File {
         let start = self.base_graphs_list_offset.unwrap_or(0);
         let base_graphs_list = &self.data[start..][..self.hash_len * usize::from(self.base_graph_count)];
         base_graphs_list
-            .chunks(self.hash_len)
+            .chunks_exact(self.hash_len)
             .map(gix_hash::oid::from_bytes_unchecked)
     }
 

--- a/gix-commitgraph/src/file/init.rs
+++ b/gix-commitgraph/src/file/init.rs
@@ -259,8 +259,10 @@ impl TryFrom<&Path> for File {
 
 // Copied from gix-odb/pack/index/init.rs
 fn read_fan(d: &[u8]) -> ([u32; FAN_LEN], usize) {
+    assert!(d.len() >= FAN_LEN * 4);
+
     let mut fan = [0; FAN_LEN];
-    for (c, f) in d.chunks(4).zip(fan.iter_mut()) {
+    for (c, f) in d.chunks_exact(4).zip(fan.iter_mut()) {
         *f = u32::from_be_bytes(c.try_into().unwrap());
     }
     (fan, FAN_LEN * 4)

--- a/gix-index/src/decode/mod.rs
+++ b/gix-index/src/decode/mod.rs
@@ -96,9 +96,10 @@ impl State {
                     let entries_res = match index_offsets_table {
                         Some(entry_offsets) => {
                             let chunk_size = (entry_offsets.len() as f32 / num_threads as f32).ceil() as usize;
-                            let num_chunks = entry_offsets.chunks(chunk_size).count();
+                            let entry_offsets_chunked = entry_offsets.chunks(chunk_size);
+                            let num_chunks = entry_offsets_chunked.len();
                             let mut threads = Vec::with_capacity(num_chunks);
-                            for (id, chunks) in entry_offsets.chunks(chunk_size).enumerate() {
+                            for (id, chunks) in entry_offsets_chunked.enumerate() {
                                 let chunks = chunks.to_vec();
                                 threads.push(
                                     gix_features::parallel::build_thread()

--- a/gix-pack/src/index/init.rs
+++ b/gix-pack/src/index/init.rs
@@ -83,8 +83,10 @@ impl index::File {
 }
 
 fn read_fan(d: &[u8]) -> ([u32; FAN_LEN], usize) {
+    assert!(d.len() >= FAN_LEN * N32_SIZE);
+
     let mut fan = [0; FAN_LEN];
-    for (c, f) in d.chunks(N32_SIZE).zip(fan.iter_mut()) {
+    for (c, f) in d.chunks_exact(N32_SIZE).zip(fan.iter_mut()) {
         *f = crate::read_u32(c);
     }
     (fan, FAN_LEN * N32_SIZE)

--- a/gix-pack/src/index/traverse/with_lookup.rs
+++ b/gix-pack/src/index/traverse/with_lookup.rs
@@ -121,7 +121,7 @@ impl index::File {
                 let (chunk_size, thread_limit, available_cores) =
                     parallel::optimize_chunk_size_and_thread_limit(1000, Some(index_entries.len()), thread_limit, None);
                 let there_are_enough_entries_to_process = || index_entries.len() > chunk_size * available_cores;
-                let input_chunks = index_entries.chunks(chunk_size.max(chunk_size));
+                let input_chunks = index_entries.chunks(chunk_size);
                 let reduce_progress = OwnShared::new(Mutable::new({
                     let mut p = progress.add_child_with_id("Traversing".into(), ProgressId::DecodedObjects.into());
                     p.init(Some(self.num_objects() as usize), progress::count("objects"));

--- a/gix-pack/src/multi_index/chunk.rs
+++ b/gix-pack/src/multi_index/chunk.rs
@@ -121,7 +121,7 @@ pub mod fanout {
             return None;
         }
         let mut out = [0; 256];
-        for (c, f) in chunk.chunks(4).zip(out.iter_mut()) {
+        for (c, f) in chunk.chunks_exact(4).zip(out.iter_mut()) {
             *f = u32::from_be_bytes(c.try_into().unwrap());
         }
         out.into()

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -226,8 +226,8 @@ pub fn main() -> Result<()> {
                         add_paths: add_path,
                         prefix,
                         files: add_virtual_file
-                            .chunks(2)
-                            .map(|c| (c[0].to_owned(), c[1].clone()))
+                            .chunks_exact(2)
+                            .map(|c| (c[0].clone(), c[1].clone()))
                             .collect(),
                         format: format.map(|f| match f {
                             crate::plumbing::options::archive::Format::Internal => {


### PR DESCRIPTION
I've noticed a few functions use `chunks(len)`, but assume they will actually get `len`-long chunks, even though there could be a shorter remainder chunk.

I suspect there should be more strict length checks for the inputs to `chunks_(exact)`, and `zip` iterators. For example `read_fan` would tolerate inputs shorter than the number of bytes read it returns.

