### PR TITLE
Update winnow to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,9 +5538,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.36"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ dependencies = [
  "gix-date 0.8.1",
  "itoa",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1421,7 +1421,7 @@ dependencies = [
  "gix-date 0.8.1",
  "itoa",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1439,7 +1439,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "thiserror",
- "winnow",
+ "winnow 0.6.0",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow",
+ "winnow 0.6.0",
 ]
 
 [[package]]
@@ -2132,7 +2132,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2151,7 +2151,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2173,7 +2173,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "winnow",
+ "winnow 0.6.0",
 ]
 
 [[package]]
@@ -2361,7 +2361,7 @@ dependencies = [
  "maybe-async",
  "serde",
  "thiserror",
- "winnow",
+ "winnow 0.6.0",
 ]
 
 [[package]]
@@ -2406,7 +2406,7 @@ dependencies = [
  "gix-validate 0.8.1",
  "memmap2 0.7.1",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2429,7 +2429,7 @@ dependencies = [
  "memmap2 0.9.3",
  "serde",
  "thiserror",
- "winnow",
+ "winnow 0.6.0",
 ]
 
 [[package]]
@@ -2648,7 +2648,7 @@ dependencies = [
  "parking_lot",
  "tar",
  "tempfile",
- "winnow",
+ "winnow 0.6.0",
  "xz2",
 ]
 
@@ -4864,7 +4864,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5541,6 +5541,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
 dependencies = [
  "memchr",
 ]

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.8.3", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-winnow = { version = "0.5.36", features = ["simd"] }
+winnow = { version = "0.5.40", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -23,7 +23,7 @@ gix-date = { version = "^0.8.3", path = "../gix-date" }
 thiserror = "1.0.38"
 btoi = "0.4.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"]}
-winnow = { version = "0.5.40", features = ["simd"] }
+winnow = { version = "0.6.0", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -162,7 +162,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "in slice at ' 12345 -1215'\n  0: expected `<email>` at ' 12345 -1215'\n  1: expected `<name> <<email>>` at ' 12345 -1215'\n  2: expected `<name> <<email>> <timestamp> <+|-><HHMM>` at ' 12345 -1215'\n"
+                        "in slice at ' 12345 -1215'\n  0: expected `<email>` at ' 12345 -1215'\n  1: expected `<name> <<email>>` at 'hello < 12345 -1215'\n  2: expected `<name> <<email>> <timestamp> <+|-><HHMM>` at 'hello < 12345 -1215'\n"
                     );
         }
 
@@ -173,7 +173,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "in predicate verification at 'abc -1215'\n  0: expected `<timestamp>` at 'abc -1215'\n  1: expected `<name> <<email>> <timestamp> <+|-><HHMM>` at 'abc -1215'\n"
+                        "in predicate verification at 'abc -1215'\n  0: expected `<timestamp>` at 'abc -1215'\n  1: expected `<name> <<email>> <timestamp> <+|-><HHMM>` at 'hello <> abc -1215'\n"
                     );
         }
     }

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -24,7 +24,7 @@ gix-sec = { version = "^0.10.4", path = "../gix-sec" }
 gix-ref = { version = "^0.42.0", path = "../gix-ref" }
 gix-glob = { version = "^0.16.0", path = "../gix-glob" }
 
-winnow = { version = "0.5.36", features = ["simd"] }
+winnow = { version = "0.5.40", features = ["simd"] }
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -24,7 +24,7 @@ gix-sec = { version = "^0.10.4", path = "../gix-sec" }
 gix-ref = { version = "^0.42.0", path = "../gix-ref" }
 gix-glob = { version = "^0.16.0", path = "../gix-glob" }
 
-winnow = { version = "0.5.40", features = ["simd"] }
+winnow = { version = "0.6.0", features = ["simd"] }
 memchr = "2"
 thiserror = "1.0.26"
 unicode-bom = "2.0.2"

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.40", features = ["simd"] }
+winnow = { version = "0.6.0", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -38,7 +38,7 @@ btoi = "0.4.2"
 itoa = "1.0.1"
 thiserror = "1.0.34"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.36", features = ["simd"] }
+winnow = { version = "0.5.40", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -37,7 +37,7 @@ fn subject_and_body<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(
         }
     }
 
-    i.reset(start);
+    i.reset(&start);
     rest.map(|r: &[u8]| (r.as_bstr(), None)).parse_next(i)
 }
 

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -49,7 +49,7 @@ gix-credentials = { version = "^0.24.0", path = "../gix-credentials" }
 thiserror = "1.0.32"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.40", features = ["simd"] }
+winnow = { version = "0.6.0", features = ["simd"] }
 btoi = "0.4.2"
 
 # for async-client

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -49,7 +49,7 @@ gix-credentials = { version = "^0.24.0", path = "../gix-credentials" }
 thiserror = "1.0.32"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 bstr = { version = "1.3.0", default-features = false, features = ["std", "unicode"] }
-winnow = { version = "0.5.36", features = ["simd"] }
+winnow = { version = "0.5.40", features = ["simd"] }
 btoi = "0.4.2"
 
 # for async-client

--- a/gix-protocol/src/remote_progress.rs
+++ b/gix-protocol/src/remote_progress.rs
@@ -4,7 +4,7 @@ use bstr::ByteSlice;
 use winnow::{
     combinator::{opt, preceded, terminated},
     prelude::*,
-    token::{tag, take_till},
+    token::take_till,
 };
 
 /// The information usually found in remote progress messages as sent by a git server during
@@ -85,7 +85,7 @@ fn next_optional_percentage(i: &mut &[u8]) -> PResult<Option<u32>, ()> {
             take_till(0.., |c: u8| c.is_ascii_digit()),
             parse_number.try_map(u32::try_from),
         ),
-        tag(b"%"),
+        b"%",
     ))
     .parse_next(i)
 }

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -32,7 +32,7 @@ gix-lock = { version = "^13.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^13.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-winnow = { version = "0.5.36", features = ["simd"] }
+winnow = { version = "0.5.40", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -32,7 +32,7 @@ gix-lock = { version = "^13.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^13.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "1.0.34"
-winnow = { version = "0.5.40", features = ["simd"] }
+winnow = { version = "0.6.0", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"]}
 
 # packed refs

--- a/gix-ref/src/store/packed/iter.rs
+++ b/gix-ref/src/store/packed/iter.rs
@@ -46,7 +46,7 @@ impl<'a> Iterator for packed::Iter<'a> {
                 Some(Ok(reference))
             }
             Err(_) => {
-                self.cursor.reset(start);
+                self.cursor.reset(&start);
                 let (failed_line, next_cursor) = self
                     .cursor
                     .find_byte(b'\n')

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.26"
 gix-fs = { version = "^0.10.0", path = "../../gix-fs" }
 gix-tempfile = { version = "^13.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-winnow = { version = "0.5.36", features = ["simd"] }
+winnow = { version = "0.5.40", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -21,7 +21,7 @@ gix-worktree = "0.26"
 gix-fs = { version = "^0.10.0", path = "../../gix-fs" }
 gix-tempfile = { version = "^13.0.0", default-features = false, features = ["signals"], path = "../../gix-tempfile" }
 
-winnow = { version = "0.5.40", features = ["simd"] }
+winnow = { version = "0.6.0", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 pub use bstr;
-use bstr::{BStr, ByteSlice};
+use bstr::ByteSlice;
 use io_close::Close;
 pub use is_ci;
 pub use once_cell;
@@ -697,9 +697,9 @@ fn extract_archive(
 /// Transform a verbose parser errors from raw bytes into a `BStr` to make printing/debugging human-readable.
 pub fn to_bstr_err(
     err: winnow::error::ErrMode<winnow::error::TreeError<&[u8], winnow::error::StrContext>>,
-) -> winnow::error::TreeError<&BStr, winnow::error::StrContext> {
+) -> winnow::error::TreeError<&winnow::stream::BStr, winnow::error::StrContext> {
     let err = err.into_inner().expect("not a streaming parser");
-    err.map_input(ByteSlice::as_bstr)
+    err.map_input(winnow::stream::BStr::new)
 }
 
 fn family_name() -> &'static str {


### PR DESCRIPTION
This required using `winnow::stream::BStr` in test errors because `TreeError` now needs `impl Stream for I`.