### PR TITLE
remove itertools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,6 @@ dependencies = [
  "gix-status",
  "gix-transport",
  "gix-url",
- "itertools 0.12.0",
  "jwalk",
  "layout-rs",
  "open",

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 ## Discover all git repositories within a directory. Particularly useful with [skim](https://github.com/lotabout/skim).
 organize = ["dep:gix-url", "dep:jwalk"]
 ## Derive the amount of time invested into a git repository akin to [git-hours](https://github.com/kimmobrunfeldt/git-hours).
-estimate-hours = ["dep:itertools", "dep:fs-err", "dep:crossbeam-channel", "dep:smallvec"]
+estimate-hours = ["dep:fs-err", "dep:crossbeam-channel", "dep:smallvec"]
 ## Gather information about repositories and store it in a database for easy querying.
 query = ["dep:rusqlite"]
 ## Run algorithms on a corpus of repositories and store their results for later comparison and intelligence gathering.
@@ -29,7 +29,7 @@ corpus = [ "dep:rusqlite", "dep:sysinfo", "organize", "dep:crossbeam-channel", "
 archive = ["dep:gix-archive-for-configuration-only", "gix/worktree-archive"]
 
 ## The ability to clean a repository, similar to `git clean`.
-clean = [ "gix/dirwalk" ]
+clean = ["gix/dirwalk"]
 
 #! ### Mutually Exclusive Networking
 #! If both are set, _blocking-client_ will take precedence, allowing `--all-features` to be used.
@@ -72,7 +72,6 @@ gix-url = { version = "^0.27.0", path = "../gix-url", optional = true }
 jwalk = { version = "0.8.0", optional = true }
 
 # for 'hours'
-itertools = { version = "0.12.0", optional = true }
 fs-err = { version = "2.6.0", optional = true }
 crossbeam-channel = { version = "0.5.6", optional = true }
 smallvec = { version = "1.10.0", optional = true }

--- a/gitoxide-core/src/hours/core.rs
+++ b/gitoxide-core/src/hours/core.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use gix::bstr::BStr;
-use itertools::Itertools;
 
 use crate::hours::{
     util::{add_lines, remove_lines},
@@ -25,17 +24,25 @@ pub fn estimate_hours(
     const MAX_COMMIT_DIFFERENCE_IN_MINUTES: f32 = 2.0 * MINUTES_PER_HOUR;
     const FIRST_COMMIT_ADDITION_IN_MINUTES: f32 = 2.0 * MINUTES_PER_HOUR;
 
-    let hours_for_commits = commits.iter().map(|t| &t.1).rev().tuple_windows().fold(
-        0_f32,
-        |hours, (cur, next): (&gix::actor::SignatureRef<'_>, &gix::actor::SignatureRef<'_>)| {
+    let hours_for_commits = {
+        let mut hours = 0.0;
+
+        let mut commits = commits.iter().map(|t| &t.1).rev();
+        let mut cur = commits.next().expect("not a single commit found");
+
+        for next in commits {
             let change_in_minutes = (next.time.seconds.saturating_sub(cur.time.seconds)) as f32 / MINUTES_PER_HOUR;
             if change_in_minutes < MAX_COMMIT_DIFFERENCE_IN_MINUTES {
-                hours + change_in_minutes / MINUTES_PER_HOUR
+                hours += change_in_minutes / MINUTES_PER_HOUR
             } else {
-                hours + (FIRST_COMMIT_ADDITION_IN_MINUTES / MINUTES_PER_HOUR)
+                hours += FIRST_COMMIT_ADDITION_IN_MINUTES / MINUTES_PER_HOUR
             }
-        },
-    );
+
+            cur = next;
+        }
+
+        hours
+    };
 
     let author = &commits[0].1;
     let (files, lines) = (!stats.is_empty())

--- a/gitoxide-core/src/hours/core.rs
+++ b/gitoxide-core/src/hours/core.rs
@@ -28,7 +28,7 @@ pub fn estimate_hours(
         let mut hours = 0.0;
 
         let mut commits = commits.iter().map(|t| &t.1).rev();
-        let mut cur = commits.next().expect("not a single commit found");
+        let mut cur = commits.next().expect("at least one commit if we are here");
 
         for next in commits {
             let change_in_minutes = (next.time.seconds.saturating_sub(cur.time.seconds)) as f32 / MINUTES_PER_HOUR;
@@ -37,7 +37,6 @@ pub fn estimate_hours(
             } else {
                 hours += FIRST_COMMIT_ADDITION_IN_MINUTES / MINUTES_PER_HOUR
             }
-
             cur = next;
         }
 

--- a/gitoxide-core/src/hours/util.rs
+++ b/gitoxide-core/src/hours/util.rs
@@ -55,10 +55,10 @@ where
             // estimate lower bound of capacity needed
             let (lower, _) = iter.size_hint();
             let mut result = String::with_capacity(sep.len() * lower);
-            write!(&mut result, "{first_elt}").unwrap();
+            write!(&mut result, "{first_elt}").expect("enough memory");
             iter.for_each(|elt| {
                 result.push_str(sep);
-                write!(&mut result, "{elt}").unwrap();
+                write!(&mut result, "{elt}").expect("enough memory");
             });
             result
         }

--- a/gitoxide-core/src/hours/util.rs
+++ b/gitoxide-core/src/hours/util.rs
@@ -42,6 +42,29 @@ impl<'a> From<&'a WorkByEmail> for WorkByPerson {
     }
 }
 
+fn join<I>(mut iter: I, sep: &str) -> String
+where
+    I: Iterator,
+    <I as Iterator>::Item: std::fmt::Display,
+{
+    use ::std::fmt::Write;
+
+    match iter.next() {
+        None => String::new(),
+        Some(first_elt) => {
+            // estimate lower bound of capacity needed
+            let (lower, _) = iter.size_hint();
+            let mut result = String::with_capacity(sep.len() * lower);
+            write!(&mut result, "{first_elt}").unwrap();
+            iter.for_each(|elt| {
+                result.push_str(sep);
+                write!(&mut result, "{elt}").unwrap();
+            });
+            result
+        }
+    }
+}
+
 impl WorkByPerson {
     pub fn write_to(
         &self,
@@ -53,22 +76,8 @@ impl WorkByPerson {
         writeln!(
             out,
             "{names} <{mails}>",
-            names = self
-                .name
-                .iter()
-                // BStr does not impl slice::Join
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .as_slice()
-                .join(", "),
-            mails = self
-                .email
-                .iter()
-                // BStr does not impl slice::Join
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .as_slice()
-                .join(", ")
+            names = join(self.name.iter(), ", "),
+            mails = join(self.email.iter(), ", ")
         )?;
         writeln!(out, "{} commits found", self.num_commits)?;
         writeln!(

--- a/gitoxide-core/src/hours/util.rs
+++ b/gitoxide-core/src/hours/util.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use gix::bstr::{BStr, ByteSlice};
-use itertools::Itertools;
 
 use crate::hours::core::HOURS_PER_WORKDAY;
 
@@ -53,9 +52,23 @@ impl WorkByPerson {
     ) -> std::io::Result<()> {
         writeln!(
             out,
-            "{} <{}>",
-            self.name.iter().join(", "),
-            self.email.iter().join(", ")
+            "{names} <{mails}>",
+            names = self
+                .name
+                .iter()
+                // BStr does not impl slice::Join
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .as_slice()
+                .join(", "),
+            mails = self
+                .email
+                .iter()
+                // BStr does not impl slice::Join
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .as_slice()
+                .join(", ")
         )?;
         writeln!(out, "{} commits found", self.num_commits)?;
         writeln!(


### PR DESCRIPTION
follow up from https://github.com/Byron/gitoxide/pull/1293#issuecomment-1948023333 and https://github.com/Byron/gitoxide/pull/1293#issuecomment-1948047161

Removes around 9s of cpu compilation time at the exchange of some allocations for displaying mails (which should not be critical) and a for loop instead of a fold.