### PR TITLE
Copy over code from gix to generate completions for ein as well

### DIFF
--- a/src/porcelain/main.rs
+++ b/src/porcelain/main.rs
@@ -3,8 +3,8 @@ use std::sync::{
     Arc,
 };
 
-use anyhow::Result;
-use clap::Parser;
+use anyhow::{anyhow, Result};
+use clap::{CommandFactory, Parser};
 use gitoxide::shared::pretty::prepare_and_run;
 use gitoxide_core as core;
 
@@ -169,6 +169,21 @@ pub fn main() -> Result<()> {
                 )
             }
         },
+        Subcommands::Completions { shell, out_dir } => {
+            let mut app = Args::command();
+
+            let shell = shell
+                .or_else(clap_complete::Shell::from_env)
+                .ok_or_else(|| anyhow!("The shell could not be derived from the environment"))?;
+
+            let bin_name = app.get_name().to_owned();
+            if let Some(out_dir) = out_dir {
+                clap_complete::generate_to(shell, &mut app, bin_name, &out_dir)?;
+            } else {
+                clap_complete::generate(shell, &mut app, bin_name, &mut std::io::stdout());
+            }
+            Ok(())
+        }
     }?;
     Ok(())
 }

--- a/src/porcelain/options.rs
+++ b/src/porcelain/options.rs
@@ -2,7 +2,7 @@ use clap_complete::Shell;
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
-#[clap(about = "The rusty git", version = option_env!("GIX_VERSION"))]
+#[clap(name = "ein", about = "The rusty git", version = option_env!("GIX_VERSION"))]
 #[clap(subcommand_required = true)]
 pub struct Args {
     /// Do not display verbose messages and progress information

--- a/src/porcelain/options.rs
+++ b/src/porcelain/options.rs
@@ -1,3 +1,4 @@
+use clap_complete::Shell;
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
@@ -39,6 +40,15 @@ pub enum Subcommands {
     /// A selection of useful tools
     #[clap(subcommand)]
     Tool(ToolCommands),
+    /// Generate shell completions to stdout or a directory.
+    #[clap(visible_alias = "generate-completions", visible_alias = "shell-completions")]
+    Completions {
+        /// The shell to generate completions for. Otherwise it's derived from the environment.
+        #[clap(long, short)]
+        shell: Option<Shell>,
+        /// The output directory in case multiple files are generated. If not provided, will write to stdout.
+        out_dir: Option<String>,
+    },
     #[cfg(debug_assertions)]
     Panic,
 }


### PR DESCRIPTION
One thing to note: It currently takes `gitoxide` instead of `ein` as the command.
I don't know why it does that.
The command name is taken from Args, and using the locally build version of gix does not do that (I figured it might be an issue with the manual build).

I'll try to investigate but I'd be glad about any hints.

If nothing comes up it would always be possible to just hardcode the name of the binary until the culprit is found.