### PR TITLE
Fix a typo in `gix::clone::PrepareFetch::new`, crate_opts -> create_opts

### DIFF
--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -55,7 +55,7 @@ pub enum Error {
 
 /// Instantiation
 impl PrepareFetch {
-    /// Create a new repository at `path` with `crate_opts` which is ready to clone from `url`, possibly after making additional adjustments to
+    /// Create a new repository at `path` with `create_opts` which is ready to clone from `url`, possibly after making additional adjustments to
     /// configuration and settings.
     ///
     /// Note that this is merely a handle to perform the actual connection to the remote, and if any of it fails the freshly initialized repository


### PR DESCRIPTION
Fix a documentation typo in `gix::clone::PrepareFetch::new` crate_opts -> create_opts

