### PR TITLE
integrate gix-status

### DIFF
--- a/gix-dir/src/entry.rs
+++ b/gix-dir/src/entry.rs
@@ -2,40 +2,45 @@ use crate::walk::ForDeletionMode;
 use crate::{Entry, EntryRef};
 use std::borrow::Cow;
 
-/// The kind of the entry.
+/// A way of attaching additional information to an [Entry] .
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub enum Property {
+    /// The entry was named `.git`, matched according to the case-sensitivity rules of the repository.
+    DotGit,
+    /// The entry is a directory, and that directory is empty.
+    EmptyDirectory,
+    /// Always in conjunction with a directory on disk that is also known as cone-mode sparse-checkout exclude marker
+    /// - i.e. a directory that is excluded, so its whole content is excluded and not checked out nor is part of the index.
+    ///
+    /// Note that evne if the directory is empty, it will only have this state, not `EmptyDirectory`.
+    TrackedExcluded,
+}
+
+/// The kind of the entry, seated in their kinds available on disk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Kind {
     /// The entry is a blob, executable or not.
     File,
     /// The entry is a symlink.
     Symlink,
-    /// A directory that contains no file or directory.
-    EmptyDirectory,
     /// The entry is an ordinary directory.
     ///
     /// Note that since we don't check for bare repositories, this could in fact be a collapsed
     /// bare repository. To be sure, check it again with [`gix_discover::is_git()`] and act accordingly.
     Directory,
-    /// The entry is a directory which *contains* a `.git` folder.
+    /// The entry is a directory which *contains* a `.git` folder, or a submodule entry in the index.
     Repository,
 }
 
 /// The kind of entry as obtained from a directory.
-///
-/// The order of variants roughly relates from cheap-to-compute to most expensive, as each level needs more tests to assert.
-/// Thus, `DotGit` is the cheapest, while `Untracked` is among the most expensive and one of the major outcomes of any
-/// [`walk`](crate::walk()) run.
-/// For example, if an entry was `Pruned`, we effectively don't know if it would have been `Untracked` as well as we stopped looking.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Status {
-    /// The filename of an entry was `.git`, which is generally pruned.
-    DotGit,
-    /// The provided pathspec prevented further processing as the path didn't match.
-    /// If this happens, no further checks are done so we wouldn't know if the path is also ignored for example (by mention in `.gitignore`).
+    /// The entry was removed from the walk due to its other properties, like [Property] or [PathspecMatch]
+    ///
+    /// Note that entries flagged as `DotGit` directory will always be considered `Pruned`, but if they are
+    /// also ignored, in delete mode, they will be considered `Ignored` instead. This way, it's easier to remove them
+    /// while they will not be available for any interactions in read-only mode.
     Pruned,
-    /// Always in conjunction with a directory on disk that is also known as cone-mode sparse-checkout exclude marker - i.e. a directory
-    /// that is excluded, so its whole content is excluded and not checked out nor is part of the index.
-    TrackedExcluded,
     /// The entry is tracked in Git.
     Tracked,
     /// The entry is ignored as per `.gitignore` files and their rules.
@@ -52,7 +57,7 @@ pub enum Status {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]
 pub enum PathspecMatch {
     /// The match happened because there wasn't any pattern, which matches all, or because there was a nil pattern or one with an empty path.
-    /// Thus this is not a match by merit.
+    /// Thus, this is not a match by merit.
     Always,
     /// A match happened, but the pattern excludes everything it matches, which means this entry was excluded.
     Excluded,
@@ -84,12 +89,24 @@ impl From<gix_pathspec::search::MatchKind> for PathspecMatch {
     }
 }
 
+impl From<gix_pathspec::search::Match<'_>> for PathspecMatch {
+    fn from(m: gix_pathspec::search::Match<'_>) -> Self {
+        if m.is_excluded() {
+            PathspecMatch::Excluded
+        } else {
+            m.kind.into()
+        }
+    }
+}
+
+/// Conversion
 impl EntryRef<'_> {
     /// Strip the lifetime to obtain a fully owned copy.
     pub fn to_owned(&self) -> Entry {
         Entry {
             rela_path: self.rela_path.clone().into_owned(),
             status: self.status,
+            property: self.property,
             disk_kind: self.disk_kind,
             index_kind: self.index_kind,
             pathspec_match: self.pathspec_match,
@@ -101,6 +118,7 @@ impl EntryRef<'_> {
         Entry {
             rela_path: self.rela_path.into_owned(),
             status: self.status,
+            property: self.property,
             disk_kind: self.disk_kind,
             index_kind: self.index_kind,
             pathspec_match: self.pathspec_match,
@@ -108,12 +126,14 @@ impl EntryRef<'_> {
     }
 }
 
+/// Conversion
 impl Entry {
     /// Obtain an [`EntryRef`] from this instance.
     pub fn to_ref(&self) -> EntryRef<'_> {
         EntryRef {
             rela_path: Cow::Borrowed(self.rela_path.as_ref()),
             status: self.status,
+            property: self.property,
             disk_kind: self.disk_kind,
             index_kind: self.index_kind,
             pathspec_match: self.pathspec_match,
@@ -136,10 +156,7 @@ impl From<std::fs::FileType> for Kind {
 impl Status {
     /// Return true if this status is considered pruned. A pruned entry is typically hidden from view due to a pathspec.
     pub fn is_pruned(&self) -> bool {
-        match self {
-            Status::DotGit | Status::TrackedExcluded | Status::Pruned => true,
-            Status::Ignored(_) | Status::Untracked | Status::Tracked => false,
-        }
+        matches!(&self, Status::Pruned)
     }
     /// Return `true` if `file_type` is a directory on disk and isn't ignored, and is not a repository.
     /// This implements the default rules of `git status`, which is good for a minimal traversal through
@@ -158,7 +175,7 @@ impl Status {
             return false;
         }
         match self {
-            Status::DotGit | Status::TrackedExcluded | Status::Pruned => false,
+            Status::Pruned => false,
             Status::Ignored(_) => {
                 for_deletion.map_or(false, |fd| {
                     matches!(
@@ -180,6 +197,6 @@ impl Kind {
 
     /// Return `true` if this is a directory on disk. Note that this is true for repositories as well.
     pub fn is_dir(&self) -> bool {
-        matches!(self, Kind::EmptyDirectory | Kind::Directory | Kind::Repository)
+        matches!(self, Kind::Directory | Kind::Repository)
     }
 }

--- a/gix-dir/src/entry.rs
+++ b/gix-dir/src/entry.rs
@@ -9,6 +9,12 @@ pub enum Property {
     DotGit,
     /// The entry is a directory, and that directory is empty.
     EmptyDirectory,
+    /// The entry is a directory, it is empty and the current working directory.
+    ///
+    /// The caller should pay special attention to this very special case, as it is indeed only possible to run into it
+    /// while traversing the directory for deletion.
+    /// Non-empty directory will never be collapsed, hence if they are working directories, they naturally become unobservable.
+    EmptyDirectoryAndCWD,
     /// Always in conjunction with a directory on disk that is also known as cone-mode sparse-checkout exclude marker
     /// - i.e. a directory that is excluded, so its whole content is excluded and not checked out nor is part of the index.
     ///

--- a/gix-dir/src/entry.rs
+++ b/gix-dir/src/entry.rs
@@ -191,7 +191,7 @@ impl Status {
 }
 
 impl Kind {
-    fn is_recursable_dir(&self) -> bool {
+    pub(super) fn is_recursable_dir(&self) -> bool {
         matches!(self, Kind::Directory)
     }
 

--- a/gix-dir/src/lib.rs
+++ b/gix-dir/src/lib.rs
@@ -29,14 +29,14 @@ pub struct EntryRef<'a> {
     /// Note that many entries with status `Pruned` will not show up as their kind hasn't yet been determined when they were
     /// pruned very early on.
     pub status: entry::Status,
-    /// Further specify the what the entry is on disk, similar to a file mode.
-    /// This is `None` if the entry was pruned by a pathspec that could not match, as we then won't invest the time to obtain
-    /// the kind of the entry on disk.
+    /// Additional properties of the entry.
+    pub property: Option<entry::Property>,
+    /// Further specify what the entry is on disk, similar to a file mode.
+    /// This is `None` if we decided it's not worth it to exit early and avoid trying to obtain this information.
     pub disk_kind: Option<entry::Kind>,
     /// The kind of entry according to the index, if tracked. *Usually* the same as `disk_kind`.
     pub index_kind: Option<entry::Kind>,
     /// Determines how the pathspec matched.
-    /// Can also be `None` if no pathspec matched, or if the status check stopped prior to checking for pathspec matches which is the case for [`entry::Status::DotGit`].
     /// Note that it can also be `Some(PathspecMatch::Excluded)` if a negative pathspec matched.
     pub pathspec_match: Option<entry::PathspecMatch>,
 }
@@ -48,7 +48,9 @@ pub struct Entry {
     pub rela_path: BString,
     /// The status of entry, most closely related to what we know from `git status`, but not the same.
     pub status: entry::Status,
-    /// Further specify the what the entry is on disk, similar to a file mode.
+    /// Additional flags that further clarify properties of the entry.
+    pub property: Option<entry::Property>,
+    /// Further specify what the entry is on disk, similar to a file mode.
     pub disk_kind: Option<entry::Kind>,
     /// The kind of entry according to the index, if tracked. *Usually* the same as `disk_kind`.
     pub index_kind: Option<entry::Kind>,

--- a/gix-dir/src/walk/classify.rs
+++ b/gix-dir/src/walk/classify.rs
@@ -1,4 +1,5 @@
-use crate::{entry, Entry};
+use crate::{entry, Entry, EntryRef};
+use std::borrow::Cow;
 
 use crate::entry::PathspecMatch;
 use crate::walk::{Context, Error, ForDeletionMode, Options};
@@ -61,7 +62,10 @@ pub fn root(
 pub struct Outcome {
     /// The computed status of an entry. It can be seen as aggregate of things we know about an entry.
     pub status: entry::Status,
-    /// What the entry is on disk, or `None` if we aborted the classification early.
+    /// An additional property.
+    pub property: Option<entry::Property>,
+    /// What the entry is on disk, or `None` if we aborted the classification early or an IO-error occurred
+    /// when querying the disk.
     ///
     /// Note that the index is used to avoid disk access provided its entries are marked uptodate
     /// (possibly by a prior call to update the status).
@@ -89,9 +93,23 @@ impl From<&Entry> for Outcome {
     fn from(e: &Entry) -> Self {
         Outcome {
             status: e.status,
+            property: e.property,
             disk_kind: e.disk_kind,
             index_kind: e.index_kind,
             pathspec_match: e.pathspec_match,
+        }
+    }
+}
+
+impl<'a> EntryRef<'a> {
+    pub(super) fn from_outcome(rela_path: Cow<'a, BStr>, info: crate::walk::classify::Outcome) -> Self {
+        EntryRef {
+            rela_path,
+            property: info.property,
+            status: info.status,
+            disk_kind: info.disk_kind,
+            index_kind: info.index_kind,
+            pathspec_match: info.pathspec_match,
         }
     }
 }
@@ -123,12 +141,36 @@ pub fn path(
     ctx: &mut Context<'_>,
 ) -> Result<Outcome, Error> {
     let mut out = Outcome {
-        status: entry::Status::DotGit,
+        status: entry::Status::Pruned,
+        property: None,
         disk_kind,
         index_kind: None,
         pathspec_match: None,
     };
     if is_eq(rela_path[filename_start_idx..].as_bstr(), ".git", ignore_case) {
+        out.pathspec_match = ctx
+            .pathspec
+            .pattern_matching_relative_path(
+                rela_path.as_bstr(),
+                disk_kind.map(|ft| ft.is_dir()),
+                ctx.pathspec_attributes,
+            )
+            .map(Into::into);
+        if for_deletion.is_some() {
+            if let Some(excluded) = ctx
+                .excludes
+                .as_mut()
+                .map_or(Ok(None), |stack| {
+                    stack
+                        .at_entry(rela_path.as_bstr(), disk_kind.map(|ft| ft.is_dir()), ctx.objects)
+                        .map(|platform| platform.excluded_kind())
+                })
+                .map_err(Error::ExcludesAccess)?
+            {
+                out.status = entry::Status::Ignored(excluded);
+            }
+        }
+        out.property = entry::Property::DotGit.into();
         return Ok(out);
     }
     let pathspec_could_match = rela_path.is_empty()
@@ -139,31 +181,25 @@ pub fn path(
         return Ok(out.with_status(entry::Status::Pruned));
     }
 
-    let (uptodate_index_kind, index_kind, mut maybe_status) = resolve_file_type_with_index(
+    let (uptodate_index_kind, index_kind, property) = resolve_file_type_with_index(
         rela_path,
         ctx.index,
         ctx.ignore_case_index_lookup.filter(|_| ignore_case),
     );
     let mut kind = uptodate_index_kind.or(disk_kind).or_else(on_demand_disk_kind);
 
-    maybe_status = maybe_status
-        .or_else(|| (index_kind.map(|k| k.is_dir()) == kind.map(|k| k.is_dir())).then_some(entry::Status::Tracked));
+    let maybe_status = if property.is_none() {
+        (index_kind.map(|k| k.is_dir()) == kind.map(|k| k.is_dir())).then_some(entry::Status::Tracked)
+    } else {
+        out.property = property;
+        Some(entry::Status::Pruned)
+    };
 
     // We always check the pathspec to have the value filled in reliably.
     out.pathspec_match = ctx
         .pathspec
-        .pattern_matching_relative_path(
-            rela_path.as_bstr(),
-            disk_kind.map(|ft| ft.is_dir()),
-            ctx.pathspec_attributes,
-        )
-        .map(|m| {
-            if m.is_excluded() {
-                PathspecMatch::Excluded
-            } else {
-                m.kind.into()
-            }
-        });
+        .pattern_matching_relative_path(rela_path.as_bstr(), kind.map(|ft| ft.is_dir()), ctx.pathspec_attributes)
+        .map(Into::into);
 
     let mut maybe_upgrade_to_repository = |current_kind, find_harder: bool| {
         if recurse_repositories {
@@ -258,8 +294,7 @@ pub fn path(
 
 /// Note that `rela_path` is used as buffer for convenience, but will be left as is when this function returns.
 /// Also note `maybe_file_type` will be `None` for entries that aren't up-to-date and files, for directories at least one entry must be uptodate.
-/// Returns `(maybe_file_type, Option<index_file_type>, Option(TrackedExcluded)`, with the last option being set only for sparse directories.
-/// `tracked_exclued` indicates it's a sparse directory was found.
+/// Returns `(maybe_file_type, Option<index_file_type>, flags)`, with the last option being a flag set only for sparse directories in the index.
 /// `index_file_type` is the type of `rela_path` as available in the index.
 ///
 /// ### Shortcoming
@@ -271,9 +306,9 @@ fn resolve_file_type_with_index(
     rela_path: &mut BString,
     index: &gix_index::State,
     ignore_case: Option<&gix_index::AccelerateLookup<'_>>,
-) -> (Option<entry::Kind>, Option<entry::Kind>, Option<entry::Status>) {
+) -> (Option<entry::Kind>, Option<entry::Kind>, Option<entry::Property>) {
     // TODO: either get this to work for icase as well, or remove the need for it. Logic is different in both branches.
-    let mut special_status = None;
+    let mut special_property = None;
 
     fn entry_to_kinds(entry: &gix_index::Entry) -> (Option<entry::Kind>, Option<entry::Kind>) {
         let kind = if entry.mode.is_submodule() {
@@ -352,14 +387,14 @@ fn resolve_file_type_with_index(
                         .filter(|_| kind.is_none())
                         .map_or(false, |idx| index.entries()[idx].mode.is_sparse())
                 {
-                    special_status = Some(entry::Status::TrackedExcluded);
+                    special_property = Some(entry::Property::TrackedExcluded);
                 }
                 (kind, is_tracked.then_some(entry::Kind::Directory))
             }
             Some(entry) => entry_to_kinds(entry),
         }
     };
-    (uptodate_kind, index_kind, special_status)
+    (uptodate_kind, index_kind, special_property)
 }
 
 fn is_eq(lhs: &BStr, rhs: impl AsRef<BStr>, ignore_case: bool) -> bool {

--- a/gix-dir/src/walk/classify.rs
+++ b/gix-dir/src/walk/classify.rs
@@ -253,13 +253,6 @@ pub fn path(
         .map_err(Error::ExcludesAccess)?
     {
         if emit_ignored.is_some() {
-            if kind.map_or(false, |d| d.is_dir()) && out.pathspec_match.is_none() {
-                // we have patterns that didn't match at all. Try harder.
-                out.pathspec_match = ctx
-                    .pathspec
-                    .directory_matches_prefix(rela_path.as_bstr(), true)
-                    .then_some(PathspecMatch::Prefix);
-            }
             if matches!(
                 for_deletion,
                 Some(
@@ -274,6 +267,10 @@ pub fn path(
                         Some(ForDeletionMode::FindRepositoriesInIgnoredDirectories)
                     ),
                 );
+            }
+            if kind.map_or(false, |d| d.is_recursable_dir()) && out.pathspec_match.is_none() {
+                // we have patterns that didn't match at all, *yet*. We want to look inside.
+                out.pathspec_match = Some(PathspecMatch::Prefix);
             }
         }
         return Ok(out

--- a/gix-dir/src/walk/function.rs
+++ b/gix-dir/src/walk/function.rs
@@ -146,14 +146,7 @@ pub(super) fn can_recurse(
     if info.disk_kind.map_or(true, |k| !k.is_dir()) {
         return false;
     }
-    let entry = EntryRef {
-        rela_path: Cow::Borrowed(rela_path),
-        status: info.status,
-        disk_kind: info.disk_kind,
-        index_kind: info.index_kind,
-        pathspec_match: info.pathspec_match,
-    };
-    delegate.can_recurse(entry, for_deletion)
+    delegate.can_recurse(EntryRef::from_outcome(Cow::Borrowed(rela_path), info), for_deletion)
 }
 
 /// Possibly emit an entry to `for_each` in case the provided information makes that possible.
@@ -174,7 +167,7 @@ pub(super) fn emit_entry(
 ) -> Action {
     out.seen_entries += 1;
 
-    if (!emit_empty_directories && info.disk_kind == Some(entry::Kind::EmptyDirectory)
+    if (!emit_empty_directories && info.property == Some(entry::Property::EmptyDirectory)
         || !emit_tracked && info.status == entry::Status::Tracked)
         || emit_ignored.is_none() && matches!(info.status, entry::Status::Ignored(_))
         || !emit_pruned
@@ -187,14 +180,5 @@ pub(super) fn emit_entry(
     }
 
     out.returned_entries += 1;
-    delegate.emit(
-        EntryRef {
-            rela_path,
-            status: info.status,
-            disk_kind: info.disk_kind,
-            index_kind: info.index_kind,
-            pathspec_match: info.pathspec_match,
-        },
-        dir_status,
-    )
+    delegate.emit(EntryRef::from_outcome(rela_path, info), dir_status)
 }

--- a/gix-dir/src/walk/readdir.rs
+++ b/gix-dir/src/walk/readdir.rs
@@ -6,7 +6,7 @@ use crate::entry::{PathspecMatch, Status};
 use crate::walk::function::{can_recurse, emit_entry};
 use crate::walk::EmissionMode::CollapseDirectory;
 use crate::walk::{classify, Action, CollapsedEntriesEmissionMode, Context, Delegate, Error, Options, Outcome};
-use crate::{entry, walk, Entry};
+use crate::{entry, walk, Entry, EntryRef};
 
 /// ### Deviation
 ///
@@ -115,13 +115,8 @@ impl State {
     /// Hold the entry with the given `status` if it's a candidate for collapsing the containing directory.
     fn held_for_directory_collapse(&mut self, rela_path: &BStr, info: classify::Outcome, opts: &Options) -> bool {
         if opts.should_hold(info.status) {
-            self.on_hold.push(Entry {
-                rela_path: rela_path.to_owned(),
-                status: info.status,
-                disk_kind: info.disk_kind,
-                index_kind: info.index_kind,
-                pathspec_match: info.pathspec_match,
-            });
+            self.on_hold
+                .push(EntryRef::from_outcome(Cow::Borrowed(rela_path), info).into_owned());
             true
         } else {
             false
@@ -200,15 +195,19 @@ impl Mark {
     ) -> walk::Action {
         if num_entries == 0 {
             let empty_info = classify::Outcome {
-                disk_kind: if num_entries == 0 {
+                property: if num_entries == 0 {
                     assert_ne!(
                         dir_info.disk_kind,
                         Some(entry::Kind::Repository),
                         "BUG: it shouldn't be possible to classify an empty dir as repository"
                     );
-                    Some(entry::Kind::EmptyDirectory)
+                    if dir_info.property.is_none() {
+                        entry::Property::EmptyDirectory.into()
+                    } else {
+                        dir_info.property
+                    }
                 } else {
-                    dir_info.disk_kind
+                    dir_info.property
                 },
                 pathspec_match: ctx
                     .pathspec
@@ -217,13 +216,9 @@ impl Mark {
                 ..dir_info
             };
             if opts.should_hold(empty_info.status) {
-                state.on_hold.push(Entry {
-                    rela_path: dir_rela_path.to_owned(),
-                    status: empty_info.status,
-                    disk_kind: empty_info.disk_kind,
-                    index_kind: empty_info.index_kind,
-                    pathspec_match: empty_info.pathspec_match,
-                });
+                state
+                    .on_hold
+                    .push(EntryRef::from_outcome(Cow::Borrowed(dir_rela_path), empty_info).into_owned());
                 Action::Continue
             } else {
                 emit_entry(Cow::Borrowed(dir_rela_path), empty_info, None, opts, out, delegate)
@@ -285,7 +280,7 @@ impl Mark {
             }
             matching_entries += usize::from(pathspec_match.map_or(false, |m| !m.should_ignore()));
             match status {
-                Status::DotGit | Status::Pruned | Status::TrackedExcluded => {
+                Status::Pruned => {
                     unreachable!("BUG: pruned aren't ever held, check `should_hold()`")
                 }
                 Status::Tracked => { /* causes the folder not to be collapsed */ }
@@ -359,13 +354,17 @@ impl Mark {
         }
         out.seen_entries += removed_without_emitting as u32;
 
-        state.on_hold.push(Entry {
-            rela_path: dir_rela_path.to_owned(),
-            status: dir_status,
-            disk_kind: dir_info.disk_kind,
-            index_kind: dir_info.index_kind,
-            pathspec_match: dir_pathspec_match,
-        });
+        state.on_hold.push(
+            EntryRef::from_outcome(
+                Cow::Borrowed(dir_rela_path),
+                classify::Outcome {
+                    status: dir_status,
+                    pathspec_match: dir_pathspec_match,
+                    ..dir_info
+                },
+            )
+            .into_owned(),
+        );
         Some(action)
     }
 }

--- a/gix-dir/tests/fixtures/many.sh
+++ b/gix-dir/tests/fixtures/many.sh
@@ -178,6 +178,14 @@ git init only-untracked
   >c
 )
 
+git init ignored-with-empty
+(cd ignored-with-empty
+  echo "/target/" >> .gitignore
+  git add .gitignore && git commit -m "init"
+  mkdir -p target/empty target/debug target/release
+  touch target/debug/a target/release/b
+)
+
 cp -R only-untracked subdir-untracked
 (cd subdir-untracked
   git add .

--- a/gix-dir/tests/fixtures/many.sh
+++ b/gix-dir/tests/fixtures/many.sh
@@ -159,6 +159,13 @@ git init partial-checkout-non-cone
   mkdir d && touch d/file-created-manually
 )
 
+git init precious-nested-repository
+(cd precious-nested-repository
+  echo '$precious*/' > .gitignore
+  git init precious-repo
+  git add .gitignore && git commit -m "init"
+)
+
 git init only-untracked
 (cd only-untracked
   >a

--- a/gix-dir/tests/walk/mod.rs
+++ b/gix-dir/tests/walk/mod.rs
@@ -1208,6 +1208,38 @@ fn untracked_and_ignored_for_deletion_nonmatching_wildcard_spec() -> crate::Resu
     );
     Ok(())
 }
+#[test]
+fn nested_precious_repo_respects_wildcards() -> crate::Result {
+    let root = fixture("precious-nested-repository");
+    for for_deletion in [
+        Some(ForDeletionMode::FindNonBareRepositoriesInIgnoredDirectories),
+        Some(ForDeletionMode::FindRepositoriesInIgnoredDirectories),
+    ] {
+        let (_out, entries) = collect_filtered(
+            &root,
+            None,
+            |keep, ctx| {
+                walk(
+                    &root,
+                    ctx,
+                    walk::Options {
+                        emit_ignored: Some(CollapseDirectory),
+                        emit_untracked: CollapseDirectory,
+                        emit_pruned: false,
+                        for_deletion,
+                        ..options()
+                    },
+                    keep,
+                )
+            },
+            Some("*foo/"),
+        );
+        // NOTE: do not use `_out` as `.git` directory contents can change, it's controlled by Git, causing flakiness.
+
+        assert_eq!(entries, [], "nothing matches, of course");
+    }
+    Ok(())
+}
 
 #[test]
 fn nested_ignored_dirs_for_deletion_nonmatching_wildcard_spec() -> crate::Result {

--- a/gix-dir/tests/walk/mod.rs
+++ b/gix-dir/tests/walk/mod.rs
@@ -9,6 +9,7 @@ use crate::walk_utils::{
 use gix_dir::entry;
 use gix_dir::entry::Kind::*;
 use gix_dir::entry::PathspecMatch::*;
+use gix_dir::entry::Property::*;
 use gix_dir::entry::Status::*;
 use gix_dir::walk::CollapsedEntriesEmissionMode::{All, OnStatusMismatch};
 use gix_dir::walk::EmissionMode::*;
@@ -81,7 +82,7 @@ fn empty_root() -> crate::Result {
     );
     assert_eq!(
         entries,
-        [entry("", Untracked, EmptyDirectory)],
+        [entry("", Untracked, Directory).with_property(EmptyDirectory)],
         "this is how we can indicate the worktree is entirely untracked"
     );
     Ok(())
@@ -103,10 +104,10 @@ fn complex_empty() -> crate::Result {
         entries,
         &[
             entry("dirs-and-files/dir/file", Untracked, File),
-            entry("dirs-and-files/sub", Untracked, EmptyDirectory),
-            entry("empty-toplevel", Untracked, EmptyDirectory),
-            entry("only-dirs/other", Untracked, EmptyDirectory),
-            entry("only-dirs/sub/subsub", Untracked, EmptyDirectory),
+            entry("dirs-and-files/sub", Untracked, Directory).with_property(EmptyDirectory),
+            entry("empty-toplevel", Untracked, Directory).with_property(EmptyDirectory),
+            entry("only-dirs/other", Untracked, Directory).with_property(EmptyDirectory),
+            entry("only-dirs/sub/subsub", Untracked, Directory).with_property(EmptyDirectory),
         ],
         "we see each and every directory, and get it classified as empty as it's set to be emitted"
     );
@@ -160,7 +161,7 @@ fn complex_empty() -> crate::Result {
         entries,
         &[
             entry("dirs-and-files", Untracked, Directory),
-            entry("empty-toplevel", Untracked, EmptyDirectory),
+            entry("empty-toplevel", Untracked, Directory).with_property(EmptyDirectory),
             entry("only-dirs", Untracked, Directory),
         ],
         "empty directories collapse just fine"
@@ -243,6 +244,120 @@ fn ignored_with_prefix_pathspec_collapses_just_like_untracked() -> crate::Result
 }
 
 #[test]
+fn ignored_dir_with_cwd_handling() -> crate::Result {
+    let root = fixture("untracked-and-ignored-for-collapse");
+    let ((out, _root), entries) = collect_filtered_with_cwd(
+        &root,
+        Some(&root.join("ignored")),
+        None,
+        |keep, ctx| {
+            walk(
+                &root,
+                ctx,
+                walk::Options {
+                    for_deletion: Some(Default::default()),
+                    emit_ignored: Some(CollapseDirectory),
+                    ..options()
+                },
+                keep,
+            )
+        },
+        None::<&str>,
+    );
+
+    assert_eq!(
+        out,
+        walk::Outcome {
+            read_dir_calls: 2,
+            returned_entries: entries.len(),
+            seen_entries: 3,
+        }
+    );
+    assert_eq!(
+        entries,
+        [entryps("ignored", Ignored(Expendable), Directory, Prefix)],
+        "even if the traversal root is for deletion, unless the CWD is set it will be collapsed (no special cases)"
+    );
+
+    let real_root = gix_path::realpath(&root)?;
+    let ((out, _root), entries) = collect_filtered_with_cwd(
+        &real_root,
+        Some(&real_root.join("ignored")),
+        Some("ignored"),
+        |keep, ctx| {
+            walk(
+                &real_root,
+                ctx,
+                walk::Options {
+                    for_deletion: Some(Default::default()),
+                    emit_ignored: Some(CollapseDirectory),
+                    ..options()
+                },
+                keep,
+            )
+        },
+        None::<&str>,
+    );
+
+    assert_eq!(
+        out,
+        walk::Outcome {
+            read_dir_calls: 2,
+            returned_entries: entries.len(),
+            seen_entries: 2,
+        }
+    );
+    assert_eq!(
+        entries,
+        [
+            entryps("ignored/b", Ignored(Expendable), File, Prefix),
+        ],
+        "the traversal starts from the top, but we automatically prevent the 'd' directory from being deleted by stopping its collapse."
+    );
+
+    let real_root = gix_path::realpath(fixture("subdir-untracked-and-ignored"))?;
+    let ((out, _root), entries) = collect_filtered_with_cwd(
+        &real_root,
+        None,
+        Some("d/d/generated"),
+        |keep, ctx| {
+            walk(
+                &real_root,
+                ctx,
+                walk::Options {
+                    for_deletion: Some(Default::default()),
+                    emit_ignored: Some(CollapseDirectory),
+                    emit_pruned: false,
+                    ..options()
+                },
+                keep,
+            )
+        },
+        Some(":/*generated/*"),
+    );
+
+    assert_eq!(
+        out,
+        walk::Outcome {
+            read_dir_calls: 8,
+            returned_entries: entries.len(),
+            seen_entries: 26
+        }
+    );
+    assert_eq!(
+        entries,
+        [
+            entryps("d/d/generated/b", Ignored(Expendable), File, WildcardMatch),
+            entryps("d/generated", Ignored(Expendable), Directory, WildcardMatch),
+            entryps("generated", Ignored(Expendable), Directory, WildcardMatch),
+        ],
+        "'d/d/generated/b' is there because the parent directory isn't allowed to fold due to the CWD rule."
+    );
+
+    Ok(())
+}
+
+#[test]
 fn only_untracked_with_cwd_handling() -> crate::Result {
     let root = fixture("only-untracked");
     let ((out, _root), entries) = collect_filtered_with_cwd(
@@ -316,7 +431,6 @@ fn only_untracked_with_cwd_handling() -> crate::Result {
         "even if the traversal root is for deletion, unless the CWD is set it will be collapsed (no special cases)"
     );
 
-    // Needs real-root to assure
     let real_root = gix_path::realpath(&root)?;
     let ((out, _root), entries) = collect_filtered_with_cwd(
         &real_root,
@@ -374,15 +488,15 @@ fn only_untracked_with_cwd_handling() -> crate::Result {
                 keep,
             )
         },
-        Some("../d"),
+        Some("../d/"),
     );
 
     assert_eq!(
         out,
         walk::Outcome {
-            read_dir_calls: 3,
+            read_dir_calls: 2,
             returned_entries: entries.len(),
-            seen_entries: 8,
+            seen_entries: 4,
         }
     );
     assert_eq!(
@@ -429,7 +543,7 @@ fn only_untracked_with_pathspec() -> crate::Result {
     );
     assert_eq!(
         entries,
-        [entryps("d", Untracked, Directory, Prefix),],
+        [entryps("d", Untracked, Directory, Prefix)],
         "this is equivalent as if we use a prefix, as we end up starting the traversal from 'd'"
     );
 
@@ -720,7 +834,7 @@ fn expendable_and_precious() {
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
             entry(".gitignore", Tracked, File),
             entry("a.o", Ignored(Expendable), File),
             entry("all-expendable", Ignored(Expendable), Directory),
@@ -969,7 +1083,7 @@ fn untracked_and_ignored_for_deletion_negative_wildcard_spec() -> crate::Result 
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
             entry(".gitignore", Untracked, File),
             entry("a.o", Ignored(Expendable), File),
             entry("b.o", Ignored(Expendable), File),
@@ -1024,7 +1138,7 @@ fn untracked_and_ignored_for_deletion_positive_wildcard_spec() -> crate::Result 
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).no_kind().with_property(DotGit),
             entry_nomatch(".gitignore", Pruned, File),
             entry_nomatch("a.o", Ignored(Expendable), File),
             entry_nomatch("b.o", Ignored(Expendable), File),
@@ -1077,7 +1191,7 @@ fn untracked_and_ignored_for_deletion_nonmatching_wildcard_spec() -> crate::Resu
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).no_match().with_property(DotGit),
             entry_nomatch(".gitignore", Pruned, File),
             entry_nomatch("a.o", Ignored(Expendable), File),
             entry_nomatch("b.o", Ignored(Expendable), File),
@@ -1149,7 +1263,7 @@ fn nested_ignored_dirs_for_deletion_nonmatching_wildcard_spec() -> crate::Result
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit),
             entry_nomatch(".gitignore", Pruned, File),
             entry_nomatch("bare/HEAD", Pruned, File),
             entry_nomatch("bare/info/exclude", Pruned, File),
@@ -1192,7 +1306,7 @@ fn expendable_and_precious_in_ignored_dir_with_pathspec() -> crate::Result {
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
             entry(".gitignore", Tracked, File).with_index_kind(File),
             entry("ignored", Ignored(Expendable), Directory),
             entry("other", Ignored(Expendable), Directory),
@@ -1234,8 +1348,8 @@ fn expendable_and_precious_in_ignored_dir_with_pathspec() -> crate::Result {
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
-            entry_nokind("ignored/d/.git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).no_match(),
+            entry_nokind("ignored/d/.git", Ignored(Expendable) ).with_property(DotGit).with_match(WildcardMatch),
             entryps("ignored/d/.gitignore", Ignored(Expendable), File, WildcardMatch),
             entryps("ignored/d/a.o", Ignored(Expendable), File, WildcardMatch),
             entryps(
@@ -1253,7 +1367,59 @@ fn expendable_and_precious_in_ignored_dir_with_pathspec() -> crate::Result {
          It seems strange that 'precious' isn't precious, while 'all-precious' is. However, the ignore-search is special
          as it goes backward through directories (using directory-declarations), and aborts if it matched. Thus it finds
          that '$/all-precious/' matched, but in the other cases it maches 'ignored/'.
-        'other' gets folded and inherits, just like before."
+        'other' gets folded and inherits, just like before.
+        Also, look how the ignore-state overrides the prune-default for DotGit kinds, to have more finegrained classification."
+    );
+
+    let ((out, _root), entries) = collect_filtered(
+        &root,
+        None,
+        |keep, ctx| {
+            walk(
+                &root,
+                ctx,
+                walk::Options {
+                    emit_ignored: Some(CollapseDirectory),
+                    emit_untracked: CollapseDirectory,
+                    emit_pruned: true,
+                    for_deletion: None,
+                    ..options()
+                },
+                keep,
+            )
+        },
+        Some("*ignored*"),
+    );
+    assert_eq!(
+        out,
+        walk::Outcome {
+            read_dir_calls: 9,
+            returned_entries: entries.len(),
+            seen_entries: 19,
+        },
+    );
+
+    assert_eq!(
+        entries,
+        [
+            entry_nokind(".git", Pruned).with_property(DotGit).no_match(),
+            entry_nokind("ignored/d/.git", Pruned)
+                .with_property(DotGit)
+                .with_match(WildcardMatch),
+            entryps("ignored/d/.gitignore", Ignored(Expendable), File, WildcardMatch),
+            entryps("ignored/d/a.o", Ignored(Expendable), File, WildcardMatch),
+            entryps(
+                "ignored/d/all-expendable",
+                Ignored(Expendable),
+                Directory,
+                WildcardMatch
+            ),
+            entryps("ignored/d/all-precious", Ignored(Precious), Directory, WildcardMatch),
+            entryps("ignored/d/mixed", Ignored(Expendable), Directory, WildcardMatch),
+            entryps("ignored/d/precious", Ignored(Expendable), File, WildcardMatch),
+            entryps("other", Ignored(Expendable), Directory, WildcardMatch),
+        ],
+        "The same as above, but without delete mode, we don't upgrade the status of ignored dot-git entries"
     );
     Ok(())
 }
@@ -1331,7 +1497,7 @@ fn untracked_and_ignored() -> crate::Result {
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).no_match(),
             entry_nomatch(".gitignore", Pruned, File),
             entryps("d/d/a", Untracked, File, WildcardMatch),
         ],
@@ -2058,7 +2224,7 @@ fn precious_are_not_expendable() {
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
             entry(".gitignore", Tracked, File),
             entry("a.o", Ignored(Expendable), File),
             entry("d/a", Tracked, File),
@@ -2327,7 +2493,7 @@ fn worktree_root_can_be_symlink() -> crate::Result {
 #[test]
 fn root_may_not_go_through_dot_git() -> crate::Result {
     let root = fixture("with-nested-dot-git");
-    for dir in ["", "subdir"] {
+    for (dir, expected_pathspec) in [("", Some(Verbatim)), ("subdir", None)] {
         let troot = root.join("dir").join(".git").join(dir);
         let ((out, _root), entries) = collect(&root, Some(&troot), |keep, ctx| {
             walk(&root, ctx, options_emit_all(), keep)
@@ -2342,7 +2508,11 @@ fn root_may_not_go_through_dot_git() -> crate::Result {
         );
         assert_eq!(
             entries,
-            [entry_nomatch("dir/.git", DotGit, Directory)],
+            [{
+                let mut e = entry("dir/.git", Pruned, Directory).with_property(DotGit);
+                e.0.pathspec_match = expected_pathspec;
+                e
+            }],
             "no traversal happened as root passes though .git"
         );
     }
@@ -2535,7 +2705,7 @@ fn walk_with_submodule() -> crate::Result {
     assert_eq!(
         entries,
         [
-            entry_nokind(".git", DotGit),
+            entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
             entry(".gitmodules", Tracked, File),
             entry("dir/file", Tracked, File),
             entry("submodule", Tracked, Repository)
@@ -2652,7 +2822,7 @@ fn submodules() -> crate::Result {
         }
     );
     let expected_content = [
-        entry_nokind(".git", DotGit),
+        entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
         entry(".gitmodules", Tracked, File).with_index_kind(File),
         entry("a/b", Tracked, Repository).with_index_kind(Repository),
         entry("empty", Tracked, File).with_index_kind(File),
@@ -2857,7 +3027,7 @@ fn root_with_dir_that_is_tracked_and_ignored() -> crate::Result {
         assert_eq!(
             entries,
             [
-                entry_nokind(".git", DotGit),
+                entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
                 entry(".gitignore", Tracked, File),
                 entry("dir/file", Tracked, File)
             ],
@@ -2898,7 +3068,7 @@ fn empty_and_nested_untracked() -> crate::Result {
         assert_eq!(
             entries,
             [
-                entry("empty", Untracked, EmptyDirectory),
+                entry("empty", Untracked, Directory).with_property(EmptyDirectory),
                 entry("untracked/file", Untracked, File)
             ],
             "we find all untracked entries, no matter the deletion mode"
@@ -2928,7 +3098,7 @@ fn empty_and_nested_untracked() -> crate::Result {
         assert_eq!(
             entries,
             [
-                entry("empty", Untracked, EmptyDirectory),
+                entry("empty", Untracked, Directory).with_property(EmptyDirectory),
                 entry("untracked", Untracked, Directory)
             ],
             "we find all untracked directories, no matter the deletion mode"
@@ -3395,7 +3565,7 @@ fn untracked_and_ignored_collapse_mix() {
 #[test]
 fn root_cannot_pass_through_case_altered_capital_dot_git_if_case_insensitive() -> crate::Result {
     let root = fixture("with-nested-capitalized-dot-git");
-    for dir in ["", "subdir"] {
+    for (dir, expected_pathspec) in [("", Some(Verbatim)), ("subdir", None)] {
         let troot = root.join("dir").join(".GIT").join(dir);
         let ((out, _root), entries) = collect(&root, Some(&troot), |keep, ctx| {
             walk(
@@ -3418,7 +3588,11 @@ fn root_cannot_pass_through_case_altered_capital_dot_git_if_case_insensitive() -
         );
         assert_eq!(
             entries,
-            [entry_nomatch("dir/.GIT", DotGit, Directory)],
+            [{
+                let mut e = entry("dir/.GIT", Pruned, Directory).with_property(DotGit);
+                e.0.pathspec_match = expected_pathspec;
+                e
+            }],
             "no traversal happened as root passes though .git, it compares in a case-insensitive fashion"
         );
     }
@@ -3476,7 +3650,9 @@ fn partial_checkout_cone_and_non_one() -> crate::Result {
         );
         assert_eq!(
             entries,
-            [entry("d", TrackedExcluded, Directory)],
+            [entry("d", Pruned, Directory)
+                .with_index_kind(Directory)
+                .with_property(TrackedExcluded)],
             "{fixture_name}: we avoid entering excluded sparse-checkout directories even if they are present on disk,\
             no matter with cone or without."
         );

--- a/gix-dir/tests/walk_utils/mod.rs
+++ b/gix-dir/tests/walk_utils/mod.rs
@@ -51,6 +51,7 @@ pub fn entry_nomatch(
         Entry {
             rela_path: rela_path.as_ref().to_owned(),
             status,
+            property: None,
             disk_kind: Some(disk_kind),
             index_kind: index_kind_from_status(status, disk_kind),
             pathspec_match: None,
@@ -64,6 +65,7 @@ pub fn entry_nokind(rela_path: impl AsRef<BStr>, status: entry::Status) -> (Entr
         Entry {
             rela_path: rela_path.as_ref().to_owned(),
             status,
+            property: None,
             disk_kind: None,
             index_kind: None,
             pathspec_match: None,
@@ -82,6 +84,7 @@ pub fn entryps(
         Entry {
             rela_path: rela_path.as_ref().to_owned(),
             status,
+            property: None,
             disk_kind: Some(disk_kind),
             index_kind: index_kind_from_status(status, disk_kind),
             pathspec_match: Some(pathspec_match),
@@ -100,6 +103,7 @@ pub fn entry_dirstat(
         Entry {
             rela_path: rela_path.as_ref().to_owned(),
             status,
+            property: None,
             disk_kind: Some(disk_kind),
             index_kind: index_kind_from_status(status, disk_kind),
             pathspec_match: Some(entry::PathspecMatch::Always),
@@ -120,6 +124,7 @@ pub fn entryps_dirstat(
         Entry {
             rela_path: rela_path.as_ref().to_owned(),
             status,
+            property: None,
             disk_kind: Some(disk_kind),
             index_kind: index_kind_from_status(status, disk_kind),
             pathspec_match: Some(pathspec_match),
@@ -129,16 +134,37 @@ pub fn entryps_dirstat(
 }
 
 fn index_kind_from_status(status: entry::Status, disk_kind: entry::Kind) -> Option<entry::Kind> {
-    matches!(status, entry::Status::Tracked | entry::Status::TrackedExcluded).then_some(disk_kind)
+    matches!(status, entry::Status::Tracked).then_some(disk_kind)
 }
 
 pub trait EntryExt {
     fn with_index_kind(self, index_kind: entry::Kind) -> Self;
+    fn with_property(self, flags: entry::Property) -> Self;
+    fn with_match(self, m: entry::PathspecMatch) -> Self;
+    fn no_match(self) -> Self;
+    fn no_kind(self) -> Self;
 }
 
 impl EntryExt for (Entry, Option<entry::Status>) {
     fn with_index_kind(mut self, index_kind: entry::Kind) -> Self {
         self.0.index_kind = index_kind.into();
+        self
+    }
+    fn with_property(mut self, property: entry::Property) -> Self {
+        self.0.property = property.into();
+        self
+    }
+    fn with_match(mut self, m: entry::PathspecMatch) -> Self {
+        self.0.pathspec_match = Some(m);
+        self
+    }
+
+    fn no_match(mut self) -> Self {
+        self.0.pathspec_match = None;
+        self
+    }
+    fn no_kind(mut self) -> Self {
+        self.0.disk_kind = None;
         self
     }
 }

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -149,6 +149,7 @@ pub fn main() -> Result<()> {
         #[cfg(feature = "gitoxide-core-tools-clean")]
         Subcommands::Clean(crate::plumbing::options::clean::Command {
             debug,
+            dry_run: _,
             execute,
             ignored,
             precious,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -155,6 +155,7 @@ pub fn main() -> Result<()> {
             directories,
             pathspec,
             repositories,
+            pathspec_matches_result,
             skip_hidden_repositories,
             find_untracked_repositories,
         }) => prepare_and_run(
@@ -178,6 +179,7 @@ pub fn main() -> Result<()> {
                         precious,
                         directories,
                         repositories,
+                        pathspec_matches_result,
                         skip_hidden_repositories: skip_hidden_repositories.map(Into::into),
                         find_untracked_repositories: find_untracked_repositories.into(),
                     },

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -274,7 +274,6 @@ pub mod corpus {
 }
 
 pub mod config {
-
     use gix::bstr::BString;
 
     /// Print all entries in a configuration file or access other sub-commands
@@ -506,6 +505,9 @@ pub mod clean {
         /// Print additional debug information to help understand decisions it made.
         #[arg(long)]
         pub debug: bool,
+        /// A dummy to easy with muscle-memory. This flag is assumed if provided or not, and has no effect.
+        #[arg(short = 'n', long)]
+        pub dry_run: bool,
         /// Actually perform the operation, which deletes files on disk without chance of recovery.
         #[arg(long, short = 'e')]
         pub execute: bool,
@@ -689,6 +691,7 @@ pub mod revision {
             DiffOrGit,
         }
     }
+
     #[derive(Debug, clap::Subcommand)]
     #[clap(visible_alias = "rev", visible_alias = "r")]
     pub enum Subcommands {
@@ -859,7 +862,6 @@ pub mod index {
 }
 
 pub mod submodule {
-
     #[derive(Debug, clap::Parser)]
     pub struct Platform {
         #[clap(subcommand)]

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -521,6 +521,12 @@ pub mod clean {
         /// Remove nested repositories.
         #[arg(long, short = 'r')]
         pub repositories: bool,
+        /// Pathspec patterns are used to match the result of the dirwalk, not the dirwalk itself.
+        ///
+        /// Use this if there is trouble using wildcard pathspecs, which affect the directory walk
+        /// in reasonable, but often unexpected ways.
+        #[arg(long, short = 'm')]
+        pub pathspec_matches_result: bool,
         /// Enter ignored directories to skip repositories contained within.
         #[arg(long)]
         pub skip_hidden_repositories: Option<FindRepository>,


### PR DESCRIPTION
Based on #1291 

----

### diff-correctness → `gix-status` → gix reset

----

Improve `gix status` to the point where it's suitable for use in `reset` functinoality.
Leads to a proper worktree reset implementation, eventually leading to a high-level reset similar to how git supports it.

### Architecture

The reason this PR deals quite a bit with `gix status` is that for a safe implementation of `reset()` we need to be sure that the files we *would* want to touch don't don't carry modifications or are untracked files. In order to know what would need to be done, we have to diff the `current-index with target-index`. The set of files to touch can then be used to lookup information provided by `git-status`, like worktree modifications, index modifications, and untracked files, to know if we can proceed or not. Here is also where the reset-modes would affect the outcome, i.e. what to change and how.

This is a very modular approach which facilitates testing and understanding of what otherwise would be a very complex algorithm. Having a set of changes as output also allows to one day parallelize applying these changes.

This leaves us in a situation where the current `checkout()` implementation wants to become a fastpath for situations where the reset involves an empty tree as source (i.e. create everything and overwrite local changes).

On the way to `reset()` it's a valid choice to warm up more with the matter by improving on the current `gix status` implementation and assure correctness of what's there, which currently doesn't seem to be the case in comparison. Further, implementing `gix status` similarly to `git status ` should be made possible.

### Tasks for `main`

- [x] If pruned ‘.gitdirs’ are inside of ignored directories that are matched with ‘*’ pathspec, they can’t be deleted unless one searches for repositories, but that isn’t suggested as git dirs always seem pruned. They should have the same data like everything else.
- [x] `gix clean -dx '*/generated-do-not-edit/'  --skip-hidden-repositories=all -rp` is showing precious repos outside of the pathspec range. **That's a no-go**. Happens during dirwalk, maybe related to repositories but not always. Pathspec shouldn't even match
- [x] Strange, but not wrong, behaviour when doing using wildcard matches (i.e. hide directories that have undeletable files inside instead of avoiding to collapse them). This happens because a wildcard search causes a deep search, without the option to not recurse into otherwise ignored directories. So `*/generated-do-not-edit` yields three directories, with everything else pruned as it doesn’t match the pathspec. However, `*/generated-do-not-edit/*` matches all previously pruned items.
     - With recent changes, it's possible to delete them at least, dot-git isn't always pruned by default anymore.
- [x] It fails to collapse a folder that has precious files and/or repositories inside, even if you tell to delete them, leaving an empty directory that needs deletion in a second pass. This is intended, as these items prevent collapse and there is no way to say you want to delete them.
    - In theory, it shouldn't walk into these at all, recheck if this is still the case.

### Tasks 
* [ ] mix index-check with dirwalk
* [ ] rename-tracking in `gix-status` crate
* [ ] adjust printed path according to `prefix()` in `gix status`
* [ ] diff index with index to learn what we would want to do in the worktree, or alternatively, 
      diff tree with index (with reverse-diff functionality to simulate diff of index with tree), for better performance as it 
      would avoid having to allocate a whole index even though we are only interested in a diff.
     - *Must include rename tracking*.
* [ ] how to make diff results available from status with all transformations applied, to allow user to obtain diffs of any kind?

### Status Enables

* https://github.com/Byron/built/pull/1
* starship native dirty check
* onefetch finalize integration
* helix PR

### Next PR: Reset

* [ ] `reset()` that checks if it's allowed to perform a worktree modification is allowed, or if an entry should be skipped. *That way we can postpone safety checks like --hard*

### Postponed

What follows is important for resets, but won't be needed for `cargo` worktree resets.

* [ ] a way to expand sparse dirs (but figure out if this is truly always necessary) - probably not, unless sparse dirs can be empty, but even then no expansion is needed
     - [ ] wire it up in `gix index entries` to optionally expand sparse entries
* [ ] `gix status` with actual submodule support - needs `status` in `gix` (crate) effectively
* [ ] `gix status` with actual conflict support

### Research
 
* Ignored files are considered expandable and can be overwritten on reset
* How to integrate submodules - probably easy to answer once `gix status` can deal a little better with submodules. Even though in this case a lot of submodule-related information is needed for a complete reset, probably only doable by a higher-level caller which orchestrates it.
* How to deal with various modes like `merge` and `keep`? How to control `refresh`? Maybe partial (only the files we touch), and full, to also update the files we don't touch as part of status? Maybe it's part of status if that is run before.
* Worthwhile to make explicit the difference between `git reset` and `git checkout` in terms of `HEAD` modifications. With the former changing `HEAD`s referent, and the latter changing `HEAD` itself.
* figure out how this relates to the current `checkout()` method as technically that's a `reset --hard` with optional overwrite check. Could it be rolled into one, with pathspec support added? 
   - just keep them separate until it's clear that `reset()` performs just as well, which is unlikely as there is more overhead. But maybe it's not worth to maintain two versions over it. But if so, one should probably rename it.
* for `git status`: what about rename tracking? It's available for tree-diffs and quite complex on its own. Probably only needs HEAD-vs-index rename tracking. No, also can have worktree rename tracking, even though it's hard to imagine how this can be fast unless it's tightly integrated with untracked-files handling. This screams for a generalization of the tracking code though as the testing and implementation is complex, but *should* be generalisable.


### Re-learn

* `pathspecs` normalize themselves to turn from any kind of specification into repo-root relative patterns.
* attribute/ignore file sources are naturally relative to the root of the repo, which remains relative (i.e. can be `..` and that root will be always be used to open files like `../.gitignore`, which is useful for display to the user)
