### PR TITLE
fix: missing closing backtick in gix lib documentation

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -122,7 +122,7 @@ worktree-archive = ["gix-archive", "worktree-stream", "attributes"]
 async-network-client = ["gix-protocol/async-client", "gix-pack/streaming-input", "attributes", "credentials"]
 ## Use this if your crate uses `async-std` as runtime, and enable basic runtime integration when connecting to remote servers via the `git://` protocol.
 async-network-client-async-std = ["async-std", "async-network-client", "gix-transport/async-std"]
-## Make `gix-protocol` available along with a blocking client, providing access to the `file://`, git://` and `ssh://` transports.
+## Make `gix-protocol` available along with a blocking client, providing access to the `file://`, `git://` and `ssh://` transports.
 blocking-network-client = ["gix-protocol/blocking-client", "gix-pack/streaming-input", "attributes", "credentials"]
 ## Stacks with `blocking-network-client` to provide support for HTTP/S using **curl**, and implies blocking networking as a whole, making the `https://` transport available.
 blocking-http-transport-curl = ["blocking-network-client", "gix-transport/http-client-curl"]

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! What follows is a list of methods you might be missing, along with workarounds if available.
 //! * [`git2::Repository::open_bare()`](https://docs.rs/git2/*/git2/struct.Repository.html#method.open_bare) ➡ ❌ - use [`open()`] and discard if it is not bare.
-//! * [`git2::build::CheckoutBuilder::disable_filters()](https://docs.rs/git2/*/git2/build/struct.CheckoutBuilder.html#method.disable_filters) ➡ ❌ *(filters are always applied during checkouts)*
+//! * [`git2::build::CheckoutBuilder::disable_filters()`](https://docs.rs/git2/*/git2/build/struct.CheckoutBuilder.html#method.disable_filters) ➡ ❌ *(filters are always applied during checkouts)*
 //! * [`git2::Repository::submodule_status()`](https://docs.rs/git2/*/git2/struct.Repository.html#method.submodule_status) ➡ [`Submodule::state()`] - status provides more information and conveniences though, and an actual worktree status isn't performed.
 //!
 //! #### Integrity checks


### PR DESCRIPTION
This is a silly and very simple change to just correct a formatting mistake in the documentation of the `gix` crate.

You can see the formatting error on the [docs.rs documentation](https://docs.rs/gix/latest/gix/#libgit2-api-to-gix). Put simply, an opening backtick was opened and never closed, this PR correct the issue by adding the closing backtick.

![image](https://github.com/Byron/gitoxide/assets/2295721/3604e987-a311-4c79-9c28-b6123c382e1f)
