### PR TITLE
Fix git-fsck to handle non-root trees

### DIFF
--- a/gix-fsck/src/lib.rs
+++ b/gix-fsck/src/lib.rs
@@ -80,9 +80,7 @@ where
             match entry_ref.mode.kind() {
                 EntryKind::Tree => {
                     let tree_id = entry_ref.oid.to_owned();
-                    if self.seen.insert(tree_id) {
-                        tree_ids.push_back(tree_id);
-                    }
+                    tree_ids.push_back(tree_id);
                 }
                 EntryKind::Blob | EntryKind::BlobExecutable | EntryKind::Link => {
                     let blob_id = entry_ref.oid.to_owned();
@@ -91,7 +89,7 @@ where
                     }
                 }
                 EntryKind::Commit => {
-                    // Skip submodules as it's not in this repository!
+                    // Skip submodules as they wouldn't be in this repository!
                 }
             }
         }

--- a/gix-fsck/tests/connectivity/mod.rs
+++ b/gix-fsck/tests/connectivity/mod.rs
@@ -42,8 +42,8 @@ fn hex_to_objects<'a>(hex_ids: impl IntoIterator<Item = &'a str>, kind: Kind) ->
 fn all_commits() -> &'static [ObjectId] {
     static ALL_COMMITS: Lazy<Vec<ObjectId>> = Lazy::new(|| {
         hex_to_ids([
-            "5d18db2e2aabadf7b914435ef34f2faf8b4546dd",
-            "3a3dfaa55a515f3fb3a25751107bbb523af6a1b0",
+            "ebed23648b19484cb1f340c4ee04dda08479188a",
+            "8ff6d0f8891c3cb22827be142cc64606121d47b3",
             "734c926856a328d1168ffd7088532e0d1ad19bbe",
         ])
     });
@@ -59,7 +59,13 @@ fn no_missing() {
 #[test]
 fn missing_blobs() {
     // The "blobless" repo is cloned with `--filter=blob:none`, and is missing one blob
-    let expected = hex_to_objects(["c18147dc648481eeb65dc5e66628429a64843327"], Kind::Blob);
+    let expected = hex_to_objects(
+        [
+            "4cdeaab5b01f9a9fbbb2fb6c08404cf12b7bdab1",
+            "c18147dc648481eeb65dc5e66628429a64843327",
+        ],
+        Kind::Blob,
+    );
     assert_eq!(check_missing("blobless", all_commits()), expected);
 }
 
@@ -69,7 +75,7 @@ fn missing_trees() {
     // NOTE: This repo is also missing a blob, but we have no way of knowing that, as the tree referencing it is missing
     let expected = hex_to_objects(
         [
-            "9561cfbae43c5e2accdfcd423378588dd10d827f",
+            "20317ffa7614f49b2702a057bf2833918ea9fd24",
             "fc264b3b6875a46e9031483aeb9994a1b897ffd3",
         ],
         Kind::Tree,

--- a/gix-fsck/tests/fixtures/make_test_repos.sh
+++ b/gix-fsck/tests/fixtures/make_test_repos.sh
@@ -18,9 +18,11 @@ git init base
     git add -A
     git commit -m "commit 1"
     echo "blob-2" > blob-2
+    mkdir tree-1
+    echo "blob-3" > tree-1/blob-3
     git add -A
     git commit -m "commit 2"
-    git rm blob-1
+    git rm blob-1 tree-1/blob-3
     git add -A
     git commit -m "commit 3"
 )


### PR DESCRIPTION
- Trees except the commit's root tree were being skipped
- Make `check_commit()` the only functioning marking trees as "seen"
- Update unit tests to catch the failure (add a directory to test repo)

