### PR TITLE
Fix zombie ssh processes from accumulating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
Noticed that with a long-running app that makes use of SSH transport, I end up with a bunch of zombie `ssh` processes. Fix this by implementing `Drop` trait on `SpawnProcessOnDemand`.