### PR TITLE
[gix-config] Run parse::tests::section::size_of_events only on 64 bit architectures

### DIFF
--- a/gix-config/src/parse/tests.rs
+++ b/gix-config/src/parse/tests.rs
@@ -5,6 +5,7 @@ mod section {
     use std::borrow::Cow;
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn size_of_events() {
         assert_eq!(
             std::mem::size_of::<Section<'_>>(),


### PR DESCRIPTION
The problem with `parse::tests::section::size_of_events` is that assumes that the test is always run on a 64 bit architectures. This PR simply disables the test on non 64 bit architectures. I am unsure if you want this kind of problem to be handled like this.  What would be your (@Byron) desired behavior in this case?