### PR TITLE
Refine and strengthen diagnostics for problematic URLs

### DIFF
--- a/gix-transport/src/client/blocking_io/file.rs
+++ b/gix-transport/src/client/blocking_io/file.rs
@@ -316,8 +316,13 @@ mod tests {
                     "user@-oProxyCommand=open$IFS-aCalculator:username/repo",
                 ] {
                     let url = gix_url::parse((*url).into()).expect("valid url");
+                    let options = ssh::connect::Options {
+                        command: Some("unrecognized".into()),
+                        disallow_shell: false,
+                        kind: None,
+                    };
                     assert!(matches!(
-                        ssh::connect(url, Protocol::V1, Default::default(), false),
+                        ssh::connect(url, Protocol::V1, options, false),
                         Err(ssh::Error::AmbiguousHostName { host }) if host == "-oProxyCommand=open$IFS-aCalculator",
                     ));
                 }

--- a/gix-transport/src/client/blocking_io/file.rs
+++ b/gix-transport/src/client/blocking_io/file.rs
@@ -291,7 +291,7 @@ pub fn connect(
 mod tests {
     mod ssh {
         mod connect {
-            use crate::{client::blocking_io::ssh::connect, Protocol};
+            use crate::{client::blocking_io::ssh, Protocol};
 
             #[test]
             fn path() {
@@ -304,8 +304,22 @@ mod tests {
                     ("user@host.xy:~/repo", "~/repo"),
                 ] {
                     let url = gix_url::parse((*url).into()).expect("valid url");
-                    let cmd = connect(url, Protocol::V1, Default::default(), false).expect("parse success");
+                    let cmd = ssh::connect(url, Protocol::V1, Default::default(), false).expect("parse success");
                     assert_eq!(cmd.path, expected, "the path will be substituted by the remote shell");
+                }
+            }
+
+            #[test]
+            fn ambiguous_host_disallowed() {
+                for url in [
+                    "ssh://-oProxyCommand=open$IFS-aCalculator/foo",
+                    "user@-oProxyCommand=open$IFS-aCalculator:username/repo",
+                ] {
+                    let url = gix_url::parse((*url).into()).expect("valid url");
+                    assert!(matches!(
+                        ssh::connect(url, Protocol::V1, Default::default(), false),
+                        Err(ssh::Error::AmbiguousHostName { host }) if host == "-oProxyCommand=open$IFS-aCalculator",
+                    ));
                 }
             }
         }

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -118,6 +118,8 @@ pub fn connect(
                 .stdin(Stdio::null())
                 .with_shell()
                 .arg("-G")
+                // Username affects the stdout from `ssh -G` but may not affect the status. But if
+                // we end up needing it, it can be added here, with a user_argument_safe() check.
                 .arg(url.host_argument_safe().ok_or_else(|| Error::AmbiguousHostName {
                     host: url.host().expect("set in ssh urls").into(),
                 })?),

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -124,7 +124,7 @@ pub fn connect(
                     Usable(host) => host,
                     Dangerous(host) => Err(Error::AmbiguousHostName { host: host.into() })?,
                     Absent => panic!("BUG: host should always be present in SSH URLs"),
-                }),
+                }), // We omit `user@` with `-G`, so it need not be safe here, but host must be safe.
         );
         gix_features::trace::debug!(cmd = ?cmd, "invoking `ssh` for feature check");
         kind = if cmd.status().ok().map_or(false, |status| status.success()) {

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -124,7 +124,7 @@ pub fn connect(
                     Usable(host) => host,
                     Dangerous(host) => Err(Error::AmbiguousHostName { host: host.into() })?,
                     Absent => panic!("BUG: host should always be present in SSH URLs"),
-                }), // We omit `user@` with `-G`, so it need not be safe here, but host must be safe.
+                }),
         );
         gix_features::trace::debug!(cmd = ?cmd, "invoking `ssh` for feature check");
         kind = if cmd.status().ok().map_or(false, |status| status.success()) {

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -42,6 +42,8 @@ pub mod invocation {
     #[derive(Debug, thiserror::Error)]
     #[allow(missing_docs)]
     pub enum Error {
+        #[error("Username '{user}' could be mistaken for a command-line argument")]
+        AmbiguousUserName { user: String },
         #[error("Host name '{host}' could be mistaken for a command-line argument")]
         AmbiguousHostName { host: String },
         #[error("The 'Simple' ssh variant doesn't support {function}")]

--- a/gix-transport/src/client/blocking_io/ssh/program_kind.rs
+++ b/gix-transport/src/client/blocking_io/ssh/program_kind.rs
@@ -72,9 +72,9 @@ impl ProgramKind {
             (_, Absent) => panic!("BUG: host should always be present in SSH URLs"),
         };
 
-        // Try to force ssh to yield English messages (for parsing later).
         Ok(prepare
             .arg(host_maybe_with_user_as_ssh_arg)
+            // Try to force ssh to yield English messages (for parsing later).
             .env("LANG", "C")
             .env("LC_ALL", "C"))
     }

--- a/gix-transport/src/client/blocking_io/ssh/program_kind.rs
+++ b/gix-transport/src/client/blocking_io/ssh/program_kind.rs
@@ -65,6 +65,7 @@ impl ProgramKind {
 
         let host_maybe_with_user_as_ssh_arg = match (url.user_as_argument(), url.host_as_argument()) {
             (Usable(user), Usable(host)) => format!("{user}@{host}"),
+            (Usable(user), Dangerous(host)) => format!("{user}@{host}"), // The `user@` makes it safe.
             (Absent, Usable(host)) => host.into(),
             (Dangerous(user), _) => Err(ssh::invocation::Error::AmbiguousUserName { user: user.into() })?,
             (_, Dangerous(host)) => Err(ssh::invocation::Error::AmbiguousHostName { host: host.into() })?,

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -90,7 +90,7 @@ pub struct Url {
     /// URLs allow paths to start with `-` which makes it possible to mask command-line arguments as path which then leads to
     /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
     ///
-    /// If this value is going to be used in a command-line application, call [Self::path_argument_safe()] instead.
+    /// If this value is ever going to be passed to a command-line application, call [Self::path_argument_safe()] instead.
     pub path: BString,
 }
 
@@ -171,7 +171,7 @@ impl Url {
     /// URLs allow usernames to start with `-` which makes it possible to mask command-line arguments as username which then leads to
     /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
     ///
-    /// If this value is going to be used in a command-line application, call [Self::user_argument_safe()] instead.
+    /// If this value is ever going to be passed to a command-line application, call [Self::user_argument_safe()] instead.
     pub fn user(&self) -> Option<&str> {
         self.user.as_deref()
     }
@@ -195,7 +195,7 @@ impl Url {
     /// URLs allow hosts to start with `-` which makes it possible to mask command-line arguments as host which then leads to
     /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
     ///
-    /// If this value is going to be used in a command-line application, call [Self::host_argument_safe()] instead.
+    /// If this value is ever going to be passed to a command-line application, call [Self::host_argument_safe()] instead.
     pub fn host(&self) -> Option<&str> {
         self.host.as_deref()
     }

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -165,8 +165,22 @@ impl Url {
 /// Access
 impl Url {
     /// Return the user mentioned in the URL, if present.
+    ///
+    /// # Security-Warning
+    ///
+    /// URLs allow usernames to start with `-` which makes it possible to mask command-line arguments as username which then leads to
+    /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
+    ///
+    /// If this value is going to be used in a command-line application, call [Self::user_argument_safe()] instead.
     pub fn user(&self) -> Option<&str> {
         self.user.as_deref()
+    }
+
+    /// Return the user from this URL if present *and* if it can't be mistaken for a command-line argument.
+    ///
+    /// Use this method if the user or a portion of the URL that begins with it will be passed to a command-line application.
+    pub fn user_argument_safe(&self) -> Option<&str> {
+        self.user().filter(|user| !looks_like_argument(user.as_bytes()))
     }
 
     /// Return the password mentioned in the url, if present.

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -180,6 +180,13 @@ impl Url {
     ///
     /// Use this method if the user or a portion of the URL that begins with it will be passed to a command-line application.
     pub fn user_argument_safe(&self) -> Option<&str> {
+        // FIXME: A return value of None from this method, or host_argument_safe(), is ambiguous: the user (or host) is
+        // either present but unsafe, or absent. Furthermore, in practice the value is usually needed even if unsafe,
+        // in order to report it in an error message. In gix-transport, the ambiguity makes it easy to write a new bug
+        // while using this interface for user_argument_safe(). In contrast, in host_argument_safe(), the ambiguity is
+        // much less of a problem, because the host is expected to be present. Yet the host() method must still be
+        // called when handling the None case, to include it in the error. If possible, both methods should be replaced
+        // by methods with a richer return type (a new enum). If not, the ambiguity should be prominently documented.
         self.user().filter(|user| !looks_like_argument(user.as_bytes()))
     }
 

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -164,15 +164,17 @@ impl Url {
 
 /// Access
 impl Url {
-    /// Returns the user mentioned in the url, if present.
+    /// Return the user mentioned in the URL, if present.
     pub fn user(&self) -> Option<&str> {
         self.user.as_deref()
     }
-    /// Returns the password mentioned in the url, if present.
+
+    /// Return the password mentioned in the url, if present.
     pub fn password(&self) -> Option<&str> {
         self.password.as_deref()
     }
-    /// Returns the host mentioned in the url, if present.
+
+    /// Return the host mentioned in the URL, if present.
     ///
     /// # Security-Warning
     ///
@@ -191,7 +193,7 @@ impl Url {
         self.host().filter(|host| !looks_like_argument(host.as_bytes()))
     }
 
-    /// Return the path of this URL *and* if it can't be mistaken for a command-line argument.
+    /// Return the path of this URL *if* it can't be mistaken for a command-line argument.
     /// Note that it always begins with a slash, which is ignored for this comparison.
     ///
     /// Use this method if the path is going to be passed to a command-line application.
@@ -201,11 +203,12 @@ impl Url {
             .and_then(|truncated| (!looks_like_argument(truncated)).then_some(self.path.as_ref()))
     }
 
-    /// Returns true if the path portion of the url is `/`.
+    /// Return true if the path portion of the URL is `/`.
     pub fn path_is_root(&self) -> bool {
         self.path == "/"
     }
-    /// Returns the actual or default port for use according to the url scheme.
+
+    /// Return the actual or default port for use according to the URL scheme.
     /// Note that there may be no default port either.
     pub fn port_or_default(&self) -> Option<u16> {
         self.port.or_else(|| {
@@ -227,7 +230,7 @@ fn looks_like_argument(b: &[u8]) -> bool {
 
 /// Transformation
 impl Url {
-    /// Turn a file url like `file://relative` into `file:///root/relative`, hence it assures the url's path component is absolute, using
+    /// Turn a file URL like `file://relative` into `file:///root/relative`, hence it assures the URL's path component is absolute, using
     /// `current_dir` if necessary.
     pub fn canonicalized(&self, current_dir: &std::path::Path) -> Result<Self, gix_path::realpath::Error> {
         let mut res = self.clone();
@@ -287,7 +290,7 @@ impl Url {
 
 /// Deserialization
 impl Url {
-    /// Parse a URL from `bytes`
+    /// Parse a URL from `bytes`.
     pub fn from_bytes(bytes: &BStr) -> Result<Self, parse::Error> {
         parse(bytes)
     }

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -187,7 +187,8 @@ impl Url {
         // much less of a problem, because the host is expected to be present. Yet the host() method must still be
         // called when handling the None case, to include it in the error. If possible, both methods should be replaced
         // by methods with a richer return type (a new enum). If not, the ambiguity should be prominently documented.
-        self.user().filter(|user| !looks_like_argument(user.as_bytes()))
+        self.user()
+            .filter(|user| !looks_like_command_line_option(user.as_bytes()))
     }
 
     /// Return the password mentioned in the url, if present.
@@ -211,7 +212,8 @@ impl Url {
     ///
     /// Use this method if the host is going to be passed to a command-line application.
     pub fn host_argument_safe(&self) -> Option<&str> {
-        self.host().filter(|host| !looks_like_argument(host.as_bytes()))
+        self.host()
+            .filter(|host| !looks_like_command_line_option(host.as_bytes()))
     }
 
     /// Return the path of this URL *if* it can't be mistaken for a command-line argument.
@@ -221,7 +223,7 @@ impl Url {
     pub fn path_argument_safe(&self) -> Option<&BStr> {
         self.path
             .get(1..)
-            .and_then(|truncated| (!looks_like_argument(truncated)).then_some(self.path.as_ref()))
+            .and_then(|truncated| (!looks_like_command_line_option(truncated)).then_some(self.path.as_ref()))
     }
 
     /// Return true if the path portion of the URL is `/`.
@@ -245,7 +247,7 @@ impl Url {
     }
 }
 
-fn looks_like_argument(b: &[u8]) -> bool {
+fn looks_like_command_line_option(b: &[u8]) -> bool {
     b.first() == Some(&b'-')
 }
 

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -66,13 +66,13 @@ pub fn expand_path(user: Option<&expand_path::ForUser>, path: &BStr) -> Result<P
 ///
 /// This type only expresses known *syntactic* risk. It does not cover other risks, such as passing a personal access
 /// token as a username rather than a password in an application that logs usernames.
-enum ArgumentSafety<'a, T> {
+pub enum ArgumentSafety<T> {
     /// May be safe. There is nothing to pass, so there is nothing dangerous.
     Absent,
     /// May be safe. The argument does not begin with a `-` and so will not be confused as an option.
-    Usable(&'a T),
+    Usable(T),
     /// Dangerous! Begins with `-` and could be treated as an option. Use the value in error messages only.
-    Dangerous(&'a T),
+    Dangerous(T),
 }
 
 /// A URL with support for specialized git related capabilities.
@@ -200,7 +200,7 @@ impl Url {
     ///
     /// Use this method instead of [Self::user()] if the host is going to be passed to a command-line application.
     /// If the unsafe and absent cases need not be distinguished, [Self::user_argument_safe()] may also be used.
-    pub fn user_as_argument(&self) -> ArgumentSafety<str> {
+    pub fn user_as_argument(&self) -> ArgumentSafety<&str> {
         match self.user() {
             Some(user) if looks_like_command_line_option(user.as_bytes()) => ArgumentSafety::Dangerous(user),
             Some(user) => ArgumentSafety::Usable(user),
@@ -242,7 +242,7 @@ impl Url {
     ///
     /// Use this method instead of [Self::host()] if the host is going to be passed to a command-line application.
     /// If the unsafe and absent cases need not be distinguished, [Self::host_argument_safe()] may also be used.
-    pub fn host_as_argument(&self) -> ArgumentSafety<str> {
+    pub fn host_as_argument(&self) -> ArgumentSafety<&str> {
         match self.host() {
             Some(host) if looks_like_command_line_option(host.as_bytes()) => ArgumentSafety::Dangerous(host),
             Some(host) => ArgumentSafety::Usable(host),
@@ -269,7 +269,7 @@ impl Url {
     /// passed to a command-line application, unless it is certain that the leading `/` will always be included.
     ///
     /// This method never returns an [ArgumentSafety::Absent].
-    pub fn path_as_argument(&self) -> ArgumentSafety<BStr> {
+    pub fn path_as_argument(&self) -> ArgumentSafety<&BStr> {
         match self.path_argument_safe() {
             Some(path) => ArgumentSafety::Usable(path),
             None => ArgumentSafety::Dangerous(self.path.as_ref()),

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -66,6 +66,7 @@ pub fn expand_path(user: Option<&expand_path::ForUser>, path: &BStr) -> Result<P
 ///
 /// This type only expresses known *syntactic* risk. It does not cover other risks, such as passing a personal access
 /// token as a username rather than a password in an application that logs usernames.
+#[derive(Debug, PartialEq)]
 pub enum ArgumentSafety<T> {
     /// May be safe. There is nothing to pass, so there is nothing dangerous.
     Absent,

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -60,14 +60,13 @@ fn user_argument_safety() -> crate::Result {
 
     assert_eq!(url.user(), Some("-Fconfigfile"));
     assert_eq!(url.user_as_argument(), ArgumentSafety::Dangerous("-Fconfigfile"));
-    assert_eq!(url.user_argument_safe(), None); // An unsafe username is blocked.
+    assert_eq!(url.user_argument_safe(), None, "An unsafe username is blocked.");
 
     assert_eq!(url.host(), Some("foo"));
     assert_eq!(url.host_as_argument(), ArgumentSafety::Usable("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));
 
     assert_eq!(url.path, "/bar");
-    assert_eq!(url.path_as_argument(), ArgumentSafety::Usable("/bar".into()));
     assert_eq!(url.path_argument_safe(), Some("/bar".into()));
 
     Ok(())
@@ -79,17 +78,20 @@ fn host_argument_safety() -> crate::Result {
 
     assert_eq!(url.user(), None);
     assert_eq!(url.user_as_argument(), ArgumentSafety::Absent);
-    assert_eq!(url.user_argument_safe(), None); // As there is no user. See all_argument_safe_valid().
+    assert_eq!(
+        url.user_argument_safe(),
+        None,
+        "As there is no user. See all_argument_safe_valid()"
+    );
 
     assert_eq!(url.host(), Some("-oProxyCommand=open$IFS-aCalculator"));
     assert_eq!(
         url.host_as_argument(),
         ArgumentSafety::Dangerous("-oProxyCommand=open$IFS-aCalculator")
     );
-    assert_eq!(url.host_argument_safe(), None); // An unsafe host string is blocked.
+    assert_eq!(url.host_argument_safe(), None, "An unsafe host string is blocked");
 
     assert_eq!(url.path, "/foo");
-    assert_eq!(url.path_as_argument(), ArgumentSafety::Usable("/foo".into()));
     assert_eq!(url.path_argument_safe(), Some("/foo".into()));
 
     Ok(())
@@ -101,18 +103,18 @@ fn path_argument_safety() -> crate::Result {
 
     assert_eq!(url.user(), None);
     assert_eq!(url.user_as_argument(), ArgumentSafety::Absent);
-    assert_eq!(url.user_argument_safe(), None); // As there is no user. See all_argument_safe_valid().
+    assert_eq!(
+        url.user_argument_safe(),
+        None,
+        "As there is no user. See all_argument_safe_valid()"
+    );
 
     assert_eq!(url.host(), Some("foo"));
     assert_eq!(url.host_as_argument(), ArgumentSafety::Usable("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));
 
     assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
-    assert_eq!(
-        url.path_as_argument(),
-        ArgumentSafety::Dangerous("/-oProxyCommand=open$IFS-aCalculator".into())
-    );
-    assert_eq!(url.path_argument_safe(), None); // An unsafe path is blocked.
+    assert_eq!(url.path_argument_safe(), None, "An unsafe path is blocked");
 
     Ok(())
 }
@@ -130,7 +132,6 @@ fn all_argument_safety_safe() -> crate::Result {
     assert_eq!(url.host_argument_safe(), Some("example.com"));
 
     assert_eq!(url.path, "/path/to/file");
-    assert_eq!(url.path_as_argument(), ArgumentSafety::Usable("/path/to/file".into()));
     assert_eq!(url.path_argument_safe(), Some("/path/to/file".into()));
 
     Ok(())
@@ -150,14 +151,10 @@ fn all_argument_safety_not_safe() -> crate::Result {
         url.host_as_argument(),
         ArgumentSafety::Dangerous("-oProxyCommand=open$IFS-aCalculator")
     );
-    assert_eq!(url.host_argument_safe(), None); // An unsafe host string is blocked.
+    assert_eq!(url.host_argument_safe(), None, "An unsafe host string is blocked");
 
     assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
-    assert_eq!(
-        url.path_as_argument(),
-        ArgumentSafety::Dangerous("/-oProxyCommand=open$IFS-aCalculator".into())
-    );
-    assert_eq!(url.path_argument_safe(), None); // An unsafe path is blocked.
+    assert_eq!(url.path_argument_safe(), None, "An unsafe path is blocked");
 
     Ok(())
 }

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -30,6 +30,8 @@ mod canonicalized {
     }
 }
 
+use gix_url::ArgumentSafety;
+
 #[test]
 fn user() -> crate::Result {
     let mut url = gix_url::parse("https://user:password@host/path".into())?;
@@ -53,81 +55,108 @@ fn password() -> crate::Result {
 }
 
 #[test]
-fn user_argument_safe() -> crate::Result {
+fn user_argument_safety() -> crate::Result {
     let url = gix_url::parse("ssh://-Fconfigfile@foo/bar".into())?;
 
     assert_eq!(url.user(), Some("-Fconfigfile"));
+    assert_eq!(url.user_as_argument(), ArgumentSafety::Dangerous("-Fconfigfile"));
     assert_eq!(url.user_argument_safe(), None); // An unsafe username is blocked.
 
     assert_eq!(url.host(), Some("foo"));
+    assert_eq!(url.host_as_argument(), ArgumentSafety::Usable("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));
 
     assert_eq!(url.path, "/bar");
+    assert_eq!(url.path_as_argument(), ArgumentSafety::Usable("/bar".into()));
     assert_eq!(url.path_argument_safe(), Some("/bar".into()));
 
     Ok(())
 }
 
 #[test]
-fn host_argument_safe() -> crate::Result {
+fn host_argument_safety() -> crate::Result {
     let url = gix_url::parse("ssh://-oProxyCommand=open$IFS-aCalculator/foo".into())?;
 
     assert_eq!(url.user(), None);
+    assert_eq!(url.user_as_argument(), ArgumentSafety::Absent);
     assert_eq!(url.user_argument_safe(), None); // As there is no user. See all_argument_safe_valid().
 
     assert_eq!(url.host(), Some("-oProxyCommand=open$IFS-aCalculator"));
+    assert_eq!(
+        url.host_as_argument(),
+        ArgumentSafety::Dangerous("-oProxyCommand=open$IFS-aCalculator")
+    );
     assert_eq!(url.host_argument_safe(), None); // An unsafe host string is blocked.
 
     assert_eq!(url.path, "/foo");
+    assert_eq!(url.path_as_argument(), ArgumentSafety::Usable("/foo".into()));
     assert_eq!(url.path_argument_safe(), Some("/foo".into()));
 
     Ok(())
 }
 
 #[test]
-fn path_argument_safe() -> crate::Result {
+fn path_argument_safety() -> crate::Result {
     let url = gix_url::parse("ssh://foo/-oProxyCommand=open$IFS-aCalculator".into())?;
 
     assert_eq!(url.user(), None);
+    assert_eq!(url.user_as_argument(), ArgumentSafety::Absent);
     assert_eq!(url.user_argument_safe(), None); // As there is no user. See all_argument_safe_valid().
 
     assert_eq!(url.host(), Some("foo"));
+    assert_eq!(url.host_as_argument(), ArgumentSafety::Usable("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));
 
     assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
+    assert_eq!(
+        url.path_as_argument(),
+        ArgumentSafety::Dangerous("/-oProxyCommand=open$IFS-aCalculator".into())
+    );
     assert_eq!(url.path_argument_safe(), None); // An unsafe path is blocked.
 
     Ok(())
 }
 
 #[test]
-fn all_argument_safe_allowed() -> crate::Result {
+fn all_argument_safety_safe() -> crate::Result {
     let url = gix_url::parse("ssh://user.name@example.com/path/to/file".into())?;
 
     assert_eq!(url.user(), Some("user.name"));
+    assert_eq!(url.user_as_argument(), ArgumentSafety::Usable("user.name"));
     assert_eq!(url.user_argument_safe(), Some("user.name"));
 
     assert_eq!(url.host(), Some("example.com"));
+    assert_eq!(url.host_as_argument(), ArgumentSafety::Usable("example.com"));
     assert_eq!(url.host_argument_safe(), Some("example.com"));
 
     assert_eq!(url.path, "/path/to/file");
+    assert_eq!(url.path_as_argument(), ArgumentSafety::Usable("/path/to/file".into()));
     assert_eq!(url.path_argument_safe(), Some("/path/to/file".into()));
 
     Ok(())
 }
 
 #[test]
-fn all_argument_safe_disallowed() -> crate::Result {
+fn all_argument_safety_not_safe() -> crate::Result {
     let all_bad = "ssh://-Fconfigfile@-oProxyCommand=open$IFS-aCalculator/-oProxyCommand=open$IFS-aCalculator";
     let url = gix_url::parse(all_bad.into())?;
 
     assert_eq!(url.user(), Some("-Fconfigfile"));
+    assert_eq!(url.user_as_argument(), ArgumentSafety::Dangerous("-Fconfigfile"));
     assert_eq!(url.user_argument_safe(), None); // An unsafe username is blocked.
 
     assert_eq!(url.host(), Some("-oProxyCommand=open$IFS-aCalculator"));
+    assert_eq!(
+        url.host_as_argument(),
+        ArgumentSafety::Dangerous("-oProxyCommand=open$IFS-aCalculator")
+    );
     assert_eq!(url.host_argument_safe(), None); // An unsafe host string is blocked.
 
     assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
+    assert_eq!(
+        url.path_as_argument(),
+        ArgumentSafety::Dangerous("/-oProxyCommand=open$IFS-aCalculator".into())
+    );
     assert_eq!(url.path_argument_safe(), None); // An unsafe path is blocked.
 
     Ok(())

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -56,7 +56,8 @@ fn password() -> crate::Result {
 fn user_argument_safe() -> crate::Result {
     let url = gix_url::parse("ssh://-Fconfigfile@foo/bar".into())?;
 
-    // FIXME: Add the critical assertions for the user argument here.
+    assert_eq!(url.user(), Some("-Fconfigfile"));
+    // FIXME: Add the critical user_argument_safe assertion here.
 
     assert_eq!(url.host(), Some("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));
@@ -71,7 +72,8 @@ fn user_argument_safe() -> crate::Result {
 fn host_argument_safe() -> crate::Result {
     let url = gix_url::parse("ssh://-oProxyCommand=open$IFS-aCalculator/foo".into())?;
 
-    // FIXME: Add assertions for the user argument here.
+    assert_eq!(url.user(), None);
+    // FIXME: Add the user_argument_safe assertion here.
 
     assert_eq!(url.host(), Some("-oProxyCommand=open$IFS-aCalculator"));
     assert_eq!(url.host_argument_safe(), None);
@@ -86,7 +88,8 @@ fn host_argument_safe() -> crate::Result {
 fn path_argument_safe() -> crate::Result {
     let url = gix_url::parse("ssh://foo/-oProxyCommand=open$IFS-aCalculator".into())?;
 
-    // FIXME: Add assertions for the user argument here.
+    assert_eq!(url.user(), None);
+    // FIXME: Add the user_argument_safe assertion here.
 
     assert_eq!(url.host(), Some("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -57,7 +57,7 @@ fn user_argument_safe() -> crate::Result {
     let url = gix_url::parse("ssh://-Fconfigfile@foo/bar".into())?;
 
     assert_eq!(url.user(), Some("-Fconfigfile"));
-    // FIXME: Add the critical user_argument_safe assertion here.
+    assert_eq!(url.user_argument_safe(), None);
 
     assert_eq!(url.host(), Some("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));

--- a/gix-url/tests/access/mod.rs
+++ b/gix-url/tests/access/mod.rs
@@ -31,17 +31,6 @@ mod canonicalized {
 }
 
 #[test]
-fn password() -> crate::Result {
-    let mut url = gix_url::parse("https://user:password@host/path".into())?;
-
-    assert_eq!(url.password(), Some("password"));
-    assert_eq!(url.set_password(Some("new-pass".into())), Some("password".into()));
-    assert_eq!(url.password(), Some("new-pass"));
-
-    Ok(())
-}
-
-#[test]
 fn user() -> crate::Result {
     let mut url = gix_url::parse("https://user:password@host/path".into())?;
 
@@ -53,22 +42,58 @@ fn user() -> crate::Result {
 }
 
 #[test]
+fn password() -> crate::Result {
+    let mut url = gix_url::parse("https://user:password@host/path".into())?;
+
+    assert_eq!(url.password(), Some("password"));
+    assert_eq!(url.set_password(Some("new-pass".into())), Some("password".into()));
+    assert_eq!(url.password(), Some("new-pass"));
+
+    Ok(())
+}
+
+#[test]
+fn user_argument_safe() -> crate::Result {
+    let url = gix_url::parse("ssh://-Fconfigfile@foo/bar".into())?;
+
+    // FIXME: Add the critical assertions for the user argument here.
+
+    assert_eq!(url.host(), Some("foo"));
+    assert_eq!(url.host_argument_safe(), Some("foo"));
+
+    assert_eq!(url.path, "/bar");
+    assert_eq!(url.path_argument_safe(), Some("/bar".into()));
+
+    Ok(())
+}
+
+#[test]
 fn host_argument_safe() -> crate::Result {
     let url = gix_url::parse("ssh://-oProxyCommand=open$IFS-aCalculator/foo".into())?;
+
+    // FIXME: Add assertions for the user argument here.
+
     assert_eq!(url.host(), Some("-oProxyCommand=open$IFS-aCalculator"));
     assert_eq!(url.host_argument_safe(), None);
+
     assert_eq!(url.path, "/foo");
     assert_eq!(url.path_argument_safe(), Some("/foo".into()));
+
     Ok(())
 }
 
 #[test]
 fn path_argument_safe() -> crate::Result {
     let url = gix_url::parse("ssh://foo/-oProxyCommand=open$IFS-aCalculator".into())?;
+
+    // FIXME: Add assertions for the user argument here.
+
     assert_eq!(url.host(), Some("foo"));
     assert_eq!(url.host_argument_safe(), Some("foo"));
+
     assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
     assert_eq!(url.path_argument_safe(), None);
+
     Ok(())
 }
 

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -345,6 +345,21 @@ title "gix commit-graph"
               }
             )
           )
+          (with "an ambiguous ssh username which could be mistaken for an argument"
+            snapshot="$snapshot/fail-ambiguous-username"
+            (with "explicit ssh (true url with scheme)"
+              it "fails without trying to pass it to command-line programs" && {
+                WITH_SNAPSHOT="$snapshot/explicit-ssh" \
+                expect_run $WITH_FAILURE "$exe_plumbing" free pack receive 'ssh://-Fconfigfile@foo/bar'
+              }
+            )
+            (with "implicit ssh (special syntax with no scheme)"
+              it "fails without trying to pass it to command-line programs" && {
+                WITH_SNAPSHOT="$snapshot/implicit-ssh" \
+                expect_run $WITH_FAILURE "$exe_plumbing" free pack receive -- '-Fconfigfile@foo:bar/baz'
+              }
+            )
+          )
           (with "an ambiguous ssh host which could be mistaken for an argument"
               it "fails without trying to pass it to command-line programs" && {
                 WITH_SNAPSHOT="$snapshot/fail-ambiguous-host" \
@@ -370,6 +385,21 @@ title "gix commit-graph"
     if test "$kind" = "max" || test "$kind" = "max-pure"; then
     (with "the 'clone' sub-command"
         snapshot="$snapshot/clone"
+        (with "an ambiguous ssh username which could be mistaken for an argument"
+          snapshot="$snapshot/fail-ambiguous-username"
+          (with "explicit ssh (true url with scheme)"
+            it "fails without trying to pass it to command-line programs" && {
+              WITH_SNAPSHOT="$snapshot/explicit-ssh" \
+              expect_run $WITH_FAILURE "$exe_plumbing" clone 'ssh://-Fconfigfile@foo/bar'
+            }
+          )
+          (with "implicit ssh (special syntax with no scheme)"
+            it "fails without trying to pass it to command-line programs" && {
+              WITH_SNAPSHOT="$snapshot/implicit-ssh" \
+              expect_run $WITH_FAILURE "$exe_plumbing" clone -- '-Fconfigfile@foo:bar/baz'
+            }
+          )
+        )
         (with "an ambiguous ssh host which could be mistaken for an argument"
             it "fails without trying to pass it to command-line programs" && {
               WITH_SNAPSHOT="$snapshot/fail-ambiguous-host" \

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -351,6 +351,12 @@ title "gix commit-graph"
                 expect_run $WITH_FAILURE "$exe_plumbing" free pack receive 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'
               }
           )
+          (with "an ambiguous ssh path which could be mistaken for an argument"
+              it "fails without trying to pass it to command-line programs" && {
+                WITH_SNAPSHOT="$snapshot/fail-ambiguous-path" \
+                expect_run $WITH_FAILURE "$exe_plumbing" free pack receive 'git@foo:-oProxyCommand=open$IFS-aCalculator/bar'
+              }
+          )
           fi
         )
         elif [[ "$kind" = "small" ]]; then
@@ -368,6 +374,12 @@ title "gix commit-graph"
             it "fails without trying to pass it to command-line programs" && {
               WITH_SNAPSHOT="$snapshot/fail-ambiguous-host" \
               expect_run $WITH_FAILURE "$exe_plumbing" clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'
+            }
+        )
+        (with "an ambiguous ssh path which could be mistaken for an argument"
+            it "fails without trying to pass it to command-line programs" && {
+              WITH_SNAPSHOT="$snapshot/fail-ambiguous-path" \
+              expect_run $WITH_FAILURE "$exe_plumbing" clone 'git@foo:-oProxyCommand=open$IFS-aCalculator/bar'
             }
         )
     )

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -347,7 +347,7 @@ title "gix commit-graph"
           )
           (with "an ambiguous ssh host which could be mistaken for an argument"
               it "fails without trying to pass it to command-line programs" && {
-                WITH_SNAPSHOT="$snapshot/fail-ambigous-host" \
+                WITH_SNAPSHOT="$snapshot/fail-ambiguous-host" \
                 expect_run $WITH_FAILURE "$exe_plumbing" free pack receive 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'
               }
           )
@@ -366,7 +366,7 @@ title "gix commit-graph"
         snapshot="$snapshot/clone"
         (with "an ambiguous ssh host which could be mistaken for an argument"
             it "fails without trying to pass it to command-line programs" && {
-              WITH_SNAPSHOT="$snapshot/fail-ambigous-host" \
+              WITH_SNAPSHOT="$snapshot/fail-ambiguous-host" \
               expect_run $WITH_FAILURE "$exe_plumbing" clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'
             }
         )

--- a/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambiguous-path
+++ b/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambiguous-path
@@ -1,0 +1,1 @@
+[2KError: The repository path '-oProxyCommand=open$IFS-aCalculator/bar' could be mistaken for a command-line argument

--- a/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambiguous-username/explicit-ssh
+++ b/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambiguous-username/explicit-ssh
@@ -1,0 +1,1 @@
+[2KError: Username '-Fconfigfile' could be mistaken for a command-line argument

--- a/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambiguous-username/implicit-ssh
+++ b/tests/snapshots/plumbing/no-repo/pack/clone/fail-ambiguous-username/implicit-ssh
@@ -1,0 +1,1 @@
+[2KError: Username '-Fconfigfile' could be mistaken for a command-line argument

--- a/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambiguous-path
+++ b/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambiguous-path
@@ -1,0 +1,1 @@
+Error: The repository path '-oProxyCommand=open$IFS-aCalculator/bar' could be mistaken for a command-line argument

--- a/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambiguous-username/explicit-ssh
+++ b/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambiguous-username/explicit-ssh
@@ -1,0 +1,1 @@
+Error: Username '-Fconfigfile' could be mistaken for a command-line argument

--- a/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambiguous-username/implicit-ssh
+++ b/tests/snapshots/plumbing/no-repo/pack/receive/fail-ambiguous-username/implicit-ssh
@@ -1,0 +1,1 @@
+Error: Username '-Fconfigfile' could be mistaken for a command-line argument


### PR DESCRIPTION
This adds more unit tests and journey tests for existing error messages about URLs that are often not usable as remotes because they cause problems when used with external commands. It also distinguishes a further subcategory of these URLs, adds both kinds of test cases for them, and ensures they are identified and that the associated error messages are accurate.

For background on what led me to some of the new `Url` methods, see [that comment from an intermediate stage](https://github.com/Byron/gitoxide/blob/f56ad390a5569d0129b7b16632991d18b9ddb4f7/gix-url/src/lib.rs#L183-L189). I had at that time thought the existing ambiguous method (and the new ambiguous method I added) should be removed, but now I think that may not be the case, though I've moved code over to using the new ones.

This may be ready, though I strongly suspect some revisions may be needed, stylistically, in naming, or otherwise.

Two things I had thought of while working on this but that seemed better to leave out of this PR, unless requested, were:

- Fuzz testing already touches on some of the kinds of inputs that are already handled properly, for which this PR only adds more unit and journey tests. I am unsure if fuzz testing should be extended to cover the other cases that this PR addresses, and if so, if there is anything this PR should do for that.
- As before, checking for strange paths is done separately from the gix-url facilities related to that. This doesn't seem like a problem, but I am curious if something ought to be documented to avoid regressions and/or to advise application developers. I haven't identified such an area though; the documentation seems to cover the issues.

The most important points and considerations are not those, but rather are presented outside this PR, such as in code comments/documentation and commit messages.