### PR TITLE
tree ➡ index diff for status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,24 +802,24 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
 dependencies = [
  "curl-sys",
  "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.10",
- "winapi",
+ "socket2 0.5.5",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.70+curl-8.5.0"
+version = "0.4.72+curl-8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0333d8849afe78a4c8102a429a446bfdd055832af071945520e835ae2d841e"
+checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
 dependencies = [
  "cc",
  "libc",
@@ -828,7 +828,7 @@ dependencies = [
  "pkg-config",
  "rustls-ffi",
  "vcpkg",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3042,7 +3042,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3964,7 +3964,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pemfile 1.0.4",
  "rustls-pki-types",
  "serde",
@@ -4074,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring 0.17.7",
@@ -4674,7 +4674,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -22,7 +22,10 @@ yanked = "warn"
 # 2019-12-17 there are no security notice advisories in
 # https://github.com/rustsec/advisory-db
 notice = "warn"
-ignore = []
+ignore = [
+    # this is `rustls@0.20.9` coming in with `curl`, which doesn't have an update yet. It's only active optionally, not by default.
+    "RUSTSEC-2024-0336",
+]
 
 
 

--- a/gix-date/src/lib.rs
+++ b/gix-date/src/lib.rs
@@ -23,11 +23,11 @@ pub use parse::function::parse;
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Time {
-    /// time in seconds since epoch.
+    /// The seconds that passed since UNIX epoch. This makes it UTC, or `<seconds>+0000`.
     pub seconds: SecondsSinceUnixEpoch,
-    /// time offset in seconds, may be negative to match the `sign` field.
+    /// The time's offset in seconds, which may be negative to match the `sign` field.
     pub offset: OffsetInSeconds,
-    /// the sign of `offset`, used to encode `-0000` which would otherwise loose sign information.
+    /// the sign of `offset`, used to encode `-0000` which would otherwise lose sign information.
     pub sign: time::Sign,
 }
 

--- a/gix-dir/tests/walk/mod.rs
+++ b/gix-dir/tests/walk/mod.rs
@@ -2732,7 +2732,7 @@ fn worktree_root_can_be_symlink() -> crate::Result {
 #[test]
 fn root_may_not_go_through_dot_git() -> crate::Result {
     let root = fixture("with-nested-dot-git");
-    for (dir, expected_pathspec) in [("", Verbatim), ("subdir", Always)] {
+    for (dir, expected_pathspec) in [("", Some(Verbatim)), ("subdir", None)] {
         let troot = root.join("dir").join(".git").join(dir);
         let ((out, _root), entries) = collect(&root, Some(&troot), |keep, ctx| {
             walk(&root, ctx, options_emit_all(), keep)
@@ -2747,9 +2747,11 @@ fn root_may_not_go_through_dot_git() -> crate::Result {
         );
         assert_eq!(
             entries,
-            [entry("dir/.git", Pruned, Directory)
-                .with_property(DotGit)
-                .with_match(expected_pathspec)],
+            [{
+                let mut e = entry("dir/.git", Pruned, Directory).with_property(DotGit);
+                e.0.pathspec_match = expected_pathspec;
+                e
+            }],
             "{dir}: no traversal happened as root passes though .git"
         );
     }
@@ -3165,7 +3167,7 @@ fn root_can_be_pruned_early_with_pathspec() -> crate::Result {
 
     assert_eq!(
         entries,
-        [entry("dir", Pruned, Directory)],
+        [entry_nomatch("dir", Pruned, Directory)],
         "the pathspec didn't match the root, early abort"
     );
     Ok(())
@@ -3927,7 +3929,7 @@ fn untracked_and_ignored_collapse_mix() {
 #[test]
 fn root_cannot_pass_through_case_altered_capital_dot_git_if_case_insensitive() -> crate::Result {
     let root = fixture("with-nested-capitalized-dot-git");
-    for (dir, expected_pathspec) in [("", Verbatim), ("subdir", Always)] {
+    for (dir, expected_pathspec) in [("", Some(Verbatim)), ("subdir", None)] {
         let troot = root.join("dir").join(".GIT").join(dir);
         let ((out, _root), entries) = collect(&root, Some(&troot), |keep, ctx| {
             walk(
@@ -3950,9 +3952,11 @@ fn root_cannot_pass_through_case_altered_capital_dot_git_if_case_insensitive() -
         );
         assert_eq!(
             entries,
-            [entry("dir/.GIT", Pruned, Directory)
-                .with_property(DotGit)
-                .with_match(expected_pathspec)],
+            [{
+                let mut e = entry("dir/.GIT", Pruned, Directory).with_property(DotGit);
+                e.0.pathspec_match = expected_pathspec;
+                e
+            }],
             "{dir}: no traversal happened as root passes though .git, it compares in a case-insensitive fashion"
         );
     }

--- a/gix-pathspec/src/search/matching.rs
+++ b/gix-pathspec/src/search/matching.rs
@@ -31,6 +31,21 @@ impl Search {
         is_dir: Option<bool>,
         attributes: &mut dyn FnMut(&BStr, Case, bool, &mut gix_attributes::search::Outcome) -> bool,
     ) -> Option<Match<'_>> {
+        static MATCH_ALL_STAND_IN: Pattern = Pattern {
+            path: BString::new(Vec::new()),
+            signature: MagicSignature::empty(),
+            search_mode: SearchMode::ShellGlob,
+            attributes: Vec::new(),
+            prefix_len: 0,
+            nil: true,
+        };
+        if relative_path.is_empty() {
+            return Some(Match {
+                pattern: &MATCH_ALL_STAND_IN,
+                sequence_number: 0,
+                kind: Always,
+            });
+        }
         let basename_not_important = None;
         if relative_path
             .get(..self.common_prefix_len)
@@ -106,14 +121,6 @@ impl Search {
         });
 
         if res.is_none() && self.all_patterns_are_excluded {
-            static MATCH_ALL_STAND_IN: Pattern = Pattern {
-                path: BString::new(Vec::new()),
-                signature: MagicSignature::empty(),
-                search_mode: SearchMode::ShellGlob,
-                attributes: Vec::new(),
-                prefix_len: 0,
-                nil: true,
-            };
             Some(Match {
                 pattern: &MATCH_ALL_STAND_IN,
                 sequence_number: patterns_len,
@@ -133,7 +140,7 @@ impl Search {
     /// is ignored.
     /// Returns `false` if this pathspec has no chance of ever matching `relative_path`.
     pub fn can_match_relative_path(&self, relative_path: &BStr, is_dir: Option<bool>) -> bool {
-        if self.patterns.is_empty() {
+        if self.patterns.is_empty() || relative_path.is_empty() {
             return true;
         }
         let common_prefix_len = self.common_prefix_len.min(relative_path.len());
@@ -194,7 +201,7 @@ impl Search {
     /// When `leading` is `true`, then `d` matches `d/d` as well. Thus, `relative_path` must may be
     /// partially included in `pathspec`, otherwise it has to be fully included.
     pub fn directory_matches_prefix(&self, relative_path: &BStr, leading: bool) -> bool {
-        if self.patterns.is_empty() {
+        if self.patterns.is_empty() || relative_path.is_empty() {
             return true;
         }
         let common_prefix_len = self.common_prefix_len.min(relative_path.len());

--- a/gix-pathspec/tests/search/mod.rs
+++ b/gix-pathspec/tests/search/mod.rs
@@ -58,6 +58,31 @@ fn directory_matches_prefix_starting_wildcards_always_match() -> crate::Result {
 }
 
 #[test]
+fn empty_dir_always_matches() -> crate::Result {
+    for specs in [
+        &["*ir"] as &[_],
+        &[],
+        &["included", ":!excluded"],
+        &[":!all", ":!excluded"],
+    ] {
+        let mut search = gix_pathspec::Search::from_specs(pathspecs(specs), None, Path::new(""))?;
+        assert_eq!(
+            search
+                .pattern_matching_relative_path("".into(), None, &mut no_attrs)
+                .map(|m| m.kind),
+            Some(Always),
+            "{specs:?}"
+        );
+        assert!(search.directory_matches_prefix("".into(), false));
+        assert!(search.directory_matches_prefix("".into(), false));
+        for is_dir in [Some(true), Some(false), None] {
+            assert!(search.can_match_relative_path("".into(), is_dir));
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn directory_matches_prefix_leading() -> crate::Result {
     let search = gix_pathspec::Search::from_specs(pathspecs(&["d/d/generated/b"]), None, Path::new(""))?;
     assert!(!search.directory_matches_prefix("di".into(), false));

--- a/gix-ref/src/store/file/packed.rs
+++ b/gix-ref/src/store/file/packed.rs
@@ -84,7 +84,14 @@ pub(crate) mod modifiable {
     pub(crate) type MutableSharedBuffer = OwnShared<gix_fs::SharedFileSnapshotMut<packed::Buffer>>;
 
     impl file::Store {
-        pub(crate) fn force_refresh_packed_buffer(&self) -> Result<(), packed::buffer::open::Error> {
+        /// Forcefully reload the packed refs buffer.
+        ///
+        /// This method should be used if it's clear that the buffer on disk has changed, to
+        /// make the latest changes visible before other operations are done on this instance.
+        ///
+        /// As some filesystems don't have nanosecond granularity, changes are likely to be missed
+        /// if they happen within one second otherwise.
+        pub fn force_refresh_packed_buffer(&self) -> Result<(), packed::buffer::open::Error> {
             self.packed.force_refresh(|| {
                 let modified = self.packed_refs_path().metadata()?.modified()?;
                 self.open_packed_buffer().map(|packed| Some(modified).zip(packed))


### PR DESCRIPTION
Based on #1339

----

### diff-correctness → `gix-status` → gix reset

----

Improve `gix status` to the point where it's suitable for use in `reset` functionality.
Leads to a proper worktree reset implementation, eventually leading to a high-level reset similar to how git supports it.

### Architecture

The reason this PR deals quite a bit with `gix status` is that for a safe implementation of `reset()` we need to be sure that the files we *would* want to touch don't don't carry modifications or are untracked files. In order to know what would need to be done, we have to diff the `current-index with target-index`. The set of files to touch can then be used to lookup information provided by `git-status`, like worktree modifications, index modifications, and untracked files, to know if we can proceed or not. Here is also where the reset-modes would affect the outcome, i.e. what to change and how.

This is a very modular approach which facilitates testing and understanding of what otherwise would be a very complex algorithm. Having a set of changes as output also allows to one day parallelize applying these changes.

This leaves us in a situation where the current `checkout()` implementation wants to become a fastpath for situations where the reset involves an empty tree as source (i.e. create everything and overwrite local changes).

### Extra Tasks

Out-of-band tasks that just should finally be done, with potential for great impact.

* [ ] support for [`hasconfig`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-codehasconfigremoteurlcode)  as part of `resolve_includes()` without actual lookahead.

### Tasks 

* [ ] diff index with index to learn what we would want to do in the worktree, or alternatively, 
      diff tree with index (with reverse-diff functionality to simulate diff of index with tree), for better performance as it 
      would avoid having to allocate a whole index even though we are only interested in a diff.
     - *Must include rename tracking*.
* [ ] how to make diff results available from status with all transformations applied, to allow user to obtain diffs of any kind? Compare to tree-tree-diff which has that functionality already.
* [ ] update `is_dirty()` and `Submodule::status()` to do full status.

### Status Enables

* `cargo package` and its use of complete status information.
* https://github.com/Byron/built/pull/1
* starship native dirty check (but needs diffstats of worktree-vs-index)
* `built` can get fully-functional is-dirty flag for 'describe()'

### Inbetween

* [ ] sort out #1319 

### Next PR: Reset

* [ ] `reset()` that checks if it's allowed to perform a worktree modification is allowed, or if an entry should be skipped. *That way we can postpone safety checks like --hard*

### Postponed

What follows is important for resets, but won't be needed for `cargo` worktree resets.

* [ ] a way to expand sparse dirs (but figure out if this is truly always necessary) - probably not, unless sparse dirs can be empty, but even then no expansion is needed
     - [ ] wire it up in `gix index entries` to optionally expand sparse entries
* [ ] `gix status` with implemented 'porcelain-v2` display mode

### Research
 
* Ignored files are considered expandable and can be overwritten on reset
* How to integrate submodules - probably easy to answer once `gix status` can deal a little better with submodules. Even though in this case a lot of submodule-related information is needed for a complete reset, probably only doable by a higher-level caller which orchestrates it.
* How to deal with various modes like `merge` and `keep`? How to control `refresh`? Maybe partial (only the files we touch), and full, to also update the files we don't touch as part of status? Maybe it's part of status if that is run before.
* Worthwhile to make explicit the difference between `git reset` and `git checkout` in terms of `HEAD` modifications. With the former changing `HEAD`s referent, and the latter changing `HEAD` itself.
* figure out how this relates to the current `checkout()` method as technically that's a `reset --hard` with optional overwrite check. Could it be rolled into one, with pathspec support added? 
   - just keep them separate until it's clear that `reset()` performs just as well, which is unlikely as there is more overhead. But maybe it's not worth to maintain two versions over it. But if so, one should probably rename it.
* for `git status`: what about rename tracking? It's available for tree-diffs and quite complex on its own. Probably only needs HEAD-vs-index rename tracking. No, also can have worktree rename tracking, even though it's hard to imagine how this can be fast unless it's tightly integrated with untracked-files handling. This screams for a generalization of the tracking code though as the testing and implementation is complex, but *should* be generalisable.


### Re-learn

* `pathspecs` normalize themselves to turn from any kind of specification into repo-root relative patterns.
* attribute/ignore file sources are naturally relative to the root of the repo, which remains relative (i.e. can be `..` and that root will be always be used to open files like `../.gitignore`, which is useful for display to the user)


