### PR TITLE
Improve wasi support for gix-config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,25 @@ jobs:
       - run: cd gix-pack && cargo build --all-features --target ${{ matrix.target }}
         name: gix-pack with all features (including wasm)
 
+  wasi:
+    name: WASI check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ gix-config, gix-fs, gix-sec ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # The `fs` API in `wasi` target is unstable, so we need to use nightly here.
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          targets: wasm32-wasi
+      - name: "check"
+        run: cargo check -p ${{ matrix.package }} --target wasm32-wasi --all-features
+
   check-packetline:
     strategy:
       fail-fast: false

--- a/gix-config-value/src/path.rs
+++ b/gix-config-value/src/path.rs
@@ -51,9 +51,12 @@ pub mod interpolate {
     /// Obtain the home directory for the given user `name` or return `None` if the user wasn't found
     /// or any other error occurred.
     /// It can be used as `home_for_user` parameter in [`Path::interpolate()`][crate::Path::interpolate()].
-    #[cfg_attr(windows, allow(unused_variables))]
+    #[cfg_attr(
+        any(target_os = "android", target_os = "windows", target_os = "wasi"),
+        allow(unused_variables)
+    )]
     pub fn home_for_user(name: &str) -> Option<PathBuf> {
-        #[cfg(not(any(target_os = "android", target_os = "windows")))]
+        #[cfg(not(any(target_os = "android", target_os = "windows", target_os = "wasi")))]
         {
             let cname = std::ffi::CString::new(name).ok()?;
             // SAFETY: calling this in a threaded program that modifies the pw database is not actually safe.
@@ -71,7 +74,7 @@ pub mod interpolate {
                 Some(std::ffi::OsStr::from_bytes(cstr.to_bytes()).into())
             }
         }
-        #[cfg(any(target_os = "android", target_os = "windows"))]
+        #[cfg(any(target_os = "android", target_os = "windows", target_os = "wasi"))]
         {
             None
         }

--- a/gix-fs/src/capabilities.rs
+++ b/gix-fs/src/capabilities.rs
@@ -15,6 +15,18 @@ impl Default for Capabilities {
     }
 }
 
+#[cfg(target_os = "wasi")]
+impl Default for Capabilities {
+    fn default() -> Self {
+        Capabilities {
+            precompose_unicode: false,
+            ignore_case: false,
+            executable_bit: false,
+            symlink: true,
+        }
+    }
+}
+
 #[cfg(target_os = "macos")]
 impl Default for Capabilities {
     fn default() -> Self {

--- a/gix-fs/src/lib.rs
+++ b/gix-fs/src/lib.rs
@@ -1,6 +1,7 @@
 //! A crate with file-system specific utilities.
 #![deny(rust_2018_idioms, missing_docs)]
 #![forbid(unsafe_code)]
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 use std::path::PathBuf;
 

--- a/gix-fs/src/symlink.rs
+++ b/gix-fs/src/symlink.rs
@@ -3,7 +3,14 @@ use std::{io, io::ErrorKind::AlreadyExists, path::Path};
 #[cfg(not(windows))]
 /// Create a new symlink at `link` which points to `original`.
 pub fn create(original: &Path, link: &Path) -> io::Result<()> {
-    std::os::unix::fs::symlink(original, link)
+    #[cfg(not(target_os = "wasi"))]
+    {
+        std::os::unix::fs::symlink(original, link)
+    }
+    #[cfg(target_os = "wasi")]
+    {
+        std::os::wasi::fs::symlink_path(original, link)
+    }
 }
 
 #[cfg(not(windows))]

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -21,6 +21,13 @@ pub fn is_path_owned_by_current_user(path: &Path) -> std::io::Result<bool> {
 mod impl_ {
     use std::path::Path;
 
+    #[cfg(target_os = "wasi")]
+    #[allow(unused_variables)]
+    pub fn is_path_owned_by_current_user(path: &Path) -> std::io::Result<bool> {
+        Ok(true)
+    }
+
+    #[cfg(not(target_os = "wasi"))]
     pub fn is_path_owned_by_current_user(path: &Path) -> std::io::Result<bool> {
         fn owner_from_path(path: &Path) -> std::io::Result<u32> {
             use std::os::unix::fs::MetadataExt;

--- a/gix-sec/src/lib.rs
+++ b/gix-sec/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 // `unsafe_code` not forbidden because we need to interact with the libc
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 use std::fmt::{Display, Formatter};
 


### PR DESCRIPTION
`gix-config` is used by https://github.com/nrwl/nx, I'm trying to help nx to compile with `wasm32-wasip1-threads` target so that it can be used on the [StackBlitz](https://stackblitz.com/).

This pull request is improving the `gix-config` wasi compatibility, and also introduces a CI to check the `gix-config` with `wasm32-wasi` target.