### PR TITLE
fix: don't ignore packed ref deletion in non-default transaction mode

### DIFF
--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -287,8 +287,8 @@ impl<'s, 'p> Transaction<'s, 'p> {
                             ..edit.update.clone()
                         });
                         *num_updates += 1;
+                        continue;
                     }
-                    continue;
                 }
                 match edit.update.change {
                     Change::Update {


### PR DESCRIPTION
Before, `Change::Delete` edits weren't propagated to packed refs if the mode was `DeletionsAndNonSymbolicUpdates`/`RemoveLooseSourceReference`.

