### PR TITLE
tree ➡ index diff for status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: "Install prerequisites"
         run: vcpkg install  zlib:x64-windows-static-md
       - name: "Installation from crates.io: gitoxide"
-        run: cargo +${{ matrix.rust }} install --target ${{ matrix.target }} --target-dir install-artifacts --debug --force gitoxide
+        run: cargo +${{ matrix.rust }} install --target ${{ matrix.target }} --no-default-features --features max-pure --target-dir install-artifacts --debug --force gitoxide
         shell: msys2 {0}
 
   lint:

--- a/gix/src/remote/connection/fetch/error.rs
+++ b/gix/src/remote/connection/fetch/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     RejectShallowRemote,
     #[error(transparent)]
     NegotiationAlgorithmConfig(#[from] config::key::GenericErrorWithValue),
+    #[error("Failed to read remaining bytes in stream")]
+    ReadRemainingBytes(#[source] std::io::Error),
 }
 
 impl gix_protocol::transport::IsSpuriousError for Error {

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -287,7 +287,7 @@ where
                     #[cfg(not(feature = "async-network-client"))]
                     let has_read_to_end = { rd.stopped_at().is_some() };
                     if !has_read_to_end {
-                        std::io::copy(&mut rd, &mut std::io::sink()).unwrap();
+                        std::io::copy(&mut rd, &mut std::io::sink()).map_err(Error::ReadRemainingBytes)?;
                     }
                     #[cfg(feature = "async-network-client")]
                     {


### PR DESCRIPTION
Based on #1344

----

### diff-correctness → `gix-status` → gix reset

----

Improve `gix status` to the point where it's suitable for use in `reset` functionality.
Leads to a proper worktree reset implementation, eventually leading to a high-level reset similar to how git supports it.

### Architecture

The reason this PR deals quite a bit with `gix status` is that for a safe implementation of `reset()` we need to be sure that the files we *would* want to touch don't don't carry modifications or are untracked files. In order to know what would need to be done, we have to diff the `current-index with target-index`. The set of files to touch can then be used to lookup information provided by `git-status`, like worktree modifications, index modifications, and untracked files, to know if we can proceed or not. Here is also where the reset-modes would affect the outcome, i.e. what to change and how.

This is a very modular approach which facilitates testing and understanding of what otherwise would be a very complex algorithm. Having a set of changes as output also allows to one day parallelize applying these changes.

This leaves us in a situation where the current `checkout()` implementation wants to become a fastpath for situations where the reset involves an empty tree as source (i.e. create everything and overwrite local changes).

### Extra Tasks

Out-of-band tasks that just should finally be done, with potential for great impact.

* [ ] support for [`hasconfig`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-codehasconfigremoteurlcode)  as part of `resolve_includes()` without actual lookahead.

### Tasks 

* [ ] diff index with index to learn what we would want to do in the worktree, or alternatively, 
      diff tree with index (with reverse-diff functionality to simulate diff of index with tree), for better performance as it 
      would avoid having to allocate a whole index even though we are only interested in a diff.
     - *Must include rename tracking*.
* [ ] how to make diff results available from status with all transformations applied, to allow user to obtain diffs of any kind? Compare to tree-tree-diff which has that functionality already.
* [ ] update `is_dirty()` and `Submodule::status()` to do full status.

### Status Enables

* `cargo package` and its use of complete status information.
* https://github.com/Byron/built/pull/1
* starship native dirty check (but needs diffstats of worktree-vs-index)
* `built` can get fully-functional is-dirty flag for 'describe()'

### Inbetween

* [ ] sort out #1319 

### Next PR: Reset

* [ ] `reset()` that checks if it's allowed to perform a worktree modification is allowed, or if an entry should be skipped. *That way we can postpone safety checks like --hard*

### Postponed

What follows is important for resets, but won't be needed for `cargo` worktree resets.

* [ ] a way to expand sparse dirs (but figure out if this is truly always necessary) - probably not, unless sparse dirs can be empty, but even then no expansion is needed
     - [ ] wire it up in `gix index entries` to optionally expand sparse entries
* [ ] `gix status` with implemented 'porcelain-v2` display mode

### Research
 
* Ignored files are considered expandable and can be overwritten on reset
* How to integrate submodules - probably easy to answer once `gix status` can deal a little better with submodules. Even though in this case a lot of submodule-related information is needed for a complete reset, probably only doable by a higher-level caller which orchestrates it.
* How to deal with various modes like `merge` and `keep`? How to control `refresh`? Maybe partial (only the files we touch), and full, to also update the files we don't touch as part of status? Maybe it's part of status if that is run before.
* Worthwhile to make explicit the difference between `git reset` and `git checkout` in terms of `HEAD` modifications. With the former changing `HEAD`s referent, and the latter changing `HEAD` itself.
* figure out how this relates to the current `checkout()` method as technically that's a `reset --hard` with optional overwrite check. Could it be rolled into one, with pathspec support added? 
   - just keep them separate until it's clear that `reset()` performs just as well, which is unlikely as there is more overhead. But maybe it's not worth to maintain two versions over it. But if so, one should probably rename it.
* for `git status`: what about rename tracking? It's available for tree-diffs and quite complex on its own. Probably only needs HEAD-vs-index rename tracking. No, also can have worktree rename tracking, even though it's hard to imagine how this can be fast unless it's tightly integrated with untracked-files handling. This screams for a generalization of the tracking code though as the testing and implementation is complex, but *should* be generalisable.


### Re-learn

* `pathspecs` normalize themselves to turn from any kind of specification into repo-root relative patterns.
* attribute/ignore file sources are naturally relative to the root of the repo, which remains relative (i.e. can be `..` and that root will be always be used to open files like `../.gitignore`, which is useful for display to the user)



