### PR TITLE
Use v2 of taiki-e/install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - run: |
           # it should never be a failure not to get the caches, as they can be regenerated.
           git lfs fetch && git lfs checkout || true
-      - uses: taiki-e/install-action@v1
+      - uses: taiki-e/install-action@v2
         with:
           tool: nextest
       - name: "Test (nextest)"
@@ -102,7 +102,7 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: taiki-e/install-action@v1
+      - uses: taiki-e/install-action@v2
         with:
           tool: cross
       - name: "check"


### PR DESCRIPTION
Fixes #1355 

This switches from major version 1 to major version 2 of `taiki-e/install-action` to fix the new Windows failure described in #1355.

For consistency, and because it is preferable to use new versions over very old versions provided they are stable and there is no known reason to prefer the much older version, this changes it in both job definitions that use it, even though the problem only occurs in one generated job (the Windows job) from one of the job definitions (the other one does not generate a Windows job).

However, this is *not* a general GitHub Action upgrading PR. It is intended to make the minimal change, of those that seem both reasonable and non-confusing, to fix that issue and allow CI checks to pass again. Although I think it would be good to use later versions of some other actions, some of which are quite old, I think that automating such upgrades should be considered, and my inclination is to regard that decision beyond the scope of this PR. But see #1357.

As a demonstration that #1355 really does affect his upstream repository and thus needs fixing--since when I originally opened that I had only produced it in my fork--see [this failing job](https://github.com/Byron/gitoxide/actions/runs/8977522195/job/24656429375?pr=1357) in #1357. No corresponding failure happens here, even though [the job does run here](https://github.com/Byron/gitoxide/actions/runs/8977363125/job/24655965698?pr=1356), because this PR fixes the issue.