### PR TITLE
Change to `GIX_TEST_IGNORE_ARCHIVES` on CI and docs to match code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: test
         env:
           CI: true
-          GITOXIDE_TEST_IGNORE_ARCHIVES: 1
+          GIX_TEST_IGNORE_ARCHIVES: 1
         run: just ci-test
 
   test-fast:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -262,7 +262,7 @@ get an overview.
 
 ## Reviewing PRs
 
-- be sure to clone locally and run tests with `GITOXIDE_TEST_IGNORE_ARCHIVES=1` to assure new fixture scripts (if there are any) are validated
+- be sure to clone locally and run tests with `GIX_TEST_IGNORE_ARCHIVES=1` to assure new fixture scripts (if there are any) are validated
   on _MacOS_ and _Windows_. Note that linux doesn't need to be tested that way as CI on linux ignores them by merit of not checking them out
   via `gix-lfs`.
 


### PR DESCRIPTION
The test suite checks for `GIX_TEST_IGNORE_ARCHIVES` and not for `GITOXIDE_TEST_IGNORE_ARCHIVES`. But the main test workflow `ci.yml`, as well as in the instructions in `DEVELOPMENT.md`, had given `GITOXIDE_TEST_IGNORE_ARCHIVES`. This fixes that.

I'm unsure what the effect was in practice of this disparity. Experimentation with modified workflows in my fork has not revealed any messages indicating that generated archives are skipped, before or after this change. The explanation in `DEVELOPMENT.md` says that they are absent on CI for Linux because they are never checked out from Git LFS, but running `git lfs ls-files` doesn't show anything on any systems, even after running `git lfs install` and `git lfs pull` (the latter of which entails `git lfs checkout`, but I have also tried running that just in case). In addition, I think I recall your having said that archives that were formerly stored in Git LFS are now stored normally in the repository (due to limitations of Git LFS in GitHub).

However, at least the documentation fix is important. In https://github.com/Byron/gitoxide/pull/1345#issuecomment-2054937657 I had mentioned that I had thought I'd run the tests with `GIX_TEST_IGNORE_ARCHIVES=1` before and found them to pass, yet that is not the case (#1358). I now believe what I had set was instead `GITOXIDE_TEST_IGNORE_ARCHIVES=1`, based on the instructions in `DEVELOPMENT.md`. I have since verified again that `GIX_TEST_IGNORE_ARCHIVES=1` produces the failures documented in #1358, while `GITOXIDE_TEST_IGNORE_ARCHIVES=1` has no effect compared to not setting any environment variables and does not produce any failures (presumably due to not causing archives to be ignored).

An alternative to these changes could be to modify the code so `GITOXIDE_TEST_IGNORE_ARCHIVES` is recognized, or so that both names are recognized.

I suggest reviewing this to ensure that, at least after this PR (if not before), CI tests without using generated archives in at least one job at least on Ubuntu, so that changes to shell scripts are being validated. As mentioned above, based on the (admittedly nonequivalent) CI results within my fork, I am not confident of this.