### PR TITLE
Refine Dependabot config to not update rust-toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    # Ignore version updates to dtolnay/rust-toolchain, as @X.Y.Z tags are used for exact toolchain
+    # versions (and @master and @stable are branches). To still get Dependabot *security* updates
+    # if the action itself ever has an advisory, we list all version update types explicitly. See:
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+    dependency-name: dtolnay/rust-toolchain
+    update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+    - "version-update:semver-patch"
   groups:
     github-actions:
       patterns: ["*"]


### PR DESCRIPTION
When *`X`* in <code>dtolnay/rust-toolchain@*X*</code> is a tag, it specifies a particular version of the actual Rust toolchain to use. It is also sometimes used with a branch such as `master` (to then specify the version as an option rather than in the action version) or `stable`, but branches are ineligible for Dependabot version updates and also would not ordinarily require them since they move much more readily than tags. All current uses of `dtolnay/rust-toolchain` fall into one of those cases, and therefore it is not necessary for Dependabot version updates to cover it:

```text
ek@freebsd-amd64 ~/r/g/.github (main =|✔)> git grep -Fn dtolnay/rust-toolchain
workflows/ci.yml:51:      - uses: dtolnay/rust-toolchain@stable
workflows/ci.yml:73:      - uses: dtolnay/rust-toolchain@stable
workflows/ci.yml:98:      - uses: dtolnay/rust-toolchain@stable
workflows/ci.yml:101:        uses: dtolnay/rust-toolchain@master
workflows/ci.yml:140:        uses: dtolnay/rust-toolchain@master
workflows/ci.yml:160:      - uses: dtolnay/rust-toolchain@master
workflows/msrv.yml:23:      - uses: dtolnay/rust-toolchain@1.67.0 # dictated by `firefox` to support the `helix` editor, but now driven by the `time` crate. IMPORTANT: adjust etc/msrv-badge.svg as well
workflows/release.yml:144:        uses: dtolnay/rust-toolchain@master
```

Therefore, this tells Dependabot to ignore `dtolnay/rust-toolchain` for the purpose of version updates.

Dependabot version updates and Dependabot security updates are separate, but some parts of a `dependabot.yml` file, when present, can affect Dependabot security updates. As commented with details, I have done this in a way that *should* avoid causing it to be ignored for security updates.

- Old Rust toolchains may have known vulnerabilities but still be safe to use on CI based on a consideration of the risks (for triggers such as `push` and `pull_request` that run with the same privileges of the user who can cause the triggering event to occur), and I believe the action itself does not get advisories for those versions.
- But it is possible that at some point in the future a vulnerability might be discovered in the action itself and an advisory produced for it, so having Dependabot be able to show any related alert and, if enabled, produce a security update PR for it automatically is still valuable.

Ignoring `dtolnay/rust-toolchain` addresses the problem identified in https://github.com/Byron/gitoxide/pull/1362#pullrequestreview-2044036145 without requiring any decreased use of actions to install dependencies, modification of how the actions' versions or options are given, or `@dependabot ignore` commands.

**There might be a benefit to merging this PR before #1362.** Assuming I have managed to write the configuration here correctly, it would then be possible to observe that Dependabot no longer attempts the version update on `dtolnay/rust-toolchain`. It might be necessary--and even if not, a good idea--to run `@dependabot recreate` on that PR after merging this (unless Dependabot closes that PR and makes a new one).

Although Dependabot automatically rebases PRs under many circumstances, and furthermore in most cases you should prefer `@dependabot rebase` to `@dependabot recreate`, the latter is needed to cause Dependabot to discard commits you have manually added. Usually one would not wish to do that, but in this case it would make it possible to observe whether Dependabot avoids making the change that the current manually added commit undoes.

---

Since Dependabot *alerts* provide information about known security advisories and associated updates without requiring any pull requests to be opened automatically--and offer a button that, when clicked, attempts to create an update PR--I recommend having Dependabot alerts enabled for all dependency types, which will be the case if they are enabled in https://github.com/Byron/gitoxide/settings/security_analysis. (They might already been enabled. I cannot tell if those are enabled or not, since I don't have access to that page on repositories I don't own.)

It might also be worthwhile to allow Dependabot to create security updates, since this will happen immediately, whereas I believe `cargo deny` is only running when a push or pull request triggers it. I am not advocating that `cargo deny` not be used, only that Dependabot security updates also be considered. These are separate from Dependabot version updates and much lower in volume. It is also recently a stable feature in Dependabot to group multiple security updates in a pull request.

Of course, applying only security updates would, over time, lead to a `Cargo.lock` with old versions that might benefit from being newer even for non-security reasons. Updating and pushing it based on the results of `cargo deny` updates everything in it, which could be considered a benefit. Another approach could be to bring back Dependabot version updates for `cargo` dependencies, but group them all together to get just one PR at a time, and set their cadence to `monthly`. This would be safe even without using `cargo deny` (though that could also be used), so long as Dependabot security updates are enabled, because security alerts and security updates would still occur immediately rather than on the version updates cadence.