### PR TITLE
Work around nextest macro lib compatibility bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
           tool: nextest
       - name: "Test (nextest)"
         run: cargo nextest run --all --no-fail-fast
+        env:
+          # Works around https://github.com/nextest-rs/nextest/issues/1493.
+          RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
 
   test-32bit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This sets the `RUSTUP_WINDOWS_PATH_ADD_BIN` environment variable in the multi-platform test job, to work around https://github.com/nextest-rs/nextest/issues/1493 which is keeping the test runner from working on Windows. See also https://github.com/ruffle-rs/ruffle/pull/16342, which gave the idea for this, and various other projects that have made such changes, linked in https://github.com/nextest-rs/nextest/issues/1493.

Running `cargo nextest run --all` on Windows produces output like:

```text
$ cargo nextest run --all
warning: function `evaluate_target_dir` is never used
 --> gix-prompt\tests\prompt.rs:9:8
  |
9 |     fn evaluate_target_dir() -> String {
  |        ^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(dead_code)]` on by default

warning: `gix-prompt` (test "prompt") generated 1 warning
   Compiling gix-filter v0.11.1 (C:\Users\ek\source\repos\gitoxide\gix-filter)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.39s
error: creating test list failed

Caused by:
  for `gix-macros`, command `'C:\Users\ek\source\repos\gitoxide\target\debug\deps\gix_macros-9b54cd09b507c731.exe' --list --format terse` exited with code 0xc0000135: The specified module could not be found. (os error 126)
--- stdout:

--- stderr:

---
```

I believe the relevant portion of the output starts at `error: creating test list failed`. Attempting to run the command manually shows:

```text
$ 'C:\Users\ek\source\repos\gitoxide\target\debug\deps\gix_macros-9b54cd09b507c731.exe' --list --format terse
C:/Users/ek/source/repos/gitoxide/target/debug/deps/gix_macros-9b54cd09b507c731.exe: error while loading shared libraries: std-49e3d1aefc00cc02.dll: cannot open shared object file: No such file or directory
```

As mentioned in https://github.com/Byron/gitoxide/pull/1371#issuecomment-2116838028, this occurs both locally and on CI and is not specific to changes proposed in #1371, nor is it related to `gix-macros` changes in bad5b48 (#1363).

- [Test rerun at the tip of main in my fork, showing the failure](https://github.com/EliahKagan/gitoxide/actions/runs/9089406255/job/25084807588)
- [Test rerun from an old commit in my fork, showing the failure](https://github.com/EliahKagan/gitoxide/actions/runs/8981026886/job/25085096213)

I've gone ahead and set that environment variable for all three platforms that have `test-fast` CI jobs, but not in other jobs. It does not appear to cause problems for other platforms. Once this change is no longer needed, it should probably be reverted, but I think it is useful right now because it should let #1371 and any other forthcoming PRs move forward.
