### PR TITLE
Revert "Work around nextest macro lib compatibility bug"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,6 @@ jobs:
           tool: nextest
       - name: "Test (nextest)"
         run: cargo nextest run --all --no-fail-fast
-        env:
-          # Works around https://github.com/nextest-rs/nextest/issues/1493.
-          RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
 
   test-32bit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[cargo-nextest 0.9.71](https://github.com/nextest-rs/nextest/releases/tag/cargo-nextest-0.9.71) has been released, which contains the fix in https://github.com/nextest-rs/nextest/pull/1499 for https://github.com/nextest-rs/nextest/issues/1493.

As confirmed on [nextest's own CI](https://github.com/nextest-rs/nextest/commit/f1966b254f50cc2459352cad7aeb5f9875e5a015)--and for this project in runs on my fork [before](https://github.com/EliahKagan/gitoxide/actions/runs/9208225298/attempts/1) and [after](https://github.com/EliahKagan/gitoxide/actions/runs/9208225298) the new `cargo-nextest` release--this makes it so the workaround in this repository's `test-fast` CI job, introduced in #1372, is no longer necessary.

Since that change made the workflow slightly more complicated and was intended as temporary, this PR reverts #1372.