### PR TITLE
fix gix ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.44.0",
+ "gix-ref 0.44.1",
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.13.1",
@@ -1562,7 +1562,7 @@ dependencies = [
  "gix-features 0.38.2",
  "gix-glob 0.16.2",
  "gix-path 0.10.7",
- "gix-ref 0.44.0",
+ "gix-ref 0.44.1",
  "gix-sec 0.10.6",
  "memchr",
  "once_cell",
@@ -1583,7 +1583,7 @@ dependencies = [
  "gix",
  "gix-config",
  "gix-path 0.10.7",
- "gix-ref 0.44.0",
+ "gix-ref 0.44.1",
  "gix-sec 0.10.6",
  "gix-testtools",
  "serial_test",
@@ -1730,7 +1730,7 @@ dependencies = [
  "gix-fs 0.11.0",
  "gix-hash 0.14.2",
  "gix-path 0.10.7",
- "gix-ref 0.44.0",
+ "gix-ref 0.44.1",
  "gix-sec 0.10.6",
  "gix-testtools",
  "is_ci",
@@ -2086,7 +2086,7 @@ dependencies = [
  "gix-hash 0.14.2",
  "gix-object 0.42.2",
  "gix-odb",
- "gix-ref 0.44.0",
+ "gix-ref 0.44.1",
  "gix-revwalk 0.13.1",
  "gix-testtools",
  "smallvec",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "document-features",
  "gix-actor 0.31.2",
@@ -2426,7 +2426,7 @@ dependencies = [
  "gix-lock 14.0.0",
  "gix-object 0.42.2",
  "gix-odb",
- "gix-ref 0.44.0",
+ "gix-ref 0.44.1",
  "gix-testtools",
  "gix-validate 0.8.5",
 ]

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -21,7 +21,7 @@ gix-features = { version = "^0.38.2", path = "../gix-features"}
 gix-config-value = { version = "^0.14.6", path = "../gix-config-value" }
 gix-path = { version = "^0.10.7", path = "../gix-path" }
 gix-sec = { version = "^0.10.6", path = "../gix-sec" }
-gix-ref = { version = "^0.44.0", path = "../gix-ref" }
+gix-ref = { version = "^0.44.1", path = "../gix-ref" }
 gix-glob = { version = "^0.16.2", path = "../gix-glob" }
 
 winnow = { version = "0.6.0", features = ["simd"] }

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 gix-sec = { version = "^0.10.6", path = "../gix-sec" }
 gix-path = { version = "^0.10.7", path = "../gix-path" }
-gix-ref = { version = "^0.44.0", path = "../gix-ref" }
+gix-ref = { version = "^0.44.1", path = "../gix-ref" }
 gix-hash = { version = "^0.14.2", path = "../gix-hash" }
 gix-fs = { version = "^0.11.0", path = "../gix-fs" }
 

--- a/gix-ref/CHANGELOG.md
+++ b/gix-ref/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.44.1 (2024-05-27)
+
+### Bug Fixes
+
+ - <csr-id-cd969f69d1b86030d4ea5c5a77100f36caffb8d8/> `LineRef` is now `Copy` and remove non-exhaustive
+   After all, this struct refers to what's in a reflog line, which is stable.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 4 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - `LineRef` is now `Copy` and remove non-exhaustive ([`cd969f6`](https://github.com/Byron/gitoxide/commit/cd969f69d1b86030d4ea5c5a77100f36caffb8d8))
+</details>
+
 ## 0.44.0 (2024-05-22)
 
 ### New Features
@@ -34,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 12 commits contributed to the release over the course of 30 calendar days.
+ - 13 commits contributed to the release over the course of 30 calendar days.
  - 68 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1348](https://github.com/Byron/gitoxide/issues/1348)
@@ -48,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * **[#1348](https://github.com/Byron/gitoxide/issues/1348)**
     - Add `file::Store::force_refresh_packed_buffer()` to public API ([`f2d8955`](https://github.com/Byron/gitoxide/commit/f2d8955eacc1a0ce8678f3e9026e696926bae654))
  * **Uncategorized**
+    - Release gix-features v0.38.2, gix-actor v0.31.2, gix-validate v0.8.5, gix-object v0.42.2, gix-command v0.3.7, gix-filter v0.11.2, gix-fs v0.11.0, gix-revwalk v0.13.1, gix-traverse v0.39.1, gix-worktree-stream v0.13.0, gix-archive v0.13.0, gix-tempfile v14.0.0, gix-lock v14.0.0, gix-ref v0.44.0, gix-config v0.37.0, gix-prompt v0.8.5, gix-index v0.33.0, gix-worktree v0.34.0, gix-diff v0.44.0, gix-discover v0.32.0, gix-pathspec v0.7.5, gix-dir v0.5.0, gix-macros v0.1.5, gix-mailmap v0.23.1, gix-negotiate v0.13.1, gix-pack v0.51.0, gix-odb v0.61.0, gix-transport v0.42.1, gix-protocol v0.45.1, gix-revision v0.27.1, gix-status v0.10.0, gix-submodule v0.11.0, gix-worktree-state v0.11.0, gix v0.63.0, gitoxide-core v0.38.0, gitoxide v0.36.0, safety bump 19 crates ([`4f98e94`](https://github.com/Byron/gitoxide/commit/4f98e94e0e8b79ed2899b35bef40f3c30b3025b0))
     - Adjust changelogs prior to release ([`9511416`](https://github.com/Byron/gitoxide/commit/9511416a6cd0c571233f958c165329c8705c2498))
     - Merge branch 'various-fixes' ([`d6cd449`](https://github.com/Byron/gitoxide/commit/d6cd44930fb204b06e2b70fc6965e7705530c47a))
     - Fix-CI ([`6f55f2a`](https://github.com/Byron/gitoxide/commit/6f55f2abd13078f94e8c4e10922806f195ae0d8b))

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gix-ref"
-version = "0.44.0"
+version = "0.44.1"
 repository = "https://github.com/Byron/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate to handle git references"

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -5,7 +5,7 @@ use crate::{log::Line, store_impl::file::log::LineRef};
 impl<'a> LineRef<'a> {
     /// Convert this instance into its mutable counterpart
     pub fn to_owned(&self) -> Line {
-        self.clone().into()
+        (*self).into()
     }
 }
 

--- a/gix-ref/src/store/file/log/mod.rs
+++ b/gix-ref/src/store/file/log/mod.rs
@@ -8,9 +8,8 @@ pub mod iter;
 mod line;
 
 /// A parsed ref log line.
-#[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
+#[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[non_exhaustive]
 pub struct LineRef<'a> {
     /// The previous object id in hexadecimal. Use [`LineRef::previous_oid()`] to get a more usable form.
     pub previous_oid: &'a BStr,

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -294,7 +294,7 @@ cache-efficiency-debug = ["gix-features/cache-efficiency-debug"]
 gix-macros = { version = "^0.1.5", path = "../gix-macros" }
 gix-utils = { version = "^0.1.12", path = "../gix-utils" }
 gix-fs = { version = "^0.11.0", path = "../gix-fs" }
-gix-ref = { version = "^0.44.0", path = "../gix-ref" }
+gix-ref = { version = "^0.44.1", path = "../gix-ref" }
 gix-discover = { version = "^0.32.0", path = "../gix-discover" }
 gix-tempfile = { version = "^14.0.0", path = "../gix-tempfile", default-features = false }
 gix-lock = { version = "^14.0.0", path = "../gix-lock" }


### PR DESCRIPTION
- **fix: `LineRef` is now `Copy` and remove non-exhaustive**
- **Release gix-ref v0.44.1**
