### PR TITLE
fix: ignore `.gitignore` files that are directories

### DIFF
--- a/gix-fs/src/symlink.rs
+++ b/gix-fs/src/symlink.rs
@@ -59,7 +59,7 @@ pub fn create(original: &Path, link: &Path) -> io::Result<()> {
 pub fn is_collision_error(err: &std::io::Error) -> bool {
     // TODO: use ::IsDirectory as well when stabilized instead of raw_os_error(), and ::FileSystemLoop respectively
     err.kind() == AlreadyExists
-            || err.raw_os_error() == Some(21)
+            || err.raw_os_error() == Some(if cfg!(windows) { 5 } else { 21 })
             || err.raw_os_error() == Some(62) // no-follow on symlnk on mac-os
             || err.raw_os_error() == Some(40) // no-follow on symlnk on ubuntu
 }

--- a/gix-glob/tests/search/pattern.rs
+++ b/gix-glob/tests/search/pattern.rs
@@ -85,7 +85,7 @@ mod list {
     }
 
     #[test]
-    fn from_file() {
+    fn from_file_that_does_not_exist() {
         let mut buf = Vec::new();
         for path in [
             Path::new(".").join("non-existing-dir").join("pattern-file"),
@@ -94,5 +94,17 @@ mod list {
             let list = List::<Dummy>::from_file(path, None, false, &mut buf).expect("no io error");
             assert!(list.is_none(), "the file does not exist");
         }
+    }
+
+    #[test]
+    fn from_file_that_is_a_directory() -> gix_testtools::Result<()> {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let dir_path = tmp.path().join(".gitignore");
+        std::fs::create_dir(&dir_path)?;
+        let mut buf = Vec::new();
+        let list = List::<Dummy>::from_file(dir_path, None, false, &mut buf).expect("no io error");
+        assert!(list.is_none(), "directories are ignored just like Git does it");
+
+        Ok(())
     }
 }

--- a/gix-worktree/src/stack/delegate.rs
+++ b/gix-worktree/src/stack/delegate.rs
@@ -1,4 +1,3 @@
-use crate::stack::mode_is_dir;
 use crate::{stack::State, PathIdMapping};
 
 /// Various aggregate numbers related to the stack delegate itself.
@@ -167,7 +166,7 @@ fn create_leading_directory(
     mkdir_calls: &mut usize,
     unlink_on_collision: bool,
 ) -> std::io::Result<()> {
-    if is_last_component && !mode_is_dir(mode).unwrap_or(false) {
+    if is_last_component && !crate::stack::mode_is_dir(mode).unwrap_or(false) {
         return Ok(());
     }
     *mkdir_calls += 1;


### PR DESCRIPTION
This happens in real-life, and Git itself doesn't budge.

Related to https://github.com/gitbutlerapp/gitbutler/issues/3876
