### PR TITLE
chore: Fixed the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Rust](https://github.com/Byron/gitoxide/workflows/Rust/badge.svg)](https://github.com/Byron/gitoxide/actions)
+[![CI](https://github.com/Byron/gitoxide/workflows/ci/badge.svg)](https://github.com/Byron/gitoxide/actions)
 [![Crates.io](https://img.shields.io/crates/v/gitoxide.svg)](https://crates.io/crates/gitoxide)
 <img src="etc/msrv-badge.svg">
 
@@ -10,6 +10,7 @@ like `fetch` and `clone`, and to validate the usability and control of the API o
 
 `gitoxide` aspires to be a production-grade server implementation and the `ein` binary aspires to become the default way to interact with git repositories.
 
+[![asciicast](https://asciinema.org/a/542159.svg)](https://asciinema.org/a/542159)
 [![asciicast](https://asciinema.org/a/542159.svg)](https://asciinema.org/a/542159)
 
 [`gix`]: https://docs.rs/gix

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ like `fetch` and `clone`, and to validate the usability and control of the API o
 `gitoxide` aspires to be a production-grade server implementation and the `ein` binary aspires to become the default way to interact with git repositories.
 
 [![asciicast](https://asciinema.org/a/542159.svg)](https://asciinema.org/a/542159)
-[![asciicast](https://asciinema.org/a/542159.svg)](https://asciinema.org/a/542159)
 
 [`gix`]: https://docs.rs/gix
 


### PR DESCRIPTION
Hi, I did some digging and the `Rust` badge on the readme was renamed in https://github.com/Byron/gitoxide/commit/86cafe3c38ae7b40cee2f532a19e1d48de389a04 from `rust` -> `ci`

| current | after |
|--------|--------|
| ![image](https://github.com/Byron/gitoxide/assets/26258709/bf2b5e6d-12c0-4622-991a-12f47339240f) | ![image](https://github.com/Byron/gitoxide/assets/26258709/f67c5cd3-60b2-4052-902a-abc830ef8ba8) | 
