### PR TITLE
PrepareCheckout non-head references

### DIFF
--- a/gitoxide-core/src/repository/clone.rs
+++ b/gitoxide-core/src/repository/clone.rs
@@ -6,6 +6,7 @@ pub struct Options {
     pub handshake_info: bool,
     pub no_tags: bool,
     pub shallow: gix::remote::fetch::Shallow,
+    pub ref_name: Option<gix::refs::PartialName>,
 }
 
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
@@ -31,6 +32,7 @@ pub(crate) mod function {
             handshake_info,
             bare,
             no_tags,
+            ref_name,
             shallow,
         }: Options,
     ) -> anyhow::Result<()>
@@ -75,6 +77,7 @@ pub(crate) mod function {
         }
         let (mut checkout, fetch_outcome) = prepare
             .with_shallow(shallow)
+            .with_ref_name(ref_name.as_ref())?
             .fetch_then_checkout(&mut progress, &gix::interrupt::IS_INTERRUPTED)?;
 
         let (repo, outcome) = if bare {

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -307,11 +307,8 @@ mod baseline {
 
         let mut buf = Vec::new();
         let mut collection = MetadataCollection::default();
-        let group = gix_attributes::Search::new_globals(
-            &mut [base.join("user.attributes")].into_iter(),
-            &mut buf,
-            &mut collection,
-        )?;
+        let group =
+            gix_attributes::Search::new_globals([base.join("user.attributes")].into_iter(), &mut buf, &mut collection)?;
 
         Ok((group, collection, base, input))
     }

--- a/gix-odb/tests/odb/find/mod.rs
+++ b/gix-odb/tests/odb/find/mod.rs
@@ -16,7 +16,7 @@ fn can_find(db: impl gix_object::Find, hex_id: &str) {
 
 #[test]
 fn loose_object() {
-    can_find(&db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
+    can_find(db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
 }
 
 #[test]

--- a/gix-odb/tests/odb/header/mod.rs
+++ b/gix-odb/tests/odb/header/mod.rs
@@ -8,7 +8,7 @@ fn find_header(db: impl gix_odb::Header, hex_id: &str) -> gix_odb::find::Header 
 
 #[test]
 fn loose_object() {
-    find_header(&db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
+    find_header(db(), "37d4e6c5c48ba0d245164c4e10d5f41140cab980");
 }
 
 #[test]

--- a/gix-pack/tests/pack/index.rs
+++ b/gix-pack/tests/pack/index.rs
@@ -363,8 +363,8 @@ fn pack_lookup() -> Result<(), Box<dyn std::error::Error>> {
             },
         ),
     ] {
-        let idx = index::File::at(&fixture_path(index_path), gix_hash::Kind::Sha1)?;
-        let pack = pack::data::File::at(&fixture_path(pack_path), gix_hash::Kind::Sha1)?;
+        let idx = index::File::at(fixture_path(index_path), gix_hash::Kind::Sha1)?;
+        let pack = pack::data::File::at(fixture_path(pack_path), gix_hash::Kind::Sha1)?;
 
         assert_eq!(pack.version(), pack::data::Version::V2);
         assert_eq!(pack.num_objects(), idx.num_objects());
@@ -471,7 +471,7 @@ fn iter() -> Result<(), Box<dyn std::error::Error>> {
             "0f3ea84cd1bba10c2a03d736a460635082833e59",
         ),
     ] {
-        let idx = index::File::at(&fixture_path(path), gix_hash::Kind::Sha1)?;
+        let idx = index::File::at(fixture_path(path), gix_hash::Kind::Sha1)?;
         assert_eq!(idx.version(), *kind);
         assert_eq!(idx.num_objects(), *num_objects);
         assert_eq!(

--- a/gix/src/clone/access.rs
+++ b/gix/src/clone/access.rs
@@ -11,7 +11,7 @@ impl PrepareFetch {
     ///
     /// It can also be used to configure additional options, like those for fetching tags. Note that
     /// [`with_fetch_tags()`](crate::Remote::with_fetch_tags()) should be called here to configure the clone as desired.
-    /// Otherwise a clone is configured to be complete and fetches all tags, not only those reachable from all branches.
+    /// Otherwise, a clone is configured to be complete and fetches all tags, not only those reachable from all branches.
     pub fn configure_remote(
         mut self,
         f: impl FnMut(crate::Remote<'_>) -> Result<crate::Remote<'_>, Box<dyn std::error::Error + Send + Sync>> + 'static,
@@ -41,6 +41,19 @@ impl PrepareFetch {
     pub fn with_in_memory_config_overrides(mut self, values: impl IntoIterator<Item = impl Into<BString>>) -> Self {
         self.config_overrides = values.into_iter().map(Into::into).collect();
         self
+    }
+
+    /// Set the `name` of the reference to check out, instead of the remote `HEAD`.
+    /// If `None`, the `HEAD` will be used, which is the default.
+    ///
+    /// Note that `name` should be a partial name like `main` or `feat/one`, but can be a full ref name.
+    /// If a branch on the remote matches, it will automatically be retrieved even without a refspec.
+    pub fn with_ref_name<'a, Name, E>(mut self, name: Option<Name>) -> Result<Self, E>
+    where
+        Name: TryInto<&'a gix_ref::PartialNameRef, Error = E>,
+    {
+        self.ref_name = name.map(TryInto::try_into).transpose()?.map(ToOwned::to_owned);
+        Ok(self)
     }
 }
 

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -65,6 +65,12 @@ pub mod main_worktree {
         ///
         /// Note that this is a no-op if the remote was empty, leaving this repository empty as well. This can be validated by checking
         /// if the `head()` of the returned repository is *not* unborn.
+        ///
+        /// # Panics
+        ///
+        /// If called after it was successful. The reason here is that it auto-deletes the contained repository,
+        /// and keeps track of this by means of keeping just one repository instance, which is passed to the user
+        /// after success.
         pub fn main_worktree<P>(
             &mut self,
             mut progress: P,
@@ -86,7 +92,7 @@ pub mod main_worktree {
             let repo = self
                 .repo
                 .as_ref()
-                .expect("still present as we never succeeded the worktree checkout yet");
+                .expect("BUG: this method may only be called until it is successful");
             let workdir = repo.work_dir().ok_or_else(|| Error::BareRepository {
                 git_dir: repo.git_dir().to_owned(),
             })?;
@@ -138,7 +144,7 @@ pub mod main_worktree {
             bytes.show_throughput(start);
 
             index.write(Default::default())?;
-            Ok((self.repo.take().expect("still present"), outcome))
+            Ok((self.repo.take().expect("still present").clone(), outcome))
         }
     }
 }

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -34,6 +34,9 @@ pub struct PrepareFetch {
     /// How to handle shallow clones
     #[cfg_attr(not(feature = "blocking-network-client"), allow(dead_code))]
     shallow: remote::fetch::Shallow,
+    /// The name of the reference to fetch. If `None`, the reference pointed to by `HEAD` will be checked out.
+    #[cfg_attr(not(feature = "blocking-network-client"), allow(dead_code))]
+    ref_name: Option<gix_ref::PartialName>,
 }
 
 /// The error returned by [`PrepareFetch::new()`].
@@ -132,6 +135,7 @@ impl PrepareFetch {
             #[cfg(any(feature = "async-network-client", feature = "blocking-network-client"))]
             configure_connection: None,
             shallow: remote::fetch::Shallow::NoChange,
+            ref_name: None,
         })
     }
 }
@@ -140,9 +144,12 @@ impl PrepareFetch {
 /// the fetched repository will be dropped.
 #[must_use]
 #[cfg(feature = "worktree-mutation")]
+#[derive(Debug)]
 pub struct PrepareCheckout {
     /// A freshly initialized repository which is owned by us, or `None` if it was handed to the user
     pub(self) repo: Option<crate::Repository>,
+    /// The name of the reference to check out. If `None`, the reference pointed to by `HEAD` will be checked out.
+    pub(self) ref_name: Option<gix_ref::PartialName>,
 }
 
 // This module encapsulates functionality that works with both feature toggles. Can be combined with `fetch`

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -140,13 +140,13 @@ impl PrepareFetch {
     }
 }
 
-/// A utility to collect configuration on how to perform a checkout into a working tree, and when dropped without checking out successfully
-/// the fetched repository will be dropped.
+/// A utility to collect configuration on how to perform a checkout into a working tree,
+/// and when dropped without checking out successfully the fetched repository will be deleted from disk.
 #[must_use]
 #[cfg(feature = "worktree-mutation")]
 #[derive(Debug)]
 pub struct PrepareCheckout {
-    /// A freshly initialized repository which is owned by us, or `None` if it was handed to the user
+    /// A freshly initialized repository which is owned by us, or `None` if it was successfully checked out.
     pub(self) repo: Option<crate::Repository>,
     /// The name of the reference to check out. If `None`, the reference pointed to by `HEAD` will be checked out.
     pub(self) ref_name: Option<gix_ref::PartialName>,

--- a/gix/src/remote/connection/fetch/negotiate.rs
+++ b/gix/src/remote/connection/fetch/negotiate.rs
@@ -38,7 +38,7 @@ pub(crate) enum Action {
     SkipToRefUpdate,
     /// We can't know for sure if fetching *is not* needed, so we go ahead and negotiate.
     MustNegotiate {
-        /// Each `ref_map.mapping` has a slot here which is `true` if we have the object the remote ref points to locally.
+        /// Each `ref_map.mapping` has a slot here which is `true` if we have the object the remote ref points to, locally.
         remote_ref_target_known: Vec<bool>,
     },
 }
@@ -221,7 +221,7 @@ pub(crate) fn add_wants(
     shallow: &fetch::Shallow,
     mapping_is_ignored: impl Fn(&fetch::Mapping) -> bool,
 ) {
-    // When using shallow, we can't exclude `wants` as the remote won't send anything then. Thus we have to resend everything
+    // When using shallow, we can't exclude `wants` as the remote won't send anything then. Thus, we have to resend everything
     // we have as want instead to get exactly the same graph, but possibly deepened.
     let is_shallow = !matches!(shallow, fetch::Shallow::NoChange);
     let wants = ref_map

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -114,7 +114,7 @@ where
         gix_protocol::fetch::Response::check_required_features(protocol_version, &fetch_features)?;
         let sideband_all = fetch_features.iter().any(|(n, _)| *n == "sideband-all");
         let mut arguments = gix_protocol::fetch::Arguments::new(protocol_version, fetch_features, con.trace);
-        if matches!(con.remote.fetch_tags, crate::remote::fetch::Tags::Included) {
+        if matches!(con.remote.fetch_tags, fetch::Tags::Included) {
             if !arguments.can_use_include_tag() {
                 return Err(Error::MissingServerFeature {
                     feature: "include-tag",

--- a/gix/src/remote/connection/ref_map.rs
+++ b/gix/src/remote/connection/ref_map.rs
@@ -79,14 +79,14 @@ where
     /// for _fetching_.
     ///
     /// This comes in the form of all matching tips on the remote and the object they point to, along with
-    /// with the local tracking branch of these tips (if available).
+    /// the local tracking branch of these tips (if available).
     ///
     /// Note that this doesn't fetch the objects mentioned in the tips nor does it make any change to underlying repository.
     ///
     /// # Consumption
     ///
-    /// Due to management of the transport, it's cleanest to only use it for a single interaction. Thus it's consumed along with
-    /// the connection.
+    /// Due to management of the transport, it's cleanest to only use it for a single interaction. Thus, it's consumed
+    /// along with the connection.
     ///
     /// ### Configuration
     ///

--- a/gix/tests/clone/mod.rs
+++ b/gix/tests/clone/mod.rs
@@ -1,11 +1,12 @@
 use crate::{remote, util::restricted};
 
-#[cfg(feature = "blocking-network-client")]
+#[cfg(all(feature = "worktree-mutation", feature = "blocking-network-client"))]
 mod blocking_io {
+    use std::path::Path;
     use std::{borrow::Cow, sync::atomic::AtomicBool};
 
     use gix::{
-        bstr::{BStr, BString},
+        bstr::BString,
         config::tree::{Clone, Core, Init, Key},
         remote::{
             fetch::{Shallow, SpecIndex},
@@ -500,49 +501,128 @@ mod blocking_io {
         let index = repo.index()?;
         assert_eq!(index.entries().len(), 1, "All entries are known as per HEAD tree");
 
-        let work_dir = repo.work_dir().expect("non-bare");
-        for entry in index.entries() {
-            let entry_path = work_dir.join(gix_path::from_bstr(entry.path(&index)));
-            assert!(entry_path.is_file(), "{entry_path:?} not found on disk")
-        }
+        assure_index_entries_on_disk(&index, repo.work_dir().expect("non-bare"));
         Ok(())
     }
     #[test]
-    fn fetch_and_checkout_branch() -> crate::Result {
+    fn fetch_and_checkout_specific_ref() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let remote_repo = remote::repo("base");
+        let ref_to_checkout = "a";
         let mut prepare = gix::clone::PrepareFetch::new(
-            remote::repo("base").path(),
+            remote_repo.path(),
             tmp.path(),
             gix::create::Kind::WithWorktree,
             Default::default(),
             restricted(),
-        )?;
+        )?
+        .with_ref_name(Some(ref_to_checkout))?;
         let (mut checkout, _out) =
             prepare.fetch_then_checkout(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
 
-        let branch_names = checkout.repo().branch_names();
-        let target_branch: &BStr = "a".into();
-        let branch_result = checkout.repo().find_reference(target_branch);
+        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
 
-        assert!(
-            branch_result.is_ok(),
-            "branch {target_branch} not found: {branch_result:?}. Available branches: {branch_names:?}"
+        assert_eq!(
+            repo.references()?.all()?.count() - 2,
+            remote_repo.references()?.all()?.count(),
+            "all references have been cloned, + remote HEAD + remote main (not listed in remote_repo)"
         );
-        let (repo, _) = checkout.worktree(
-            gix::progress::Discard,
-            &std::sync::atomic::AtomicBool::default(),
-            Some("a".into()),
-        )?;
+        let checked_out_ref = repo.head_ref()?.expect("head points to ref");
+        let remote_ref_name = format!("refs/heads/{ref_to_checkout}");
+        assert_eq!(
+            checked_out_ref.name().as_bstr(),
+            remote_ref_name,
+            "it's possible to checkout anything with that name, but here we have an ordinary branch"
+        );
+
+        assert_eq!(
+            checked_out_ref
+                .remote_ref_name(gix::remote::Direction::Fetch)
+                .transpose()?
+                .unwrap()
+                .as_bstr(),
+            remote_ref_name,
+            "the merge configuration is using the given name"
+        );
 
         let index = repo.index()?;
         assert_eq!(index.entries().len(), 1, "All entries are known as per HEAD tree");
 
-        let work_dir = repo.work_dir().expect("non-bare");
+        assure_index_entries_on_disk(&index, repo.work_dir().expect("non-bare"));
+        Ok(())
+    }
+
+    #[test]
+    fn fetch_and_checkout_specific_non_existing() -> crate::Result {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let remote_repo = remote::repo("base");
+        let ref_to_checkout = "does-not-exist";
+        let mut prepare = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            tmp.path(),
+            gix::create::Kind::WithWorktree,
+            Default::default(),
+            restricted(),
+        )?
+        .with_ref_name(Some(ref_to_checkout))?;
+
+        let err = prepare
+            .fetch_then_checkout(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "The remote didn't have any ref that matched 'does-not-exist'",
+            "we don't test this, but it's important that it determines this before receiving a pack"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fetch_and_checkout_specific_annotated_tag() -> crate::Result {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let remote_repo = remote::repo("base");
+        let ref_to_checkout = "annotated-detached-tag";
+        let mut prepare = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            tmp.path(),
+            gix::create::Kind::WithWorktree,
+            Default::default(),
+            restricted(),
+        )?
+        .with_ref_name(Some(ref_to_checkout))?;
+        let (mut checkout, _out) =
+            prepare.fetch_then_checkout(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
+
+        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
+
+        assert_eq!(
+            repo.references()?.all()?.count() - 1,
+            remote_repo.references()?.all()?.count(),
+            "all references have been cloned, + remote HEAD (not listed in remote_repo)"
+        );
+        let checked_out_ref = repo.head_ref()?.expect("head points to ref");
+        let remote_ref_name = format!("refs/tags/{ref_to_checkout}");
+        assert_eq!(
+            checked_out_ref.name().as_bstr(),
+            remote_ref_name,
+            "it also works with tags"
+        );
+
+        assert_eq!(
+            checked_out_ref
+                .remote_ref_name(gix::remote::Direction::Fetch)
+                .transpose()?,
+            None,
+            "there is no merge configuration for tags"
+        );
+        Ok(())
+    }
+
+    fn assure_index_entries_on_disk(index: &gix::worktree::Index, work_dir: &Path) {
         for entry in index.entries() {
             let entry_path = work_dir.join(gix_path::from_bstr(entry.path(&index)));
             assert!(entry_path.is_file(), "{entry_path:?} not found on disk")
         }
-        Ok(())
     }
 
     #[test]

--- a/gix/tests/clone/mod.rs
+++ b/gix/tests/clone/mod.rs
@@ -620,7 +620,7 @@ mod blocking_io {
 
     fn assure_index_entries_on_disk(index: &gix::worktree::Index, work_dir: &Path) {
         for entry in index.entries() {
-            let entry_path = work_dir.join(gix_path::from_bstr(entry.path(&index)));
+            let entry_path = work_dir.join(gix_path::from_bstr(entry.path(index)));
             assert!(entry_path.is_file(), "{entry_path:?} not found on disk")
         }
     }

--- a/gix/tests/repository/object.rs
+++ b/gix/tests/repository/object.rs
@@ -6,7 +6,7 @@ mod write_object {
     #[test]
     fn empty_tree() -> crate::Result {
         let (_tmp, repo) = empty_bare_repo()?;
-        let oid = repo.write_object(&gix::objs::TreeRef::empty())?;
+        let oid = repo.write_object(gix::objs::TreeRef::empty())?;
         assert_eq!(
             oid,
             gix::hash::ObjectId::empty_tree(repo.object_hash()),
@@ -280,7 +280,7 @@ mod commit {
             crate::restricted(),
         )?
         .to_thread_local();
-        let empty_tree_id = repo.write_object(&gix::objs::Tree::empty())?.detach();
+        let empty_tree_id = repo.write_object(gix::objs::Tree::empty())?.detach();
         let err = repo
             .commit("HEAD", "initial", empty_tree_id, [empty_tree_id])
             .unwrap_err();
@@ -304,7 +304,7 @@ mod commit {
             restricted_and_git(),
         )?
         .to_thread_local();
-        let empty_tree_id = repo.write_object(&gix::objs::Tree::empty())?;
+        let empty_tree_id = repo.write_object(gix::objs::Tree::empty())?;
         let commit_id = repo.commit("HEAD", "initial", empty_tree_id, gix::commit::NO_PARENT_IDS)?;
         assert_eq!(
             commit_id,

--- a/gix/tests/repository/worktree.rs
+++ b/gix/tests/repository/worktree.rs
@@ -49,7 +49,7 @@ mod with_core_worktree_config {
             } else {
                 assert_eq!(
                     repo.work_dir().unwrap(),
-                    gix_path::realpath(&repo.git_dir().parent().unwrap().parent().unwrap().join("worktree"))?,
+                    gix_path::realpath(repo.git_dir().parent().unwrap().parent().unwrap().join("worktree"))?,
                     "absolute workdirs are left untouched"
                 );
             }

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -404,6 +404,7 @@ pub fn main() -> Result<()> {
             handshake_info,
             bare,
             no_tags,
+            ref_name,
             remote,
             shallow,
             directory,
@@ -413,6 +414,7 @@ pub fn main() -> Result<()> {
                 bare,
                 handshake_info,
                 no_tags,
+                ref_name,
                 shallow: shallow.into(),
             };
             prepare_and_run(

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -434,6 +434,10 @@ pub mod clone {
         /// The url of the remote to connect to, like `https://github.com/byron/gitoxide`.
         pub remote: OsString,
 
+        /// The name of the reference to check out.
+        #[clap(long = "ref", value_parser = crate::shared::AsPartialRefName, value_name = "REF_NAME")]
+        pub ref_name: Option<gix::refs::PartialName>,
+
         /// The directory to initialize with the new repository and to which all data should be written.
         pub directory: Option<PathBuf>,
     }


### PR DESCRIPTION
This PR adds support for checking non-head references such as commits, tags, branches etc. using `repo.find_reference()` in `PrepareCheckout`.

While I preferred using `Reference` as a parameter rather than `&BStr`, I kept running into lifetime issues related to borrows with `self.repo` in PrepareCheckout. 

At the time of writing this, it seems this solution is incomplete as the checkout does not set the git repo to checkout the reference. Specifically (excuse my lack of git terminology) `git status` is still set to track the HEAD reference it seems. However, the files are correctly cloned.
```
git status
On branch master
Your branch is up to date with 'origin/master'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   qpm.shared.json
        modified:   src/logger.cpp
```

I hope this PR isn't too messy, though feel free to ask for changes to follow the repo's code style. Thanks!

In reference to discussion https://github.com/Byron/gitoxide/discussions/1389


# Research

## How does Git do it?

The ls-refs call of `git clone --branch status <gitoxide-url>`, thus `--branch` definitely assures anything with that name (if the protocol supports filtering).

```
0014command=ls-refs
0024agent=git/2.39.3.(Apple.Git-146)0016object-format=sha100010009peel
000csymrefs
000bunborn
0014ref-prefix HEAD
001bref-prefix refs/heads/
0016ref-prefix status
001bref-prefix refs/status
0020ref-prefix refs/tags/status
0021ref-prefix refs/heads/status
0023ref-prefix refs/remotes/status
0028ref-prefix refs/remotes/status/HEAD
001aref-prefix refs/tags/
0000
```

With `--single-branch` also specified, we get:

```
0014command=ls-refs
0024agent=git/2.39.3.(Apple.Git-146)0016object-format=sha100010009peel
000csymrefs
000bunborn
0014ref-prefix HEAD
001bref-prefix refs/heads/
0016ref-prefix status
001bref-prefix refs/status
0020ref-prefix refs/tags/status
0021ref-prefix refs/heads/status
0023ref-prefix refs/remotes/status
0028ref-prefix refs/remotes/status/HEAD
001aref-prefix refs/tags/
0000
```

So it's the same, but what's different is the list of wants, which now is very short, matching `954bab9f16839002a02ac809c7ca3184e8588261 refs/heads/status`

```
0011command=fetch
0024agent=git/2.39.3.(Apple.Git-146)
0016object-format=sha1
0001
000dthin-pack000finclude-tag
000dofs-delta
0032want 954bab9f16839002a02ac809c7ca3184e8588261
0009done
0000
```

Lastly, without `--branch --single-branch` the ls-refs call looks like this:

```
0014command=ls-refs
0024agent=git/2.39.3.(Apple.Git-146)0016object-format=sha100010009peel
000csymrefs
000bunborn
0014ref-prefix HEAD
001bref-prefix refs/heads/
001aref-prefix refs/tags/
0000
```

With a long want list.

## How does Gix do it?

By default, it auto-generates the ref-prefix [from refspecs](https://github.com/Byron/gitoxide/blob/a146d140da6c848a39d9f14b40f3fd46b749cc11/gix/src/remote/connection/ref_map.rs#L232-L241), creating an ls-refs call similar to what Git produces.

```
0014command=ls-refs
001bagent=git/oxide-0.63.0
0001000csymrefs
0009peel
000bunborn
001bref-prefix refs/heads/
0014ref-prefix HEAD
001aref-prefix refs/tags/
0000
```

## Conclusion

* **--single-branch** - trims the want-list to only the branch we *would* check out
* **--branch** - controls the **ref** (i.e. possibly refs) that *is* checked out

# Tasks

* [x] RefMap can receive any prefix to be sure the branch makes it into the set of returned refs automatically
* [x] checkout the named branch (with correct branch configuration)
* [x] add `--ref` to the `gix` CLI

# Postponed: single-ref support

Implementing this should be fairly simple, but also might take longer if the parts don't work as anticipated. Let's leave it for another day or to a request.

* [ ] single-ref support
    - [ ] affect negotiation
    - [ ] affect refspec updates
* [ ] add `--single-ref` to the `gix` CLI to make this feature more broadly available (and verifiable by hand)
