### PR TITLE
find git.exe harder on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
  "gix-testtools",
  "gix-trace 0.1.9",
  "gix-url",
+ "once_cell",
  "serde",
  "thiserror",
 ]

--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -74,7 +74,7 @@ pub(crate) mod function {
                 let tx_base = tx_base.clone();
                 let mut progress = progress.add_child("attributes");
                 move || -> anyhow::Result<()> {
-                    let mut child = std::process::Command::new(GIT_NAME)
+                    let mut child = std::process::Command::new(gix::path::env::exe_invocation())
                         .args(["check-attr", "--stdin", "-a"])
                         .stdin(std::process::Stdio::piped())
                         .stdout(std::process::Stdio::piped())
@@ -125,7 +125,7 @@ pub(crate) mod function {
                 let tx_base = tx_base.clone();
                 let mut progress = progress.add_child("excludes");
                 move || -> anyhow::Result<()> {
-                    let mut child = std::process::Command::new(GIT_NAME)
+                    let mut child = std::process::Command::new(gix::path::env::exe_invocation())
                         .args(["check-ignore", "--stdin", "-nv", "--no-index"])
                         .stdin(std::process::Stdio::piped())
                         .stdout(std::process::Stdio::piped())
@@ -253,8 +253,6 @@ pub(crate) mod function {
             );
         }
     }
-
-    static GIT_NAME: &str = if cfg!(windows) { "git.exe" } else { "git" };
 
     enum Baseline {
         Attribute { assignments: Vec<gix::attrs::Assignment> },

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -27,7 +27,7 @@ gix-trace = { version = "^0.1.8", path = "../gix-trace" }
 
 thiserror = "1.0.32"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
-bstr = { version = "1.3.0", default-features = false, features = ["std"]}
+bstr = { version = "1.3.0", default-features = false, features = ["std"] }
 
 
 
@@ -36,6 +36,7 @@ document-features = { version = "0.2.1", optional = true }
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
 gix-sec = { path = "../gix-sec" }
+once_cell = "1.19.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-credentials/src/program/mod.rs
+++ b/gix-credentials/src/program/mod.rs
@@ -68,7 +68,7 @@ impl Program {
 
     /// Convert the program into the respective command, suitable to invoke `action`.
     pub fn to_command(&self, action: &helper::Action) -> std::process::Command {
-        let git_program = cfg!(windows).then(|| "git.exe").unwrap_or("git");
+        let git_program = gix_path::env::exe_invocation();
         let mut cmd = match &self.kind {
             Kind::Builtin => {
                 let mut cmd = Command::new(git_program);
@@ -79,7 +79,7 @@ impl Program {
                 let mut args = name_and_args.clone();
                 args.insert_str(0, "credential-");
                 args.insert_str(0, " ");
-                args.insert_str(0, git_program);
+                args.insert_str(0, git_program.to_string_lossy().as_ref());
                 gix_command::prepare(gix_path::from_bstr(args.as_ref()).into_owned())
                     .arg(action.as_arg(true))
                     .with_shell_allow_argument_splitting()

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::env::git::EXE_NAME;
 use bstr::{BString, ByteSlice};
 
 mod git;
@@ -25,6 +26,39 @@ pub fn installation_config() -> Option<&'static Path> {
 /// This invokes the git binary which is slow on windows.
 pub fn installation_config_prefix() -> Option<&'static Path> {
     installation_config().map(git::config_to_base_path)
+}
+
+/// Return the name of the Git executable to invoke it.
+/// If it's in the `PATH`, it will always be a short name.
+///
+/// Note that on Windows, we will find the executable in the `PATH` if it exists there, or search it
+/// in alternative locations which when found yields the full path to it.
+pub fn exe_invocation() -> &'static Path {
+    if cfg!(windows) {
+        /// The path to the Git executable as located in the `PATH` or in other locations that it's known to be installed to.
+        /// It's `None` if environment variables couldn't be read or if no executable could be found.
+        static EXECUTABLE_PATH: once_cell::sync::Lazy<Option<PathBuf>> = once_cell::sync::Lazy::new(|| {
+            std::env::split_paths(&std::env::var_os("PATH")?)
+                .chain(git::ALTERNATIVE_LOCATIONS.iter().map(Into::into))
+                .find_map(|prefix| {
+                    let full_path = prefix.join(EXE_NAME);
+                    full_path.is_file().then_some(full_path)
+                })
+                .map(|exe_path| {
+                    let is_in_alternate_location = git::ALTERNATIVE_LOCATIONS
+                        .iter()
+                        .any(|prefix| exe_path.strip_prefix(prefix).is_ok());
+                    if is_in_alternate_location {
+                        exe_path
+                    } else {
+                        EXE_NAME.into()
+                    }
+                })
+        });
+        EXECUTABLE_PATH.as_deref().unwrap_or(Path::new(git::EXE_NAME))
+    } else {
+        Path::new("git")
+    }
 }
 
 /// Returns the fully qualified path in the *xdg-home* directory (or equivalent in the home dir) to `file`,
@@ -74,7 +108,7 @@ pub fn system_prefix() -> Option<&'static Path> {
                 }
             }
 
-            let mut cmd = std::process::Command::new("git.exe");
+            let mut cmd = std::process::Command::new(exe_invocation());
             cmd.arg("--exec-path").stderr(std::process::Stdio::null());
             gix_trace::debug!(cmd = ?cmd, "invoking git to get system prefix/exec path");
             let path = cmd.output().ok()?.stdout;

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -89,7 +89,7 @@ pub fn xdg_config(file: &str, env_var: &mut dyn FnMut(&str) -> Option<OsString>)
 ///
 /// ### Performance
 ///
-/// On windows, the slowest part is the launch of the `git.exe` executable in the PATH, which only happens when launched
+/// On windows, the slowest part is the launch of the Git executable in the PATH, which only happens when launched
 /// from outside of the `msys2` shell.
 ///
 /// ### When `None` is returned

--- a/gix-path/tests/path.rs
+++ b/gix-path/tests/path.rs
@@ -14,29 +14,67 @@ mod home_dir {
     }
 }
 
-mod xdg_config_path {
-    use std::ffi::OsStr;
-
+mod env {
     #[test]
-    fn prefers_xdg_config_bases() {
-        let actual = gix_path::env::xdg_config("test", &mut |n| {
-            (n == OsStr::new("XDG_CONFIG_HOME")).then(|| "marker".into())
-        })
-        .expect("set");
-        #[cfg(unix)]
-        assert_eq!(actual.to_str(), Some("marker/git/test"));
-        #[cfg(windows)]
-        assert_eq!(actual.to_str(), Some("marker\\git\\test"));
+    fn executable_invocation() {
+        let actual = gix_path::env::exe_invocation();
+        assert!(
+            !actual.as_os_str().is_empty(),
+            "it finds something as long as git is installed somewhere on the system (or a default location)"
+        );
     }
 
     #[test]
-    fn falls_back_to_home() {
-        let actual = gix_path::env::xdg_config("test", &mut |n| (n == OsStr::new("HOME")).then(|| "marker".into()))
+    fn installation_config() {
+        assert_ne!(
+            gix_path::env::installation_config().map(|p| p.components().count()),
+            gix_path::env::installation_config_prefix().map(|p| p.components().count()),
+            "the prefix is a bit shorter than the installation config path itself"
+        );
+    }
+
+    #[test]
+    fn system_prefix() {
+        assert_ne!(
+            gix_path::env::system_prefix(),
+            None,
+            "git should be present when running tests"
+        );
+    }
+
+    #[test]
+    fn home_dir() {
+        assert_ne!(
+            gix_path::env::home_dir(),
+            None,
+            "we find a home on every system these tests execute"
+        );
+    }
+
+    mod xdg_config {
+        use std::ffi::OsStr;
+
+        #[test]
+        fn prefers_xdg_config_bases() {
+            let actual = gix_path::env::xdg_config("test", &mut |n| {
+                (n == OsStr::new("XDG_CONFIG_HOME")).then(|| "marker".into())
+            })
             .expect("set");
-        #[cfg(unix)]
-        assert_eq!(actual.to_str(), Some("marker/.config/git/test"));
-        #[cfg(windows)]
-        assert_eq!(actual.to_str(), Some("marker\\.config\\git\\test"));
+            #[cfg(unix)]
+            assert_eq!(actual.to_str(), Some("marker/git/test"));
+            #[cfg(windows)]
+            assert_eq!(actual.to_str(), Some("marker\\git\\test"));
+        }
+
+        #[test]
+        fn falls_back_to_home() {
+            let actual = gix_path::env::xdg_config("test", &mut |n| (n == OsStr::new("HOME")).then(|| "marker".into()))
+                .expect("set");
+            #[cfg(unix)]
+            assert_eq!(actual.to_str(), Some("marker/.config/git/test"));
+            #[cfg(windows)]
+            assert_eq!(actual.to_str(), Some("marker\\.config\\git\\test"));
+        }
     }
 }
 mod util;

--- a/gix-path/tests/path.rs
+++ b/gix-path/tests/path.rs
@@ -16,7 +16,7 @@ mod home_dir {
 
 mod env {
     #[test]
-    fn executable_invocation() {
+    fn exe_invocation() {
         let actual = gix_path::env::exe_invocation();
         assert!(
             !actual.as_os_str().is_empty(),


### PR DESCRIPTION
Try harder to find the git executable on Windows, including known locations.
Also try really hard not to do any unnecessary IO work.

### Tasks

* [x] utilities to find Git executable
* [x] use these within Gitoxide instead of relying on PATH exclusively.
