### PR TITLE
credentials helper from globals

### DIFF
--- a/gix-config/src/file/init/comfort.rs
+++ b/gix-config/src/file/init/comfort.rs
@@ -17,31 +17,35 @@ use crate::{
 impl File<'static> {
     /// Open all global configuration files which involves the following sources:
     ///
-    /// * [system][crate::Source::System]
-    /// * [git][crate::Source::Git]
-    /// * [user][crate::Source::User]
+    /// * [git-installation](source::Kind::GitInstallation)
+    /// * [system](source::Kind::System)
+    /// * [globals](source::Kind::Global)
     ///
     /// which excludes repository local configuration, as well as override-configuration from environment variables.
     ///
     /// Note that the file might [be empty][File::is_void()] in case no configuration file was found.
     pub fn from_globals() -> Result<File<'static>, init::from_paths::Error> {
-        let metas = [source::Kind::System, source::Kind::Global]
-            .iter()
-            .flat_map(|kind| kind.sources())
-            .filter_map(|source| {
-                let path = source
-                    .storage_location(&mut gix_path::env::var)
-                    .and_then(|p| p.is_file().then_some(p))
-                    .map(Cow::into_owned);
+        let metas = [
+            source::Kind::GitInstallation,
+            source::Kind::System,
+            source::Kind::Global,
+        ]
+        .iter()
+        .flat_map(|kind| kind.sources())
+        .filter_map(|source| {
+            let path = source
+                .storage_location(&mut gix_path::env::var)
+                .and_then(|p| p.is_file().then_some(p))
+                .map(Cow::into_owned);
 
-                Metadata {
-                    path,
-                    source: *source,
-                    level: 0,
-                    trust: gix_sec::Trust::Full,
-                }
-                .into()
-            });
+            Metadata {
+                path,
+                source: *source,
+                level: 0,
+                trust: gix_sec::Trust::Full,
+            }
+            .into()
+        });
 
         let home = gix_path::env::home_dir();
         let options = init::Options {

--- a/gix-credentials/src/protocol/context/mod.rs
+++ b/gix-credentials/src/protocol/context/mod.rs
@@ -59,6 +59,7 @@ mod mutate {
             let url = gix_url::parse(self.url.as_ref().ok_or(protocol::Error::UrlMissing)?.as_ref())?;
             self.protocol = Some(url.scheme.as_str().into());
             self.username = url.user().map(ToOwned::to_owned);
+            self.password = url.password().map(ToOwned::to_owned);
             self.host = url.host().map(ToOwned::to_owned).map(|mut host| {
                 if let Some(port) = url.port {
                     use std::fmt::Write;

--- a/gix-credentials/tests/protocol/context.rs
+++ b/gix-credentials/tests/protocol/context.rs
@@ -36,6 +36,15 @@ mod destructure_url_in_place {
         assert_eq_parts("ssh://user@host:21/path", "ssh", "user", "host:21", "path", false);
         assert_eq_parts("ssh://host.org/path", "ssh", None, "host.org", "path", true);
     }
+
+    #[test]
+    fn passwords_are_placed_in_context_too() -> crate::Result {
+        let mut ctx = url_ctx("http://user:password@host/path");
+        ctx.destructure_url_in_place(false)?;
+        assert_eq!(ctx.password.as_deref(), Some("password"));
+        Ok(())
+    }
+
     #[test]
     fn http_and_https_ignore_the_path_by_default() {
         assert_eq_parts(

--- a/gix/src/config/cache/mod.rs
+++ b/gix/src/config/cache/mod.rs
@@ -11,7 +11,7 @@ impl std::fmt::Debug for Cache {
     }
 }
 
-mod access;
+pub(crate) mod access;
 
 pub(crate) mod util;
 

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -627,7 +627,7 @@ pub(crate) struct Cache {
     /// If true, we are on a case-insensitive file system.
     pub ignore_case: bool,
     /// If true, we should default what's possible if something is misconfigured, on case by case basis, to be more resilient.
-    /// Also available in options! Keep in sync!
+    /// Also, available in options! Keep in sync!
     pub lenient_config: bool,
     #[cfg_attr(not(feature = "worktree-mutation"), allow(dead_code))]
     attributes: crate::open::permissions::Attributes,

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -42,7 +42,11 @@ pub struct CommitAutoRollback<'repo> {
     pub(crate) prev_config: crate::Config,
 }
 
-pub(crate) mod section {
+///
+#[allow(clippy::empty_docs)]
+pub mod section {
+    /// A filter that returns `true` for `meta` if the meta-data attached to a configuration section can be trusted.
+    /// This is either the case if its file is fully trusted, or if it's a section from a system-wide file.
     pub fn is_trusted(meta: &gix_config::file::Metadata) -> bool {
         meta.trust == gix_sec::Trust::Full || meta.source.kind() != gix_config::source::Kind::Repository
     }

--- a/gix/src/config/snapshot/mod.rs
+++ b/gix/src/config/snapshot/mod.rs
@@ -4,3 +4,5 @@ mod access;
 ///
 #[cfg(feature = "credentials")]
 pub mod credential_helpers;
+#[cfg(feature = "credentials")]
+pub use credential_helpers::function::credential_helpers;


### PR DESCRIPTION
Make it easy to get pre-configured credential helper access from globals.

### Tasks

* [x] truly global configuration via `gix-config`
* [x] credential configuration independently of a repository instance
