### PR TITLE
Remove execution-specific code in sourcing-only .sh files

### DIFF
--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -1,3 +1,4 @@
+# Must be sourced into the main journey test
 
 function set-static-git-environment() {
   set -a
@@ -66,4 +67,3 @@ function launch-git-daemon() {
     done
     trap 'kill $daemon_pid' EXIT
 }
-

--- a/tests/journey/ein.sh
+++ b/tests/journey/ein.sh
@@ -1,5 +1,4 @@
 # Must be sourced into the main journey test
-set -eu
 
 if test "$kind" = "max" || test "$kind" = "max-pure"; then
 title "Porcelain ${kind}"

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -1,5 +1,4 @@
 # Must be sourced into the main journey test
-set -eu
 
 title plumbing "${kind}"
 snapshot="$snapshot/plumbing"

--- a/tests/utilities.sh
+++ b/tests/utilities.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# Must be sourced into the main journey test
 
 WHITE="$(tput setaf 9 2>/dev/null || echo -n '')"
 YELLOW="$(tput setaf 3 2>/dev/null || echo -n '')"


### PR DESCRIPTION
Some of the `.sh` script files are only meant ever to be sourced and not to be executed. These are already correctly not marked executable, but some of them contained code that would only be proper for scripts that are actually run, and not for scripts that are only sourced:

- One contained a `#!` line, which this removes because it falsely indicated an intent to be executed, and because it was not effective even in principle when sourcing the script.

- Two contained `set -eu` commands affecting the behavior of the running interpreter, which were redundant because the script for which they are helpers already runs such a command. If they are later sourced into other scripts (a use for which they are not intended and would probably require further modification), those other scripts might not have these `set` commands, but in that case those commands' behavior would probably not be wanted.

This also adds "Must be sourced into the main journey test" comments at the top of `.sh` files to which they apply, mirroring the presence of such comments in other such files. Besides consistency, this has the advantage of making clear what all the scripts that are meant only for sourcing are being used for.

---

I was originally going to include this in #1435, but it doesn't overlap with the changes there, is not essential to them, probably makes sense to evaluate separately, and could overcomplicate #1435 given the other subtlety raised there relating to which archives that PR should regenerate. So I've opened this separate PR instead.

