### PR TITLE
reproduce failure when parsing malformed commit (#1438)

### DIFF
--- a/gix-object/tests/commit/from_bytes.rs
+++ b/gix-object/tests/commit/from_bytes.rs
@@ -38,10 +38,10 @@ fn invalid_timestsamp() {
 #[test]
 fn invalid_email_of_committer() {
     let actor = gix_actor::SignatureRef {
-        name: b"Gregor Hartmann<gh".as_bstr(),
-        email: b"Gregor Hartmann<gh@openoffice.org>".as_bstr(),
+        name: b"Gregor Hartmann".as_bstr(),
+        email: b"gh <Gregor Hartmann<gh@openoffice.org".as_bstr(),
         time: Time {
-            seconds: 1270814970,
+            seconds: 1282910542,
             offset: 2 * 60 * 60,
             sign: Sign::Plus,
         },
@@ -50,12 +50,12 @@ fn invalid_email_of_committer() {
         CommitRef::from_bytes(&fixture_name("commit", "invalid-actor.txt"))
             .expect("ignore strangely formed actor format"),
         CommitRef {
-            tree: b"aee896327aa08c20f9ce80c9060aefe47edc65be".as_bstr(),
-            parents: [b"d93091832789fc586916720da62a341a731fbd66".as_bstr()].into(),
+            tree: b"220738fd4199e95a2b244465168366a73ebdf271".as_bstr(),
+            parents: [b"209fbe2d632761b30b7b17422914e11b93692833".as_bstr()].into(),
             author: actor,
             committer: actor,
             encoding: None,
-            message: b"add methods for tablecontrol".as_bstr(),
+            message: b"build breakers".as_bstr(),
             extra_headers: vec![]
         }
     );

--- a/gix-object/tests/commit/from_bytes.rs
+++ b/gix-object/tests/commit/from_bytes.rs
@@ -36,6 +36,32 @@ fn invalid_timestsamp() {
 }
 
 #[test]
+fn invalid_email_of_committer() {
+    let actor = gix_actor::SignatureRef {
+        name: b"Gregor Hartmann<gh".as_bstr(),
+        email: b"Gregor Hartmann<gh@openoffice.org>".as_bstr(),
+        time: Time {
+            seconds: 1270814970,
+            offset: 2 * 60 * 60,
+            sign: Sign::Plus,
+        },
+    };
+    assert_eq!(
+        CommitRef::from_bytes(&fixture_name("commit", "invalid-actor.txt"))
+            .expect("ignore strangely formed actor format"),
+        CommitRef {
+            tree: b"aee896327aa08c20f9ce80c9060aefe47edc65be".as_bstr(),
+            parents: [b"d93091832789fc586916720da62a341a731fbd66".as_bstr()].into(),
+            author: actor,
+            committer: actor,
+            encoding: None,
+            message: b"add methods for tablecontrol".as_bstr(),
+            extra_headers: vec![]
+        }
+    );
+}
+
+#[test]
 fn unsigned() -> crate::Result {
     assert_eq!(
         CommitRef::from_bytes(&fixture_name("commit", "unsigned.txt"))?,

--- a/gix-object/tests/fixtures/commit/invalid-actor.txt
+++ b/gix-object/tests/fixtures/commit/invalid-actor.txt
@@ -1,0 +1,6 @@
+tree 220738fd4199e95a2b244465168366a73ebdf271
+parent 209fbe2d632761b30b7b17422914e11b93692833
+author Gregor Hartmann<gh <Gregor Hartmann<gh@openoffice.org>> 1282910542 +0200
+committer Gregor Hartmann<gh <Gregor Hartmann<gh@openoffice.org>> 1282910542 +0200
+
+build breakers

--- a/gix-object/tests/tag/mod.rs
+++ b/gix-object/tests/tag/mod.rs
@@ -124,14 +124,14 @@ fn invalid() {
     assert_eq!(
         TagRef::from_bytes(partial_tag).unwrap_err().to_string(),
         if cfg!(feature = "verbose-object-parsing-errors") {
-            "object parsing failed at `tagger Sebasti`"
+            "object parsing failed at `Sebasti`\ninvalid Closing '>' not found\nexpected `<name> <<email>> <timestamp> <+|-><HHMM>`, `tagger <signature>`"
         } else {
             "object parsing failed"
         }
     );
     assert_eq!(
         TagRefIter::from_bytes(partial_tag).take_while(Result::is_ok).count(),
-        4,
+        3,
         "we can decode some fields before failing"
     );
 }


### PR DESCRIPTION
Note that Git can parse it.

It's notable that it parses the name as `Gregor Hartmann` and the email as `gh <Gregor Hartmann<gh@openoffice.org`, while the author/commiter lines are `Gregor Hartmann<gh <Gregor Hartmann<gh@openoffice.org>>`

### Tasks

* [x] reproduce issue
* [x] make commit parser more more flexible
