### PR TITLE
windows test robsustness

### DIFF
--- a/gix-index/src/entry/mode.rs
+++ b/gix-index/src/entry/mode.rs
@@ -74,6 +74,7 @@ impl From<gix_object::tree::EntryMode> for Mode {
 }
 
 /// A change of a [`Mode`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Change {
     /// The type of mode changed, like symlink => file.
     Type {

--- a/gix-status/tests/stack/mod.rs
+++ b/gix-status/tests/stack/mod.rs
@@ -83,21 +83,11 @@ fn paths_leading_through_symlinks_are_rejected() {
 }
 
 fn is_symlink(m: &std::fs::Metadata) -> bool {
-    if cfg!(windows) {
-        // On windows, symlinks can't be seen, at least not through std
-        m.is_file()
-    } else {
-        m.is_symlink()
-    }
+    m.is_symlink()
 }
 
 fn is_symlinked_dir(m: &std::fs::Metadata) -> bool {
-    if cfg!(windows) {
-        // On windows, symlinks can't be seen, at least not through std
-        m.is_dir()
-    } else {
-        m.is_symlink()
-    }
+    m.is_symlink()
 }
 fn is_file(m: &std::fs::Metadata) -> bool {
     m.is_file()

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -469,16 +469,7 @@ fn refresh() {
                     }
                     .into(),
                 ),
-                (
-                    BStr::new("empty"),
-                    3,
-                    Change::Modification {
-                        executable_bit_changed: false,
-                        content_change: Some(()),
-                        set_entry_stat_size_zero: false
-                    }
-                    .into(),
-                ),
+                (BStr::new("empty"), 3, Change::Type.into()),
                 (
                     BStr::new("executable"),
                     4,
@@ -551,16 +542,7 @@ fn modified() {
                 }
                 .into(),
             ),
-            (
-                BStr::new("empty"),
-                3,
-                Change::Modification {
-                    executable_bit_changed: false,
-                    content_change: Some(()),
-                    set_entry_stat_size_zero: false,
-                }
-                .into(),
-            ),
+            (BStr::new("empty"), 3, Change::Type.into()),
             (
                 BStr::new("executable"),
                 4,

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -115,11 +115,7 @@ mod from_tree {
         } else {
             EntryKind::BlobExecutable
         };
-        let expected_link_mode = if cfg!(windows) {
-            EntryKind::Blob
-        } else {
-            EntryKind::Link
-        };
+        let expected_link_mode = EntryKind::Link;
         assert_eq!(
             paths_and_modes,
             &[
@@ -141,11 +137,7 @@ mod from_tree {
                 (
                     "symlink-to-a".into(),
                     expected_link_mode,
-                    hex_to_id(if cfg!(windows) {
-                        "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
-                    } else {
-                        "2e65efe2a145dda7ee51d1741299f848e5bf752e"
-                    })
+                    hex_to_id("2e65efe2a145dda7ee51d1741299f848e5bf752e")
                 ),
                 (
                     "dir/.gitattributes".into(),

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -590,6 +590,8 @@ fn configure_command<'a>(
     script_result_directory: &Path,
 ) -> &'a mut std::process::Command {
     let never_path = if cfg!(windows) { "-" } else { ":" };
+    let mut msys_for_git_bash_on_windows = std::env::var("MSYS").unwrap_or_default();
+    msys_for_git_bash_on_windows.push_str(" winsymlinks:nativestrict");
     cmd.args(args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -597,6 +599,7 @@ fn configure_command<'a>(
         .env_remove("GIT_DIR")
         .env_remove("GIT_ASKPASS")
         .env_remove("SSH_ASKPASS")
+        .env("MSYS", msys_for_git_bash_on_windows)
         .env("GIT_CONFIG_SYSTEM", never_path)
         .env("GIT_CONFIG_GLOBAL", never_path)
         .env("GIT_TERMINAL_PROMPT", "false")

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -754,7 +754,6 @@ fn extract_archive(
         }
         #[cfg(not(feature = "xz"))]
         {
-            use std::io::Read;
             input_archive.read_to_end(&mut buf)?;
         }
         buf


### PR DESCRIPTION
Allow windows tests to work even if symlinks are available.

Fixes #1443.

### Tasks

* [x] fix tests
* [x] actually enable `MSYS=winsymlinks:nativestrict` to make these tests pass