### PR TITLE
Mention cargo-diet and sort in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Project non-goals can change over time as we learn more, and they can be challen
 
 If what you have seen so far sparked your interest to contribute, then let us say: We are happy to have you and help you to get started.
 
-We recommend running `just test check-size` during the development process to assure CI is green before pushing. Make sure to have [cargo-diet][cargo-diet] installed before you run `just check-size`. When running tests, make sure to have `LC_ALL=C` set in order to make `sort` which is used in some of the tests behave as expected.
+We recommend running `just test` during the development process to assure CI is green before pushing.
 
 A backlog for work ready to be picked up is [available in the Project's Kanban board][project-board], which contains instructions on how
 to pick a task. If it's empty or you have other questions, feel free to [start a discussion][discussions] or reach out to @Byron [privately][keybase].

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Project non-goals can change over time as we learn more, and they can be challen
 
 If what you have seen so far sparked your interest to contribute, then let us say: We are happy to have you and help you to get started.
 
-We recommend running `just test check-size` during the development process to assure CI is green before pushing.
+We recommend running `just test check-size` during the development process to assure CI is green before pushing. Make sure to have [cargo-diet][cargo-diet] installed before you run `just check-size`. When running tests, make sure to have `LC_ALL=C` set in order to make `sort` which is used in some of the tests behave as expected.
 
 A backlog for work ready to be picked up is [available in the Project's Kanban board][project-board], which contains instructions on how
 to pick a task. If it's empty or you have other questions, feel free to [start a discussion][discussions] or reach out to @Byron [privately][keybase].
@@ -335,6 +335,7 @@ For additional details, also take a look at the [collaboration guide].
 [project-board]: https://github.com/Byron/gitoxide/projects
 [discussions]: https://github.com/Byron/gitoxide/discussions
 [keybase]: https://keybase.io/byronbates
+[cargo-diet]: https://crates.io/crates/cargo-diet
 
 ### Getting started with Video Tutorials
 

--- a/tests/journey.sh
+++ b/tests/journey.sh
@@ -29,6 +29,10 @@ SUCCESSFULLY=0
 WITH_FAILURE=1
 WITH_CLAP_FAILURE=2
 
+# `sort` which is used in some of the snapshots tests depends on the value of
+# `LC_ALL` when it comes to the order of dotfiles and non-dotfiles. It sorts
+# differently when `LC_ALL=C` vs. when it is not set at all.
+export LC_ALL=C
 
 set-static-git-environment
 


### PR DESCRIPTION
This PR mentions 2 issues I encountered when I ran `just test check-size` for the first time.

- I did not have `cargo-diet` installed, so I thought it might be a good idea to mention it.
- I did not have `LC_ALL` set in my environment which made one of the tests fail with the following diff:

    ```
    < ./a-non-bare-repo-with-extension.git/.git
    4a4
    > ./a-non-bare-repo-with-extension.git/.git
    8d7
    < ./no-origin/.git
    9a9
    > ./no-origin/.git
    11d10
    < ./origin-and-fork/.git
    12a12
    > ./origin-and-fork/.git
    14,15c14,15
    < ./special-origin/.git
    < ./special-origin/a
    \ No newline at end of file
    ---
    > ./special-origin/a
    > ./special-origin/.git
    \ No newline at end of file
    ```

    Notice that dotfiles and non-dotfiles were sorted in a way that did not match the snapshot. One could also individually set `LC_ALL=C` for all or just the failing invocations of `sort` in shell scripts.
