### PR TITLE
use portable-atomic for AtomicU64 where needed

### DIFF
--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -34,6 +34,7 @@ gix-diff = { version = "^0.44.0", path = "../gix-diff", default-features = false
 thiserror = "1.0.26"
 filetime = "0.2.15"
 bstr = { version = "1.3.0", default-features = false }
+portable-atomic = "1"
 
 document-features = { version = "0.2.0", optional = true }
 

--- a/gix-status/src/index_as_worktree/function.rs
+++ b/gix-status/src/index_as_worktree/function.rs
@@ -2,8 +2,14 @@ use std::{
     io,
     path::Path,
     slice::Chunks,
-    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    sync::atomic::{AtomicUsize, Ordering},
 };
+
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 use bstr::BStr;
 use filetime::FileTime;

--- a/gix-status/src/index_as_worktree/traits.rs
+++ b/gix-status/src/index_as_worktree/traits.rs
@@ -52,7 +52,12 @@ pub trait ReadData<'a> {
 ///
 #[allow(clippy::empty_docs)]
 pub mod read_data {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    #[cfg(target_has_atomic = "64")]
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+
+    #[cfg(not(target_has_atomic = "64"))]
+    use portable_atomic::AtomicU64;
 
     use gix_filter::pipeline::convert::ToGitOutcome;
 


### PR DESCRIPTION
AtomicU64 isn't available in libstd on all targets. portable-atomic fills the gap, and can be nicely cfg-guarded to only be used on such targets.

without this patch, gix-status (and thus a lot of other gix crates, and cargo) cannot be built on Debian armel.

technically, AtomicUsize is also not guaranteed to exist for all targets, and a similar patch could be written to support those as well if desired.

