### PR TITLE
Pull in portable-atomic only when needed

### DIFF
--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -34,9 +34,11 @@ gix-diff = { version = "^0.44.0", path = "../gix-diff", default-features = false
 thiserror = "1.0.26"
 filetime = "0.2.15"
 bstr = { version = "1.3.0", default-features = false }
-portable-atomic = "1"
 
 document-features = { version = "0.2.0", optional = true }
+
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = "1"
 
 [package.metadata.docs.rs]
 features = ["document-features", "worktree-rewrites"]

--- a/gix-status/src/index_as_worktree/function.rs
+++ b/gix-status/src/index_as_worktree/function.rs
@@ -5,12 +5,6 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-#[cfg(target_has_atomic = "64")]
-use std::sync::atomic::AtomicU64;
-
-#[cfg(not(target_has_atomic = "64"))]
-use portable_atomic::AtomicU64;
-
 use bstr::BStr;
 use filetime::FileTime;
 use gix_features::parallel::{in_parallel_if, Reduce};
@@ -25,7 +19,7 @@ use crate::{
         types::{Error, Options},
         Change, Conflict, EntryStatus, Outcome, VisitEntry,
     },
-    is_dir_to_mode, SymlinkCheck,
+    is_dir_to_mode, AtomicU64, SymlinkCheck,
 };
 
 /// Calculates the changes that need to be applied to an `index` to match the state of the `worktree` and makes them

--- a/gix-status/src/index_as_worktree/traits.rs
+++ b/gix-status/src/index_as_worktree/traits.rs
@@ -52,14 +52,11 @@ pub trait ReadData<'a> {
 ///
 #[allow(clippy::empty_docs)]
 pub mod read_data {
-    #[cfg(target_has_atomic = "64")]
-    use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering;
 
-    #[cfg(not(target_has_atomic = "64"))]
-    use portable_atomic::AtomicU64;
-
     use gix_filter::pipeline::convert::ToGitOutcome;
+
+    use crate::AtomicU64;
 
     /// A stream with worktree file data.
     pub struct Stream<'a> {

--- a/gix-status/src/lib.rs
+++ b/gix-status/src/lib.rs
@@ -15,6 +15,12 @@
 #![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
+
 pub mod index_as_worktree;
 pub use index_as_worktree::function::index_as_worktree;
 


### PR DESCRIPTION
Use cargo conditional dependencies to only depend on portable-atomic on
platforms without 64-bit atomics.

Centralize the conditionals for `AtomicU64` import in one place, to avoid
duplicating them.
