### PR TITLE
gix-clean fixes

### DIFF
--- a/gitoxide-core/src/repository/mod.rs
+++ b/gitoxide-core/src/repository/mod.rs
@@ -51,3 +51,4 @@ pub mod status;
 pub mod submodule;
 pub mod tree;
 pub mod verify;
+pub mod worktree;

--- a/gitoxide-core/src/repository/status.rs
+++ b/gitoxide-core/src/repository/status.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use gix::bstr::{BStr, BString};
+use gix::bstr::{BStr, BString, ByteSlice};
 use gix::status::index_worktree::iter::Item;
 use gix_status::index_as_worktree::{Change, Conflict, EntryStatus};
 use std::path::Path;
@@ -152,7 +152,7 @@ pub fn show(
                     source_rela_path =
                         gix::path::relativize_with_prefix(&gix::path::from_bstr(source.rela_path()), prefix).display(),
                     dest_rela_path = gix::path::relativize_with_prefix(
-                        &gix::path::from_bstr(dirwalk_entry.rela_path.as_ref()),
+                        &gix::path::from_bstr(dirwalk_entry.rela_path.as_bstr()),
                         prefix
                     )
                     .display(),

--- a/gitoxide-core/src/repository/worktree.rs
+++ b/gitoxide-core/src/repository/worktree.rs
@@ -1,0 +1,28 @@
+use crate::OutputFormat;
+use anyhow::bail;
+
+pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write, format: OutputFormat) -> anyhow::Result<()> {
+    if format != OutputFormat::Human {
+        bail!("JSON output isn't implemented yet");
+    }
+
+    if let Some(worktree) = repo.worktree() {
+        writeln!(
+            out,
+            "{base} [{branch}]",
+            base = gix::path::realpath(worktree.base())?.display(),
+            branch = repo
+                .head_name()?
+                .map_or("<detached>".into(), |name| name.shorten().to_owned()),
+        )?;
+    }
+    for proxy in repo.worktrees()? {
+        writeln!(
+            out,
+            "{base} [{name}]",
+            base = proxy.base()?.display(),
+            name = proxy.id()
+        )?;
+    }
+    Ok(())
+}

--- a/gix-credentials/src/program/mod.rs
+++ b/gix-credentials/src/program/mod.rs
@@ -80,7 +80,7 @@ impl Program {
                 args.insert_str(0, "credential-");
                 args.insert_str(0, " ");
                 args.insert_str(0, git_program.to_string_lossy().as_ref());
-                gix_command::prepare(gix_path::from_bstr(args.as_ref()).into_owned())
+                gix_command::prepare(gix_path::from_bstr(args.as_bstr()).into_owned())
                     .arg(action.as_arg(true))
                     .with_shell_allow_argument_splitting()
                     .into()

--- a/gix-dir/src/lib.rs
+++ b/gix-dir/src/lib.rs
@@ -53,6 +53,8 @@ pub struct Entry {
     /// Further specify what the entry is on disk, similar to a file mode.
     pub disk_kind: Option<entry::Kind>,
     /// The kind of entry according to the index, if tracked. *Usually* the same as `disk_kind`.
+    /// Note that even if tracked, this might be `None` which indicates this is a worktree placed
+    /// within the parent repository.
     pub index_kind: Option<entry::Kind>,
     /// Indicate how the pathspec matches the entry. See more in [`EntryRef::pathspec_match`].
     pub pathspec_match: Option<entry::PathspecMatch>,

--- a/gix-dir/src/walk/function.rs
+++ b/gix-dir/src/walk/function.rs
@@ -42,7 +42,7 @@ use crate::{entry, EntryRef};
 pub fn walk(
     worktree_root: &Path,
     mut ctx: Context<'_>,
-    options: Options,
+    options: Options<'_>,
     delegate: &mut dyn Delegate,
 ) -> Result<(Outcome, PathBuf), Error> {
     let root = match ctx.explicit_traversal_root {
@@ -182,7 +182,7 @@ pub(super) fn emit_entry(
         emit_ignored,
         emit_empty_directories,
         ..
-    }: Options,
+    }: Options<'_>,
     out: &mut Outcome,
     delegate: &mut dyn Delegate,
 ) -> Action {

--- a/gix-dir/src/walk/mod.rs
+++ b/gix-dir/src/walk/mod.rs
@@ -1,5 +1,6 @@
 use crate::{entry, EntryRef};
-use bstr::BStr;
+use bstr::{BStr, BString};
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
@@ -143,12 +144,12 @@ pub enum ForDeletionMode {
 
 /// Options for use in [`walk()`](function::walk()) function.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct Options {
-    /// If true, the filesystem will store paths as decomposed unicode, i.e. `ä` becomes `"a\u{308}"`, which means that
+pub struct Options<'a> {
+    /// If `true`, the filesystem will store paths as decomposed unicode, i.e. `ä` becomes `"a\u{308}"`, which means that
     /// we have to turn these forms back from decomposed to precomposed unicode before storing it in the index or generally
     /// using it. This also applies to input received from the command-line, so callers may have to be aware of this and
     /// perform conversions accordingly.
-    /// If false, no conversions will be performed.
+    /// If `false`, no conversions will be performed.
     pub precompose_unicode: bool,
     /// If true, the filesystem ignores the case of input, which makes `A` the same file as `a`.
     /// This is also called case-folding.
@@ -192,6 +193,11 @@ pub struct Options {
     ///
     /// In other words, for Git compatibility this flag should be `false`, the default, for `git2` compatibility it should be `true`.
     pub symlinks_to_directories_are_ignored_like_directories: bool,
+    /// A set of all git worktree checkouts that are located within the main worktree directory.
+    ///
+    /// They will automatically be detected as 'tracked', but without providing index information (as there is no actual index entry).
+    /// Note that the unicode composition must match the `precompose_unicode` field so that paths will match verbatim.
+    pub worktree_relative_worktree_dirs: Option<&'a BTreeSet<BString>>,
 }
 
 /// All information that is required to perform a dirwalk, and classify paths properly.

--- a/gix-dir/src/walk/readdir.rs
+++ b/gix-dir/src/walk/readdir.rs
@@ -21,7 +21,7 @@ pub(super) fn recursive(
     current_bstr: &mut BString,
     current_info: classify::Outcome,
     ctx: &mut Context<'_>,
-    opts: Options,
+    opts: Options<'_>,
     delegate: &mut dyn Delegate,
     out: &mut Outcome,
     state: &mut State,
@@ -141,7 +141,7 @@ pub(super) struct State {
 
 impl State {
     /// Hold the entry with the given `status` if it's a candidate for collapsing the containing directory.
-    fn held_for_directory_collapse(&mut self, rela_path: &BStr, info: classify::Outcome, opts: &Options) -> bool {
+    fn held_for_directory_collapse(&mut self, rela_path: &BStr, info: classify::Outcome, opts: &Options<'_>) -> bool {
         if opts.should_hold(info.status) {
             self.on_hold
                 .push(EntryRef::from_outcome(Cow::Borrowed(rela_path), info).into_owned());
@@ -186,7 +186,7 @@ impl State {
     pub(super) fn emit_remaining(
         &mut self,
         may_collapse: bool,
-        opts: Options,
+        opts: Options<'_>,
         out: &mut walk::Outcome,
         delegate: &mut dyn walk::Delegate,
     ) {
@@ -217,7 +217,7 @@ impl Mark {
         dir_path: &Path,
         dir_rela_path: &BStr,
         dir_info: classify::Outcome,
-        opts: Options,
+        opts: Options<'_>,
         out: &mut walk::Outcome,
         ctx: &mut Context<'_>,
         delegate: &mut dyn walk::Delegate,
@@ -266,7 +266,7 @@ impl Mark {
     fn emit_all_held(
         &mut self,
         state: &mut State,
-        opts: Options,
+        opts: Options<'_>,
         out: &mut walk::Outcome,
         delegate: &mut dyn walk::Delegate,
     ) -> Action {
@@ -287,7 +287,7 @@ impl Mark {
         dir_info: classify::Outcome,
         state: &mut State,
         out: &mut walk::Outcome,
-        opts: Options,
+        opts: Options<'_>,
         ctx: &mut Context<'_>,
         delegate: &mut dyn walk::Delegate,
     ) -> Option<Action> {
@@ -408,7 +408,7 @@ fn filter_dir_pathspec(current: Option<PathspecMatch>) -> Option<PathspecMatch> 
     })
 }
 
-impl Options {
+impl Options<'_> {
     fn should_hold(&self, status: entry::Status) -> bool {
         if status.is_pruned() {
             return false;

--- a/gix-dir/tests/fixtures/many.sh
+++ b/gix-dir/tests/fixtures/many.sh
@@ -431,3 +431,10 @@ EOF
     git commit -m "init"
   )
 )
+
+git init with-sub-repo
+(cd with-sub-repo
+  echo '*' > .gitignore
+  git add -f .gitignore
+  git clone ../dir-with-file sub-repo
+)

--- a/gix-dir/tests/fixtures/many.sh
+++ b/gix-dir/tests/fixtures/many.sh
@@ -438,3 +438,9 @@ git init with-sub-repo
   git add -f .gitignore
   git clone ../dir-with-file sub-repo
 )
+
+git clone dir-with-tracked-file in-repo-worktree
+(cd in-repo-worktree
+  git worktree add worktree
+  git worktree add -b other-worktree dir/worktree
+)

--- a/gix-dir/tests/walk_utils/mod.rs
+++ b/gix-dir/tests/walk_utils/mod.rs
@@ -14,12 +14,12 @@ pub fn fixture(name: &str) -> PathBuf {
 }
 
 /// Default options
-pub fn options() -> walk::Options {
+pub fn options() -> walk::Options<'static> {
     walk::Options::default()
 }
 
 /// Default options
-pub fn options_emit_all() -> walk::Options {
+pub fn options_emit_all() -> walk::Options<'static> {
     walk::Options {
         precompose_unicode: false,
         ignore_case: false,
@@ -33,6 +33,7 @@ pub fn options_emit_all() -> walk::Options {
         emit_empty_directories: true,
         emit_collapsed: None,
         symlinks_to_directories_are_ignored_like_directories: false,
+        worktree_relative_worktree_dirs: None,
     }
 }
 
@@ -145,6 +146,7 @@ pub trait EntryExt {
     fn with_match(self, m: entry::PathspecMatch) -> Self;
     fn no_match(self) -> Self;
     fn no_kind(self) -> Self;
+    fn no_index_kind(self) -> Self;
 }
 
 impl EntryExt for (Entry, Option<entry::Status>) {
@@ -167,6 +169,10 @@ impl EntryExt for (Entry, Option<entry::Status>) {
     }
     fn no_kind(mut self) -> Self {
         self.0.disk_kind = None;
+        self
+    }
+    fn no_index_kind(mut self) -> Self {
+        self.0.index_kind = None;
         self
     }
 }

--- a/gix-status/src/index_as_worktree_with_renames/mod.rs
+++ b/gix-status/src/index_as_worktree_with_renames/mod.rs
@@ -49,7 +49,7 @@ pub(super) mod function {
         objects: Find,
         progress: &mut dyn gix_features::progress::Progress,
         mut ctx: Context<'_>,
-        options: Options,
+        options: Options<'_>,
     ) -> Result<Outcome, Error>
     where
         T: Send + Clone,

--- a/gix-status/src/index_as_worktree_with_renames/types.rs
+++ b/gix-status/src/index_as_worktree_with_renames/types.rs
@@ -274,7 +274,7 @@ impl<ContentChange, SubmoduleStatus> Entry<'_, ContentChange, SubmoduleStatus> {
 
 /// Options for use in [index_as_worktree_with_renames()](crate::index_as_worktree_with_renames()).
 #[derive(Clone, Default)]
-pub struct Options {
+pub struct Options<'a> {
     /// The way all output should be sorted.
     ///
     /// If `None`, and depending on the `rewrites` field, output will be immediate but the output order
@@ -299,7 +299,7 @@ pub struct Options {
     ///
     /// If `None`, the directory walk portion will not run at all, yielding data similar
     /// to a bare [index_as_worktree()](crate::index_as_worktree()) call.
-    pub dirwalk: Option<gix_dir::walk::Options>,
+    pub dirwalk: Option<gix_dir::walk::Options<'a>>,
     /// The configuration for the rewrite tracking. Note that if set, the [`dirwalk`](Self::dirwalk) should be configured
     /// to *not* collapse untracked and ignored entries, as rewrite tracking is on a file-by-file basis.
     /// Also note that when `Some(_)`, it will collect certain changes depending on the exact configuration, which typically increases

--- a/gix/src/dirwalk/mod.rs
+++ b/gix/src/dirwalk/mod.rs
@@ -54,6 +54,8 @@ pub enum Error {
     Prefix(#[from] gix_path::realpath::Error),
     #[error(transparent)]
     FilesystemOptions(#[from] config::boolean::Error),
+    #[error("Could not list worktrees to assure they are no candidates for deletion")]
+    ListWorktrees(#[from] std::io::Error),
 }
 
 /// The outcome of the [dirwalk()](crate::Repository::dirwalk).

--- a/gix/src/dirwalk/options.rs
+++ b/gix/src/dirwalk/options.rs
@@ -22,7 +22,7 @@ impl Options {
     }
 }
 
-impl From<Options> for gix_dir::walk::Options {
+impl From<Options> for gix_dir::walk::Options<'static> {
     fn from(v: Options) -> Self {
         gix_dir::walk::Options {
             precompose_unicode: v.precompose_unicode,
@@ -38,6 +38,7 @@ impl From<Options> for gix_dir::walk::Options {
             emit_collapsed: v.emit_collapsed,
             symlinks_to_directories_are_ignored_like_directories: v
                 .symlinks_to_directories_are_ignored_like_directories,
+            worktree_relative_worktree_dirs: None,
         }
     }
 }

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -146,6 +146,17 @@ pub fn main() -> Result<()> {
     }
 
     match cmd {
+        Subcommands::Worktree(crate::plumbing::options::worktree::Platform { cmd }) => match cmd {
+            crate::plumbing::options::worktree::SubCommands::List => prepare_and_run(
+                "worktree-list",
+                trace,
+                verbose,
+                progress,
+                progress_keep_open,
+                None,
+                move |_progress, out, _err| core::repository::worktree::list(repository(Mode::Lenient)?, out, format),
+            ),
+        },
         Subcommands::IsClean | Subcommands::IsChanged => {
             let mode = if matches!(cmd, Subcommands::IsClean) {
                 core::repository::dirty::Mode::IsClean

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -138,6 +138,7 @@ pub enum Subcommands {
     Config(config::Platform),
     #[cfg(feature = "gitoxide-core-tools-corpus")]
     Corpus(corpus::Platform),
+    Worktree(worktree::Platform),
     /// Subcommands that need no git repository to run.
     #[clap(subcommand)]
     Free(free::Subcommands),
@@ -264,6 +265,21 @@ pub mod status {
         /// The git path specifications to list attributes for, or unset to read from stdin one per line.
         #[clap(value_parser = CheckPathSpec)]
         pub pathspec: Vec<BString>,
+    }
+}
+
+pub mod worktree {
+    #[derive(Debug, clap::Parser)]
+    #[command(about = "Commands for handling worktrees")]
+    pub struct Platform {
+        #[clap(subcommand)]
+        pub cmd: SubCommands,
+    }
+
+    #[derive(Debug, clap::Subcommand)]
+    pub enum SubCommands {
+        /// List all worktrees, along with some accompanying information
+        List,
     }
 }
 


### PR DESCRIPTION
Fixes #1464

### Tasks

* [x] handle ignored sub-repos correctly in deletion mode
* [x] add list of worktree-directories to prevent deleting them.
    - There probably is no need to specifically classify them, as users who want that can always perform their own match later.
