### PR TITLE
Improve help text about hidden repos

### DIFF
--- a/gitoxide-core/src/repository/clean.rs
+++ b/gitoxide-core/src/repository/clean.rs
@@ -325,7 +325,7 @@ pub(crate) mod function {
                     wrote_nl = true;
                     writeln!(
                         err,
-                        "WARNING: would remove repositories and worktrees hidden inside ignored directories - use --skip-hidden-repositories to skip{}",
+                        "WARNING: would remove repositories hidden inside ignored directories - use --skip-hidden-repositories to skip{}",
                         wrap_in_parens(msg.take().unwrap_or_default())
                     )?;
                 }

--- a/gitoxide-core/src/repository/clean.rs
+++ b/gitoxide-core/src/repository/clean.rs
@@ -325,7 +325,7 @@ pub(crate) mod function {
                     wrote_nl = true;
                     writeln!(
                         err,
-                        "WARNING: would remove repositories hidden inside ignored directories - use --skip-hidden-repositories to skip{}",
+                        "WARNING: would remove repositories and worktrees hidden inside ignored directories - use --skip-hidden-repositories to skip{}",
                         wrap_in_parens(msg.take().unwrap_or_default())
                     )?;
                 }

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -592,10 +592,10 @@ pub mod clean {
         /// in reasonable, but often unexpected ways.
         #[arg(long, short = 'm')]
         pub pathspec_matches_result: bool,
-        /// Enter ignored directories to skip repositories (and worktrees) contained within.
+        /// Enter ignored directories to skip repositories contained within.
         ///
-        /// This identifies and avoids deleting any unrelated repositories, or alternate worktrees
-        /// of this repository, that are nested inside ignored directories eligible for removal.
+        /// This identifies and avoids deleting separate repositories that are nested inside
+        /// ignored directories eligible for removal.
         #[arg(long)]
         pub skip_hidden_repositories: Option<FindRepository>,
         /// What kind of repositories to find inside of untracked directories.

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -583,7 +583,7 @@ pub mod clean {
         /// Remove whole directories.
         #[arg(long, short = 'd')]
         pub directories: bool,
-        /// Remove nested repositories.
+        /// Remove nested repositories, even outside ignored directories.
         #[arg(long, short = 'r')]
         pub repositories: bool,
         /// Pathspec patterns are used to match the result of the dirwalk, not the dirwalk itself.
@@ -592,7 +592,10 @@ pub mod clean {
         /// in reasonable, but often unexpected ways.
         #[arg(long, short = 'm')]
         pub pathspec_matches_result: bool,
-        /// Enter ignored directories to skip repositories contained within.
+        /// Enter ignored directories to skip repositories (and worktrees) contained within.
+        ///
+        /// This identifies and avoids deleting any unrelated repositories, or alternate worktrees
+        /// of this repository, that are nested inside ignored directories eligible for removal.
         #[arg(long)]
         pub skip_hidden_repositories: Option<FindRepository>,
         /// What kind of repositories to find inside of untracked directories.


### PR DESCRIPTION
*Note: This PR ~~is either mostly or completely~~ was in substantial part superseded by #1470 as discussed in #1469, and has been narrowed in scope. The following description does not reflect that.*

#### Changes to the warning message

In the first commit, this unconditionally augments the warning suggesting to use `--skip-hidden-repositories` so that it mentions worktrees as well. It shows that slightly longer message even in a repository that has no worktrees. This has the benefit of simplicity, is the requested change in https://github.com/Byron/gitoxide/issues/1469#issuecomment-2252163765 if I understand properly, and makes sense as an initial mitigation for #1469.

The message is not much longer, and if that level of detail is acceptable, it might even be okay to have it like this longer term, though I suspect it might not be necessary given other forthcoming changes.

I considered parenthesizing "and worktrees" but it looked to like "repositories (and worktrees)" could be misread as "repositories (and their worktrees)" to mean the same thing as "repositories."

I did not make a corresponding change in the other similarly worded warning message suggesting to use `--find-untracked-repositories`, because there does not appear to be an analogous situation with untracked directories where a worktree of the current repository would be removed. I did some testing to check this.

#### Changes to the help text

It seemed like the right time to also propose changes to the help text for `gix clean` options directly relevant to the deletion of nested repositories, since I was already planning to do that for `-r`. In the second commit, this does that, at least an an initial wording that might be possible to improve on, and also applies an analogous change--but with more details, since this is help text--to the change in the warning message.

I made them separate commits so it's easy to take only one (I imagine it would be the first) if not all these changes are wanted at this time.

#### Commit messages

Even though this only adjusts messages, from [this guideline](https://github.com/Byron/gitoxide/blob/main/DEVELOPMENT.md#commit-messages) it seems like the commits should have `fix:` prefixes, so I did that. I'm not sure if that's right. This PR does not carry any behavioral change other than the text of messages that are displayed.