### PR TITLE
Fix 32-bit Windows releases so they are the correct architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,32 +75,26 @@ jobs:
           - build: linux
             os: ubuntu-latest
             rust: stable
-            cargo: cargo
             target: x86_64-unknown-linux-musl
           - build: linux-arm
             os: ubuntu-latest
             rust: nightly
-            cargo: cross
             target: arm-unknown-linux-gnueabihf
           - build: macos
             os: macos-latest
             rust: stable
-            cargo: cargo
             target: x86_64-apple-darwin
           - build: win-msvc
             os: windows-latest
             rust: nightly
-            cargo: cargo
             target: x86_64-pc-windows-msvc
           - build: win-gnu
             os: windows-latest
             rust: nightly-x86_64-gnu
-            cargo: cargo
             target: x86_64-pc-windows-gnu
           - build: win32-msvc
             os: windows-latest
             rust: nightly
-            cargo: cargo
             target: i686-pc-windows-msvc
         # on linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there
         # even though we could also build with `--features max-control,http-client-reqwest,gitoxide-core-blocking-client,gix-features/fast-sha1` for fast hashing.
@@ -145,7 +139,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Use Cross
-        if: matrix.cargo == 'cross'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           cargo install cross
           echo 'CARGO=cross' >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,26 +75,32 @@ jobs:
           - build: linux
             os: ubuntu-latest
             rust: stable
+            cargo: cargo
             target: x86_64-unknown-linux-musl
           - build: linux-arm
             os: ubuntu-latest
             rust: nightly
+            cargo: cross
             target: arm-unknown-linux-gnueabihf
           - build: macos
             os: macos-latest
             rust: stable
+            cargo: cargo
             target: x86_64-apple-darwin
           - build: win-msvc
             os: windows-latest
             rust: nightly
+            cargo: cargo
             target: x86_64-pc-windows-msvc
           - build: win-gnu
             os: windows-latest
             rust: nightly-x86_64-gnu
+            cargo: cargo
             target: x86_64-pc-windows-gnu
           - build: win32-msvc
             os: windows-latest
             rust: nightly
+            cargo: cargo
             target: i686-pc-windows-msvc
         # on linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there
         # even though we could also build with `--features max-control,http-client-reqwest,gitoxide-core-blocking-client,gix-features/fast-sha1` for fast hashing.
@@ -116,14 +122,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      # For some builds, we use cross to test on 32-bit, and maybe later big-endian, systems.
-      CARGO: cargo
-      # Whether CARGO is `cargo` or `cross`, TARGET_FLAGS will be set to `--target matrix.target`.
+      CARGO: ${{ matrix.cargo }}
       TARGET_FLAGS: --target=${{ matrix.target }}
-      # Whether CARGO is `cargo` or `cross`, TARGET_DIR will include matrix.target.
       TARGET_DIR: ./target/${{ matrix.target }}
-      # Emit backtraces on panics.
-      RUST_BACKTRACE: 1
+      RUST_BACKTRACE: 1  # Emit backtraces on panics.
 
     steps:
       - name: Checkout repository
@@ -142,11 +144,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
 
-      - name: Use Cross
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          cargo install cross
-          echo 'CARGO=cross' >> "$GITHUB_ENV"
+      - name: Install Cross
+        if: matrix.cargo == 'cross'
+        run: cargo install cross
 
       - name: Show command used for Cargo
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo '${{ steps.release.outputs.upload_url }}' > artifacts/release-upload-url
 
       - name: Save version number to artifact
-        run: echo '${{ env.VERSION }}' > artifacts/release-version
+        run: echo "$VERSION" > artifacts/release-version
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -152,9 +152,9 @@ jobs:
 
       - name: Show command used for Cargo
         run: |
-          echo 'cargo command is: ${{ env.CARGO }}'
-          echo 'target flag is: ${{ env.TARGET_FLAGS }}'
-          echo 'target dir is: ${{ env.TARGET_DIR }}'
+          echo "cargo command is: $CARGO"
+          echo "target flag is: $TARGET_FLAGS"
+          echo "target dir is: $TARGET_DIR"
 
       - name: Get release download URL
         uses: actions/download-artifact@v4
@@ -168,11 +168,12 @@ jobs:
           echo "VERSION=$(< artifacts/release-version)" >> "$GITHUB_ENV"
 
       - name: Build release binary
-        run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }} --no-default-features --features ${{ matrix.feature }}
+        run: |
+          "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features ${{ matrix.feature }}
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'linux' || matrix.build == 'macos'
-        run: strip 'target/${{ matrix.target }}/release/ein' 'target/${{ matrix.target }}/release/gix'
+        run: strip -- "$TARGET_DIR"/release/{ein,gix}
 
       - name: Strip release binary (arm)
         if: matrix.build == 'linux-arm'
@@ -192,13 +193,13 @@ jobs:
           cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
 
           if [ '${{ matrix.os }}' = 'windows-latest' ]; then
-            file 'target/${{ matrix.target }}/release/ein.exe' 'target/${{ matrix.target }}/release/gix.exe'
-            cp 'target/${{ matrix.target }}/release/ein.exe' 'target/${{ matrix.target }}/release/gix.exe' "$staging/"
+            file -- "$TARGET_DIR"/release/{ein,gix}.exe
+            cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$staging/"
             7z a "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
           else
-            file 'target/${{ matrix.target }}/release/ein' 'target/${{ matrix.target }}/release/gix'
-            cp 'target/${{ matrix.target }}/release/ein' 'target/${{ matrix.target }}/release/gix' "$staging/"
+            file -- "$TARGET_DIR"/release/{ein,gix}
+            cp -- "$TARGET_DIR"/release/{ein,gix} "$staging/"
             tar czf "$staging.tar.gz" "$staging"
             echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,9 @@ jobs:
         run: |
           cargo install cross
           echo 'CARGO=cross' >> "$GITHUB_ENV"
+
+      - name: Set target variables
+        run: |
           echo 'TARGET_FLAGS=--target ${{ matrix.target }}' >> "$GITHUB_ENV"
           echo 'TARGET_DIR=./target/${{ matrix.target }}' >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'linux' || matrix.build == 'macos'
-        run: strip -- "$TARGET_DIR"/release/{ein,gix}
+        run: strip "$TARGET_DIR"/release/{ein,gix}
 
       - name: Strip release binary (arm)
         if: matrix.build == 'linux-arm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,10 +201,12 @@ jobs:
           cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            file target/${{ matrix.target }}/release/ein.exe target/${{ matrix.target }}/release/gix.exe
             cp target/${{ matrix.target }}/release/ein.exe target/${{ matrix.target }}/release/gix.exe "$staging/"
             7z a "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> $GITHUB_ENV
           else
+            file target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix
             cp target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix "$staging/"
             tar czf "$staging.tar.gz" "$staging"
             echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,5 @@
-# The way this works is a little weird. But basically, the create-release job
-# runs purely to initialize the GitHub release itself. Once done, the upload
-# URL of the release is saved as an artifact.
-#
-# The build-release job runs only once create-release is finished. It gets
-# the release upload URL by downloading the corresponding artifact (which was
-# uploaded by create-release). It then builds the release executables for each
-# supported platform and attaches them as release assets to the previously
-# created release.
-#
-# The key here is that we create the release only once.
+# This is largely adapted from past and recent versions of the ripgrep release workflow.
+# https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml
 
 name: release
 
@@ -19,7 +10,7 @@ on:
     # branches:
      #  - fix-releases
     tags:
-      - "v.*"
+      - 'v*'
 
 env:
   RUST_BACKTRACE: 1
@@ -31,38 +22,39 @@ defaults:
     shell: bash
 
 jobs:
+  # The create-release job runs purely to initialize the GitHub release itself,
+  # and names the release after the version tag that was pushed. It's separate
+  # from building the release so that we only create the release once.
   create-release:
     name: create-release
     runs-on: ubuntu-latest
 #    env:
 #      # Set to force version number, e.g., when no tag exists.
-#      ARTIFACT_VERSION: TEST-0.0.0
+#      VERSION: TEST-0.0.0
     steps:
       - name: Create artifacts directory
         run: mkdir artifacts
 
       - name: Get the release version from the tag
-        if: env.ARTIFACT_VERSION == ''
-        run: |
-          echo "ARTIFACT_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "version is: ${{ env.ARTIFACT_VERSION }}"
+        if: env.VERSION == ''
+        run: echo 'VERSION=${{ github.ref_name }}' >> "$GITHUB_ENV"
 
       - name: Create GitHub release
         id: release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ env.ARTIFACT_VERSION }}
-          name: ${{ env.ARTIFACT_VERSION }}
+          tag: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
           allowUpdates: true
           omitBody: true
           omitPrereleaseDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save release upload URL to artifact
-        run: echo "${{ steps.release.outputs.upload_url }}" > artifacts/release-upload-url
+        run: echo '${{ steps.release.outputs.upload_url }}' > artifacts/release-upload-url
 
       - name: Save version number to artifact
-        run: echo "${{ env.ARTIFACT_VERSION }}" > artifacts/release-version
+        run: echo '${{ env.VERSION }}' > artifacts/release-version
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -72,13 +64,13 @@ jobs:
 
   build-release:
     name: build-release
-    needs: [ "create-release" ]
+    needs: [ create-release ]
     env:
       # For some builds, we use cross to test on 32-bit and big-endian
       # systems.
       CARGO: cargo
       # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS: ""
+      TARGET_FLAGS: ''
       # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
       TARGET_DIR: ./target
       # Emit backtraces on panics.
@@ -86,7 +78,7 @@ jobs:
     strategy:
       matrix:
         build: [ linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc ]
-        feature: [ "small", "lean", "max", "max-pure" ]
+        feature: [ small, lean, max, max-pure ]
         include:
           - build: linux
             os: ubuntu-latest
@@ -130,11 +122,10 @@ jobs:
             feature: max
 
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: Install packages (Ubuntu)
         # Because openssl doesn't work on musl by default, we resort to max-pure. And that won't need any dependency, so we can skip this.continue-on-error
@@ -152,15 +143,15 @@ jobs:
       - name: Use Cross
         run: |
           cargo install cross
-          echo "CARGO=cross" >> $GITHUB_ENV
-          echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
-          echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
+          echo 'CARGO=cross' >> "$GITHUB_ENV"
+          echo 'TARGET_FLAGS=--target ${{ matrix.target }}' >> "$GITHUB_ENV"
+          echo 'TARGET_DIR=./target/${{ matrix.target }}' >> "$GITHUB_ENV"
 
       - name: Show command used for Cargo
         run: |
-          echo "cargo command is: ${{ env.CARGO }}"
-          echo "target flag is: ${{ env.TARGET_FLAGS }}"
-          echo "target dir is: ${{ env.TARGET_DIR }}"
+          echo 'cargo command is: ${{ env.CARGO }}'
+          echo 'target flag is: ${{ env.TARGET_FLAGS }}'
+          echo 'target dir is: ${{ env.TARGET_DIR }}'
 
       - name: Get release download URL
         uses: actions/download-artifact@v4
@@ -170,19 +161,15 @@ jobs:
 
       - name: Set release upload URL and release version
         run: |
-          release_upload_url="$(cat artifacts/release-upload-url)"
-          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
-          echo "release upload url: $RELEASE_UPLOAD_URL"
-          release_version="$(cat artifacts/release-version)"
-          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
-          echo "release version: $RELEASE_VERSION"
+          echo "UPLOAD_URL=$(< artifacts/release-upload-url)" >> "$GITHUB_ENV"
+          echo "VERSION=$(< artifacts/release-version)" >> "$GITHUB_ENV"
 
       - name: Build release binary
         run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }} --no-default-features --features ${{ matrix.feature }}
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'linux' || matrix.build == 'macos'
-        run: strip target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix
+        run: strip 'target/${{ matrix.target }}/release/ein' 'target/${{ matrix.target }}/release/gix'
 
       - name: Strip release binary (arm)
         if: matrix.build == 'linux-arm'
@@ -193,23 +180,24 @@ jobs:
             arm-linux-gnueabihf-strip \
             /target/arm-unknown-linux-gnueabihf/release/ein \
             /target/arm-unknown-linux-gnueabihf/release/gix
+
       - name: Build archive
         run: |
-          staging="gitoxide-${{ matrix.feature }}-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
-          mkdir -p "$staging"
+          staging='gitoxide-${{ matrix.feature }}-${{ env.VERSION }}-${{ matrix.target }}'
+          mkdir -p -- "$staging"
 
           cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
 
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            file target/${{ matrix.target }}/release/ein.exe target/${{ matrix.target }}/release/gix.exe
-            cp target/${{ matrix.target }}/release/ein.exe target/${{ matrix.target }}/release/gix.exe "$staging/"
+          if [ '${{ matrix.os }}' = 'windows-latest' ]; then
+            file 'target/${{ matrix.target }}/release/ein.exe' 'target/${{ matrix.target }}/release/gix.exe'
+            cp 'target/${{ matrix.target }}/release/ein.exe' 'target/${{ matrix.target }}/release/gix.exe' "$staging/"
             7z a "$staging.zip" "$staging"
-            echo "ASSET=$staging.zip" >> $GITHUB_ENV
+            echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
           else
-            file target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix
-            cp target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix "$staging/"
+            file 'target/${{ matrix.target }}/release/ein' 'target/${{ matrix.target }}/release/gix'
+            cp 'target/${{ matrix.target }}/release/ein' 'target/${{ matrix.target }}/release/gix' "$staging/"
             tar czf "$staging.tar.gz" "$staging"
-            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+            echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
           fi
 
       - name: Upload release archive
@@ -217,7 +205,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ${{ env.ASSET }}
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            cp target/release/ein.exe target/release/gix.exe "$staging/"
+            cp target/${{ matrix.target }}/release/ein.exe target/${{ matrix.target }}/release/gix.exe "$staging/"
             7z a "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> $GITHUB_ENV
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,17 +64,9 @@ jobs:
 
   build-release:
     name: build-release
+
     needs: [ create-release ]
-    env:
-      # For some builds, we use cross to test on 32-bit and big-endian
-      # systems.
-      CARGO: cargo
-      # Whether CARGO is `cargo` or `cross`, TARGET_FLAGS will be set to `--target matrix.target`.
-      TARGET_FLAGS: ''
-      # Whether CARGO is `cargo` or `cross`, TARGET_DIR will include matrix.target.
-      TARGET_DIR: ./target
-      # Emit backtraces on panics.
-      RUST_BACKTRACE: 1
+
     strategy:
       matrix:
         build: [ linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc ]
@@ -123,6 +115,16 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      # For some builds, we use cross to test on 32-bit, and maybe later big-endian, systems.
+      CARGO: cargo
+      # Whether CARGO is `cargo` or `cross`, TARGET_FLAGS will be set to `--target matrix.target`.
+      TARGET_FLAGS: ''
+      # Whether CARGO is `cargo` or `cross`, TARGET_DIR will include matrix.target.
+      TARGET_DIR: ./target
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -141,7 +143,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Use Cross
-        if: matrix.os == 'ubuntu-latest' && matrix.target != ''
+        if: matrix.os == 'ubuntu-latest'
         run: |
           cargo install cross
           echo 'CARGO=cross' >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Use Cross
+        if: matrix.os == 'ubuntu-latest' && matrix.target != ''
         run: |
           cargo install cross
           echo 'CARGO=cross' >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CARGO: ${{ matrix.cargo }}
+      CARGO: cargo  # Sometimes changes to `cross` later (such as when building linux-arm).
       TARGET_FLAGS: --target=${{ matrix.target }}
       TARGET_DIR: ./target/${{ matrix.target }}
       RUST_BACKTRACE: 1  # Emit backtraces on panics.
@@ -144,9 +144,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
 
-      - name: Install Cross
+      - name: Use Cross
         if: matrix.cargo == 'cross'
-        run: cargo install cross
+        run: |
+          cargo install cross
+          echo 'CARGO=cross' >> "$GITHUB_ENV"
 
       - name: Show command used for Cargo
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,6 @@ jobs:
       TARGET_DIR: ./target
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
-      # The name of the executable to expect
-      EXE_NAME: ein
     strategy:
       matrix:
         build: [ linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc ]
@@ -184,7 +182,7 @@ jobs:
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'linux' || matrix.build == 'macos'
-        run: strip target/${{ matrix.target }}/release/${{ env.EXE_NAME }} target/${{ matrix.target }}/release/gix
+        run: strip target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix
 
       - name: Strip release binary (arm)
         if: matrix.build == 'linux-arm'
@@ -193,7 +191,7 @@ jobs:
             "$PWD/target:/target:Z" \
             rustembedded/cross:arm-unknown-linux-gnueabihf \
             arm-linux-gnueabihf-strip \
-            /target/arm-unknown-linux-gnueabihf/release/${{ env.EXE_NAME }} \
+            /target/arm-unknown-linux-gnueabihf/release/ein \
             /target/arm-unknown-linux-gnueabihf/release/gix
       - name: Build archive
         run: |
@@ -203,11 +201,11 @@ jobs:
           cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            cp target/release/${{ env.EXE_NAME }}.exe target/release/gix.exe "$staging/"
+            cp target/release/ein.exe target/release/gix.exe "$staging/"
             7z a "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> $GITHUB_ENV
           else
-            cp target/${{ matrix.target }}/release/${{ env.EXE_NAME }} target/${{ matrix.target }}/release/gix "$staging/"
+            cp target/${{ matrix.target }}/release/ein target/${{ matrix.target }}/release/gix "$staging/"
             tar czf "$staging.tar.gz" "$staging"
             echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
       # For some builds, we use cross to test on 32-bit and big-endian
       # systems.
       CARGO: cargo
-      # When CARGO is set to CROSS, this is set to `--target matrix.target`.
+      # Whether CARGO is `cargo` or `cross`, TARGET_FLAGS will be set to `--target matrix.target`.
       TARGET_FLAGS: ''
-      # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
+      # Whether CARGO is `cargo` or `cross`, TARGET_DIR will include matrix.target.
       TARGET_DIR: ./target
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@
 
 name: release
 
-env:
-  RUST_BACKTRACE: 1
-  CARGO_TERM_COLOR: always
-  CLICOLOR: 1
-
 on:
   workflow_dispatch:
   push:
@@ -25,6 +20,16 @@ on:
      #  - fix-releases
     tags:
       - "v.*"
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   create-release:
     name: create-release
@@ -167,7 +172,6 @@ jobs:
           path: artifacts
 
       - name: Set release upload URL and release version
-        shell: bash
         run: |
           release_upload_url="$(cat artifacts/release-upload-url)"
           echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
@@ -193,7 +197,6 @@ jobs:
             /target/arm-unknown-linux-gnueabihf/release/${{ env.EXE_NAME }} \
             /target/arm-unknown-linux-gnueabihf/release/gix
       - name: Build archive
-        shell: bash
         run: |
           staging="gitoxide-${{ matrix.feature }}-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
           mkdir -p "$staging"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,9 @@ jobs:
       # For some builds, we use cross to test on 32-bit, and maybe later big-endian, systems.
       CARGO: cargo
       # Whether CARGO is `cargo` or `cross`, TARGET_FLAGS will be set to `--target matrix.target`.
-      TARGET_FLAGS: ''
+      TARGET_FLAGS: --target=${{ matrix.target }}
       # Whether CARGO is `cargo` or `cross`, TARGET_DIR will include matrix.target.
-      TARGET_DIR: ./target
+      TARGET_DIR: ./target/${{ matrix.target }}
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
 
@@ -147,11 +147,6 @@ jobs:
         run: |
           cargo install cross
           echo 'CARGO=cross' >> "$GITHUB_ENV"
-
-      - name: Set target variables
-        run: |
-          echo 'TARGET_FLAGS=--target ${{ matrix.target }}' >> "$GITHUB_ENV"
-          echo 'TARGET_DIR=./target/${{ matrix.target }}' >> "$GITHUB_ENV"
 
       - name: Show command used for Cargo
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,6 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Use Cross
-        # if: matrix.os != 'windows-latest'
         run: |
           cargo install cross
           echo "CARGO=cross" >> $GITHUB_ENV


### PR DESCRIPTION
This fixes #1472 so that the 32-bit Windows releases contain 32-bit binaries rather than 64-bit binaries, makes it so pushing a version tag automatically triggers the release workflow, and somewhat streamlines and clarifies the workflow.

Further improvement is possible, including by incorporating some of the other recent changes from the ripgrep release workflow on which it was based. This is something I would be interested to do separately but that I think is not naturally within the scope of these changes.

At least in principle, the workflow can also at this point be extended easily for more build targets, so long as they are otherwise able to build and so long as either *(a)* they can be built with cross-compilation using `cross` on a Linux-based host or *(b)* they do not require `cross`. However, if adding more Linux-based targets, it would be a good idea to generalize the `strip` logic, or the resulting binaries would have debug symbols even though they would be optimized builds.

There are some more details in the commit messages. This includes some approaches I tried but did not keep, when they were entangled with the other changes. This information about the journey may be useful because the actual workflow runs I did for testing are not currently public. As discussed in #1472, I used a private reupload to avoid notifying people in their feeds of something the might misunderstand as an actual prerelease of gitoxide. However, I'd be pleased to republish from my public fork with distinctive tag names (e.g., with `do-not-use` in them), provide you access to the private repository, make the private repository at least temporarily public, or any combination of those things.

For verification, and to demonstrate that the bug does not occur when the release made by the revised workflow is used, I ran these commands on Windows, which correspond to those in "Demonstration checking binaries in all archives of a release" in #1472, except that they will not currently work for anyone but me because they refer to a private repository to which no one else currently has access:

```powershell
mkdir tmp
cd tmp
gh release -R EliahKagan/private-gitoxide download v0.38.0-alpha.5
gci | %{ 7z x $_ }
gci *.tar | %{ 7z x $_ }
file */gix* */ein*
file */gix* */ein* | sls -raw i686
```

The last four commands are the same. The full output is in [this second file in the related gist](https://gist.github.com/EliahKagan/5d2b5a84451c11ccec1b10ba6f2454c6#file-proposed-txt). The output just of the last command is:

```text
gitoxide-lean-v0.38.0-alpha.5-i686-pc-windows-msvc/gix.exe:        PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-pure-v0.38.0-alpha.5-i686-pc-windows-msvc/gix.exe:    PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-v0.38.0-alpha.5-i686-pc-windows-msvc/gix.exe:         PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-small-v0.38.0-alpha.5-i686-pc-windows-msvc/gix.exe:       PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-lean-v0.38.0-alpha.5-i686-pc-windows-msvc/ein.exe:        PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-pure-v0.38.0-alpha.5-i686-pc-windows-msvc/ein.exe:    PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-v0.38.0-alpha.5-i686-pc-windows-msvc/ein.exe:         PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-small-v0.38.0-alpha.5-i686-pc-windows-msvc/ein.exe:       PE32 executable (console) Intel 80386, for MS Windows, 4 sections
```

Note that these are now 32-bit executables. The other Windows builds remain 64-bit.

*Edit:* I have also manually tested the binaries from the `gitoxide-max-v0.38.0-alpha.5-i686-pc-windows-msvc.zip` test release to ensure that they run on a 32-bit Windows system and that I can use the `gix` executable to clone the `gitoxide` repository via SSH.