### PR TITLE
Add ARM64 (AArch64) binary release archives for macOS and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CARGO: cargo  # Sometimes changes to `cross` later (such as when building linux-arm).
+      CARGO: cargo  # On Linux, this will be changed to `cross` later.
       TARGET_FLAGS: --target=${{ matrix.target }}
       TARGET_DIR: ./target/${{ matrix.target }}
       RUST_BACKTRACE: 1  # Emit backtraces on panics.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,48 +69,52 @@ jobs:
 
     strategy:
       matrix:
-        build: [ linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc ]
-        feature: [ small, lean, max, max-pure ]
+        target:
+          - x86_64-unknown-linux-musl
+          - arm-unknown-linux-gnueabihf
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+          - x86_64-pc-windows-gnu
+          - i686-pc-windows-msvc
+        feature:
+          - small
+          - lean
+          - max
+          - max-pure
         include:
-          - build: linux
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             rust: stable
-            target: x86_64-unknown-linux-musl
-          - build: linux-arm
+          - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
             rust: nightly
-            target: arm-unknown-linux-gnueabihf
-          - build: macos
+          - target: x86_64-apple-darwin
             os: macos-latest
             rust: stable
-            target: x86_64-apple-darwin
-          - build: win-msvc
+          - target: x86_64-pc-windows-msvc
             os: windows-latest
             rust: nightly
-            target: x86_64-pc-windows-msvc
-          - build: win-gnu
+          - target: x86_64-pc-windows-gnu
             os: windows-latest
             rust: nightly-x86_64-gnu
-            target: x86_64-pc-windows-gnu
-          - build: win32-msvc
+          - target: i686-pc-windows-msvc
             os: windows-latest
             rust: nightly
-            target: i686-pc-windows-msvc
         # on linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there
         # even though we could also build with `--features max-control,http-client-reqwest,gitoxide-core-blocking-client,gix-features/fast-sha1` for fast hashing.
         # It's a TODO.
         exclude:
-          - build: linux
+          - target: x86_64-unknown-linux-musl
             feature: small
-          - build: linux
+          - target: x86_64-unknown-linux-musl
             feature: lean
-          - build: linux
+          - target: x86_64-unknown-linux-musl
             feature: max
-          - build: linux-arm
+          - target: arm-unknown-linux-gnueabihf
             feature: small
-          - build: linux-arm
+          - target: arm-unknown-linux-gnueabihf
             feature: lean
-          - build: linux-arm
+          - target: arm-unknown-linux-gnueabihf
             feature: max
 
     runs-on: ${{ matrix.os }}
@@ -165,12 +169,12 @@ jobs:
         run: |
           "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features ${{ matrix.feature }}
 
-      - name: Strip release binary (linux and macos)
-        if: matrix.build == 'linux' || matrix.build == 'macos'
+      - name: Strip release binary (x86-64 Linux, and macOS)
+        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'x86_64-apple-darwin'
         run: strip "$TARGET_DIR"/release/{ein,gix}
 
-      - name: Strip release binary (arm)
-        if: matrix.build == 'linux-arm'
+      - name: Strip release binary (ARM Linux)
+        if: matrix.target == 'arm-unknown-linux-gnueabihf'
         run: |
           docker run --rm -v \
             "$PWD/target:/target:Z" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
           - x86_64-unknown-linux-musl
           - arm-unknown-linux-gnueabihf
           - x86_64-apple-darwin
+          - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
@@ -89,6 +90,9 @@ jobs:
             os: ubuntu-latest
             rust: nightly
           - target: x86_64-apple-darwin
+            os: macos-latest
+            rust: stable
+          - target: aarch64-apple-darwin
             os: macos-latest
             rust: stable
           - target: x86_64-pc-windows-msvc
@@ -169,8 +173,8 @@ jobs:
         run: |
           "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features ${{ matrix.feature }}
 
-      - name: Strip release binary (x86-64 Linux, and macOS)
-        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'x86_64-apple-darwin'
+      - name: Strip release binary (x86-64 Linux, and all macOS)
+        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.os == 'macos-latest'
         run: strip "$TARGET_DIR"/release/{ein,gix}
 
       - name: Strip release binary (ARM Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
           - x86_64-pc-windows-msvc
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
+          - aarch64-pc-windows-msvc
         feature:
           - small
           - lean
@@ -102,6 +103,9 @@ jobs:
             os: windows-latest
             rust: nightly-x86_64-gnu
           - target: i686-pc-windows-msvc
+            os: windows-latest
+            rust: nightly
+          - target: aarch64-pc-windows-msvc
             os: windows-latest
             rust: nightly
         # on linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there


### PR DESCRIPTION
As mentioned in https://github.com/Byron/gitoxide/issues/1478#issuecomment-2257584083, this PR does some of the tasks for #1478. I believe this actually is a complete fix for that bug as described. But I suggest keeping the #1478 open and treating that issue more broadly, to encompass both this and other near-future changes. I've opened this PR now so that the core confusion can be avoided in the next release even if there are delays in doing the rest and even if the next release is sooner than anticipated.

Although I suggest scoping this to just those tasks, I'm willing to broaden this PR to include building universal binaries and just keep this PR open for a while until I can get that done. (But there may be some delays, even if nothing goes wrong, because I'm out of private runner minutes. That's probably a blessing in disguise, since this may not be the best way to work on this, even aside from that limitation. But it does mean I'll have to find another way to approach it.)

Details on the produced archives, analogous to [the information there](https://github.com/Byron/gitoxide/pull/1475#issue-2434501361), can be see [**in this gist**](https://gist.github.com/EliahKagan/91b16863df6873a1e0d6099725bff146), which may make even the most important part more readable than it can be here, but here's that part:

```text
C:\Users\ek\tmp> file */gix* */ein*
gitoxide-lean-v0.38.0-alpha.6-aarch64-apple-darwin/gix:            Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-lean-v0.38.0-alpha.6-aarch64-pc-windows-msvc/gix.exe:     PE32+ executable (console) Aarch64, for MS Windows, 5 sections
gitoxide-lean-v0.38.0-alpha.6-i686-pc-windows-msvc/gix.exe:        PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-lean-v0.38.0-alpha.6-x86_64-apple-darwin/gix:             Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-lean-v0.38.0-alpha.6-x86_64-pc-windows-gnu/gix.exe:       PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-lean-v0.38.0-alpha.6-x86_64-pc-windows-msvc/gix.exe:      PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-max-pure-v0.38.0-alpha.6-aarch64-apple-darwin/gix:        Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-pure-v0.38.0-alpha.6-aarch64-pc-windows-msvc/gix.exe: PE32+ executable (console) Aarch64, for MS Windows, 11 sections
gitoxide-max-pure-v0.38.0-alpha.6-arm-unknown-linux-gnueabihf/gix: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 4.19.21, stripped
gitoxide-max-pure-v0.38.0-alpha.6-i686-pc-windows-msvc/gix.exe:    PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-apple-darwin/gix:         Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-pc-windows-gnu/gix.exe:   PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-pc-windows-msvc/gix.exe:  PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-unknown-linux-musl/gix:   ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, stripped
gitoxide-max-v0.38.0-alpha.6-aarch64-apple-darwin/gix:             Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-v0.38.0-alpha.6-aarch64-pc-windows-msvc/gix.exe:      PE32+ executable (console) Aarch64, for MS Windows, 5 sections
gitoxide-max-v0.38.0-alpha.6-i686-pc-windows-msvc/gix.exe:         PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-v0.38.0-alpha.6-x86_64-apple-darwin/gix:              Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-v0.38.0-alpha.6-x86_64-pc-windows-gnu/gix.exe:        PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-max-v0.38.0-alpha.6-x86_64-pc-windows-msvc/gix.exe:       PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-small-v0.38.0-alpha.6-aarch64-apple-darwin/gix:           Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-small-v0.38.0-alpha.6-aarch64-pc-windows-msvc/gix.exe:    PE32+ executable (console) Aarch64, for MS Windows, 5 sections
gitoxide-small-v0.38.0-alpha.6-i686-pc-windows-msvc/gix.exe:       PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-small-v0.38.0-alpha.6-x86_64-apple-darwin/gix:            Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-small-v0.38.0-alpha.6-x86_64-pc-windows-gnu/gix.exe:      PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-small-v0.38.0-alpha.6-x86_64-pc-windows-msvc/gix.exe:     PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-lean-v0.38.0-alpha.6-aarch64-apple-darwin/ein:            Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-lean-v0.38.0-alpha.6-aarch64-pc-windows-msvc/ein.exe:     PE32+ executable (console) Aarch64, for MS Windows, 5 sections
gitoxide-lean-v0.38.0-alpha.6-i686-pc-windows-msvc/ein.exe:        PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-lean-v0.38.0-alpha.6-x86_64-apple-darwin/ein:             Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-lean-v0.38.0-alpha.6-x86_64-pc-windows-gnu/ein.exe:       PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-lean-v0.38.0-alpha.6-x86_64-pc-windows-msvc/ein.exe:      PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-max-pure-v0.38.0-alpha.6-aarch64-apple-darwin/ein:        Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-pure-v0.38.0-alpha.6-aarch64-pc-windows-msvc/ein.exe: PE32+ executable (console) Aarch64, for MS Windows, 11 sections
gitoxide-max-pure-v0.38.0-alpha.6-arm-unknown-linux-gnueabihf/ein: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 4.19.21, stripped
gitoxide-max-pure-v0.38.0-alpha.6-i686-pc-windows-msvc/ein.exe:    PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-apple-darwin/ein:         Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-pc-windows-gnu/ein.exe:   PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-pc-windows-msvc/ein.exe:  PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-max-pure-v0.38.0-alpha.6-x86_64-unknown-linux-musl/ein:   ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, stripped
gitoxide-max-v0.38.0-alpha.6-aarch64-apple-darwin/ein:             Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-v0.38.0-alpha.6-aarch64-pc-windows-msvc/ein.exe:      PE32+ executable (console) Aarch64, for MS Windows, 5 sections
gitoxide-max-v0.38.0-alpha.6-i686-pc-windows-msvc/ein.exe:         PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-max-v0.38.0-alpha.6-x86_64-apple-darwin/ein:              Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-max-v0.38.0-alpha.6-x86_64-pc-windows-gnu/ein.exe:        PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-max-v0.38.0-alpha.6-x86_64-pc-windows-msvc/ein.exe:       PE32+ executable (console) x86-64, for MS Windows, 5 sections
gitoxide-small-v0.38.0-alpha.6-aarch64-apple-darwin/ein:           Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-small-v0.38.0-alpha.6-aarch64-pc-windows-msvc/ein.exe:    PE32+ executable (console) Aarch64, for MS Windows, 5 sections
gitoxide-small-v0.38.0-alpha.6-i686-pc-windows-msvc/ein.exe:       PE32 executable (console) Intel 80386, for MS Windows, 4 sections
gitoxide-small-v0.38.0-alpha.6-x86_64-apple-darwin/ein:            Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
gitoxide-small-v0.38.0-alpha.6-x86_64-pc-windows-gnu/ein.exe:      PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 10 sections
gitoxide-small-v0.38.0-alpha.6-x86_64-pc-windows-msvc/ein.exe:     PE32+ executable (console) x86-64, for MS Windows, 5 sections
```

As alluded to in the task list in #1478, this includes refactoring of the workflow to make architectures more explicit. See 076c262 on this and its rationale.