### PR TITLE
Modernize release CI workflow and include universal binaries and checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,23 +292,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # This checks the draft release on GitHub and publishes it. It does not upload to crates.io.
-  publish-release:
-    name: publish-release
+  check-release:
+    name: check-release
 
     runs-on: ubuntu-latest
 
     needs: [ create-release, build-release, build-macos-universal2-release ]
-
-    env:
-      REPOSITORY: ${{ github.repository }}
-      VERSION: ${{ needs.create-release.outputs.version }}
 
     steps:
       - name: Discover assets
         run: |
           gh release --repo="$REPOSITORY" view "$VERSION" --json assets --jq '.assets.[].name' > assets.txt
         env:
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ needs.create-release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show all asset names
@@ -329,8 +326,34 @@ jobs:
           diff -- <(mask aarch64) <(mask universal)
           diff -- <(mask x86_64) <(mask universal)
 
+  publish-release:
+    name: publish-release
+
+    runs-on: ubuntu-latest
+
+    needs: [ create-release, check-release ]
+
+    env:
+      REPOSITORY: ${{ github.repository }}
+      VERSION: ${{ needs.create-release.outputs.version }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Retrieve individual checksums
+        run: gh release --repo="$REPOSITORY" download "$VERSION" --pattern='gitoxide-*.sha256'
+
+      - name: Concatenate checksums into one file
+        run: cat gitoxide-*.sha256 > hashes.sha256
+
+      - name: Upload the combined checksum file
+        run: gh release --repo="$REPOSITORY" upload "$VERSION" hashes.sha256
+
+      - name: Discard the individual checksum files
+        run: |
+          for sumfile in gitoxide-*.sha256; do
+            gh release --repo="$REPOSITORY" delete-asset "$VERSION" "$sumfile" --yes
+          done
+
       - name: Publish the release
         if: false
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the release
-        if: false
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,11 +88,7 @@ jobs:
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
           - aarch64-pc-windows-msvc
-        feature: &features
-          - small
-          - lean
-          - max
-          - max-pure
+        feature: [ small, lean, max, max-pure ]
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
@@ -239,7 +235,7 @@ jobs:
 
     strategy:
       matrix:
-        feature: *features
+        feature: [ small, lean, max, max-pure ]
 
     steps:
       - name: Placeholder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,17 +247,28 @@ jobs:
       - name: Obtain single-architecture releases
         run: |
           gh release download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unpack single-architecture releases
+        run: |
           tar xf "$(name aarch64).tar.gz"
           tar xf "$(name x86_64).tar.gz"
 
-      - name: Repack into Universal-2 release
+      - name: Pre-populate directory for archive
         run: |
           cp -R -- "$(name aarch64)" "$(name universal)"
           rm -- "$(name universal)"/{ein,gix}
+
+      - name: Create Universal 2 binaries
+        run: |
           for bin in ein gix; do
             lipo -create "$(name aarch64)/$bin" "$(name x86_64)/$bin" -output "$(name universal)/$bin"
+            file "$(name universal)/$bin"
           done
-          file "$(name universal)"/{ein,gix}
+
+      - name: Build archive
+        run: |
           tar czf "$(name universal).tar.gz" "$(name universal)"
           echo "ASSET=$(name universal).tar.gz" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  RUST_BACKTRACE: 1
-  CARGO_TERM_COLOR: always
-  CLICOLOR: 1
-
 defaults:
   run:
     shell: bash
@@ -27,10 +22,13 @@ jobs:
   # from building the release so that we only create the release once.
   create-release:
     name: create-release
+
     runs-on: ubuntu-latest
+
 #    env:
 #      # Set to force version number, e.g., when no tag exists.
 #      VERSION: TEST-0.0.0
+
     steps:
       - name: Create artifacts directory
         run: mkdir artifacts
@@ -133,10 +131,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CARGO: cargo  # On Linux, this will be changed to `cross` later.
+      CARGO: cargo  # On Linux, this will be changed to `cross` in a later step.
       TARGET_FLAGS: --target=${{ matrix.target }}
       TARGET_DIR: ./target/${{ matrix.target }}
-      RUST_BACKTRACE: 1  # Emit backtraces on panics.
+      RUST_BACKTRACE: '1'  # Emit backtraces on panics.
+      CARGO_TERM_COLOR: always
+      CLICOLOR: '1'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
             ;;
           esac
 
-      - name: Create artifacts directory
-        run: mkdir artifacts
-
       - name: Create GitHub release
         id: release
         uses: ncipollo/release-action@v1
@@ -76,6 +73,9 @@ jobs:
           omitBody: true
           omitPrereleaseDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create artifacts directory
+        run: mkdir artifacts
 
       - name: Save release upload URL to artifact
         run: echo '${{ steps.release.outputs.upload_url }}' > artifacts/release-upload-url

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,11 +174,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install packages (Ubuntu)
-        # Because openssl doesn't work on musl by default, we resort to max-pure. And that won't need any dependency, so we can skip this.continue-on-error
+        # Because openssl doesn't work on musl by default, we resort to max-pure.
+        # And that won't need any dependency, so we can skip this or use `continue-on-error`.
         # Once we want to support better zlib performance, we might have to re-add it.
         if: matrix.os == 'ubuntu-latest-disabled'
         run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,10 @@ jobs:
 
       - name: Get the release version from the tag
         if: env.VERSION == ''
-        run: echo 'VERSION=${{ github.ref_name }}' >> "$GITHUB_ENV"
+        run: echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        env:
+          VERSION: ${{ github.ref_name }}
+
 
       - name: Validate version against Cargo.toml
         run: |
@@ -78,7 +81,9 @@ jobs:
         run: mkdir artifacts
 
       - name: Save release upload URL to artifact
-        run: echo '${{ steps.release.outputs.upload_url }}' > artifacts/release-upload-url
+        run: echo "$URL" > artifacts/release-upload-url
+        env:
+          URL: ${{ steps.release.outputs.upload_url }}
 
       - name: Save version number to artifact
         run: echo "$VERSION" > artifacts/release-version
@@ -156,8 +161,10 @@ jobs:
 
     env:
       CARGO: cargo  # On Linux, this will be changed to `cross` in a later step.
+      TARGET: ${{ matrix.target }}
       TARGET_FLAGS: --target=${{ matrix.target }}
       TARGET_DIR: target/${{ matrix.target }}
+      FEATURE: ${{ matrix.feature }}
       RUST_BACKTRACE: '1'  # Emit backtraces on panics.
       CARGO_TERM_COLOR: always
       CLICOLOR: '1'
@@ -204,7 +211,7 @@ jobs:
 
       - name: Build release binary
         run: |
-          "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features ${{ matrix.feature }}
+          "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features "$FEATURE"
 
       - name: Strip release binary (x86-64 Linux, and all macOS)
         if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.os == 'macos-latest'
@@ -222,12 +229,12 @@ jobs:
 
       - name: Build archive
         run: |
-          staging='gitoxide-${{ matrix.feature }}-${{ env.VERSION }}-${{ matrix.target }}'
+          staging="gitoxide-$FEATURE-$VERSION-$TARGET"
           mkdir -p -- "$staging"
 
           cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
 
-          if [ '${{ matrix.os }}' = 'windows-latest' ]; then
+          if [ "$OS" = 'windows-latest' ]; then
             file -- "$TARGET_DIR"/release/{ein,gix}.exe
             cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$staging/"
             7z a "$staging.zip" "$staging"
@@ -238,6 +245,8 @@ jobs:
             tar czf "$staging.tar.gz" "$staging"
             echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
           fi
+        env:
+          OS: ${{ matrix.os }}
 
       - name: Upload release archive
         uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# This is largely adapted from past and recent versions of the ripgrep release workflow.
+# This is largely adapted from the ripgrep release workflow.
 # https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml
 
 name: release
@@ -65,33 +65,12 @@ jobs:
           esac
 
       - name: Create GitHub release
-        id: release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ env.VERSION }}
-          name: ${{ env.VERSION }}
-          allowUpdates: true
-          draft: true
-          omitBody: true
-          omitPrereleaseDuringUpdate: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create artifacts directory
-        run: mkdir artifacts
-
-      - name: Save release upload URL to artifact
-        run: echo "$URL" > artifacts/release-upload-url
+        run: gh release create "$VERSION" --title="$VERSION" --draft
         env:
-          URL: ${{ steps.release.outputs.upload_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Save version number to artifact
-        run: echo "$VERSION" > artifacts/release-version
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts
-          path: artifacts
+    outputs:
+      version: ${{ env.VERSION }}
 
   build-release:
     name: build-release
@@ -199,17 +178,6 @@ jobs:
           echo "target flag is: $TARGET_FLAGS"
           echo "target dir is: $TARGET_DIR"
 
-      - name: Get release download URL
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts
-          path: artifacts
-
-      - name: Set release upload URL and release version
-        run: |
-          echo "UPLOAD_URL=$(< artifacts/release-upload-url)" >> "$GITHUB_ENV"
-          echo "VERSION=$(< artifacts/release-version)" >> "$GITHUB_ENV"
-
       - name: Build release binary
         run: |
           "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features "$FEATURE"
@@ -228,33 +196,36 @@ jobs:
             /target/arm-unknown-linux-gnueabihf/release/ein \
             /target/arm-unknown-linux-gnueabihf/release/gix
 
-      - name: Build archive
-        run: |
-          staging="gitoxide-$FEATURE-$VERSION-$TARGET"
-          mkdir -p -- "$staging"
-
-          cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
-
-          if [ "$OS" = 'windows-latest' ]; then
-            file -- "$TARGET_DIR"/release/{ein,gix}.exe
-            cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$staging/"
-            7z a "$staging.zip" "$staging"
-            echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
-          else
-            file -- "$TARGET_DIR"/release/{ein,gix}
-            cp -- "$TARGET_DIR"/release/{ein,gix} "$staging/"
-            tar czf "$staging.tar.gz" "$staging"
-            echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
-          fi
+      - name: Determine version
+        run: echo "VERSION=$VERSION" >> "$GITHUB_ENV"
         env:
-          OS: ${{ matrix.os }}
+          VERSION: ${{ needs.create-release.outputs.version }}
+
+      - name: Determine archive basename
+        run: echo "ARCHIVE=gitoxide-$FEATURE-$VERSION-$TARGET" >> "$GITHUB_ENV"
+
+      - name: Pre-populate directory for archive
+        run: |
+          mkdir -- "$ARCHIVE"
+          cp {README.md,LICENSE-*,CHANGELOG.md} "$ARCHIVE/"
+
+      - name: Build archive (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          file -- "$TARGET_DIR"/release/{ein,gix}.exe
+          cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$ARCHIVE/"
+          7z a "$ARCHIVE.zip" "$ARCHIVE"
+          echo "ASSET=$ARCHIVE.zip" >> "$GITHUB_ENV"
+
+      - name: Build archive (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          file -- "$TARGET_DIR"/release/{ein,gix}
+          cp -- "$TARGET_DIR"/release/{ein,gix} "$ARCHIVE/"
+          tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+          echo "ASSET=$ARCHIVE.tar.gz" >> "$GITHUB_ENV"
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.2
+        run: gh release upload "$VERSION" "$ASSET"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# This is largely adapted from the ripgrep release workflow.
+# Much of this workflow is adapted from the ripgrep release workflow.
 # https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml
 
 name: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           tag: ${{ env.VERSION }}
           name: ${{ env.VERSION }}
           allowUpdates: true
+          draft: true
           omitBody: true
           omitPrereleaseDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  # The create-release job runs purely to initialize the GitHub release itself,
-  # and names the release after the version tag that was pushed. It's separate
-  # from building the release so that we only create the release once.
+  # Create a draft release, initially with no binary assets attached.
   create-release:
     runs-on: ubuntu-latest
 
@@ -70,6 +68,7 @@ jobs:
     outputs:
       version: ${{ env.VERSION }}
 
+  # Build for a particular feature and target, and attach an archive for it.
   build-release:
     needs: [ create-release ]
 
@@ -223,6 +222,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Add a macOS universal binary archive for a feature using its built aarch64 and x86_64 assets.
   build-macos-universal2-release:
     runs-on: macos-latest
 
@@ -286,6 +286,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Check for some problems, consolidate checksum files into one, and mark the release non-draft.
   publish-release:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,14 +134,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CARGO: cargo  # On Linux, this will be changed to `cross` in a later step.
-      TARGET: ${{ matrix.target }}
-      TARGET_FLAGS: --target=${{ matrix.target }}
-      TARGET_DIR: target/${{ matrix.target }}
-      FEATURE: ${{ matrix.feature }}
       RUST_BACKTRACE: '1'  # Emit backtraces on panics.
       CARGO_TERM_COLOR: always
       CLICOLOR: '1'
+      CARGO: cargo  # On Linux, this will be changed to `cross` in a later step.
+      FEATURE: ${{ matrix.feature }}
+      VERSION: ${{ needs.create-release.outputs.version }}
+      TARGET: ${{ matrix.target }}
+      TARGET_FLAGS: --target=${{ matrix.target }}
+      TARGET_DIR: target/${{ matrix.target }}
 
     steps:
       - name: Checkout repository
@@ -192,11 +193,6 @@ jobs:
             /target/arm-unknown-linux-gnueabihf/release/ein \
             /target/arm-unknown-linux-gnueabihf/release/gix
 
-      - name: Determine version
-        run: echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-        env:
-          VERSION: ${{ needs.create-release.outputs.version }}
-
       - name: Determine archive basename
         run: echo "ARCHIVE=gitoxide-$FEATURE-$VERSION-$TARGET" >> "$GITHUB_ENV"
 
@@ -226,8 +222,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  build-macos-universal-binary-release:
-    name: build-macos-universal-binary-release
+  build-macos-universal2-release:
+    name: build-macos-universal2-release
 
     runs-on: macos-latest
 
@@ -237,9 +233,35 @@ jobs:
       matrix:
         feature: [ small, lean, max, max-pure ]
 
+    env:
+      BASH_ENV: ./helpers.sh
+      FEATURE: ${{ matrix.feature }}
+      VERSION: ${{ needs.create-release.outputs.version }}
+
     steps:
-      - name: Placeholder
+      - name: Define helper function
         run: |
-          echo "This job is for the feature: $FEATURE"
+          name() { echo "gitoxide-$FEATURE-$VERSION-$1-apple-darwin"; }
+          declare -f name >> "$BASH_ENV"
+
+      - name: Obtain single-architecture releases
+        run: |
+          gh release download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
+          tar xf "$(name aarch64).tar.gz"
+          tar xf "$(name x86_64).tar.gz"
+
+      - name: Repack into Universal-2 release
+        run: |
+          cp -R -- "$(name aarch64)" "$(name universal)"
+          rm -- "$(name universal)"/{ein,gix}
+          for bin in ein gix; do
+            lipo -create "$(name aarch64)/$bin" "$(name x86_64)/$bin" -output "$(name universal)/$bin"
+          done
+          file "$(name universal)"/{ein,gix}
+          tar czf "$(name universal).tar.gz" "$(name universal)"
+          echo "ASSET=$(name universal).tar.gz" >> "$GITHUB_ENV"
+
+      - name: Upload release archive
+        run: gh release upload "$VERSION" "$ASSET"
         env:
-          FEATURE: ${{ matrix.feature }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,7 @@ jobs:
 
     env:
       BASH_ENV: ./helpers.sh
+      REPOSITORY: ${{ github.repository }}
       FEATURE: ${{ matrix.feature }}
       VERSION: ${{ needs.create-release.outputs.version }}
 
@@ -246,7 +247,7 @@ jobs:
 
       - name: Obtain single-architecture releases
         run: |
-          gh release download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
+          gh release --repo "$REPOSITORY" download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -273,6 +274,6 @@ jobs:
           echo "ASSET=$(name universal).tar.gz" >> "$GITHUB_ENV"
 
       - name: Upload release archive
-        run: gh release upload "$VERSION" "$ASSET"
+        run: gh release --repo "$REPOSITORY" upload "$VERSION" "$ASSET"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           file -- "$TARGET_DIR"/release/{ein,gix}.exe
           cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$ARCHIVE/"
           7z a "$ARCHIVE.zip" "$ARCHIVE"
-          certutil -hashfile "$ARCHIVE.zip" SHA256 > "$ARCHIVE.zip.sha256"
+          shasum --algorithm=256 "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
           echo "ASSET=$ARCHIVE.zip" >> "$GITHUB_ENV"
           echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,17 +45,19 @@ jobs:
 
           case "$VERSION" in
           "v$manifest_version" )
-            echo 'OK: Version to name the relase agrees with top-level Cargo.toml.'
+            echo 'OK: Release name/version agrees with Cargo.toml version.'
             ;;
           TEST-* | *-DO-NOT-USE )
-            echo 'OK: Version to name the release is strange but marked as such.'
+            echo 'OK: Release name/version is strange but marked as such.'
             ;;
           "$manifest_version" )
-            echo 'STOPPING: Version to name the release is missing the leading "v".'
+            echo 'STOPPING: Release name/version is missing the leading "v".'
             exit 1
             ;;
           * )
-            echo 'STOPPING: Version to name the release seems mistaken.'
+            echo 'STOPPING: Release name/version and Cargo.toml version do not match.'
+            echo 'STOPPING: Usually this means either a wrong tag name or wrong version in Cargo.toml.'
+            echo 'STOPPING: If intended, prepend `TEST-` or append `-DO-NOT-USE` to the release name.'
             exit 1
             ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,23 +292,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  check-release:
-    name: check-release
+  publish-release:
+    name: publish-release
 
     runs-on: ubuntu-latest
 
     needs: [ create-release, build-release, build-macos-universal2-release ]
+
+    env:
+      REPOSITORY: ${{ github.repository }}
+      VERSION: ${{ needs.create-release.outputs.version }}
 
     steps:
       - name: Discover assets
         run: |
           gh release --repo="$REPOSITORY" view "$VERSION" --json assets --jq '.assets.[].name' > assets.txt
         env:
-          REPOSITORY: ${{ github.repository }}
-          VERSION: ${{ needs.create-release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show all asset names
+      - name: Show all individual asset names
         run: cat assets.txt
 
       # The `features` array is repeated because GHA doen't support YAML anchors.
@@ -326,34 +328,33 @@ jobs:
           diff -- <(mask aarch64) <(mask universal)
           diff -- <(mask x86_64) <(mask universal)
 
-  publish-release:
-    name: publish-release
+      - name: Clean up local temporary macOS asset list files
+        run: rm {assets,aarch64,x86_64,universal}.txt
 
-    runs-on: ubuntu-latest
-
-    needs: [ create-release, check-release ]
-
-    env:
-      REPOSITORY: ${{ github.repository }}
-      VERSION: ${{ needs.create-release.outputs.version }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - name: Retrieve individual checksums
+      - name: Retrieve all individual checksums
         run: gh release --repo="$REPOSITORY" download "$VERSION" --pattern='gitoxide-*.sha256'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Concatenate checksums into one file
         run: cat gitoxide-*.sha256 > hashes.sha256
 
       - name: Upload the combined checksum file
         run: gh release --repo="$REPOSITORY" upload "$VERSION" hashes.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Discard the individual checksum files
+      # If any step of any job fails before this, the draft still has the individual checksum files.
+      - name: Remove the individual checksum file assets
         run: |
           for sumfile in gitoxide-*.sha256; do
             gh release --repo="$REPOSITORY" delete-asset "$VERSION" "$sumfile" --yes
           done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the release
         if: false
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,31 @@ jobs:
 #      VERSION: TEST-0.0.0
 
     steps:
-      - name: Create artifacts directory
-        run: mkdir artifacts
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Get the release version from the tag
         if: env.VERSION == ''
         run: echo 'VERSION=${{ github.ref_name }}' >> "$GITHUB_ENV"
 
-      - name: Show the version
+      - name: Validate version against Cargo.toml
         run: |
-          echo "version is: $VERSION"
+          manifest_version="$(yq -r .package.version Cargo.toml)"
+          echo "version to give the release: $VERSION"
+          echo "version Cargo.toml declares: $manifest_version"
+
+          case "$VERSION" in
+          "$manifest_version")
+            echo "OK: Version to give the relase agrees with top-level Cargo.toml."
+            ;;
+          *)
+            echo "STOPPING: Version to give the release seems mistaken."
+            exit 1
+            ;;
+          esac
+
+      - name: Create artifacts directory
+        run: mkdir artifacts
 
       - name: Create GitHub release
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     env:
       CARGO: cargo  # On Linux, this will be changed to `cross` in a later step.
       TARGET_FLAGS: --target=${{ matrix.target }}
-      TARGET_DIR: ./target/${{ matrix.target }}
+      TARGET_DIR: target/${{ matrix.target }}
       RUST_BACKTRACE: '1'  # Emit backtraces on panics.
       CARGO_TERM_COLOR: always
       CLICOLOR: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           manifest_version="$(yq -r .package.version Cargo.toml)"
           echo "version to give the release: $VERSION"
-          echo "version Cargo.toml declares: $manifest_version"
+          echo "version Cargo.toml suggests: v$manifest_version"
 
           case "$VERSION" in
           "v$manifest_version")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
         if: env.VERSION == ''
         run: echo 'VERSION=${{ github.ref_name }}' >> "$GITHUB_ENV"
 
+      - name: Show the version
+        run: |
+          echo "version is: $VERSION"
+
       - name: Create GitHub release
         id: release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           file -- "$TARGET_DIR"/release/{ein,gix}.exe
           cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$ARCHIVE/"
           7z a "$ARCHIVE.zip" "$ARCHIVE"
-          /usr/bin/core_perl/shasum --algorithm=256 "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
+          /usr/bin/core_perl/shasum --algorithm=256 --binary "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
           echo "ASSET=$ARCHIVE.zip" >> "$GITHUB_ENV"
           echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> "$GITHUB_ENV"
 
@@ -218,7 +218,7 @@ jobs:
           file -- "$TARGET_DIR"/release/{ein,gix}
           cp -- "$TARGET_DIR"/release/{ein,gix} "$ARCHIVE/"
           tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
-          shasum --algorithm=256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
+          shasum --algorithm=256 --binary "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
           echo "ASSET=$ARCHIVE.tar.gz" >> "$GITHUB_ENV"
           echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> "$GITHUB_ENV"
 
@@ -283,7 +283,7 @@ jobs:
       - name: Build archive
         run: |
           tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
-          shasum --algorithm=256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
+          shasum --algorithm=256 --binary "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
           echo "ASSET=$ARCHIVE.tar.gz" >> "$GITHUB_ENV"
           echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
           - aarch64-pc-windows-msvc
+        # When changing these features, make the same change in build-macos-universal2-release.
         feature: [ small, lean, max, max-pure ]
         include:
           - target: x86_64-unknown-linux-musl
@@ -231,6 +232,7 @@ jobs:
 
     strategy:
       matrix:
+        # These features need to be exactly the same as the features in build-release.
         feature: [ small, lean, max, max-pure ]
 
     env:
@@ -247,7 +249,7 @@ jobs:
 
       - name: Obtain single-architecture releases
         run: |
-          gh release --repo "$REPOSITORY" download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
+          gh release --repo="$REPOSITORY" download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -274,6 +276,49 @@ jobs:
           echo "ASSET=$(name universal).tar.gz" >> "$GITHUB_ENV"
 
       - name: Upload release archive
-        run: gh release --repo "$REPOSITORY" upload "$VERSION" "$ASSET"
+        run: gh release --repo="$REPOSITORY" upload "$VERSION" "$ASSET"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # This checks and publishes the release on GitHub. It does not upload to crates.io.
+  publish-release:
+    name: publish-release
+
+    runs-on: ubuntu-latest
+
+    needs: [ create-release, build-release, build-macos-universal2-release ]
+
+    env:
+      REPOSITORY: ${{ github.repository }}
+      VERSION: ${{ needs.create-release.outputs.version }}
+
+    steps:
+      - name: Discover assets
+        run: |
+          gh release --repo="$REPOSITORY" view "$VERSION" --json assets --jq '.assets.[].name' > assets.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Show all asset names
+        run: cat assets.txt
+
+      # The `features` array is repeated because GHA doen't support YAML anchors.
+      # We will check that the macOS `universal` features match the others exactly.
+      # In the future this and the next step may be removed, or expanded to do more validation.
+      - name: Extract macOS asset names by architecture
+        run: |
+          for arch in aarch64 x86_64 universal; do
+            grep -Fw "$arch-apple-darwin" assets.txt | sort | tee -- "$arch.txt"
+          done
+
+      - name: Check macOS archive features
+        run: |
+          mask() { sed -r 's/\w+-apple-darwin/<arch>-apple-darwin/' -- "$1.txt"; }
+          diff -- <(mask aarch64) <(mask universal)
+          diff -- <(mask x86_64) <(mask universal)
+
+      - name: Publish the release
+        if: false
+        run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           file -- "$TARGET_DIR"/release/{ein,gix}.exe
           cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$ARCHIVE/"
           7z a "$ARCHIVE.zip" "$ARCHIVE"
-          shasum --algorithm=256 "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
+          /usr/bin/core_perl/shasum --algorithm=256 "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
           echo "ASSET=$ARCHIVE.zip" >> "$GITHUB_ENV"
           echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           echo "version Cargo.toml declares: $manifest_version"
 
           case "$VERSION" in
-          "$manifest_version")
+          "v$manifest_version")
             echo "OK: Version to give the relase agrees with top-level Cargo.toml."
             ;;
           *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
           - aarch64-pc-windows-msvc
-        feature:
+        feature: &features
           - small
           - lean
           - max
@@ -229,3 +229,21 @@ jobs:
         run: gh release upload "$VERSION" "$ASSET"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos-universal-binary-release:
+    name: build-macos-universal-binary-release
+
+    runs-on: macos-latest
+
+    needs: [ create-release, build-release ]
+
+    strategy:
+      matrix:
+        feature: *features
+
+    steps:
+      - name: Placeholder
+        run: |
+          echo "This job is for the feature: $FEATURE"
+        env:
+          FEATURE: ${{ matrix.feature }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,9 @@ jobs:
           file -- "$TARGET_DIR"/release/{ein,gix}.exe
           cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$ARCHIVE/"
           7z a "$ARCHIVE.zip" "$ARCHIVE"
+          certutil -hashfile "$ARCHIVE.zip" SHA256 > "$ARCHIVE.zip.sha256"
           echo "ASSET=$ARCHIVE.zip" >> "$GITHUB_ENV"
+          echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> "$GITHUB_ENV"
 
       - name: Build archive (Unix)
         if: matrix.os != 'windows-latest'
@@ -216,10 +218,12 @@ jobs:
           file -- "$TARGET_DIR"/release/{ein,gix}
           cp -- "$TARGET_DIR"/release/{ein,gix} "$ARCHIVE/"
           tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+          shasum --algorithm=256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
           echo "ASSET=$ARCHIVE.tar.gz" >> "$GITHUB_ENV"
+          echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> "$GITHUB_ENV"
 
       - name: Upload release archive
-        run: gh release upload "$VERSION" "$ASSET"
+        run: gh release upload "$VERSION" "$ASSET" "$ASSET_SUM"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -249,38 +253,46 @@ jobs:
 
       - name: Obtain single-architecture releases
         run: |
-          gh release --repo="$REPOSITORY" download "$VERSION" --pattern="$(name aarch64).tar.gz" --pattern="$(name x86_64).tar.gz"
+          gh release --repo="$REPOSITORY" download "$VERSION" \
+            --pattern="$(name aarch64).tar.gz" --pattern="$(name aarch64).tar.gz.sha256" \
+            --pattern="$(name x86_64).tar.gz" --pattern="$(name x86_64).tar.gz.sha256"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unpack single-architecture releases
         run: |
+          shasum --check "$(name aarch64).tar.gz.sha256" "$(name x86_64).tar.gz.sha256"
           tar xf "$(name aarch64).tar.gz"
           tar xf "$(name x86_64).tar.gz"
 
+      - name: Determine archive basename
+        run: echo "ARCHIVE=$(name universal)" >> "$GITHUB_ENV"
+
       - name: Pre-populate directory for archive
         run: |
-          cp -R -- "$(name aarch64)" "$(name universal)"
-          rm -- "$(name universal)"/{ein,gix}
+          cp -R -- "$(name aarch64)" "$ARCHIVE"
+          rm -- "$ARCHIVE"/{ein,gix}
 
       - name: Create Universal 2 binaries
         run: |
           for bin in ein gix; do
-            lipo -create "$(name aarch64)/$bin" "$(name x86_64)/$bin" -output "$(name universal)/$bin"
-            file "$(name universal)/$bin"
+            lipo -create "$(name aarch64)/$bin" "$(name x86_64)/$bin" -output "$ARCHIVE/$bin"
+            file -- "$ARCHIVE/$bin"
           done
 
       - name: Build archive
         run: |
-          tar czf "$(name universal).tar.gz" "$(name universal)"
-          echo "ASSET=$(name universal).tar.gz" >> "$GITHUB_ENV"
+          tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+          shasum --algorithm=256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
+          echo "ASSET=$ARCHIVE.tar.gz" >> "$GITHUB_ENV"
+          echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> "$GITHUB_ENV"
 
       - name: Upload release archive
-        run: gh release --repo="$REPOSITORY" upload "$VERSION" "$ASSET"
+        run: gh release --repo="$REPOSITORY" upload "$VERSION" "$ASSET" "$ASSET_SUM"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # This checks and publishes the release on GitHub. It does not upload to crates.io.
+  # This checks the draft release on GitHub and publishes it. It does not upload to crates.io.
   publish-release:
     name: publish-release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
   # and names the release after the version tag that was pushed. It's separate
   # from building the release so that we only create the release once.
   create-release:
-    name: create-release
-
     runs-on: ubuntu-latest
 
 #    env:
@@ -73,8 +71,6 @@ jobs:
       version: ${{ env.VERSION }}
 
   build-release:
-    name: build-release
-
     needs: [ create-release ]
 
     strategy:
@@ -228,8 +224,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-macos-universal2-release:
-    name: build-macos-universal2-release
-
     runs-on: macos-latest
 
     needs: [ create-release, build-release ]
@@ -293,8 +287,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-release:
-    name: publish-release
-
     runs-on: ubuntu-latest
 
     needs: [ create-release, build-release, build-macos-universal2-release ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,9 @@ jobs:
 
       - name: Get the release version from the tag
         if: env.VERSION == ''
-        run: echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        run: echo "VERSION=$REF_NAME" >> "$GITHUB_ENV"
         env:
-          VERSION: ${{ github.ref_name }}
-
+          REF_NAME: ${{ github.ref_name }}
 
       - name: Validate version against Cargo.toml
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,22 @@ jobs:
       - name: Validate version against Cargo.toml
         run: |
           manifest_version="$(yq -r .package.version Cargo.toml)"
-          echo "version to give the release: $VERSION"
+          echo "version to name the release: $VERSION"
           echo "version Cargo.toml suggests: v$manifest_version"
 
           case "$VERSION" in
-          "v$manifest_version")
-            echo "OK: Version to give the relase agrees with top-level Cargo.toml."
+          "v$manifest_version" )
+            echo 'OK: Version to name the relase agrees with top-level Cargo.toml.'
             ;;
-          *)
-            echo "STOPPING: Version to give the release seems mistaken."
+          TEST-* | *-DO-NOT-USE )
+            echo 'OK: Version to name the release is strange but marked as such.'
+            ;;
+          "$manifest_version" )
+            echo 'STOPPING: Version to name the release is missing the leading "v".'
+            exit 1
+            ;;
+          * )
+            echo 'STOPPING: Version to name the release seems mistaken.'
             exit 1
             ;;
           esac


### PR DESCRIPTION
Closes #1478
Closes #1484

Major changes:

1. [x] Validate version against `Cargo.toml` unless specially named.
2. [x] Create release as a draft and publish after assets are all attached.
3. [x] Use `gh` for all release operations, eliminating deprecated actions ([#1484](https://github.com/Byron/gitoxide/issues/1484)).
4. [x] Make archives with macOS universal binaries ([#1478](https://github.com/Byron/gitoxide/issues/1478) task 3; [#1242](https://github.com/Byron/gitoxide/issues/1242) task 2).
5. [x] Generate and include SHA256 checksums.
6. [x] Document and refactor to avoid confusion.
7. [ ] Make the workflow more readily testable?

#### First… what it looks like

- [Here's an example release.](https://github.com/EliahKagan/gitoxide/releases/tag/v0.38.0-alpha.1-DO-NOT-USE) (This attempts not to change anything related to release *notes*, and I deliberately have not edited the example release in any way.)
- [Here's its associated workflow run.](https://github.com/EliahKagan/gitoxide/actions/runs/10211156907) Logs are available for each job. (Full information should be accessible to any logged-in user. Warnings from any job would be visible on that summary page as well, but there are no warnings anymore.)

To avoid confusion with real releases of gitoxide that people should actually use, I plan to delete that release eventually, but given its distinctive version "number," I'm not too worried and I'd be pleased to leave it up for at least as long as this PR is open and, if useful, possibly a bit longer.

If one wishes to do so, one can download all the files from that test release using [`gh`](https://cli.github.com/):

```sh
mkdir tmp
cd tmp
gh release -R EliahKagan/gitoxide download v0.38.0-alpha.1-DO-NOT-USE
```

Each of the above checkboxed points ("tasks") is elaborated below, including the last one which I've written as unchecked because I'm not sure the changes here really achieve it.

#### 1. Validate version against `Cargo.toml` unless specially named

This is inspired by a check performed in the ripgrep workflow, though the behavior here is different to permit `TEST-*` and `*-DO-NOT-USE` and messages that report the nature of the likely mistake. Also, while I think this may not have been the case when ripgrep added this check, now the `ubuntu-latest` runner has the `yq` command, which accepts TOML input and therefore allows extracting the version from `Cargo.toml` to be done robustly.

#### 2. Create release as a draft and publish after assets are all attached

This creates a draft release, which is only visible to users with push permissions on the repository. If any of steps (of any job) fail, it remains a draft release and the problem can be investigated. If they all succeed, then the last step of the last job marks it non-draft, publishing it.

This is directly adapted from the ripgrep workflow. The difference is that marking the release non-draft seems to be done manually there, rather than happening automatically. (For further discussion of the options related to this, see "Make the workflow more readily testable?" below.)

#### 3. Use `gh` for all release operations, eliminating deprecated actions

This fixes #1484 by using `gh` instead of several actions related to operating on releases, including the `upload-release-asset` action, but also others that are not deprecated. This is for the reasons presented there, and as mentioned there, this also uses a (single) job output rather than GHA artifacts for passing metadata (now it is just a version) to subsequent jobs, thereby eliminating the use of actions related to GHA assets as well.

Although there are minor differences, and also *more* uses of `gh` because it is also used in the changes presented below, this is perhaps the area where the greatest benefit has coming from incorporating changes that appeared in the ripgrep workflow.

#### 4. Make archives with macOS universal binaries

As recommended in https://github.com/Byron/gitoxide/issues/1478#issuecomment-2257408006, this uses `lipo` to create archives with macOS [Universal 2](https://en.wikipedia.org/wiki/Universal_binary#Universal_2) binaries. There is one such archive for each feature.

It makes them by downloading the `aarch64` and `x86_64` archives for the same feature from the draft release and making a repack in which the `ein` and `gix` binaries are each combinations of both architectures' binaries.

Unfortunately, I did not find a way to make the dependencies between jobs as granular as I had hoped in https://github.com/Byron/gitoxide/issues/1478#issuecomment-2257584083. I wanted to make them depend only on non-universal macOS and only on the ones for the same feature. It doesn't look like there is currently a supported way to do this with GitHub Actions using `needs`, and as far as I can tell it would not be made easier by using artifacts rather than the release itself to hold the assets.

It should be feasible to do it, or at least get part of the way there, using other techniques. In particular, the macOS jobs could be split off into a separate job definition, and substantial code duplication--which if present in this workflow would almost certainly lead to bugs, I think--could be avoided with a [reusable workflow or composite action](https://docs.github.com/en/actions/using-workflows/avoiding-duplication).

I decided not to try to do anything like that at this time. Instead, I just made the jobs that generate builds with universal binaries depend on all the jobs that generate the other builds. Unfortunately this means there is a substantial delay between when the architecture-specific builds are attached to the release and when the universal builds made from them are attached. There are two ways this could matter, though *currently* they are not very significant:

- If the release goes back to being crated as a non-draft, i.e., published before everything is attached, then the delay could create the appearance to users looking for them that universal builds are not available.
- If `fail-fast: false` is set in the `build-release` job definition so that jobs from that matrix are no longer cancelled automatically when others fail, then having the universal builds depend on the aarch64 and x86_64 builds could cause the universal builds not to be built when otherwise they would be able to.

#### 5. Generate and include SHA256 checksums

The ripgrep workflow does this and I figured it would be a good idea. But this differs in a few ways:

- Rather than publish with a separate file for each checksum, this initially creates the checksums that way and even attaches them to the draft release, but then once ready to publish, replaces them with a single `hashes.sha256` files that lists all of them. I wasn't sure what filename to use; the name `hashes.sha256` is inspired by that file in [PowerShell release assets](https://github.com/PowerShell/PowerShell/releases/tag/v7.4.4). If anything goes wrong in any step of any job up to that point, then the individual checksum files are retained in the unpublished draft.
- Checksums are generated in binary mode explicitly. This will probably make no difference to the value, but it leaves no doubt. Also, it causes `shasum` to include the leading `*` before each filename in its output, attesting that the checksums were computed while treating the files that way.
- `shasum` is used on all platforms, even Windows, because `certutil` produces output in a different format that, to the best of my knowledge, no common tools will automatically use. (The `shasum` command actually exists on the Windows GHA runners because Git for Windows ships it; it's just in a subdirectory that is not always in the `PATH`.) An example of a Rust project that uses this traditional Unix format for all archives including `.zip` archives for Windows targets is [`uv`](https://github.com/astral-sh/uv/releases/tag/0.2.33) (though I did not use anything from its release workflow).

Although I think this approach is reasonable or I wouldn't be doing it, I also chose it because of its proximity to other approaches: this should not be too hard to change into any of the following if preferred:

- Keep the individual `.sha256` files and still include `hashes.sha256`.
- Keep the individual `.sha256` files and don't include `hashes.sha256`.
- Never attach individual `.sha256` files even while the release is a draft.
- Use `gpg` to sign the `hashes.sha256` file (would need another secret if automatic).

#### 6. Document and refactor to avoid confusion

Overall the comments are actually sparer. But I placed one at the top of each job definition identifying what it does. I think that creating the release as a draft is also more intuitive, which does not mean we necessarily should keep it that way, but does mean that less confusion is likely when reading the workflow as long as it is the case.

The refactoring largely consists of changes to the way non-literal values get into script steps:

- Sometimes, this is simply avoided by splitting steps up so that conditional logic is in `if:` keys guarding the steps.
- For data from environment variables, access them with parameter expansion (`$VAR`) rather than by interpolating into the script with a template (`${{ env.VAR }}`).
- For data not from environment variables, put them in environment variables scoped to the step in a step-level `env:`. (When non-sensitive and frequently used, put them in the job-level `env:`.)

In other scenarios--not this one--the latter two points would be necessary for security, because untrusted data can contain arbitrary characters including quotation marks. In this case, that is not a worry (except by accident), because none of the values are ever untrusted or otherwise especially unpredictable. So this is largely a stylistic matter. But:

- It seems that the effect, in this case, is to increase readability. That is subjective.
- Previous versions of this workflow had bugs that arose due to confusion about the semantics of access to `env`, such as the lifetime of variables inserted by appending to `$GITHUB_ENV`. I think this helps avoid that too.
- Although secret redaction in GitHub Actions logs works just as well either way, having it be explicitly clear reading each step whether it can perform a privileged operation may be helpful to humans. Currently the only secret is `github.GITHUB_TOKEN`, but it does have write permissions.

Relating to the above, I had previously removed debug printing that didn't work because it attempted to print environment variables that were not set. I gave the workflow another look to see if maybe some of this information would be useful after all, and the ripgrep workflow helped too in what it prints. I brought some of that back, in subsequent steps so that the variables are set before being printed.

#### 7. Make the workflow more readily testable?

Having this make releases initially as drafts seems beneficial in and of itself, in that the release can get into its final state before being made public, and in that the failure to produce or attach assets may sometimes mean the release should not be published without fixing something.

But the bigger reason I did it this way was that it enabled me to test this in my (public) fork, without creating a large number of releases that could potentially confuse people especially if they appeared in their GitHub "what's new" type feeds. (Though I did also name my versions with the string `DO-NOT-USE`, so most likely no one will be misled.) Only pretty near the end did I add the commit that enabled the last step of the new `publish-release` job.

But there are other possible approaches and some considerations the current approach may not adequately satisfy:

- Maybe publishing should always be done manually.
- Maybe it should be made public immediately like it was before.
- Maybe considerations related to `cargo-smart-release` have bearing on this?
- Maybe considerations related to manual editing of release notes have bearing on this?
- Maybe it should work like this but have a way to keep it as a draft.
- Maybe it should work like this but (also?) have a way to make it publish immediately (i.e. never be a draft).

Customization is pretty easy to add when a workflow is triggered by the `workflow_dispatch` event (here's [an example](https://github.com/EliahKagan/hello-world/blob/d75d73384035b48590dc1285237ab4423e707e11/.github/workflows/reverse-shell.yml#L5-L14)). It is not always quite so easy in what is the more important case here of being triggered in push. But, for example, this could look at [repository variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/variables) to determine some of its behavior. It could also have different behavior based on factors like whether it is running in a fork, though I would want that only to be a matter of different defaults so that testing changes to it in a fork could still be done robustly.

Of course, it can also be changed over time as preferences about how it should work become clear or change. It will also be changing in order to simplify things related to stripping debug symbols (#1477) and to publish releases for more targets or for some existing targets with more features (#1242). This PR satisfies the second point of #1242 (and #1479 satisfied the first), but otherwise this PR does not attempt to cover any of that.