### PR TITLE
reproduce and fix date fuzz error

### DIFF
--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -33,7 +33,9 @@ pub(crate) mod function {
         }
 
         Ok(if let Ok(val) = Date::strptime(SHORT.0, input) {
-            let val = val.to_zoned(TimeZone::UTC).expect("date is in range");
+            let val = val
+                .to_zoned(TimeZone::UTC)
+                .map_err(|_| Error::InvalidDateString { input: input.into() })?;
             Time::new(val.timestamp().as_second(), val.offset().seconds())
         } else if let Ok(val) = rfc2822_relaxed(input) {
             Time::new(val.timestamp().as_second(), val.offset().seconds())

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -204,7 +204,7 @@ mod relative {
 mod fuzz {
     #[test]
     fn invalid_but_does_not_cause_panic() {
-        for input in ["7	-𬞋", "5 ڜ-09", "-4 week ago Z", "8960609 day ago"] {
+        for input in ["-9999-1-1", "7	-𬞋", "5 ڜ-09", "-4 week ago Z", "8960609 day ago"] {
             let _ = gix_date::parse(input, Some(std::time::UNIX_EPOCH)).unwrap_err();
         }
     }


### PR DESCRIPTION
Reproduce a fuzz failure.

Fortunately it's just an incorrect expectation.

### Tasks

* [x] reproduce
* [x] fix
