### PR TITLE
Split `release` profile into `release` and `release-opt`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
       TARGET: ${{ matrix.target }}
       TARGET_FLAGS: --target=${{ matrix.target }}
       TARGET_DIR: target/${{ matrix.target }}
+      PROFILE: release-opt
 
     steps:
       - name: Checkout repository
@@ -171,23 +172,9 @@ jobs:
           echo "target flag is: $TARGET_FLAGS"
           echo "target dir is: $TARGET_DIR"
 
-      - name: Build release binary
+      - name: Build release binary (with extra optimizations)
         run: |
-          "$CARGO" build --verbose --release "$TARGET_FLAGS" --no-default-features --features "$FEATURE"
-
-      - name: Strip release binary (x86-64 Linux, and all macOS)
-        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.os == 'macos-latest'
-        run: strip "$TARGET_DIR"/release/{ein,gix}
-
-      - name: Strip release binary (ARM Linux)
-        if: matrix.target == 'arm-unknown-linux-gnueabihf'
-        run: |
-          docker run --rm -v \
-            "$PWD/target:/target:Z" \
-            rustembedded/cross:arm-unknown-linux-gnueabihf \
-            arm-linux-gnueabihf-strip \
-            /target/arm-unknown-linux-gnueabihf/release/ein \
-            /target/arm-unknown-linux-gnueabihf/release/gix
+          "$CARGO" build --verbose --profile="$PROFILE" "$TARGET_FLAGS" --no-default-features --features="$FEATURE"
 
       - name: Determine archive basename
         run: echo "ARCHIVE=gitoxide-$FEATURE-$VERSION-$TARGET" >> "$GITHUB_ENV"
@@ -200,8 +187,8 @@ jobs:
       - name: Build archive (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          file -- "$TARGET_DIR"/release/{ein,gix}.exe
-          cp -- "$TARGET_DIR"/release/{ein,gix}.exe "$ARCHIVE/"
+          file -- "$TARGET_DIR/$PROFILE"/{ein,gix}.exe
+          cp -- "$TARGET_DIR/$PROFILE"/{ein,gix}.exe "$ARCHIVE/"
           7z a "$ARCHIVE.zip" "$ARCHIVE"
           /usr/bin/core_perl/shasum --algorithm=256 --binary "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
           echo "ASSET=$ARCHIVE.zip" >> "$GITHUB_ENV"
@@ -210,8 +197,8 @@ jobs:
       - name: Build archive (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          file -- "$TARGET_DIR"/release/{ein,gix}
-          cp -- "$TARGET_DIR"/release/{ein,gix} "$ARCHIVE/"
+          file -- "$TARGET_DIR/$PROFILE"/{ein,gix}
+          cp -- "$TARGET_DIR/$PROFILE"/{ein,gix} "$ARCHIVE/"
           tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
           shasum --algorithm=256 --binary "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
           echo "ASSET=$ARCHIVE.tar.gz" >> "$GITHUB_ENV"
@@ -346,7 +333,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish the release
+      - name: Publish the release  # FIXME: Reenable this.
+        if: false
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       TARGET: ${{ matrix.target }}
       TARGET_FLAGS: --target=${{ matrix.target }}
       TARGET_DIR: target/${{ matrix.target }}
-      PROFILE: release-opt
+      PROFILE: release-github
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,8 +333,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish the release  # FIXME: Reenable this.
-        if: false
+      - name: Publish the release
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,8 @@ panic = "unwind"
 incremental = false
 build-override = { opt-level = 0 }
 
+# This profile is currently used in building releases for GitHub.
+# It may be removed at any time and should not otherwise be relied on.
 [profile.release-opt]
 inherits = "release"
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,17 +206,18 @@ sha1_smol = { opt-level = 3 }
 
 [profile.release]
 overflow-checks = false
-#lto = "fat"
-# this bloats files but assures destructors are called, important for tempfiles. One day I hope we
+lto = "thin"
+# This bloats files but assures destructors are called, important for tempfiles. One day I hope we
 # can wire up the 'abrt' signal handler so tempfiles will be removed in case of panics.
-panic = 'unwind'
-#codegen-units = 1
+panic = "unwind"
 incremental = false
 build-override = { opt-level = 0 }
 
-# It's not quite worth building dependencies with more optimizations yet. Let's keep it here for later.
-#[profile.dev.package."*"]
-#opt-level = 2
+[profile.release-opt]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,15 +211,17 @@ lto = "thin"
 # can wire up the 'abrt' signal handler so tempfiles will be removed in case of panics.
 panic = "unwind"
 incremental = false
-build-override = { opt-level = 0 }
 
 # This profile is currently used in building releases for GitHub.
 # It may be removed at any time and should not otherwise be relied on.
-[profile.release-opt]
+[profile.release-github]
 inherits = "release"
+overflow-checks = false
+panic = "unwind"
 lto = "fat"
 codegen-units = 1
 strip = "symbols"
+build-override = { opt-level = 3 }
 
 [workspace]
 members = [


### PR DESCRIPTION
This makes the kind of changes discussed in comments in #1475 and further in #1477. This fixes #1477, though some other fix might be preferred, so this may benefit from being changed, or further changes could be made afterward. See https://github.com/Byron/gitoxide/issues/1477#issuecomment-2257499363 and https://github.com/Byron/gitoxide/issues/1477#issuecomment-2274445001.

In `Cargo.toml`, this adds thin LTO to the `release` profile, and creates a separate more aggressively optimized `release-opt` profile with fat LTO and max 1 codegen unit. The effect on build times seems in both cases modest, but you might disagree. For more on that, see [this gist where I timed the builds](https://gist.github.com/EliahKagan/52cedc99a8544505525706351948664a) and https://github.com/Byron/gitoxide/issues/1477#issuecomment-2274445001 (which, among other related topics, discusses it). This also removes some old commented-out code, as also discussed in #1477.

In `release.yml`, this takes the profile to use from an environment variable (some occurrences of `release` had referred to that profile while others had not), does some related other refactoring, and most significantly changes which profile is used for the GitHub releases from `release` to the new `release-opt` profile.

The results [seem okay](https://gist.github.com/EliahKagan/a8a59e0f6fb4435dcbd9555b3c8b8680), and in particular the Linux executables, which without configuring stripping in `Cargo.toml` might require more explicit logic as new targets are added, show as stripped. (The `file` implementation I am using does not seem to report the absence of symbols in macOS binaries; that affected prior runs' results as well.) That output is on assets downloaded from a draft release produced in [this workflow run](https://github.com/EliahKagan/gitoxide/actions/runs/10293234759).

In case you decide to merge this without many changes but hope for an even better approach later, I've [included a comment](https://github.com/Byron/gitoxide/pull/1495/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R216-R217) in `Cargo.toml` stating that the `release-opt` profile is not guaranteed to stick around.