### PR TITLE
Have `touch` in test fixture fall back to portable format

### DIFF
--- a/gix-index/tests/fixtures/file_metadata.sh
+++ b/gix-index/tests/fixtures/file_metadata.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-# The largest-possible date for Ext4, nanos are special there, but ont usually on other filesystems
-touch -d "2446-05-10 22:38:55.111111111" future
-# The smallest-possible date for Ext4, nanos are special there, but ont usually on other filesystems
-touch -d "1901-12-13 20:45:52.222222222" past
+# Attempt to create files with the latest and earliest possible dates for ext4. Nanoseconds are
+# special there, but not usually on other filesystems. In some touch implementations, the format
+# may be rejected. So if a command fails, we try again with a more extreme date that is out of
+# range, because some implementations will clip it to the edge of the range (but they may fail).
+touch -d '2446-05-10 22:38:55.111111111' future || touch -d '2446-05-11 22:38:56' future
+touch -d '1901-12-13 20:45:52.222222222' past || touch -d '1901-12-13 20:45:52' past


### PR DESCRIPTION
This mitigates and probably can even be considered to fix #1491, at least with respect to the main variant of that issue where the problem is solely due to the format of the `-d` operand and not to the range of supported values.

For each edge-of-range `touch`, if at first it fails, this will try it rounded to the nearest *more extreme* value in seconds, which some implementations will accept and clip it at or near the most extreme value in the range that it was going for.

This should not lead to any unexpected or harder-to-diagnose errors because the one test that uses this fixture deliberately avoids asserting anything about the actual timestamps, anticipating that they may be close-by values instead:

https://github.com/Byron/gitoxide/blob/29898e3010bd3332418c683f2ac96aff5c8e72fa/gix-index/tests/index/fs.rs#L8-L9

However, if it is *intended* that `touch` fail and bring down the test when it cannot specify nanoseconds, then that might be a reason not go with this change.

Note that while, before this change, the test fails (due to the fixture failing) when `touch` rejects nanoseconds, it would still pass if the nanoseconds are ignored. As noted in #1491, I think that happens more often than may have been anticipated, and I wonder if really it might be better to use single `touch` commands (no `&&`) with more portable date strings.

This fixture's previous code did not seem to account for or explain the intended behavior with respect to time zone, and I have not attempted to address that here either.

I have verified locally that [all tests pass](https://gist.github.com/EliahKagan/6f3abfc9104259d2bf03f7372d750067#file-output-txt) on the Alpine Linux 3.17 system on which I discovered #1491. This includes [`from_path_no_follow`](https://gist.github.com/EliahKagan/6f3abfc9104259d2bf03f7372d750067#file-output-txt-L1563), which failed on that system prior to the changes here.