### PR TITLE
Allow keeping releases drafts via repo-level GHA variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,6 +334,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the release
+        if: vars.DRY_RUN_RELEASE != 'true' && vars.DRY_RUN_RELEASE != 'yes' && vars.DRY_RUN_RELEASE != '1'
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With this, the "Publish the release" step has an `if:` that will be true unless a GitHub Actions [configuration variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#vars-context) named `DRY_RUN_RELEASE`--that is, a `DRY_RUN_RELEASE` in the `vars` context, not to be confused with an environment variable--is defined with one of the value that is often used in GHA workflows to express true conditions. The way this works is:

- The step still does not run unless the preceding steps (and all jobs in the workflow, before them) succeeded, irrespective of whether, or to what value, the variable is set.
- To minimize added complexity in the workflow, this does not strip whitespace, fold case, or diagnose weird values: anything besides `true`, `yes`, and `1` is treated as being falsy. (That is with respect to the value. Variable names themselves are automatically upcased when set.) This very deliberately includes the empty string, as obtained when the variable does not exist.
- Unlike secrets, variables are not secret. But they are still not inherited by or otherwise shared with or among forks: each repository has its own value or absence thereof.

It seems to me that the added complexity is worthwhile to avoid having to add `if: false` while developing and experiment with the release workflow, to suppress the publication of a release, i.e., setting the draft release to non-draft:

- The main reason to do that at all is that users can sometimes be notified about releases, even in forks.
- My justification for the added complexity is not the convenience of being able to avoid this, which might not necessarily justify this, but instead to avoid the *churn* of adding and removing `if:` in commits that are conceptually about something else (or having additional commits just to do it). That is, I see the main benefit as making the history of the file easier to understand in the future. The convenience is also a benefit, though.

The added complexity is only in the workflow itself. No burden is imposed on actual releasing, or on a repository whose maintainer elects not to add the variable:

- The feature of being able to suppress setting a release non-draft through this GitHub Actions variable can be ignored completely, since the default is to run the step.
- When making the change, I had worried it might issue a warning on the workflow about accessing a GHA variable that does not exist, but I tested this case and that does not happen. (I did not test it with [debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging) enabled, but a diagnostic message about this does not seem like a problem to me if it happens when debug logging is enabled.)

I anticipate that, if you choose to merge this, then you would probably not set the variable here, and that, if you do, then you would probably [set it to](https://github.com/Byron/gitoxide/settings/variables/actions) a value like `false`. However, this does not look at whether the repository is a fork, and its use is not limited to forks: if you merge this and want to test changes to the release workflow here, you can set the variable to one of the three recognized truthy values to keep the workflow from marking releases non-draft (which would affect all runs that start after the change).

[Here's a workflow run](https://github.com/EliahKagan/gitoxide/actions/runs/10294595235) that tests this, and [here's the affected job](https://github.com/EliahKagan/gitoxide/actions/runs/10294595235/job/28493154327).