### PR TITLE
Truncate files when checking out

### DIFF
--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -245,7 +245,8 @@ fn open_options(path: &Path, destination_is_initially_empty: bool, overwrite_exi
     options
         .create_new(destination_is_initially_empty && !overwrite_existing)
         .create(!destination_is_initially_empty || overwrite_existing)
-        .write(true);
+        .write(true)
+        .truncate(true);
     options
 }
 


### PR DESCRIPTION
Fixes an issue where files during a checkout could be not-fully overwritten, leaving them in an invalid state.

For example, a repository contains the following file:
![repository contents](https://github.com/user-attachments/assets/815ad508-b48a-4f48-a5e3-11fd04b20070)
could get checked out as this:
![checkout contents](https://github.com/user-attachments/assets/7e5e6ece-1ec5-4acd-81c0-2ef1fa4f7f1a)