### PR TITLE
Create codespace config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+ARG VARIANT="1"
+FROM mcr.microsoft.com/devcontainers/rust:${VARIANT}
+RUN apt update && apt install -y cmake

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Rust",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": { "VARIANT": "1" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "rust-lang.rust-analyzer"
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ indent_size = 2
 [Makefile]
 indent_style = tab
 
-# Matches the exact files either package.json or .travis.yml
-[{package.json,.travis.yml}]
+# Matches .json files or the exact file .travis.yml
+[{*.json,.travis.yml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
I was thinking of using a codespace to make a PR, but then I discovered I couldn't! :scream:

This adds configuration to allow a user to create a codespace that includes the necessary prerequisites to compile (Rust toolchain, `cmake`). It also adds a couple of helpful VS Code extensions for VS Code on the Web:
- EditorConfig, because it should be an extension if this project uses it
- Rust Analyzer, to provide helpful support like type analysis

This PR also generalizes the EditorConfig from a specific `package.json` to all `*.json` files. Before I create any file I see if it matches an EditorConfig entry and, if not, I modify it so it's included. This change was a best guess of preferred behavior.