### PR TITLE
Don't show console on Windows

### DIFF
--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -74,13 +74,14 @@ pub(crate) mod function {
                 let tx_base = tx_base.clone();
                 let mut progress = progress.add_child("attributes");
                 move || -> anyhow::Result<()> {
-                    let mut child = std::process::Command::new(gix::path::env::exe_invocation())
-                        .args(["check-attr", "--stdin", "-a"])
-                        .stdin(std::process::Stdio::piped())
-                        .stdout(std::process::Stdio::piped())
-                        .stderr(std::process::Stdio::null())
-                        .current_dir(path)
-                        .spawn()?;
+                    let mut child =
+                        std::process::Command::from(gix::command::prepare(gix::path::env::exe_invocation()))
+                            .args(["check-attr", "--stdin", "-a"])
+                            .stdin(std::process::Stdio::piped())
+                            .stdout(std::process::Stdio::piped())
+                            .stderr(std::process::Stdio::null())
+                            .current_dir(path)
+                            .spawn()?;
 
                     std::thread::spawn({
                         let mut stdin = child.stdin.take().expect("we configured it");
@@ -125,13 +126,14 @@ pub(crate) mod function {
                 let tx_base = tx_base.clone();
                 let mut progress = progress.add_child("excludes");
                 move || -> anyhow::Result<()> {
-                    let mut child = std::process::Command::new(gix::path::env::exe_invocation())
-                        .args(["check-ignore", "--stdin", "-nv", "--no-index"])
-                        .stdin(std::process::Stdio::piped())
-                        .stdout(std::process::Stdio::piped())
-                        .stderr(std::process::Stdio::null())
-                        .current_dir(path)
-                        .spawn()?;
+                    let mut child =
+                        std::process::Command::from(gix::command::prepare(gix::path::env::exe_invocation()))
+                            .args(["check-ignore", "--stdin", "-nv", "--no-index"])
+                            .stdin(std::process::Stdio::piped())
+                            .stdout(std::process::Stdio::piped())
+                            .stderr(std::process::Stdio::null())
+                            .current_dir(path)
+                            .spawn()?;
 
                     std::thread::spawn({
                         let mut stdin = child.stdin.take().expect("we configured it");

--- a/gitoxide-core/src/repository/commit.rs
+++ b/gitoxide-core/src/repository/commit.rs
@@ -20,7 +20,7 @@ pub fn verify(repo: gix::Repository, rev_spec: Option<&str>) -> Result<()> {
     signature_storage.write_all(signature.as_ref())?;
     let signed_storage = signature_storage.into_temp_path();
 
-    let mut cmd = std::process::Command::new("gpg");
+    let mut cmd: std::process::Command = gix::command::prepare("gpg").into();
     cmd.args(["--keyid-format=long", "--status-fd=1", "--verify"])
         .arg(&signed_storage)
         .arg("-")

--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -237,6 +237,13 @@ mod prepare {
             } else {
                 Command::new(prep.command)
             };
+            // We never want to have terminals pop-up on Windows if this runs from a GUI application.
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                const CREATE_NO_WINDOW: u32 = 0x08000000;
+                cmd.creation_flags(CREATE_NO_WINDOW);
+            }
             cmd.stdin(prep.stdin)
                 .stdout(prep.stdout)
                 .stderr(prep.stderr)
@@ -400,6 +407,8 @@ pub mod shebang {
 /// - `stdin` is null to prevent blocking unexpectedly on consumption of stdin
 /// - `stdout` is captured for consumption by the caller
 /// - `stderr` is inherited to allow the command to provide context to the user
+///
+/// On Windows, terminal Windows will be suppressed automatically.
 ///
 /// ### Warning
 ///

--- a/gix-credentials/src/program/mod.rs
+++ b/gix-credentials/src/program/mod.rs
@@ -71,7 +71,7 @@ impl Program {
         let git_program = gix_path::env::exe_invocation();
         let mut cmd = match &self.kind {
             Kind::Builtin => {
-                let mut cmd = Command::new(git_program);
+                let mut cmd = Command::from(gix_command::prepare(git_program));
                 cmd.arg("credential").arg(action.as_arg(false));
                 cmd
             }

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -82,6 +82,12 @@ pub(super) static EXE_NAME: &str = "git";
 pub(super) static EXE_INFO: Lazy<Option<BString>> = Lazy::new(|| {
     let git_cmd = |executable: PathBuf| {
         let mut cmd = Command::new(executable);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
         cmd.args(["config", "-l", "--show-origin"])
             .stdin(Stdio::null())
             .stderr(Stdio::null());

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -109,6 +109,12 @@ pub fn system_prefix() -> Option<&'static Path> {
             }
 
             let mut cmd = std::process::Command::new(exe_invocation());
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                const CREATE_NO_WINDOW: u32 = 0x08000000;
+                cmd.creation_flags(CREATE_NO_WINDOW);
+            }
             cmd.arg("--exec-path").stderr(std::process::Stdio::null());
             gix_trace::debug!(cmd = ?cmd, "invoking git to get system prefix/exec path");
             let path = cmd.output().ok()?.stdout;


### PR DESCRIPTION
When used inside GUI application, gix causes console window to appear temporarily, due to execution of git.

Command needs special flags to prevent that. More details: https://stackoverflow.com/a/60958956

