### PR TITLE
Run CI on moderately more events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ env:
 
 on:
   push:
-    branches: [ main ]
-    tags-ignore: [ '*' ]
+    branches:
+      - main
+      - 'run-ci/**'
+      - '**/run-ci/**'
+    tags-ignore:
+      - '*'
     paths:
       - '.github/**'
       - 'ci/**'
@@ -19,7 +23,8 @@ on:
       - '*.toml'
       - Makefile
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - '.github/**'
       - 'ci/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ on:
       - 'gix*/**'
       - '*.toml'
       - Makefile
+  workflow_dispatch:
 
 jobs:
   pure-rust-build:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,8 @@
 name: CIFuzz
-on: [pull_request]
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 jobs:
  Fuzzing:
    runs-on: ubuntu-latest

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,13 +1,17 @@
 name: Minimum Supported Rust Version
 
 on:
-  # Trigger the workflow on push to master or any pull request
-  # Ignore all tags
   push:
-    branches: [ main ]
-    tags-ignore: [ '*' ]
+    branches:
+      - main
+      - 'run-ci/**'
+      - '**/run-ci/**'
+    tags-ignore:
+      - '*'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   rustfmt:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,13 @@
 name: release
 
 on:
-  workflow_dispatch:
   push:
     # Enable when testing release infrastructure on a branch.
     # branches:
      #  - fix-releases
     tags:
       - 'v*'
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
As discussed in https://github.com/Byron/gitoxide/pull/1499#issuecomment-2278901849 and below, it is useful to be able to run CI checks in forks even when not (or not yet) having opened a pull request. That is already feasible in two ways, but neither is ideal:

1. Commit and push directly to `main` in one's fork.

2. Make another branch on which the workflows are modified.

Those approaches will still work. But with the changes in this PR, there are further options, which are usually better :

3. Name the feature branch with a `run-ci` directory-like component. By "directory-like component" I mean names like `run-ci/foo`, `run-ci/foo/bar`, `foo/run-ci/bar`, `foo/bar/run-ci/baz`, but not `run-ci` or `foo/run-ci`. Of the three approaches facilitated here, this is probably the best one, when one knows one wants CI checks to run even outside of a pull request.

   The reasons for not treating it specially when it is the last or only component is that it is more likely to be meant (or be misinterpreted) as a description of a change to be made in that position. In the case of `foo/run-ci`, that would be a mistake a significant fraction of the time, because `foo` and `foo/run-ci` cannot exist in the same repository.

4. Name the feature branch anything and, when one wishes for CI to run, make and push another temporary branch from it that matches the above naming convention. This is still simpler and much less confusing than creating a branch that has different contents, as was previously required.

5. Name the feature branch anything and, when one wishes for CI to run, trigger in manually for that branch through the workflow_dispatch event, available in the Actions tab.

I did not make the CI Fuzz workflow run on the push trigger, since it takes a while and is not even run on the push trigger on the main branch.

A small amount of additional, less important information is available in the commit messages.

The effect of this change, regarding naming branches for CI to run on push, can be observed in the [`run-ci/ci-branches`](https://github.com/EliahKagan/gitoxide/commits/run-ci/ci-branches/) branch in my fork, which is the branch for this PR. CI ran in all three commits there. (I won't keep that branch forever, but the tip of it [can be viewed by hash](https://github.com/EliahKagan/gitoxide/commits/de555b2dfb059f771434d8ce2560c2bcc256034d/) if anyone is ever interested later.)