### PR TITLE
Run the Windows MSRV checks on Server 2022

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - windows-2022
-          - ubuntu-24.04
+          - ubuntu-latest
     runs-on: ${{ matrix.os }}
     env:
       # dictated by `firefox` to support the `helix` editor, but now probably effectively be controlled by `jiff`, which also aligns with `regex`.

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
-          - ubuntu-latest
+          - windows-2022
+          - ubuntu-24.04
     runs-on: ${{ matrix.os }}
     env:
       # dictated by `firefox` to support the `helix` editor, but now probably effectively be controlled by `jiff`, which also aligns with `regex`.


### PR DESCRIPTION
This changes the Windows runner from `windows-2019` to `windows-2022`. Although `windows-2022` is also what one currently gets for `windows-latest`, this uses the specific label for that. This is as discussed in, and for the reason noted in, #1514.

The first commit checks that Ubuntu 24.04 LTS will work when `ubuntu-latest` moves from `ubuntu-22.04` to `ubuntu-24.04`. That worked fine, as I expected. As also noted in #1514, using the rolling Ubuntu runner OS version hasn't caused problems in the past, so this puts it back in the second commit, leaving only the bumping of the Windows runner version. That's what's going on with having two commits instead of one for a two-character change :smile:.