### PR TITLE
Fix ID (symbolic name) of MSRV check jobs

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  rustfmt:
+  check-msrv:
     name: cargo check MSRV
     strategy:
       matrix:


### PR DESCRIPTION
It looks like it may have been adapted from a `rustfmt` job. But this isn't using `rustfmt` or performing auto-formatting.

Although this has been the case for a while and is not related to runner versions, I would've thrown this in with #1515. But I noticed it just a second too late.

I've looked over all the other jobs in all CI workflows in this repository, and that appears to be the only place with a misnamed job ID like this. So only this one ID is changed here.