### PR TITLE
Build releases for more Linux targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,11 +143,23 @@ jobs:
             feature: lean
           - target: x86_64-unknown-linux-musl
             feature: max
+          - target: x86_64-unknown-linux-gnu
+            feature: small
+          - target: x86_64-unknown-linux-gnu
+            feature: lean
+          - target: x86_64-unknown-linux-gnu
+            feature: max
           - target: i686-unknown-linux-musl
             feature: small
           - target: i686-unknown-linux-musl
             feature: lean
           - target: i686-unknown-linux-musl
+            feature: max
+          - target: i686-unknown-linux-gnu
+            feature: small
+          - target: i686-unknown-linux-gnu
+            feature: lean
+          - target: i686-unknown-linux-gnu
             feature: max
           - target: aarch64-unknown-linux-musl
             feature: small
@@ -155,11 +167,29 @@ jobs:
             feature: lean
           - target: aarch64-unknown-linux-musl
             feature: max
+          - target: aarch64-unknown-linux-gnu
+            feature: small
+          - target: aarch64-unknown-linux-gnu
+            feature: lean
+          - target: aarch64-unknown-linux-gnu
+            feature: max
           - target: arm-unknown-linux-musleabihf
             feature: small
           - target: arm-unknown-linux-musleabihf
             feature: lean
           - target: arm-unknown-linux-musleabihf
+            feature: max
+          - target: arm-unknown-linux-gnueabihf
+            feature: small
+          - target: arm-unknown-linux-gnueabihf
+            feature: lean
+          - target: arm-unknown-linux-gnueabihf
+            feature: max
+          - target: s390x-unknown-linux-gnu
+            feature: small
+          - target: s390x-unknown-linux-gnu
+            feature: lean
+          - target: s390x-unknown-linux-gnu
             feature: max
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
           - aarch64-unknown-linux-gnu
           - arm-unknown-linux-musleabihf
           - arm-unknown-linux-gnueabihf
+          - powerpc64le-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - x86_64-apple-darwin
           - aarch64-apple-darwin
@@ -109,6 +111,10 @@ jobs:
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
           - target: arm-unknown-linux-gnueabihf
+            os: ubuntu-latest
+          - target: powerpc64le-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
@@ -176,6 +182,18 @@ jobs:
           - target: arm-unknown-linux-gnueabihf
             feature: lean
           - target: arm-unknown-linux-gnueabihf
+            feature: max
+          - target: powerpc64le-unknown-linux-gnu
+            feature: small
+          - target: powerpc64le-unknown-linux-gnu
+            feature: lean
+          - target: powerpc64le-unknown-linux-gnu
+            feature: max
+          - target: riscv64gc-unknown-linux-gnu
+            feature: small
+          - target: riscv64gc-unknown-linux-gnu
+            feature: lean
+          - target: riscv64gc-unknown-linux-gnu
             feature: max
           - target: s390x-unknown-linux-gnu
             feature: small

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,20 +76,43 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-musl
+          - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - arm-unknown-linux-musleabihf
           - arm-unknown-linux-gnueabihf
+          - s390x-unknown-linux-gnu
           - x86_64-apple-darwin
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
+          - i686-pc-windows-gnu
           - aarch64-pc-windows-msvc
+          - aarch64-pc-windows-gnullvm
         # When changing these features, make the same change in build-macos-universal2-release.
         feature: [ small, lean, max, max-pure ]
         include:
           - rust: stable
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: i686-unknown-linux-musl
+            os: ubuntu-latest
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: arm-unknown-linux-musleabihf
+            os: ubuntu-latest
           - target: arm-unknown-linux-gnueabihf
+            os: ubuntu-latest
+          - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -102,8 +125,14 @@ jobs:
             rust: stable-x86_64-gnu
           - target: i686-pc-windows-msvc
             os: windows-latest
+          - target: i686-pc-windows-gnu
+            os: windows-latest
+            rust: stable-x86_64-gnu
           - target: aarch64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-gnullvm
+            os: windows-latest
+            rust: stable-x86_64-gnu
         # on linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there
         # even though we could also build with `--features max-control,http-client-reqwest,gitoxide-core-blocking-client,gix-features/fast-sha1` for fast hashing.
         # It's a TODO.
@@ -114,11 +143,23 @@ jobs:
             feature: lean
           - target: x86_64-unknown-linux-musl
             feature: max
-          - target: arm-unknown-linux-gnueabihf
+          - target: i686-unknown-linux-musl
             feature: small
-          - target: arm-unknown-linux-gnueabihf
+          - target: i686-unknown-linux-musl
             feature: lean
-          - target: arm-unknown-linux-gnueabihf
+          - target: i686-unknown-linux-musl
+            feature: max
+          - target: aarch64-unknown-linux-musl
+            feature: small
+          - target: aarch64-unknown-linux-musl
+            feature: lean
+          - target: aarch64-unknown-linux-musl
+            feature: max
+          - target: arm-unknown-linux-musleabihf
+            feature: small
+          - target: arm-unknown-linux-musleabihf
+            feature: lean
+          - target: arm-unknown-linux-musleabihf
             feature: max
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,7 @@ jobs:
           - x86_64-pc-windows-msvc
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
-          - i686-pc-windows-gnu
           - aarch64-pc-windows-msvc
-          - aarch64-pc-windows-gnullvm
         # When changing these features, make the same change in build-macos-universal2-release.
         feature: [ small, lean, max, max-pure ]
         include:
@@ -125,14 +123,8 @@ jobs:
             rust: stable-x86_64-gnu
           - target: i686-pc-windows-msvc
             os: windows-latest
-          - target: i686-pc-windows-gnu
-            os: windows-latest
-            rust: stable-x86_64-gnu
           - target: aarch64-pc-windows-msvc
             os: windows-latest
-          - target: aarch64-pc-windows-gnullvm
-            os: windows-latest
-            rust: stable-x86_64-gnu
         # on linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there
         # even though we could also build with `--features max-control,http-client-reqwest,gitoxide-core-blocking-client,gix-features/fast-sha1` for fast hashing.
         # It's a TODO.


### PR DESCRIPTION
This builds more `*-unknown-linux-*` targets in the release workflow, but still all only for `max-pure`.

This is the (kind of) change suggested in https://github.com/Byron/gitoxide/discussions/1498#discussioncomment-10309898. Based on the subsequent comment discussion, such as https://github.com/Byron/gitoxide/discussions/1498#discussioncomment-10310780, I had hoped also to build at least the `*-linux-gnu` targets for multiple features rather than just `max-pure`. But while that should be done, I have omitted it from this PR, because it is not as easy as I had hoped. This is because, when using `cross`, extra steps have to be taken to build against OpenSSL even where `musl` is not involved and a build with the same toolchain and target would ordinarily succeed, due to https://github.com/cross-rs/cross/issues/229.

A number more targets could probably be added, at least for `max-pure` as here, without any special effort. However, for now I have limited it to targets for which I feel there is a specific justification. This divides into two cases:

- Targets for architectures that are commonly used. As a proxy for this, I included all the architectures that the latest LTS of Ubuntu (24.04) supports officially (including [official ports](https://cdimage.ubuntu.com/releases/24.04/release/) but not unofficial ones). I also included i686 (32-bit x86), which Ubuntu does not support installing the operating system itself on anymore, but which I consider quite significant.

  Independently of this, I would have included aarch64 and s390x anyway. The other reasons to include aarch64 are that is widely available including in cloud compute services (second to x86-64), we are already building for it on Windows and macOS, and it [has been requested explicitly](https://github.com/Byron/gitoxide/issues/1242#issuecomment-1908357986). The other reason to include s390x is that it is currently the most prominent big-endian architecture, and having big-endian builds is useful since, through their use, bugs related to incorrect assumptions about data representation are often discovered.

- Targets for architectures we already had builds for, for whichever of `*-gnu` or `*-musl` (or `*-gnueabihf` or `*-musleabihf`) we did not have.

  Note that the additions for `arm-*` at this point are solely for this reason. No new 32-bit ARM architectures are added, and I am unsure if there should be other 32-bit ARM targets in addition to or perhaps even instead of the current ones. Maybe it would be better to build for `armv7-*` rather than `arm-*` targets. Maybe we should have non-hard-float ARM builds. Maybe we should include all architectures, ARM or otherwise, that some other popular Rust projects such as ripgrep build releases for. But I have deliberately omitted any such changes from this PR.

A few notes:

- Some targets have only `*-gnu` and not `*-musl` because no corresponding `*-musl` Rust target currently exists. But that is the only circumstance under which the release workflow, as it stands here, builds for `*-gnu` and not `*-musl`.

  Therefore, if the *"provide \*-musl builds for all \*-gnu builds"* request in [#1242](https://github.com/Byron/gitoxide/issues/1242) is interpreted weakly, this completes that item. If it is interpreted strongly, however, then it will have to wait on the creation of more Rust targets than currently exist.

- I had originally hoped to add more non-MSVC Windows targets here, but that didn't work out. Some signs of it remain in the commit history so I (or anyone) who works on this may be reminded of what was attempted. It should be possible in the future, if it looks like it is worthwhile.

- The target for the riscv64 architecture is unaffected by [http://rust-lang/libz-sys#200](https://github.com/rust-lang/libz-sys/issues/200) because, being a Linux target, it is currently only building `max-pure`, which does not use the affected library.

[Here's a workflow run](https://github.com/EliahKagan/gitoxide/actions/runs/10350412348) for these changes, and [here's an examination of the generated release archives](https://gist.github.com/EliahKagan/3de9a6d5fafab21cff8861e44330a40c). Usually I have been doing these examinations on Windows, but here the build I was most worried about was the RISC-V one, so I did it on a risc64 Ubuntu 24.04 LTS system, including running `gix clone` on both an SSH and HTTPS URL.