### PR TITLE
run `git config -l` in temp dir when looking up system config

### DIFF
--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -88,7 +89,8 @@ pub(super) static EXE_INFO: Lazy<Option<BString>> = Lazy::new(|| {
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
-        cmd.args(["config", "-l", "--show-origin"])
+        cmd.args(["config", "-l", "--system", "--show-origin"])
+            .current_dir(env::temp_dir())
             .stdin(Stdio::null())
             .stderr(Stdio::null());
         cmd

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -89,7 +89,7 @@ pub(super) static EXE_INFO: Lazy<Option<BString>> = Lazy::new(|| {
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
-        cmd.args(["config", "-l", "--system", "--show-origin"])
+        cmd.args(["config", "-l", "--show-origin"])
             .current_dir(env::temp_dir())
             .stdin(Stdio::null())
             .stderr(Stdio::null());


### PR DESCRIPTION
Commit a9a3545db2b2 made `gix::config::File::from_globals()` try to find the system config (typically `/etc/config`) by subprocessing to `git config -l --show-origin`. That command takes about 500 ms when run in certain directories in our VFS at Google. Since we don't need anything but the system config, let's run the command in the system's temporary directory instead.

I also added `--system` for good measure. I've confirmed that just adding `--system` is not enough, however - `git config -l --system --show-origin` is still slow in our VFS.

