### PR TITLE
Improve path join test assertion messages and fix minor test bugs

### DIFF
--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -35,24 +35,24 @@ fn p(s: &str) -> &Path {
 #[test]
 #[cfg(windows)]
 fn path_join_handling() {
-    let absolute = p("/absolute");
+    let looks_absolute = p("/absolute");
     assert!(
-        absolute.is_relative(),
+        looks_absolute.is_relative(),
         "on Windows, absolute Linux paths are considered relative (and relative to the current drive)"
     );
-    let bs_absolute = p("\\absolute");
+    let bs_looks_absolute = p("\\absolute");
     assert!(
-        bs_absolute.is_relative(),
+        bs_looks_absolute.is_relative(),
         "on Windows, strange single-backslash paths are relative (and relative to the current drive)"
     );
     assert_eq!(
-        p("relative").join(absolute),
-        absolute,
+        p("relative").join(looks_absolute),
+        looks_absolute,
         "relative + absolute = absolute - however, they kind of act like they are absolute in conjunction with relative base paths"
     );
     assert_eq!(
-        p("relative").join(bs_absolute),
-        bs_absolute,
+        p("relative").join(bs_looks_absolute),
+        bs_looks_absolute,
         "relative + absolute = absolute - backslashes aren't special here, and it just acts like it's absolute"
     );
 
@@ -68,22 +68,22 @@ fn path_join_handling() {
     );
 
     assert_eq!(
-        p("\\\\?\\base").join(absolute),
+        p("\\\\?\\base").join(looks_absolute),
         p("\\\\?\\base\\absolute"),
         "absolute1 + unix-absolute2 = joined result with backslash"
     );
     assert_eq!(
-        p("\\\\.\\base").join(absolute),
+        p("\\\\.\\base").join(looks_absolute),
         p("\\\\.\\base\\absolute"),
         "absolute1 + absolute2 = joined result with backslash (device namespace)"
     );
     assert_eq!(
-        p("\\\\?\\base").join(bs_absolute),
+        p("\\\\?\\base").join(bs_looks_absolute),
         p("\\\\?\\base\\absolute"),
         "absolute1 + absolute2 = joined result"
     );
     assert_eq!(
-        p("\\\\.\\base").join(bs_absolute),
+        p("\\\\.\\base").join(bs_looks_absolute),
         p("\\\\.\\base\\absolute"),
         "absolute1 + absolute2 = joined result (device namespace)"
     );

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -38,7 +38,7 @@ fn path_join_handling() {
     let looks_absolute = p("/absolute");
     assert!(
         looks_absolute.is_relative(),
-        "on Windows, absolute Linux paths are considered relative (and relative to the current drive)"
+        "on Windows, 'absolute' Linux paths are relative (and relative to the current drive)"
     );
     let bs_looks_absolute = p("\\absolute");
     assert!(
@@ -48,12 +48,12 @@ fn path_join_handling() {
     assert_eq!(
         p("relative").join(looks_absolute),
         looks_absolute,
-        "relative + absolute = absolute - however, they kind of act like they are absolute in conjunction with relative base paths"
+        "relative + unix-absolute = unix-absolute - the relative path without a drive is replaced"
     );
     assert_eq!(
         p("relative").join(bs_looks_absolute),
         bs_looks_absolute,
-        "relative + absolute = absolute - backslashes aren't special here, and it just acts like it's absolute"
+        "relative + unix-absolute = unix-absolute - the relative path without a drive is replaced - backslashes aren't special here"
     );
 
     assert_eq!(

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -59,7 +59,7 @@ fn path_join_handling() {
     assert_eq!(
         p("c:").join("relative"),
         p("c:relative"),
-        "drive + relative = strange joined result with missing backslash, but it's a valid path that works just like `c:\relative`"
+        "drive + relative = relative to the drive-specific current directory"
     );
     assert_eq!(
         p("c:\\").join("relative"),

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -120,12 +120,12 @@ fn path_join_handling() {
     assert_eq!(
         p("/").join("\\\\localhost"),
         p("\\localhost"),
-        "unix-absolute + win-absolute-unc = win-absolute-unc"
+        "unix-absolute + win-absolute-unc-host = strangely, single-backslashed host"
     );
     assert_eq!(
         p("relative").join("\\\\localhost"),
         p("\\\\localhost"),
-        "relative + win-absolute-unc = win-absolute-unc"
+        "relative + win-absolute-unc-host = win-absolute-unc-host"
     );
 }
 

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -42,7 +42,7 @@ fn path_join_handling() {
     );
     let bs_absolute = p("\\absolute");
     assert!(
-        absolute.is_relative(),
+        bs_absolute.is_relative(),
         "on Windows, strange single-backslash paths are relative (and relative to the current drive)"
     );
     assert_eq!(

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -92,7 +92,7 @@ fn path_join_handling() {
     assert_eq!(
         p("d:/").join("C:"),
         p("C:"),
-        "d-drive + c-drive = c-drive - interesting, as C: is supposed to be relative"
+        "d-drive + c-drive-relative = c-drive-relative - C: is relative but not on D:"
     );
     assert_eq!(
         p("d:\\").join("C:\\"),
@@ -113,7 +113,7 @@ fn path_join_handling() {
     assert_eq!(
         p("\\\\.").join("C:"),
         p("C:"),
-        "device-namespace-unc + win-drive-relative = win-drive-relative - c: was supposed to be relative, but it's not acting like it."
+        "device-namespace-unc + win-drive-relative = win-drive-relative - C: as a relative path is not the C: device, so this is not \\\\.\\C:"
     );
     assert_eq!(p("relative").join("C:"), p("C:"), "relative + win-drive = win-drive");
 

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -165,14 +165,14 @@ fn path_join_handling() {
     );
 
     assert_eq!(
-        p("/").join("\\localhost"),
-        p("/\\localhost"),
-        "absolute + win-absolute-unc = joined result"
+        p("/").join("\\\\localhost"),
+        p("/\\\\localhost"),
+        "absolute + win-absolute-unc-host = joined result"
     );
     assert_eq!(
-        p("relative").join("\\localhost"),
-        p("relative/\\localhost"),
-        "relative + win-absolute-unc = joined result"
+        p("relative").join("\\\\localhost"),
+        p("relative/\\\\localhost"),
+        "relative + win-absolute-unc-host = joined result"
     );
 }
 

--- a/gix-fs/tests/stack/mod.rs
+++ b/gix-fs/tests/stack/mod.rs
@@ -40,7 +40,7 @@ fn path_join_handling() {
         looks_absolute.is_relative(),
         "on Windows, 'absolute' Linux paths are relative (and relative to the current drive)"
     );
-    let bs_looks_absolute = p("\\absolute");
+    let bs_looks_absolute = p(r"\absolute");
     assert!(
         bs_looks_absolute.is_relative(),
         "on Windows, strange single-backslash paths are relative (and relative to the current drive)"
@@ -62,29 +62,29 @@ fn path_join_handling() {
         "drive + relative = relative to the drive-specific current directory"
     );
     assert_eq!(
-        p("c:\\").join("relative"),
-        p("c:\\relative"),
+        p(r"c:\").join("relative"),
+        p(r"c:\relative"),
         "absolute + relative = joined result"
     );
 
     assert_eq!(
-        p("\\\\?\\base").join(looks_absolute),
-        p("\\\\?\\base\\absolute"),
+        p(r"\\?\base").join(looks_absolute),
+        p(r"\\?\base\absolute"),
         "absolute1 + unix-absolute2 = joined result with backslash"
     );
     assert_eq!(
-        p("\\\\.\\base").join(looks_absolute),
-        p("\\\\.\\base\\absolute"),
+        p(r"\\.\base").join(looks_absolute),
+        p(r"\\.\base\absolute"),
         "absolute1 + absolute2 = joined result with backslash (device namespace)"
     );
     assert_eq!(
-        p("\\\\?\\base").join(bs_looks_absolute),
-        p("\\\\?\\base\\absolute"),
+        p(r"\\?\base").join(bs_looks_absolute),
+        p(r"\\?\base\absolute"),
         "absolute1 + absolute2 = joined result"
     );
     assert_eq!(
-        p("\\\\.\\base").join(bs_looks_absolute),
-        p("\\\\.\\base\\absolute"),
+        p(r"\\.\base").join(bs_looks_absolute),
+        p(r"\\.\base\absolute"),
         "absolute1 + absolute2 = joined result (device namespace)"
     );
 
@@ -95,36 +95,36 @@ fn path_join_handling() {
         "d-drive + c-drive-relative = c-drive-relative - C: is relative but not on D:"
     );
     assert_eq!(
-        p("d:\\").join("C:\\"),
-        p("C:\\"),
+        p(r"d:\").join(r"C:\"),
+        p(r"C:\"),
         "d-drive-with-bs + c-drive-with-bs = c-drive-with-bs - nothing special happens with backslashes"
     );
     assert_eq!(
-        p("c:\\").join("\\\\.\\"),
-        p("\\\\.\\"),
+        p(r"c:\").join(r"\\.\"),
+        p(r"\\.\"),
         "c-drive-with-bs + device-namespace-unc = device-namespace-unc"
     );
     assert_eq!(
         p("/").join("C:/"),
-        p("C:\\"),
+        p(r"C:\"),
         "unix-absolute + win-drive = win-drive, strangely enough it changed the trailing slash to backslash, so better not have trailing slashes"
     );
-    assert_eq!(p("/").join("C:\\"), p("C:\\"), "unix-absolute + win-drive = win-drive");
+    assert_eq!(p("/").join(r"C:\"), p(r"C:\"), "unix-absolute + win-drive = win-drive");
     assert_eq!(
-        p("\\\\.").join("C:"),
+        p(r"\\.").join("C:"),
         p("C:"),
-        "device-namespace-unc + win-drive-relative = win-drive-relative - C: as a relative path is not the C: device, so this is not \\\\.\\C:"
+        r"device-namespace-unc + win-drive-relative = win-drive-relative - C: as a relative path is not the C: device, so this is not \\.\C:"
     );
     assert_eq!(p("relative").join("C:"), p("C:"), "relative + win-drive = win-drive");
 
     assert_eq!(
-        p("/").join("\\\\localhost"),
-        p("\\localhost"),
+        p("/").join(r"\\localhost"),
+        p(r"\localhost"),
         "unix-absolute + win-absolute-unc-host = strangely, single-backslashed host"
     );
     assert_eq!(
-        p("relative").join("\\\\localhost"),
-        p("\\\\localhost"),
+        p("relative").join(r"\\localhost"),
+        p(r"\\localhost"),
         "relative + win-absolute-unc-host = win-absolute-unc-host"
     );
 }
@@ -154,8 +154,8 @@ fn path_join_handling() {
     assert_eq!(p("/").join("C:"), p("/C:"), "absolute + win-drive = joined result");
     assert_eq!(p("/").join("C:/"), p("/C:/"), "absolute + win-absolute = joined result");
     assert_eq!(
-        p("/").join("C:\\"),
-        p("/C:\\"),
+        p("/").join(r"C:\"),
+        p(r"/C:\"),
         "absolute + win-absolute = joined result"
     );
     assert_eq!(
@@ -165,13 +165,13 @@ fn path_join_handling() {
     );
 
     assert_eq!(
-        p("/").join("\\\\localhost"),
-        p("/\\\\localhost"),
+        p("/").join(r"\\localhost"),
+        p(r"/\\localhost"),
         "absolute + win-absolute-unc-host = joined result"
     );
     assert_eq!(
-        p("relative").join("\\\\localhost"),
-        p("relative/\\\\localhost"),
+        p("relative").join(r"\\localhost"),
+        p(r"relative/\\localhost"),
         "relative + win-absolute-unc-host = joined result"
     );
 }


### PR DESCRIPTION
This fixes inaccurate assertion messages in the path-joining tests, improves some messages that were okay but capable of being clarified, and renames a couple of variables to avoid making it seem like relative paths are absolute. Most of the changes are to the Windows tests. This relates to https://github.com/Byron/gitoxide/pull/1374#pullrequestreview-2244385346.

It also corrects a few tests where the same thing was asserted multiple times with a different message rather than asserting the subtly different claim that the message showed was intended, or where it tested paths with a different number of backslashes than the context and message show were meant.

Finally, though this is only a refactoring, it changes all string literals with backslash-containing paths to be raw string literals. I think this makes it easier and also faster to understand what paths are being tested, and generally improves readability a bit.

(Sometimes it makes sense to write all Windows paths as raw string literals, even those without backslashes, but I didn't do that, because in this case I think it would produce an effect that, one way or another, would be confusing or at least feel strange, when comparing corresponding tests in the Windows and non-Windows build configurations.)

Several assertion messages had contained expressions of surprise at the effects. When rewording made this clear, I removed such wording. Elsewhere I kept it. In one place, I even added it: I do not know why concatenating `\` and `\\localhost` on Windows produces `\localhost`, and it seems like the intent had even been to assert that it produces `\\localhost` (because it characterized the result as being UNC). But it does produce `\localhost` for some reason. Hopefully the message there can be improved further, but unless more is known about that now, I think my characerization as "strangely, single-backslashed host" may still be an improvement.

Some more details are available in commit messages and, in what may be an easier form to work with, in review comments I've posted below on particular changes.