### PR TITLE
Fix typos in config support info

### DIFF
--- a/src/plumbing/progress.rs
+++ b/src/plumbing/progress.rs
@@ -76,7 +76,7 @@ static GIT_CONFIG: &[Record] = &[
     },
     Record {
         config: "core.packedGitLimit",
-        usage: NotApplicable("we target 32bit systems only and don't use a windowing mechanism")
+        usage: NotApplicable("we target 64-bit systems only and don't use a windowing mechanism")
     },
     Record {
         config: "core.alternateRefsCommand",
@@ -91,7 +91,7 @@ static GIT_CONFIG: &[Record] = &[
         usage: Planned("Allow to remove similar hardcoded value - passing it through will be some effort")
     },
     Record {
-        config: "core.loosecompression",
+        config: "core.looseCompression",
         usage: Planned("")
     },
     Record {
@@ -100,7 +100,7 @@ static GIT_CONFIG: &[Record] = &[
     },
     Record {
         config: "core.sparseCheckoutCone",
-        usage: Planned("this is a nice improvement over spareCheckout alone and should one day be available too")
+        usage: Planned("this is a nice improvement over sparseCheckout alone and should one day be available too")
     },
     Record {
         config: "core.gitProxy",
@@ -156,7 +156,7 @@ static GIT_CONFIG: &[Record] = &[
     },
     Record {
         config: "submodule.recurse",
-        usage: Planned("very relevant for doing the right thing during checkouts. Note that 'clone' isnt' affected by it, even though we could make it so for good measure.")
+        usage: Planned("very relevant for doing the right thing during checkouts. Note that 'clone' isn't affected by it, even though we could make it so for good measure.")
     },
     Record {
         config: "submodule.propagateBranches",


### PR DESCRIPTION
This fixes #1530 and makes some other minor improvements.

- `core.looseCompression` - use canonical capitalization for key
- `core.packedGitLimit` - work well on 64-bit, not 32-bit ([#1530](https://github.com/Byron/gitoxide/issues/1530))
- `core.sparseCheckoutCone` - fix misspelled `sparseCheckout` ref
- `submodule.recurse` - fix minor spelling typo

Further improvements are possible, such as to unify the style of the explanations so that they all follow the same capitalization and quoting conventions. I believe that should be done, but since I may inquire about other substantive areas soon anyway (as I did in #1530), I think that can wait until a subsequent PR.

This information is available by API, so maybe this should be a conventional commit? I can easily amend this so the commit message starts with `fix:` if you like. This seems like a gray area with respect to whether `fix:` ought to be used.