### PR TITLE
Fix msrv: Run msrv checks with minimal versions

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
       - run: |
-          rustup toolchain install ${{ env.rust_version }} --profile minimal --no-self-update
+          rustup toolchain install ${{ env.rust_version }} nightly --profile minimal --no-self-update
           rustup default ${{ env.rust_version }}
+          cargo +nightly update -Zminimal-versions
       - run: just ci-check-msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -3331,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
 dependencies = [
  "cmake",
  "libc",
@@ -3341,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "cmake",

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -30,7 +30,7 @@ gix-object = { version = "^0.44.0", path = "../gix-object" }
 gix-path = { version = "^0.10.10", path = "../gix-path", optional = true }
 gix-date = { version = "^0.9.0", path = "../gix-date" }
 
-flate2 = { version = "1.0.26", optional = true }
+flate2 = { version = "1.0.33", optional = true }
 zip = { version = "2.1.0", optional = true, default-features = false, features = ["deflate"] }
 jiff = { version = "0.1.2", default-features = false, features = ["std"] }
 

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -143,7 +143,7 @@ bytesize = { version = "1.0.1", optional = true }
 bytes = { version = "1.0.0", optional = true }
 
 # zlib module
-flate2 = { version = "1.0.25", optional = true, default-features = false }
+flate2 = { version = "1.0.33", optional = true, default-features = false }
 thiserror = { version = "1.0.38", optional = true }
 
 once_cell = { version = "1.13.0", optional = true }

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -22,7 +22,7 @@ gix-path = { version = "^0.10.10", path = "../gix-path" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 thiserror = "1.0.32"
-url = "2.5.1"
+url = "2.5.2"
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
 home = "0.5.5"
 


### PR DESCRIPTION
Since it is possible to for dependencies to bump MSRV in patch release, msrv checking should use the minimal versions supported by gix.

Users cares deeply about msrv can also pin them to the minimal versions to maintain their current msrv.

This would have also help discover bug in #1538 