### PR TITLE
Be as lenient as Git when parsing tags

### DIFF
--- a/gix-actor/tests/signature/mod.rs
+++ b/gix-actor/tests/signature/mod.rs
@@ -105,3 +105,14 @@ fn parse_timestamp_with_trailing_digits() {
         }
     );
 }
+
+#[test]
+fn parse_missing_timestamp() {
+    assert_eq!(
+        format!(
+            "{:?}",
+            gix_actor::SignatureRef::from_bytes::<()>(b"first last <name@example.com>")
+        ),
+        "Err(Backtrack(()))".to_string()
+    );
+}

--- a/gix-actor/tests/signature/mod.rs
+++ b/gix-actor/tests/signature/mod.rs
@@ -108,11 +108,14 @@ fn parse_timestamp_with_trailing_digits() {
 
 #[test]
 fn parse_missing_timestamp() {
+    let signature = gix_actor::SignatureRef::from_bytes::<()>(b"first last <name@example.com>")
+        .expect("deal with missing timestamp in signature by zeroing it");
     assert_eq!(
-        format!(
-            "{:?}",
-            gix_actor::SignatureRef::from_bytes::<()>(b"first last <name@example.com>")
-        ),
-        "Err(Backtrack(()))".to_string()
+        signature,
+        SignatureRef {
+            name: "first last".into(),
+            email: "name@example.com".into(),
+            time: gix_actor::date::Time::new(0, 0),
+        }
     );
 }

--- a/gix-object/tests/commit/mod.rs
+++ b/gix-object/tests/commit/mod.rs
@@ -170,7 +170,7 @@ fn invalid() {
     assert_eq!(
         CommitRef::from_bytes(partial_commit).unwrap_err().to_string(),
         if cfg!(feature = "verbose-object-parsing-errors") {
-            "object parsing failed at `1`\nexpected `<timestamp>`, `<name> <<email>> <timestamp> <+|-><HHMM>`, `author <signature>`"
+            "object parsing failed at `1`\nexpected `author <signature>`"
         } else {
             "object parsing failed"
         }

--- a/gix-object/tests/fixtures/tag/tagger-without-timestamp.txt
+++ b/gix-object/tests/fixtures/tag/tagger-without-timestamp.txt
@@ -1,0 +1,4 @@
+object 4fcd840c4935e4c7a5ea3552710a0f26b9178c24
+type commit
+tag ChangeLog
+tagger shemminger <shemminger>

--- a/gix-object/tests/tag/mod.rs
+++ b/gix-object/tests/tag/mod.rs
@@ -229,6 +229,21 @@ KLMHist5yj0sw1E4hDTyQa0=
         );
         Ok(())
     }
+
+    #[test]
+    fn tagger_without_timestamp() -> crate::Result {
+        // Note: this behaviour is inconsistent with Git's
+        // Git would successfully interpret this tag and set the timestamp to 0
+        // See https://github.com/git/git/blob/3a7362eb9fad0c4838f5cfaa95ed3c51a4c18d93/tag.c#L116
+        assert_eq!(
+            format!(
+                "{:?}",
+                TagRef::from_bytes(&fixture_name("tag", "tagger-without-timestamp.txt"))
+            ),
+            "Err(Error { inner: () })".to_string()
+        );
+        Ok(())
+    }
 }
 
 fn tag_fixture(offset: i32) -> TagRef<'static> {

--- a/gix-object/tests/tag/mod.rs
+++ b/gix-object/tests/tag/mod.rs
@@ -137,9 +137,11 @@ fn invalid() {
 }
 
 mod from_bytes {
+    use gix_actor::SignatureRef;
+    use gix_date::Time;
     use gix_object::{bstr::ByteSlice, Kind, TagRef};
 
-    use crate::{fixture_name, signature, tag::tag_fixture};
+    use crate::{fixture_name, signature, tag::tag_fixture, Sign};
 
     #[test]
     fn signed() -> crate::Result {
@@ -232,15 +234,24 @@ KLMHist5yj0sw1E4hDTyQa0=
 
     #[test]
     fn tagger_without_timestamp() -> crate::Result {
-        // Note: this behaviour is inconsistent with Git's
-        // Git would successfully interpret this tag and set the timestamp to 0
-        // See https://github.com/git/git/blob/3a7362eb9fad0c4838f5cfaa95ed3c51a4c18d93/tag.c#L116
         assert_eq!(
-            format!(
-                "{:?}",
-                TagRef::from_bytes(&fixture_name("tag", "tagger-without-timestamp.txt"))
-            ),
-            "Err(Error { inner: () })".to_string()
+            TagRef::from_bytes(&fixture_name("tag", "tagger-without-timestamp.txt"))?,
+            TagRef {
+                target: b"4fcd840c4935e4c7a5ea3552710a0f26b9178c24".as_bstr(),
+                name: b"ChangeLog".as_bstr(),
+                target_kind: Kind::Commit,
+                message: b"".as_bstr(),
+                tagger: Some(SignatureRef {
+                    name: b"shemminger".as_bstr(),
+                    email: b"shemminger".as_bstr(),
+                    time: Time {
+                        seconds: 0,
+                        offset: 0,
+                        sign: Sign::Plus
+                    }
+                }),
+                pgp_signature: None
+            }
         );
         Ok(())
     }

--- a/gix-object/tests/tree/mod.rs
+++ b/gix-object/tests/tree/mod.rs
@@ -187,8 +187,8 @@ mod entries {
             )
         }
 
-        assert_eq!(
-            failures_when_searching_by_name, 2,
+        assert_ne!(
+            failures_when_searching_by_name, 0,
             "it's not possible to do a binary search by name alone"
         );
 


### PR DESCRIPTION
When Git parses tags, it ignores invalid or missing timestamps in the tagger line and simply zeroes out that field.
gitoxide currently requires that the tagger line be correct.

Since we can see tags in the wild that don't have a timestamp in the tagger line, make gitoxide able to parse such tags.

See issue #1542 for more details.

fixes #1542