### PR TITLE
 Support compile `gix-config-value` to wasm32-wasi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
+      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
         name: crates without feature toggles
       - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd gix-features && cargo build --features $feature --target ${{ matrix.target }}); done
         name: features of gix-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
+      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-pathspec gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
         name: crates without feature toggles
       - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd gix-features && cargo build --features $feature --target ${{ matrix.target }}); done
         name: features of gix-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-pathspec gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
+      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-pathspec gix-prompt gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
         name: crates without feature toggles
       - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd gix-features && cargo build --features $feature --target ${{ matrix.target }}); done
         name: features of gix-features

--- a/gix-config-value/src/path.rs
+++ b/gix-config-value/src/path.rs
@@ -52,8 +52,13 @@ pub mod interpolate {
     /// or any other error occurred.
     /// It can be used as `home_for_user` parameter in [`Path::interpolate()`][crate::Path::interpolate()].
     #[cfg_attr(windows, allow(unused_variables))]
+    #[cfg_attr(all(target_family = "wasm", not(target_os = "emscripten")), allow(unused_variables))]
     pub fn home_for_user(name: &str) -> Option<PathBuf> {
-        #[cfg(not(any(target_os = "android", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "windows",
+            all(target_family = "wasm", not(target_os = "emscripten"))
+        )))]
         {
             let cname = std::ffi::CString::new(name).ok()?;
             // SAFETY: calling this in a threaded program that modifies the pw database is not actually safe.
@@ -71,7 +76,11 @@ pub mod interpolate {
                 Some(std::ffi::OsStr::from_bytes(cstr.to_bytes()).into())
             }
         }
-        #[cfg(any(target_os = "android", target_os = "windows"))]
+        #[cfg(any(
+            target_os = "android",
+            target_os = "windows",
+            all(target_family = "wasm", not(target_os = "emscripten"))
+        ))]
         {
             None
         }


### PR DESCRIPTION
Hi! I tried to compile gix-value-config to wasm32-wasi but encountered an error during compilation with this error:
```
   Compiling gix-config-value v0.14.8 (/gitoxide/gix-config-value)
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> gix-config-value/src/path.rs:66:30
   |
66 |                 use std::os::unix::ffi::OsStrExt;
   |                              ^^^^ could not find `unix` in `os`
   |
note: found an item that was configured out
  --> /.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/os/mod.rs:26:9
   |
26 | pub mod unix {}
   |         ^^^^
note: found an item that was configured out
  --> /.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/os/mod.rs:64:9
   |
64 | pub mod unix;
   |         ^^^^

error[E0425]: cannot find function `getpwnam` in crate `libc`
  --> gix-config-value/src/path.rs:62:38
   |
62 |             let pwd = unsafe { libc::getpwnam(cname.as_ptr()) };
   |                                      ^^^^^^^^ not found in `libc`

error[E0599]: no function or associated item named `from_bytes` found for struct `OsStr` in the current scope
  --> gix-config-value/src/path.rs:71:39
   |
71 |                 Some(std::ffi::OsStr::from_bytes(cstr.to_bytes()).into())
   |                                       ^^^^^^^^^^ function or associated item not found in `OsStr`
   |
   = help: items from traits can only be used if the trait is in scope
help: there is a method `as_bytes` with a similar name, but with different arguments
  --> /.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/os/wasi/../unix/ffi/os_str.rs:57:5
   |
57 |     fn as_bytes(&self) -> &[u8];
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: trait `OsStrExt` which provides `from_bytes` is implemented but not in scope; perhaps you want to import it
   |
10 +     use std::os::wasi::ffi::OsStrExt;
   |

Some errors have detailed explanations: E0425, E0433, E0599.
For more information about an error, try `rustc --explain E0425`.
error: could not compile `gix-config-value` (lib) due to 3 previous errors
```
So I added a cfg directive `all(target_family = "wasm", not(target_os = "emscripten”))`, because currently libc does not provide `getpwnam` for wasm32-wasi.

Now that gix-value-config can be compiled to wasm32-wasi, some crates that depend on gix-value-config can also be compiled to wasm32-wasi.
