### PR TITLE
Add missing semicolons

### DIFF
--- a/examples/log.rs
+++ b/examples/log.rs
@@ -158,7 +158,7 @@ fn run(args: Args) -> anyhow::Result<()> {
     if args.reverse {
         let mut results: Vec<_> = log_iter.collect();
         results.reverse();
-        log_iter = Box::new(results.into_iter())
+        log_iter = Box::new(results.into_iter());
     }
 
     let mut log_iter = log_iter

--- a/gitoxide-core/src/corpus/engine.rs
+++ b/gitoxide-core/src/corpus/engine.rs
@@ -100,7 +100,7 @@ impl Engine {
                     }
                     repo_progress.info(format!("with {} tasks", tasks.len()));
                     for (_, task) in tasks {
-                        repo_progress.info(format!("task '{}' ({})", task.description, task.short_name))
+                        repo_progress.info(format!("task '{}' ({})", task.description, task.short_name));
                     }
                     break 'tasks_loop;
                 }

--- a/gitoxide-core/src/corpus/run.rs
+++ b/gitoxide-core/src/corpus/run.rs
@@ -19,7 +19,7 @@ impl Task {
     ) {
         let start = std::time::Instant::now();
         if let Err(err) = self.execute.execute(repo, progress, threads, should_interrupt) {
-            run.error = Some(format!("{err:#?}"))
+            run.error = Some(format!("{err:#?}"));
         }
         run.duration = start.elapsed();
     }

--- a/gitoxide-core/src/hours/core.rs
+++ b/gitoxide-core/src/hours/core.rs
@@ -33,9 +33,9 @@ pub fn estimate_hours(
         for next in commits {
             let change_in_minutes = (next.time.seconds.saturating_sub(cur.time.seconds)) as f32 / MINUTES_PER_HOUR;
             if change_in_minutes < MAX_COMMIT_DIFFERENCE_IN_MINUTES {
-                hours += change_in_minutes / MINUTES_PER_HOUR
+                hours += change_in_minutes / MINUTES_PER_HOUR;
             } else {
-                hours += FIRST_COMMIT_ADDITION_IN_MINUTES / MINUTES_PER_HOUR
+                hours += FIRST_COMMIT_ADDITION_IN_MINUTES / MINUTES_PER_HOUR;
             }
             cur = next;
         }

--- a/gitoxide-core/src/hours/mod.rs
+++ b/gitoxide-core/src/hours/mod.rs
@@ -170,7 +170,7 @@ where
                                     .send(std::mem::replace(&mut chunk, Vec::with_capacity(CHUNK_SIZE)))
                                     .ok();
                             } else {
-                                chunk.push((commit_idx, first_parent, commit))
+                                chunk.push((commit_idx, first_parent, commit));
                             }
                         }
                         commit_idx += 1;

--- a/gitoxide-core/src/index/information.rs
+++ b/gitoxide-core/src/index/information.rs
@@ -103,10 +103,10 @@ mod serde_only {
                         names.push("fs-monitor (FSMN)");
                     };
                     if f.had_offset_table() {
-                        names.push("offset-table (IEOT)")
+                        names.push("offset-table (IEOT)");
                     }
                     if f.had_end_of_index_marker() {
-                        names.push("end-of-index (EOIE)")
+                        names.push("end-of-index (EOIE)");
                     }
                     Extensions { names, tree }
                 },

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -259,7 +259,7 @@ where
         pack::data::output::bytes::FromEntriesIter::new(
             in_order_entries.by_ref().inspect(|e| {
                 if let Ok(entries) = e {
-                    entries_progress.inc_by(entries.len())
+                    entries_progress.inc_by(entries.len());
                 }
             }),
             &mut pack_file,

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -105,7 +105,7 @@ impl<W> protocol::fetch::DelegateBlocking for CloneDelegate<W> {
             }
         } else {
             for r in &self.wanted_refs {
-                arguments.want_ref(r.as_ref())
+                arguments.want_ref(r.as_ref());
             }
         }
         Ok(Action::Cancel)
@@ -408,7 +408,7 @@ fn receive_pack_blocking<W: io::Write>(
         OutputFormat::Human => drop(print(&mut ctx.out, outcome, refs)),
         #[cfg(feature = "serde")]
         OutputFormat::Json => {
-            serde_json::to_writer_pretty(&mut ctx.out, &JsonOutcome::from_outcome_and_refs(outcome, refs))?
+            serde_json::to_writer_pretty(&mut ctx.out, &JsonOutcome::from_outcome_and_refs(outcome, refs))?;
         }
     };
     Ok(())

--- a/gitoxide-core/src/query/engine/update.rs
+++ b/gitoxide-core/src/query/engine/update.rs
@@ -315,7 +315,7 @@ pub fn update(
                                         out_chunk.push(CommitDiffStats {
                                             id: commit,
                                             changes: Vec::new(),
-                                        })
+                                        });
                                     }
                                 }
                                 if tx_stats.send(Ok((chunk_id, out_chunk))).is_err() {
@@ -500,7 +500,7 @@ fn remove_lines(out: &mut Vec<FileChange>, path: &BStr, lines_counter: &AtomicUs
             mode: FileMode::Removed,
             source_relpath: None,
             lines: Some(lines),
-        })
+        });
     }
 }
 

--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -215,7 +215,7 @@ pub(crate) mod function {
                                     actual: matches.iter().map(|m| m.assignment.to_owned()).collect(),
                                     expected,
                                 },
-                            ))
+                            ));
                         }
                     }
                 }
@@ -228,7 +228,7 @@ pub(crate) mod function {
                                 actual: match_.map(Into::into),
                                 expected: location,
                             },
-                        ))
+                        ));
                     }
                 }
             }

--- a/gitoxide-core/src/repository/index/entries.rs
+++ b/gitoxide-core/src/repository/index/entries.rs
@@ -227,7 +227,7 @@ pub(crate) mod function {
                                 to_human_simple(out, &index, entry, attrs, prefix)
                             } else {
                                 to_human(out, &index, entry, attrs, prefix)
-                            }?
+                            }?;
                         }
                         #[cfg(feature = "serde")]
                         OutputFormat::Json => to_json(out, &index, entry, attrs, entries.peek().is_none(), prefix)?,

--- a/gitoxide-core/src/repository/index/mod.rs
+++ b/gitoxide-core/src/repository/index/mod.rs
@@ -61,7 +61,7 @@ pub fn from_list(
             gix::index::entry::Flags::empty(),
             gix::index::entry::Mode::FILE,
             gix::path::to_unix_separators_on_windows(path).as_ref(),
-        )
+        );
     }
     index.sort_entries();
 

--- a/gitoxide-core/src/repository/odb.rs
+++ b/gitoxide-core/src/repository/odb.rs
@@ -128,7 +128,7 @@ pub fn statistics(
             match item {
                 find::Header::Loose { size, kind } => {
                     self.loose_objects += 1;
-                    self.count(kind, size)
+                    self.count(kind, size);
                 }
                 find::Header::Packed(packed) => {
                     self.packed_objects += 1;

--- a/gitoxide-core/src/repository/revision/explain.rs
+++ b/gitoxide-core/src/repository/revision/explain.rs
@@ -218,7 +218,7 @@ impl<'a> delegate::Kind for Explain<'a> {
 impl<'a> Delegate for Explain<'a> {
     fn done(&mut self) {
         if !self.has_implicit_anchor && self.ref_name.is_none() && self.oid_prefix.is_none() {
-            self.err = Some("Incomplete specification lacks its anchor, like a reference or object name".into())
+            self.err = Some("Incomplete specification lacks its anchor, like a reference or object name".into());
         }
     }
 }

--- a/gitoxide-core/src/repository/tree.rs
+++ b/gitoxide-core/src/repository/tree.rs
@@ -80,7 +80,7 @@ mod entries {
         }
 
         fn pop_path_component(&mut self) {
-            self.pop_element()
+            self.pop_element();
         }
 
         fn visit_tree(&mut self, _entry: &EntryRef<'_>) -> Action {

--- a/gix-attributes/src/search/attributes.rs
+++ b/gix-attributes/src/search/attributes.rs
@@ -63,7 +63,7 @@ impl Search {
             let last = self.patterns.last_mut().expect("just added");
             if !allow_macros {
                 last.patterns
-                    .retain(|p| !matches!(p.value, Value::MacroAssignments { .. }))
+                    .retain(|p| !matches!(p.value, Value::MacroAssignments { .. }));
             }
             collection.update_from_list(last);
         }
@@ -84,7 +84,7 @@ impl Search {
         let last = self.patterns.last_mut().expect("just added");
         if !allow_macros {
             last.patterns
-                .retain(|p| !matches!(p.value, Value::MacroAssignments { .. }))
+                .retain(|p| !matches!(p.value, Value::MacroAssignments { .. }));
         }
         collection.update_from_list(last);
     }

--- a/gix-attributes/src/search/outcome.rs
+++ b/gix-attributes/src/search/outcome.rs
@@ -26,11 +26,11 @@ impl Outcome {
             for (order, macro_attributes) in collection.iter().filter_map(|(_, meta)| {
                 (!meta.macro_attributes.is_empty()).then_some((meta.id.0, &meta.macro_attributes))
             }) {
-                self.matches_by_id[order].macro_attributes.clone_from(macro_attributes)
+                self.matches_by_id[order].macro_attributes.clone_from(macro_attributes);
             }
 
             for (name, id) in self.selected.iter_mut().filter(|(_, id)| id.is_none()) {
-                *id = collection.name_to_meta.get(name.as_str()).map(|meta| meta.id)
+                *id = collection.name_to_meta.get(name.as_str()).map(|meta| meta.id);
             }
         }
         self.reset();
@@ -46,7 +46,7 @@ impl Outcome {
         collection: &MetadataCollection,
         attribute_names: impl IntoIterator<Item = impl Into<KStringRef<'a>>>,
     ) {
-        self.initialize_with_selection_inner(collection, &mut attribute_names.into_iter().map(Into::into))
+        self.initialize_with_selection_inner(collection, &mut attribute_names.into_iter().map(Into::into));
     }
 
     fn initialize_with_selection_inner(

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -272,7 +272,7 @@ fn size_of_outcome() {
         std::mem::size_of::<Outcome>(),
         840,
         "it's quite big, shouldn't change without us noticing"
-    )
+    );
 }
 
 fn by_name(assignments: Vec<AssignmentRef>) -> BTreeMap<NameRef, StateRef> {

--- a/gix-bitmap/src/ewah.rs
+++ b/gix-bitmap/src/ewah.rs
@@ -33,7 +33,7 @@ pub fn decode(data: &[u8]) -> Result<(Vec, &[u8]), decode::Error> {
     for _ in 0..len {
         let (bit_num, rest) = bits.split_at(std::mem::size_of::<u64>());
         bits = rest;
-        buf.push(u64::from_be_bytes(bit_num.try_into().unwrap()))
+        buf.push(u64::from_be_bytes(bit_num.try_into().unwrap()));
     }
 
     let (rlw, data) = decode::u32(data).ok_or(Error::Corrupt {

--- a/gix-chunk/src/file/decode.rs
+++ b/gix-chunk/src/file/decode.rs
@@ -81,7 +81,7 @@ impl file::Index {
                     start: offset,
                     end: next_offset,
                 },
-            })
+            });
         }
 
         let sentinel = to_kind(&toc_entry[..4]);

--- a/gix-chunk/src/file/write.rs
+++ b/gix-chunk/src/file/write.rs
@@ -61,7 +61,7 @@ mod write_chunk {
                     entry.offset.end,
                     self.written_bytes,
                     std::str::from_utf8(&entry.kind)
-                )
+                );
             }
             self.written_bytes = 0;
             self.next_chunk = self.chunks_to_write.pop_front();
@@ -92,7 +92,7 @@ impl Index {
         self.chunks.push(Entry {
             kind: chunk,
             offset: 0..exact_size_on_disk,
-        })
+        });
     }
 
     /// Return the total size of all planned chunks thus far.

--- a/gix-config-value/src/color.rs
+++ b/gix-config-value/src/color.rs
@@ -18,7 +18,7 @@ impl Display for Color {
                 write!(f, " ")?;
             }
             bg.fmt(f)?;
-            write_space = Some(())
+            write_space = Some(());
         }
 
         if !self.attributes.is_empty() {
@@ -267,7 +267,7 @@ impl Display for Attribute {
             };
             if self.contains(attr) {
                 if write_space.take().is_some() {
-                    write!(f, " ")?
+                    write!(f, " ")?;
                 }
                 match attr {
                     Attribute::RESET => write!(f, "reset"),

--- a/gix-config/benches/large_config_file.rs
+++ b/gix-config/benches/large_config_file.rs
@@ -3,13 +3,13 @@ use gix_config::{parse::Events, File};
 
 fn gix_config(c: &mut Criterion) {
     c.bench_function("GitConfig large config file", |b| {
-        b.iter(|| File::try_from(black_box(CONFIG_FILE)).unwrap())
+        b.iter(|| File::try_from(black_box(CONFIG_FILE)).unwrap());
     });
 }
 
 fn parser(c: &mut Criterion) {
     c.bench_function("Parser large config file", |b| {
-        b.iter(|| Events::try_from(black_box(CONFIG_FILE)).unwrap())
+        b.iter(|| Events::try_from(black_box(CONFIG_FILE)).unwrap());
     });
 }
 

--- a/gix-config/src/file/access/mutate.rs
+++ b/gix-config/src/file/access/mutate.rs
@@ -380,7 +380,7 @@ impl<'event> File<'event> {
             if !ends_with_newline(lhs.as_ref(), nl, true)
                 && !rhs.first().map_or(true, |e| e.to_bstr_lossy().starts_with(nl.as_ref()))
             {
-                lhs.push(Event::Newline(Cow::Owned(nl.as_ref().into())))
+                lhs.push(Event::Newline(Cow::Owned(nl.as_ref().into())));
             }
             lhs.extend(rhs);
         }

--- a/gix-config/src/file/includes/mod.rs
+++ b/gix-config/src/file/includes/mod.rs
@@ -66,12 +66,12 @@ fn resolve_includes_recursive(
         let header = &section.header;
         let header_name = header.name.as_ref();
         if header_name == "include" && header.subsection_name.is_none() {
-            detach_include_paths(&mut section_ids_and_include_paths, section, id)
+            detach_include_paths(&mut section_ids_and_include_paths, section, id);
         } else if header_name == "includeIf" {
             if let Some(condition) = &header.subsection_name {
                 let target_config_path = section.meta.path.as_deref();
                 if include_condition_match(condition.as_ref(), target_config_path, options.includes)? {
-                    detach_include_paths(&mut section_ids_and_include_paths, section, id)
+                    detach_include_paths(&mut section_ids_and_include_paths, section, id);
                 }
             }
         }
@@ -142,7 +142,7 @@ fn detach_include_paths(
             .values("path")
             .into_iter()
             .map(|path| (id, crate::Path::from(Cow::Owned(path.into_owned())))),
-    )
+    );
 }
 
 fn include_condition_match(
@@ -251,7 +251,7 @@ fn gitdir_matches(
     {
         let mut prefixed = pattern_path.into_owned();
         prefixed.insert_str(0, "**/");
-        pattern_path = prefixed.into()
+        pattern_path = prefixed.into();
     }
     if pattern_path.ends_with(b"/") {
         let mut suffixed = pattern_path.into_owned();

--- a/gix-config/src/file/section/body.rs
+++ b/gix-config/src/file/section/body.rs
@@ -148,9 +148,9 @@ impl<'event> Body<'event> {
                 }
                 Event::ValueNotDone(_) | Event::ValueDone(_) => {
                     if value_range.end == 0 {
-                        value_range.end = i
+                        value_range.end = i;
                     } else {
-                        value_range.start = i
+                        value_range.start = i;
                     };
                 }
                 _ => (),

--- a/gix-config/src/parse/events.rs
+++ b/gix-config/src/parse/events.rs
@@ -314,7 +314,7 @@ fn from_bytes<'a, 'b>(
         }
         event => {
             if filter.map_or(true, |f| f(&event)) {
-                events.push(convert(event))
+                events.push(convert(event));
             }
         }
     })?;

--- a/gix-config/tests/key/mod.rs
+++ b/gix-config/tests/key/mod.rs
@@ -21,7 +21,7 @@ fn valid_and_invalid() {
     assert_eq!(key.value_name, "baz");
 
     let key = "includeIf.gitdir/i:C:\\bare.git.path".as_key();
-    assert_eq!(key.subsection_name, Some("gitdir/i:C:\\bare.git".into()),)
+    assert_eq!(key.subsection_name, Some("gitdir/i:C:\\bare.git".into()),);
 }
 
 mod _ref {

--- a/gix-config/tests/parse/mod.rs
+++ b/gix-config/tests/parse/mod.rs
@@ -35,7 +35,7 @@ fn newlines_with_spaces() {
     assert_eq!(
         Events::from_str("\n   \n \n").unwrap().into_vec(),
         vec![newline(), whitespace("   "), newline(), whitespace(" "), newline()]
-    )
+    );
 }
 
 #[test]

--- a/gix-credentials/src/protocol/mod.rs
+++ b/gix-credentials/src/protocol/mod.rs
@@ -61,7 +61,7 @@ pub struct Context {
 pub fn helper_outcome_to_result(outcome: Option<helper::Outcome>, action: helper::Action) -> Result {
     fn redact(mut ctx: Context) -> Context {
         if let Some(pw) = ctx.password.as_mut() {
-            *pw = "<redacted>".into()
+            *pw = "<redacted>".into();
         }
         ctx
     }

--- a/gix-credentials/tests/helper/context.rs
+++ b/gix-credentials/tests/helper/context.rs
@@ -74,7 +74,7 @@ username=bob";
                 host: Some("example.com".into()),
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -89,7 +89,7 @@ username=bob";
                 username: Some("bob".into()),
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -100,7 +100,7 @@ username=bob";
                 Context::from_bytes(input.as_bytes()).unwrap().quit,
                 Some(true),
                 "{input}"
-            )
+            );
         }
         for false_value in ["0", "false", "off", "no"] {
             let input = format!("quit={false_value}");
@@ -108,7 +108,7 @@ username=bob";
                 Context::from_bytes(input.as_bytes()).unwrap().quit,
                 Some(false),
                 "{input}"
-            )
+            );
         }
     }
 

--- a/gix-date/tests/time/format.rs
+++ b/gix-date/tests/time/format.rs
@@ -67,7 +67,7 @@ fn default() {
     assert_eq!(
         time_dec1().format(gix_date::time::format::GITOXIDE),
         "Sat Dec 01 1973 00:03:09 +0230"
-    )
+    );
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn git_default() {
     assert_eq!(
         time_dec1().format(gix_date::time::format::DEFAULT),
         "Sat Dec 1 00:03:09 1973 +0230"
-    )
+    );
 }
 
 fn time() -> Time {

--- a/gix-diff/src/blob/platform.rs
+++ b/gix-diff/src/blob/platform.rs
@@ -32,9 +32,9 @@ impl std::hash::Hash for CacheKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         if self.use_id {
             self.id.hash(state);
-            self.is_link.hash(state)
+            self.is_link.hash(state);
         } else {
-            self.location.hash(state)
+            self.location.hash(state);
         }
     }
 }

--- a/gix-diff/src/rewrites/tracker.rs
+++ b/gix-diff/src/rewrites/tracker.rs
@@ -411,12 +411,12 @@ fn estimate_involved_items(
                 }
                 ChangeKind::Deletion => {
                     if kind == visit::SourceKind::Rename {
-                        src += 1
+                        src += 1;
                     }
                 }
                 ChangeKind::Modification => {
                     if kind == visit::SourceKind::Copy {
-                        src += 1
+                        src += 1;
                     }
                 }
             }

--- a/gix-diff/src/tree/changes.rs
+++ b/gix-diff/src/tree/changes.rs
@@ -159,7 +159,7 @@ fn add_entry_schedule_recursion<R: tree::Visit>(
     if entry.mode.is_tree() {
         delegate.pop_path_component();
         delegate.push_back_tracked_path_component(entry.filename);
-        queue.push_back((None, Some(entry.oid.to_owned())))
+        queue.push_back((None, Some(entry.oid.to_owned())));
     }
     Ok(())
 }

--- a/gix-diff/src/tree/visit.rs
+++ b/gix-diff/src/tree/visit.rs
@@ -142,6 +142,6 @@ mod tests {
         assert!(
             actual <= 46,
             "{actual} <= 46: this type shouldn't grow without us knowing"
-        )
+        );
     }
 }

--- a/gix-dir/tests/walk_utils/mod.rs
+++ b/gix-dir/tests/walk_utils/mod.rs
@@ -338,7 +338,7 @@ pub fn try_collect_filtered_opts(
             worktree_root.is_absolute(),
             "BUG: need absolute worktree root for CWD checks to work"
         );
-        cwd.push(suffix)
+        cwd.push(suffix);
     }
     let git_dir_realpath = gix_path::realpath_opts(&git_dir, &cwd, gix_path::realpath::MAX_SYMLINKS).unwrap();
     let lookup = index.prepare_icase_backing();

--- a/gix-features/src/decode.rs
+++ b/gix-features/src/decode.rs
@@ -15,7 +15,7 @@ pub fn leb64_from_read(mut r: impl Read) -> Result<(u64, usize), std::io::Error>
         i += 1;
         debug_assert!(i <= 10, "Would overflow value at 11th iteration");
         value += 1;
-        value = (value << 7) + (b[0] as u64 & 0x7f)
+        value = (value << 7) + (b[0] as u64 & 0x7f);
     }
     Ok((value, i))
 }
@@ -32,7 +32,7 @@ pub fn leb64(d: &[u8]) -> (u64, usize) {
         i += 1;
         debug_assert!(i <= 10, "Would overflow value at 11th iteration");
         value += 1;
-        value = (value << 7) + (c as u64 & 0x7f)
+        value = (value << 7) + (c as u64 & 0x7f);
     }
     (value, i)
 }

--- a/gix-features/src/hash.rs
+++ b/gix-features/src/hash.rs
@@ -40,7 +40,7 @@ mod _impl {
     impl Sha1 {
         /// Digest the given `bytes`.
         pub fn update(&mut self, bytes: &[u8]) {
-            self.0.update(bytes)
+            self.0.update(bytes);
         }
         /// Finalize the hash and produce a digest.
         pub fn digest(self) -> Sha1Digest {

--- a/gix-features/src/interrupt.rs
+++ b/gix-features/src/interrupt.rs
@@ -120,7 +120,7 @@ where
     }
 
     fn consume(&mut self, amt: usize) {
-        self.inner.consume(amt)
+        self.inner.consume(amt);
     }
 }
 

--- a/gix-features/src/progress.rs
+++ b/gix-features/src/progress.rs
@@ -110,7 +110,7 @@ where
     }
 
     fn consume(&mut self, amt: usize) {
-        self.inner.consume(amt)
+        self.inner.consume(amt);
     }
 }
 

--- a/gix-features/tests/hash.rs
+++ b/gix-features/tests/hash.rs
@@ -12,5 +12,5 @@ fn size_of_sha1() {
     assert_eq!(
         std::mem::size_of::<Sha1>(),
         if cfg!(target_arch = "x86") { 96 } else { 104 }
-    )
+    );
 }

--- a/gix-features/tests/parallel/in_order_iter.rs
+++ b/gix-features/tests/parallel/in_order_iter.rs
@@ -9,7 +9,7 @@ fn in_order_stays_in_order() {
             .collect::<Result<Vec<_>, _>>()
             .expect("infallible"),
         vec!['a', 'b', 'c']
-    )
+    );
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn out_of_order_items_are_held_until_the_sequence_is_complete() {
         .collect::<Result<Vec<_>, _>>()
         .expect("infallible"),
         vec!['a', 'b', 'c', 'd']
-    )
+    );
 }
 
 #[test]

--- a/gix-features/tests/pipe.rs
+++ b/gix-features/tests/pipe.rs
@@ -11,7 +11,7 @@ mod io {
         std::thread::spawn(move || {
             writer
                 .write_all(message.as_bytes())
-                .expect("writes to work if reader is present")
+                .expect("writes to work if reader is present");
         });
 
         let mut received = String::new();
@@ -51,7 +51,7 @@ mod io {
         assert_eq!(
             reader.lines().map_while(Result::ok).collect::<Vec<_>>(),
             vec!["a", "b", "c"]
-        )
+        );
     }
 
     #[test]

--- a/gix-filter/examples/arrow.rs
+++ b/gix-filter/examples/arrow.rs
@@ -150,7 +150,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 buf.clear();
                                 buf.push_str("pathname=");
                                 buf.extend_from_slice(path);
-                                out.write_all(&buf)?
+                                out.write_all(&buf)?;
                             }
                         }
                         request.write_status(process::Status::success())?;

--- a/gix-filter/src/driver/delayed.rs
+++ b/gix-filter/src/driver/delayed.rs
@@ -70,7 +70,7 @@ impl State {
         let mut out = Vec::new();
         let result = client.invoke_without_content("list_available_blobs", &mut None.into_iter(), &mut |line| {
             if let Some(path) = line.strip_prefix(b"pathname=") {
-                out.push(path.into())
+                out.push(path.into());
             }
         });
         let status = match result {

--- a/gix-filter/src/driver/process/server.rs
+++ b/gix-filter/src/driver/process/server.rs
@@ -194,7 +194,7 @@ impl Server {
                     actual: line.into(),
                 })?;
             assert!(tokens.next().is_none(), "configured to yield at most two tokens");
-            meta.push((key.as_bstr().to_string(), value.into()))
+            meta.push((key.as_bstr().to_string(), value.into()));
         }
 
         drop(read);

--- a/gix-filter/src/eol/convert_to_git.rs
+++ b/gix-filter/src/eol/convert_to_git.rs
@@ -120,7 +120,7 @@ pub(crate) mod function {
                         gix_trace::warn!(
                             "in the working copy of '{}', CRLF will be replaced by LF next time git touches it",
                             rela_path.display()
-                        )
+                        );
                     }
                 }
             } else if stats.lone_lf > 0 && new_stats.lone_lf == 0 {
@@ -137,7 +137,7 @@ pub(crate) mod function {
                         gix_trace::warn!(
                             "in the working copy of '{}', LF will be replaced by CRLF next time git touches it",
                             rela_path.display()
-                        )
+                        );
                     }
                 }
             }

--- a/gix-filter/src/eol/utils.rs
+++ b/gix-filter/src/eol/utils.rs
@@ -58,7 +58,7 @@ impl Stats {
                 match bytes.peek() {
                     Some(n) if **n == b'\n' => {
                         bytes.next();
-                        crlf += 1
+                        crlf += 1;
                     }
                     _ => lone_cr += 1,
                 }

--- a/gix-filter/tests/eol/convert_to_git.rs
+++ b/gix-filter/tests/eol/convert_to_git.rs
@@ -159,7 +159,7 @@ fn round_trip_check() -> crate::Result {
         assert!(
             changed,
             "in warn mode, we will get a result even though it won't round-trip"
-        )
+        );
     }
     Ok(())
 }

--- a/gix-filter/tests/worktree/mod.rs
+++ b/gix-filter/tests/worktree/mod.rs
@@ -74,7 +74,7 @@ mod encode_to_git {
         for round_trip in [RoundTripCheck::Skip, RoundTripCheck::Fail] {
             let mut buf = Vec::new();
             worktree::encode_to_git(input, encoding_rs::UTF_8, &mut buf, round_trip)?;
-            assert_eq!(buf.as_bstr(), input)
+            assert_eq!(buf.as_bstr(), input);
         }
         Ok(())
     }

--- a/gix-fsck/tests/connectivity/mod.rs
+++ b/gix-fsck/tests/connectivity/mod.rs
@@ -25,7 +25,7 @@ fn check_missing<'a>(repo_name: &str, commits: impl IntoIterator<Item = &'a Obje
 
     let mut check = Connectivity::new(db, record_missing_and_assert_no_duplicate);
     for commit in commits.into_iter() {
-        check.check_commit(commit).expect("commit is present")
+        check.check_commit(commit).expect("commit is present");
     }
     missing
 }

--- a/gix-glob/src/wildmatch.rs
+++ b/gix-glob/src/wildmatch.rs
@@ -206,7 +206,7 @@ pub(crate) mod function {
                             BACKSLASH => match p.next() {
                                 Some((_, p_ch)) => {
                                     if p_ch == t_ch {
-                                        matched = true
+                                        matched = true;
                                     } else {
                                         prev_p_ch = p_ch;
                                     }
@@ -252,7 +252,7 @@ pub(crate) mod function {
                                     || pattern[closing_bracket_idx - 1] != COLON
                                 {
                                     if t_ch == BRACKET_OPEN {
-                                        matched = true
+                                        matched = true;
                                     }
                                     if p_idx > pattern.len() {
                                         return AbortAll;

--- a/gix-hash/src/object_id.rs
+++ b/gix-hash/src/object_id.rs
@@ -23,7 +23,7 @@ pub enum ObjectId {
 #[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for ObjectId {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(self.as_slice())
+        state.write(self.as_slice());
     }
 }
 

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -30,7 +30,7 @@ pub struct oid {
 #[allow(clippy::derived_hash_with_manual_eq)]
 impl hash::Hash for oid {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(self.as_bytes())
+        state.write(self.as_bytes());
     }
 }
 

--- a/gix-index/src/access/mod.rs
+++ b/gix-index/src/access/mod.rs
@@ -28,7 +28,7 @@ impl State {
     /// **will cause (file system) race conditions** see racy-git.txt in the git documentation
     /// for more details.
     pub fn set_timestamp(&mut self, timestamp: FileTime) {
-        self.timestamp = timestamp
+        self.timestamp = timestamp;
     }
 
     /// Return the kind of hashes used in this instance.

--- a/gix-index/src/extension/decode.rs
+++ b/gix-index/src/extension/decode.rs
@@ -61,7 +61,7 @@ pub(crate) fn all(
                         // only used as a marker, if this changes we need this implementation.
                         return Err(Error::MandatoryUnimplemented { signature: mandatory });
                     }
-                    ext.is_sparse = true
+                    ext.is_sparse = true;
                 }
                 unknown => return Err(Error::MandatoryUnimplemented { signature: unknown }),
             },

--- a/gix-index/src/init.rs
+++ b/gix-index/src/init.rs
@@ -133,7 +133,7 @@ pub mod from_tree {
             self.path.push_str(name);
             if self.invalid_path.is_none() {
                 if let Err(err) = gix_validate::path::component(name, None, self.validate) {
-                    self.invalid_path = Some((self.path.clone(), err))
+                    self.invalid_path = Some((self.path.clone(), err));
                 }
             }
         }

--- a/gix-index/src/write.rs
+++ b/gix-index/src/write.rs
@@ -95,7 +95,7 @@ impl State {
                 .is_some()
             && !extension_toc.is_empty()
         {
-            extension::end_of_index_entry::write_to(out, self.object_hash, offset_to_extensions, extension_toc)?
+            extension::end_of_index_entry::write_to(out, self.object_hash, offset_to_extensions, extension_toc)?;
         }
 
         Ok(version)

--- a/gix-index/tests/index/access.rs
+++ b/gix-index/tests/index/access.rs
@@ -58,7 +58,7 @@ fn dirwalk_api_and_icase_support() {
             let other_entry = file
                 .entry_closest_to_directory_icase(dir_upper.as_bstr(), true, &icase)
                 .unwrap_or_else(|| panic!("didn't find upper-cased {dir_upper}"));
-            assert_eq!(other_entry, entry, "the first entry is always the same, no matter what kind of search is conducted (as there are no clashes/ambiguities here)")
+            assert_eq!(other_entry, entry, "the first entry is always the same, no matter what kind of search is conducted (as there are no clashes/ambiguities here)");
         }
     }
 }

--- a/gix-index/tests/index/file/read.rs
+++ b/gix-index/tests/index/file/read.rs
@@ -109,7 +109,7 @@ fn v2_with_multiple_entries_without_eoie_ext() {
         assert_eq!(e.path(&file), path);
         assert!(e.flags.is_empty());
         assert_eq!(e.mode, entry::Mode::FILE);
-        assert_eq!(e.id, hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"))
+        assert_eq!(e.id, hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"));
     }
 
     let tree = file.tree().unwrap();
@@ -173,7 +173,7 @@ fn v2_very_long_path() {
     assert_eq!(tree.num_entries, None, "root tree has invalid entries actually");
     assert_eq!(tree.name.as_bstr(), "");
     assert_eq!(tree.num_entries, None, "it's marked invalid actually");
-    assert!(tree.id.is_null(), "there is no id for the root")
+    assert!(tree.id.is_null(), "there is no id for the root");
 }
 
 #[test]
@@ -250,7 +250,7 @@ fn v4_with_delta_paths_and_ieot_ext() {
         assert_eq!(e.path(&file), path);
         assert!(e.flags.is_empty());
         assert_eq!(e.mode, entry::Mode::FILE);
-        assert_eq!(e.id, hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"))
+        assert_eq!(e.id, hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"));
     }
 }
 
@@ -373,5 +373,5 @@ fn split_index_and_regular_index_of_same_content_are_indeed_the_same() {
         assert_eq!(s.id, r.id);
         assert_eq!(s.flags, r.flags);
         assert_eq!(s.path_in(split.path_backing()), r.path_in(regular.path_backing()));
-    })
+    });
 }

--- a/gix-index/tests/index/init.rs
+++ b/gix-index/tests/index/init.rs
@@ -23,7 +23,7 @@ fn from_tree() -> crate::Result {
         let odb = gix_odb::at(git_dir.join("objects"))?;
         let actual_state = State::from_tree(&tree_id, &odb, Default::default())?;
 
-        compare_states(&actual_state, &expected_state, fixture)
+        compare_states(&actual_state, &expected_state, fixture);
     }
     Ok(())
 }

--- a/gix-negotiate/src/consecutive.rs
+++ b/gix-negotiate/src/consecutive.rs
@@ -77,7 +77,7 @@ impl Algorithm {
                                 if prev_flags.contains(Flags::SEEN) && !prev_flags.contains(Flags::POPPED) {
                                     self.non_common_revs -= 1;
                                 }
-                                queue.insert(parent.commit_time, (parent_id, generation + 1))
+                                queue.insert(parent.commit_time, (parent_id, generation + 1));
                             }
                         }
                     }

--- a/gix-negotiate/src/skipping.rs
+++ b/gix-negotiate/src/skipping.rs
@@ -59,7 +59,7 @@ impl Algorithm {
                             .try_lookup_or_insert_commit(parent_id, |entry| {
                                 was_unseen_or_common =
                                     !entry.flags.contains(Flags::SEEN) || entry.flags.contains(Flags::COMMON);
-                                entry.flags |= Flags::COMMON
+                                entry.flags |= Flags::COMMON;
                             })?
                             .filter(|_| !was_unseen_or_common)
                         {

--- a/gix-object/benches/decode_objects.rs
+++ b/gix-object/benches/decode_objects.rs
@@ -2,28 +2,28 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn parse_commit(c: &mut Criterion) {
     c.bench_function("CommitRef(sig)", |b| {
-        b.iter(|| black_box(gix_object::CommitRef::from_bytes(COMMIT_WITH_MULTI_LINE_HEADERS)).unwrap())
+        b.iter(|| black_box(gix_object::CommitRef::from_bytes(COMMIT_WITH_MULTI_LINE_HEADERS)).unwrap());
     });
     c.bench_function("CommitRefIter(sig)", |b| {
-        b.iter(|| black_box(gix_object::CommitRefIter::from_bytes(COMMIT_WITH_MULTI_LINE_HEADERS).count()))
+        b.iter(|| black_box(gix_object::CommitRefIter::from_bytes(COMMIT_WITH_MULTI_LINE_HEADERS).count()));
     });
 }
 
 fn parse_tag(c: &mut Criterion) {
     c.bench_function("TagRef(sig)", |b| {
-        b.iter(|| black_box(gix_object::TagRef::from_bytes(TAG_WITH_SIGNATURE)).unwrap())
+        b.iter(|| black_box(gix_object::TagRef::from_bytes(TAG_WITH_SIGNATURE)).unwrap());
     });
     c.bench_function("TagRefIter(sig)", |b| {
-        b.iter(|| black_box(gix_object::TagRefIter::from_bytes(TAG_WITH_SIGNATURE).count()))
+        b.iter(|| black_box(gix_object::TagRefIter::from_bytes(TAG_WITH_SIGNATURE).count()));
     });
 }
 
 fn parse_tree(c: &mut Criterion) {
     c.bench_function("TreeRef()", |b| {
-        b.iter(|| black_box(gix_object::TreeRef::from_bytes(TREE)).unwrap())
+        b.iter(|| black_box(gix_object::TreeRef::from_bytes(TREE)).unwrap());
     });
     c.bench_function("TreeRefIter()", |b| {
-        b.iter(|| black_box(gix_object::TreeRefIter::from_bytes(TREE).count()))
+        b.iter(|| black_box(gix_object::TreeRefIter::from_bytes(TREE).count()));
     });
 }
 

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -143,7 +143,7 @@ mod test_parse_trailer {
     #[test]
     fn extra_whitespace_before_token_or_value_is_error() {
         assert!(parse_single_line_trailer::<()>.parse_peek(b"foo : bar").is_err());
-        assert!(parse_single_line_trailer::<()>.parse_peek(b"foo:  bar").is_err())
+        assert!(parse_single_line_trailer::<()>.parse_peek(b"foo:  bar").is_err());
     }
 
     #[test]

--- a/gix-object/src/tag/write/tests.rs
+++ b/gix-object/src/tag/write/tests.rs
@@ -6,11 +6,11 @@ mod validated_name {
 
         #[test]
         fn only_dash() {
-            assert!(validated_name(b"-".as_bstr()).is_err())
+            assert!(validated_name(b"-".as_bstr()).is_err());
         }
         #[test]
         fn leading_dash() {
-            assert!(validated_name(b"-hello".as_bstr()).is_err())
+            assert!(validated_name(b"-hello".as_bstr()).is_err());
         }
     }
 
@@ -22,7 +22,7 @@ mod validated_name {
         #[test]
         fn version() {
             for version in &["v1.0.0", "0.2.1", "0-alpha1"] {
-                assert!(validated_name(version.as_bytes().as_bstr()).is_ok())
+                assert!(validated_name(version.as_bytes().as_bstr()).is_ok());
             }
         }
     }

--- a/gix-object/tests/commit/message.rs
+++ b/gix-object/tests/commit/message.rs
@@ -151,7 +151,7 @@ mod body {
             .body()
             .expect("present"),
             BodyRef::from_bytes("hello".as_bytes())
-        )
+        );
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod body {
                 token: "token".into(),
                 value: "value".into()
             }]
-        )
+        );
     }
 
     #[test]
@@ -210,7 +210,7 @@ mod body {
                     value: "d".into()
                 }
             ]
-        )
+        );
     }
 
     #[test]

--- a/gix-object/tests/object.rs
+++ b/gix-object/tests/object.rs
@@ -83,7 +83,7 @@ fn size_in_memory() {
     assert!(
         actual <= 264,
         "{actual} <= 264: Prevent unexpected growth of what should be lightweight objects"
-    )
+    );
 }
 
 fn hex_to_id(hex: &str) -> ObjectId {

--- a/gix-object/tests/tree/mod.rs
+++ b/gix-object/tests/tree/mod.rs
@@ -184,7 +184,7 @@ mod entries {
                 tree.bisect_entry(entry.filename, entry.mode.is_tree())
                     .expect("entry is present"),
                 entry
-            )
+            );
         }
 
         assert_ne!(
@@ -270,7 +270,7 @@ mod entry_mode {
                 "100644".into(),
             ),
         ] {
-            assert_eq!(mode.as_bytes(&mut buf), expected)
+            assert_eq!(mode.as_bytes(&mut buf), expected);
         }
     }
 }

--- a/gix-odb/src/alternate/parse.rs
+++ b/gix-odb/src/alternate/parse.rs
@@ -27,7 +27,7 @@ pub(crate) fn content(input: &[u8]) -> Result<Vec<PathBuf>, Error> {
             })
             .map_err(|_| Error::PathConversion(line.to_vec()))?
             .into_owned(),
-        )
+        );
     }
     Ok(out)
 }

--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -335,7 +335,7 @@ where
 {
     fn drop(&mut self) {
         if let Some(token) = self.token.take() {
-            self.store.remove_handle(token)
+            self.store.remove_handle(token);
         }
     }
 }

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -64,7 +64,7 @@ impl super::Store {
     pub(crate) fn load_all_indices(&self) -> Result<Snapshot, Error> {
         let mut snapshot = self.collect_snapshot();
         while let Some(new_snapshot) = self.load_one_index(RefreshMode::Never, snapshot.marker)? {
-            snapshot = new_snapshot
+            snapshot = new_snapshot;
         }
         Ok(snapshot)
     }
@@ -157,7 +157,7 @@ impl super::Store {
                         // or its effects.
                         std::thread::yield_now();
                         while index.num_indices_currently_being_loaded.load(Ordering::SeqCst) != 0 {
-                            std::thread::yield_now()
+                            std::thread::yield_now();
                         }
                         break 'retry_with_next_slot_index;
                     }
@@ -497,7 +497,7 @@ impl super::Store {
                     indices
                         .into_iter()
                         .filter_map(|(p, a, b)| (!is_multipack_index(&p)).then_some((Either::IndexPath(p), a, b))),
-                )
+                );
             }
         }
         // Unlike libgit2, do not sort by modification date, but by size and put the biggest indices first. That way

--- a/gix-odb/src/store_impls/dynamic/types.rs
+++ b/gix-odb/src/store_impls/dynamic/types.rs
@@ -222,7 +222,7 @@ impl<T: Clone> OnDiskFile<T> {
         match std::mem::replace(&mut self.state, OnDiskFileState::Missing) {
             OnDiskFileState::Loaded(v) => self.state = OnDiskFileState::Garbage(v),
             other @ (OnDiskFileState::Garbage(_) | OnDiskFileState::Unloaded | OnDiskFileState::Missing) => {
-                self.state = other
+                self.state = other;
             }
         }
     }

--- a/gix-odb/src/store_impls/dynamic/verify.rs
+++ b/gix-odb/src/store_impls/dynamic/verify.rs
@@ -128,7 +128,7 @@ impl super::Store {
             assert!(
                 index.is_initialized(),
                 "BUG: after consolidating successfully, we have an initialized index"
-            )
+            );
         }
 
         progress.init(

--- a/gix-pack/src/bundle/write/types.rs
+++ b/gix-pack/src/bundle/write/types.rs
@@ -91,7 +91,7 @@ where
     }
 
     fn consume(&mut self, amt: usize) {
-        self.reader.consume(amt)
+        self.reader.consume(amt);
     }
 }
 

--- a/gix-pack/src/cache/lru.rs
+++ b/gix-pack/src/cache/lru.rs
@@ -71,9 +71,9 @@ mod memory {
                 Some((e.kind, e.compressed_size))
             });
             if res.is_some() {
-                self.debug.hit()
+                self.debug.hit();
             } else {
-                self.debug.miss()
+                self.debug.miss();
             }
             res
         }
@@ -176,9 +176,9 @@ mod _static {
                 }
             });
             if res.is_some() {
-                self.debug.hit()
+                self.debug.hit();
             } else {
-                self.debug.miss()
+                self.debug.miss();
             }
             res
         }

--- a/gix-pack/src/cache/mod.rs
+++ b/gix-pack/src/cache/mod.rs
@@ -28,7 +28,7 @@ impl DecodeEntry for Never {
 
 impl<T: DecodeEntry + ?Sized> DecodeEntry for Box<T> {
     fn put(&mut self, pack_id: u32, offset: u64, data: &[u8], kind: Kind, compressed_size: usize) {
-        self.deref_mut().put(pack_id, offset, data, kind, compressed_size)
+        self.deref_mut().put(pack_id, offset, data, kind, compressed_size);
     }
 
     fn get(&mut self, pack_id: u32, offset: u64, out: &mut Vec<u8>) -> Option<(Kind, usize)> {

--- a/gix-pack/src/cache/object.rs
+++ b/gix-pack/src/cache/object.rs
@@ -72,9 +72,9 @@ mod memory {
                 Some(e.kind)
             });
             if res.is_some() {
-                self.debug.hit()
+                self.debug.hit();
             } else {
-                self.debug.miss()
+                self.debug.miss();
             }
             res
         }
@@ -99,7 +99,7 @@ impl cache::Object for Never {
 impl<T: cache::Object + ?Sized> cache::Object for Box<T> {
     fn put(&mut self, id: gix_hash::ObjectId, kind: gix_object::Kind, data: &[u8]) {
         use std::ops::DerefMut;
-        self.deref_mut().put(id, kind, data)
+        self.deref_mut().put(id, kind, data);
     }
 
     fn get(&mut self, id: &gix_hash::ObjectId, out: &mut Vec<u8>) -> Option<gix_object::Kind> {

--- a/gix-pack/src/data/entry/decode.rs
+++ b/gix-pack/src/data/entry/decode.rs
@@ -111,7 +111,7 @@ fn streaming_parse_header_info(read: &mut dyn io::Read) -> Result<(u8, u64, usiz
         c = byte[0];
         i += 1;
         size += ((c & 0b0111_1111) as u64) << s;
-        s += 7
+        s += 7;
     }
     Ok((type_id, size, i))
 }
@@ -128,7 +128,7 @@ fn parse_header_info(data: &[u8]) -> (u8, u64, usize) {
         c = data[i];
         i += 1;
         size += ((c & 0b0111_1111) as u64) << s;
-        s += 7
+        s += 7;
     }
     (type_id, size, i)
 }

--- a/gix-pack/src/data/file/decode/header.rs
+++ b/gix-pack/src/data/file/decode/header.rs
@@ -66,7 +66,7 @@ impl File {
                     if first_delta_decompressed_size.is_none() {
                         first_delta_decompressed_size = Some(self.decode_delta_object_size(inflate, &entry)?);
                     }
-                    entry = self.entry(entry.base_pack_offset(base_distance))?
+                    entry = self.entry(entry.base_pack_offset(base_distance))?;
                 }
                 RefDelta { base_id } => {
                     num_deltas += 1;

--- a/gix-pack/src/data/input/bytes_to_entries.rs
+++ b/gix-pack/src/data/input/bytes_to_entries.rs
@@ -254,7 +254,7 @@ where
         self.write
             .write_all(&buf[..amt])
             .expect("a write to never fail - should be a memory buffer");
-        self.read.consume(amt)
+        self.read.consume(amt);
     }
 }
 

--- a/gix-pack/src/data/output/count/objects/mod.rs
+++ b/gix-pack/src/data/output/count/objects/mod.rs
@@ -194,7 +194,7 @@ mod expand {
                                     for token in commit_iter {
                                         match token {
                                             Ok(gix_object::commit::ref_iter::Token::Parent { id }) => {
-                                                parent_commit_ids.push(id)
+                                                parent_commit_ids.push(id);
                                             }
                                             Ok(_) => break,
                                             Err(err) => return Err(Error::CommitDecode(err)),

--- a/gix-pack/src/multi_index/chunk.rs
+++ b/gix-pack/src/multi_index/chunk.rs
@@ -70,7 +70,7 @@ pub mod index_names {
                 ascii_path.is_ascii(),
                 "must use ascii bytes for correct size computation"
             );
-            count += (ascii_path.as_bytes().len() + 1/* null byte */) as u64
+            count += (ascii_path.as_bytes().len() + 1/* null byte */) as u64;
         }
 
         let needed_alignment = CHUNK_ALIGNMENT - (count % CHUNK_ALIGNMENT);

--- a/gix-pack/src/multi_index/write.rs
+++ b/gix-pack/src/multi_index/write.rs
@@ -191,12 +191,12 @@ impl multi_index::File {
             while let Some(chunk_to_write) = chunk_write.next_chunk() {
                 match chunk_to_write {
                     multi_index::chunk::index_names::ID => {
-                        multi_index::chunk::index_names::write(&index_filenames_sorted, &mut chunk_write)?
+                        multi_index::chunk::index_names::write(&index_filenames_sorted, &mut chunk_write)?;
                     }
                     multi_index::chunk::fanout::ID => multi_index::chunk::fanout::write(&entries, &mut chunk_write)?,
                     multi_index::chunk::lookup::ID => multi_index::chunk::lookup::write(&entries, &mut chunk_write)?,
                     multi_index::chunk::offsets::ID => {
-                        multi_index::chunk::offsets::write(&entries, num_large_offsets.is_some(), &mut chunk_write)?
+                        multi_index::chunk::offsets::write(&entries, num_large_offsets.is_some(), &mut chunk_write)?;
                     }
                     multi_index::chunk::large_offsets::ID => multi_index::chunk::large_offsets::write(
                         &entries,

--- a/gix-pack/tests/pack/data/file.rs
+++ b/gix-pack/tests/pack/data/file.rs
@@ -174,7 +174,7 @@ mod decompress_entry {
     fn commit() {
         let buf = decompress_entry_at_offset(1968);
         assert_eq!(buf.as_bstr(), b"tree e90926b07092bccb7bf7da445fae6ffdfacf3eae\nauthor Sebastian Thiel <byronimo@gmail.com> 1286529993 +0200\ncommitter Sebastian Thiel <byronimo@gmail.com> 1286529993 +0200\n\nInitial commit\n".as_bstr());
-        assert_eq!(buf.len(), 187)
+        assert_eq!(buf.len(), 187);
     }
 
     #[test]
@@ -185,13 +185,13 @@ mod decompress_entry {
             b"GitPython is a python library used to interact with Git repositories.\n\nHi there\n\nHello Other\n"
                 .as_bstr()
         );
-        assert_eq!(buf.len(), 93)
+        assert_eq!(buf.len(), 93);
     }
 
     #[test]
     fn blob_with_two_chain_links() {
         let buf = decompress_entry_at_offset(3033);
-        assert_eq!(buf.len(), 6, "it decompresses delta objects, but won't resolve them")
+        assert_eq!(buf.len(), 6, "it decompresses delta objects, but won't resolve them");
     }
 
     #[test]

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -185,7 +185,7 @@ mod lookup_ref_delta_objects {
             Err(input::Error::NotFound {
                 object_id
             }) if object_id == gix_hash::Kind::Sha1.null()
-        ))
+        ));
     }
 
     #[test]

--- a/gix-pack/tests/pack/data/output/mod.rs
+++ b/gix-pack/tests/pack/data/output/mod.rs
@@ -8,7 +8,7 @@ fn size_of_entry() {
         std::mem::size_of::<output::Entry>(),
         80,
         "The size of the structure shouldn't change unexpectedly"
-    )
+    );
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn size_of_count() {
         std::mem::size_of::<output::Count>(),
         56,
         "The size of the structure shouldn't change unexpectedly"
-    )
+    );
 }
 
 enum DbKind {

--- a/gix-pack/tests/pack/index.rs
+++ b/gix-pack/tests/pack/index.rs
@@ -47,7 +47,7 @@ mod version {
                         index
                     );
                     if let Some(candidates) = candidates {
-                        assert_eq!(candidates, index..index + 1)
+                        assert_eq!(candidates, index..index + 1);
                     }
                 }
             }

--- a/gix-packetline-blocking/src/read/sidebands/blocking_io.rs
+++ b/gix-packetline-blocking/src/read/sidebands/blocking_io.rs
@@ -71,7 +71,7 @@ where
 
     /// Forwards to the parent [`StreamingPeekableIter::reset_with()`]
     pub fn reset_with(&mut self, delimiters: &'static [PacketLineRef<'static>]) {
-        self.parent.reset_with(delimiters)
+        self.parent.reset_with(delimiters);
     }
 
     /// Forwards to the parent [`StreamingPeekableIter::stopped_at()`]

--- a/gix-packetline/src/read/sidebands/blocking_io.rs
+++ b/gix-packetline/src/read/sidebands/blocking_io.rs
@@ -69,7 +69,7 @@ where
 
     /// Forwards to the parent [`StreamingPeekableIter::reset_with()`]
     pub fn reset_with(&mut self, delimiters: &'static [PacketLineRef<'static>]) {
-        self.parent.reset_with(delimiters)
+        self.parent.reset_with(delimiters);
     }
 
     /// Forwards to the parent [`StreamingPeekableIter::stopped_at()`]

--- a/gix-path/src/convert.rs
+++ b/gix-path/src/convert.rs
@@ -278,7 +278,7 @@ pub fn normalize<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Option<Cow<'a, 
                 return None;
             }
         } else {
-            path.push(component)
+            path.push(component);
         }
     }
 

--- a/gix-pathspec/tests/parse/valid.rs
+++ b/gix-pathspec/tests/parse/valid.rs
@@ -142,7 +142,7 @@ fn empty_signatures() {
         (":():some/path", pat_with_path(":some/path")),
     ];
 
-    check_valid_inputs(inputs)
+    check_valid_inputs(inputs);
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn whitespace_in_pathspec() {
         ),
     ];
 
-    check_valid_inputs(inputs)
+    check_valid_inputs(inputs);
 }
 
 #[test]
@@ -190,7 +190,7 @@ fn short_signatures() {
         ),
     ];
 
-    check_valid_inputs(inputs)
+    check_valid_inputs(inputs);
 }
 
 #[test]
@@ -286,7 +286,7 @@ fn attributes_in_signature() {
         ),
     ];
 
-    check_valid_inputs(inputs)
+    check_valid_inputs(inputs);
 }
 
 #[test]
@@ -318,7 +318,7 @@ fn attributes_with_escape_chars_in_state_values() {
         ),
     ];
 
-    check_valid_inputs(inputs)
+    check_valid_inputs(inputs);
 }
 
 fn pat_with_path(path: &str) -> NormalizedPattern {

--- a/gix-prompt/src/types.rs
+++ b/gix-prompt/src/types.rs
@@ -59,11 +59,11 @@ impl Options<'_> {
         use_git_terminal_prompt: bool,
     ) -> Self {
         if let Some(askpass) = use_git_askpass.then(|| std::env::var_os("GIT_ASKPASS")).flatten() {
-            self.askpass = Some(Cow::Owned(askpass.into()))
+            self.askpass = Some(Cow::Owned(askpass.into()));
         }
         if self.askpass.is_none() {
             if let Some(askpass) = use_ssh_askpass.then(|| std::env::var_os("SSH_ASKPASS")).flatten() {
-                self.askpass = Some(Cow::Owned(askpass.into()))
+                self.askpass = Some(Cow::Owned(askpass.into()));
             }
         }
         self.mode = use_git_terminal_prompt

--- a/gix-protocol/src/command/tests.rs
+++ b/gix-protocol/src/command/tests.rs
@@ -73,7 +73,7 @@ mod v2 {
                         .iter()
                         .map(|s| (*s, None))
                         .collect::<Vec<_>>()
-                )
+                );
             }
         }
 
@@ -94,7 +94,7 @@ mod v2 {
                         .map(|s| s.as_bytes().as_bstr().to_owned())
                         .collect::<Vec<_>>(),
                     "packfile-uris isn't really supported that well and we don't support it either yet"
-                )
+                );
             }
         }
     }

--- a/gix-protocol/src/fetch/arguments/mod.rs
+++ b/gix-protocol/src/fetch/arguments/mod.rs
@@ -183,7 +183,7 @@ impl Arguments {
                     .features_for_first_want
                     .as_mut()
                     .expect("call add_feature before first want()");
-                features.push(feature.into())
+                features.push(feature.into());
             }
             gix_transport::Protocol::V2 => {
                 self.args.push(feature.into());

--- a/gix-protocol/src/fetch/tests.rs
+++ b/gix-protocol/src/fetch/tests.rs
@@ -410,7 +410,7 @@ mod arguments {
 0009done
 0000"
                     .as_bstr()
-            )
+            );
         }
     }
 }

--- a/gix-protocol/src/handshake/refs/shared.rs
+++ b/gix-protocol/src/handshake/refs/shared.rs
@@ -115,7 +115,7 @@ pub(crate) fn from_capabilities<'a>(
                 b"(null)" => None,
                 name => Some(name.into()),
             },
-        })
+        });
     }
     Ok(out_refs)
 }

--- a/gix-protocol/src/handshake/refs/tests.rs
+++ b/gix-protocol/src/handshake/refs/tests.rs
@@ -115,7 +115,7 @@ dce0ea858eef7ff61ad345cc5cdac62203fb3c10 refs/tags/gix-commitgraph-v0.0.0
                 object: oid("21c9b7500cb144b3169a6537961ec2b9e865be81")
             },
         ]
-    )
+    );
 }
 
 #[test]
@@ -163,7 +163,7 @@ impl<'a> std::io::BufRead for Fixture<'a> {
     }
 
     fn consume(&mut self, amt: usize) {
-        self.0.consume(amt)
+        self.0.consume(amt);
     }
 }
 

--- a/gix-protocol/tests/fetch/mod.rs
+++ b/gix-protocol/tests/fetch/mod.rs
@@ -100,7 +100,7 @@ impl fetch::DelegateBlocking for CloneRefInWantDelegate {
         _prev: Option<&Response>,
     ) -> io::Result<Action> {
         for wanted_ref in &self.want_refs {
-            arguments.want_ref(wanted_ref.as_ref())
+            arguments.want_ref(wanted_ref.as_ref());
         }
 
         Ok(Action::Cancel)

--- a/gix-protocol/tests/fetch/response.rs
+++ b/gix-protocol/tests/fetch/response.rs
@@ -343,7 +343,7 @@ mod v2 {
                 Ok(_) => panic!("need error response"),
                 Err(err) => match err {
                     fetch::response::Error::UploadPack(err) => {
-                        assert_eq!(err.message, "segmentation fault\n")
+                        assert_eq!(err.message, "segmentation fault\n");
                     }
                     err => panic!("we expect upload pack errors, got {err:#?}"),
                 },

--- a/gix-protocol/tests/remote_progress/mod.rs
+++ b/gix-protocol/tests/remote_progress/mod.rs
@@ -7,7 +7,7 @@ mod parse {
         assert_eq!(
             RemoteProgress::from_bytes(b"something that might be progress: but is not."),
             None
-        )
+        );
     }
 
     #[test]
@@ -20,7 +20,7 @@ mod parse {
                 step: Some(10),
                 max: None
             })
-        )
+        );
     }
 
     #[test]
@@ -33,6 +33,6 @@ mod parse {
                 step: Some(5),
                 max: Some(10)
             })
-        )
+        );
     }
 }

--- a/gix-ref/src/store/file/transaction/commit.rs
+++ b/gix-ref/src/store/file/transaction/commit.rs
@@ -170,7 +170,7 @@ impl<'s, 'p> Transaction<'s, 'p> {
                         });
                     }
                 }
-                drop(lock)
+                drop(lock);
             }
         }
         Ok(updates.into_iter().map(|edit| edit.update).collect())

--- a/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/collisions.rs
+++ b/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/collisions.rs
@@ -33,7 +33,7 @@ fn conflicting_creation_without_packed_refs() -> crate::Result {
         Ok(_) if !case_sensitive => panic!("should fail as 'a' and 'A' clash"),
         Err(err) if case_sensitive => panic!("should work as case sensitivity allows 'a' and 'A' to coexist: {err:?}"),
         Err(err) if !case_sensitive => {
-            assert_eq!(err.to_string(), "A lock could not be obtained for reference \"refs/A\"")
+            assert_eq!(err.to_string(), "A lock could not be obtained for reference \"refs/A\"");
         }
         _ => unreachable!("actually everything is covered"),
     }

--- a/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -632,7 +632,7 @@ fn symbolic_head_missing_referent_then_update_referent() -> crate::Result {
                     assert!(
                         store.reflog_iter(*ref_name, &mut buf)?.is_none(),
                         "nothing is ever written if its disabled"
-                    )
+                    );
                 }
             }
         }

--- a/gix-ref/tests/namespace/mod.rs
+++ b/gix-ref/tests/namespace/mod.rs
@@ -7,7 +7,7 @@ fn into_namespaced_prefix() {
             .unwrap()
             .into_namespaced_prefix("prefix".as_ref()),
         Path::new("refs").join("namespaces").join("foo").join("prefix")
-    )
+    );
 }
 
 mod expand {
@@ -16,7 +16,7 @@ mod expand {
         assert_eq!(
             gix_ref::namespace::expand("foo").unwrap().as_bstr(),
             "refs/namespaces/foo/"
-        )
+        );
     }
 
     #[test]
@@ -24,7 +24,7 @@ mod expand {
         assert_eq!(
             gix_ref::namespace::expand("foo/bar").unwrap().as_bstr(),
             "refs/namespaces/foo/refs/namespaces/bar/"
-        )
+        );
     }
 
     #[test]

--- a/gix-refspec/src/match_group/mod.rs
+++ b/gix-refspec/src/match_group/mod.rs
@@ -76,7 +76,7 @@ impl<'a> MatchGroup<'a> {
                             lhs: SourceRef::FullName(item.full_ref_name),
                             rhs,
                             spec_index,
-                        })
+                        });
                     }
                 }
             }

--- a/gix-refspec/src/match_group/validate.rs
+++ b/gix-refspec/src/match_group/validate.rs
@@ -102,7 +102,7 @@ impl<'spec, 'item> Outcome<'spec, 'item> {
         {
             let sources = sources_by_destinations.entry(dst).or_insert_with(Vec::new);
             if !sources.iter().any(|(_, lhs)| lhs == &src) {
-                sources.push((spec_index, src))
+                sources.push((spec_index, src));
             }
         }
         let mut issues = Vec::new();
@@ -114,7 +114,7 @@ impl<'spec, 'item> Outcome<'spec, 'item> {
                     .map(|(spec_idx, _)| self.group.specs[*spec_idx].to_bstring())
                     .collect(),
                 sources: conflicting_sources.into_iter().map(|(_, src)| src.to_owned()).collect(),
-            })
+            });
         }
         if !issues.is_empty() {
             Err(Error { issues })

--- a/gix-refspec/src/spec.rs
+++ b/gix-refspec/src/spec.rs
@@ -41,13 +41,13 @@ mod impls {
 
     impl Hash for RefSpec {
         fn hash<H: Hasher>(&self, state: &mut H) {
-            self.to_ref().hash(state)
+            self.to_ref().hash(state);
         }
     }
 
     impl Hash for RefSpecRef<'_> {
         fn hash<H: Hasher>(&self, state: &mut H) {
-            self.instruction().hash(state)
+            self.instruction().hash(state);
         }
     }
 

--- a/gix-refspec/tests/impls/mod.rs
+++ b/gix-refspec/tests/impls/mod.rs
@@ -10,13 +10,13 @@ fn pair() -> Vec<RefSpec> {
 
 #[test]
 fn cmp() {
-    assert_eq!(BTreeSet::from_iter(pair()).len(), 1)
+    assert_eq!(BTreeSet::from_iter(pair()).len(), 1);
 }
 
 #[test]
 fn hash() {
     let set: HashSet<_> = pair().into_iter().collect();
-    assert_eq!(set.len(), 1)
+    assert_eq!(set.len(), 1);
 }
 
 #[test]

--- a/gix-refspec/tests/match_group/mod.rs
+++ b/gix-refspec/tests/match_group/mod.rs
@@ -181,6 +181,6 @@ mod multiple {
                 },
             ],
             ["refs/heads/f1:refs/heads/f1"],
-        )
+        );
     }
 }

--- a/gix-refspec/tests/matching/mod.rs
+++ b/gix-refspec/tests/matching/mod.rs
@@ -53,7 +53,7 @@ pub mod baseline {
         specs: impl IntoIterator<Item = &'a str> + Clone,
         expected: impl IntoIterator<Item = &'b str>,
     ) {
-        agrees_and_applies_fixes(specs, Vec::new(), expected)
+        agrees_and_applies_fixes(specs, Vec::new(), expected);
     }
 
     pub fn agrees_and_applies_fixes<'a, 'b>(
@@ -76,17 +76,17 @@ pub mod baseline {
                     .collect(),
                 fixes: fixes.into_iter().collect(),
             },
-        )
+        );
     }
 
     pub fn of_objects_always_matches_if_the_server_has_the_object<'a, 'b>(
         specs: impl IntoIterator<Item = &'a str> + Clone,
     ) {
-        check_fetch_remote(specs, Mode::Normal { validate_err: None })
+        check_fetch_remote(specs, Mode::Normal { validate_err: None });
     }
 
     pub fn agrees_with_fetch_specs<'a>(specs: impl IntoIterator<Item = &'a str> + Clone) {
-        check_fetch_remote(specs, Mode::Normal { validate_err: None })
+        check_fetch_remote(specs, Mode::Normal { validate_err: None });
     }
 
     pub fn agrees_with_fetch_specs_validation_error<'a>(
@@ -98,7 +98,7 @@ pub mod baseline {
             Mode::Normal {
                 validate_err: Some(validate_err.into()),
             },
-        )
+        );
     }
 
     pub fn invalid_specs_fail_to_parse_where_git_shows_surprising_behaviour<'a>(
@@ -116,7 +116,7 @@ pub mod baseline {
                 Err(err) => panic!("Unexpected parse error: {err:?}"),
             }
         }
-        assert!(saw_err, "Failed to see error when parsing specs: {err:?}")
+        assert!(saw_err, "Failed to see error when parsing specs: {err:?}");
     }
 
     /// Here we checked by hand which refs are actually written with a particular refspec
@@ -124,7 +124,7 @@ pub mod baseline {
         specs: impl IntoIterator<Item = &'a str> + Clone,
         expected: impl IntoIterator<Item = &'b str>,
     ) {
-        of_objects_with_destinations_are_written_into_given_local_branches(specs, expected)
+        of_objects_with_destinations_are_written_into_given_local_branches(specs, expected);
     }
 
     enum Mode {
@@ -212,7 +212,7 @@ pub mod baseline {
                     name: name.into(),
                     target,
                     object: None,
-                })
+                });
             } else {
                 out.last_mut().unwrap().object = Some(target);
             }
@@ -267,7 +267,7 @@ pub mod baseline {
                                 mappings.push(Mapping {
                                     remote: full_remote_ref(lhs.into()),
                                     local,
-                                })
+                                });
                             }
                         }
                     },

--- a/gix-revision/src/spec/parse/function.rs
+++ b/gix-revision/src/spec/parse/function.rs
@@ -123,7 +123,7 @@ mod intercept {
     {
         fn done(&mut self) {
             self.done = true;
-            self.inner.done()
+            self.inner.done();
         }
     }
 
@@ -252,14 +252,14 @@ fn parens(input: &[u8]) -> Result<Option<InsideParensRestConsumed<'_>>, Error> {
                 if ignore_next {
                     ignore_next = false;
                 } else {
-                    open_braces += 1
+                    open_braces += 1;
                 }
             }
             b'}' => {
                 if ignore_next {
                     ignore_next = false;
                 } else {
-                    open_braces -= 1
+                    open_braces -= 1;
                 }
             }
             b'\\' => {
@@ -275,7 +275,7 @@ fn parens(input: &[u8]) -> Result<Option<InsideParensRestConsumed<'_>>, Error> {
                 if ignore_next {
                     skip_list.pop();
                 };
-                ignore_next = false
+                ignore_next = false;
             }
         }
         if open_braces == 0 {
@@ -441,7 +441,7 @@ where
                     delegate.sibling_branch(kind).ok_or(Error::Delegate)
                 } else {
                     Err(Error::SiblingBranchNeedsBranchName { name: (*name).into() })
-                }?
+                }?;
             } else if has_ref_or_implied_name {
                 let time = nav
                     .to_str()

--- a/gix-revision/tests/spec/parse/anchor/at_symbol.rs
+++ b/gix-revision/tests/spec/parse/anchor/at_symbol.rs
@@ -6,7 +6,7 @@ use crate::spec::parse::{parse, try_parse};
 fn braces_must_be_closed() {
     for unclosed_spec in ["@{something", "@{", "@{..@"] {
         let err = try_parse(unclosed_spec).unwrap_err();
-        assert!(matches!(err, spec::parse::Error::UnclosedBracePair {input} if input == unclosed_spec[1..]))
+        assert!(matches!(err, spec::parse::Error::UnclosedBracePair {input} if input == unclosed_spec[1..]));
     }
 }
 

--- a/gix-revision/tests/spec/parse/anchor/colon_symbol.rs
+++ b/gix-revision/tests/spec/parse/anchor/colon_symbol.rs
@@ -107,7 +107,7 @@ fn empty_top_level_regex_are_invalid() {
     assert!(
         matches!(err, spec::parse::Error::EmptyTopLevelRegex),
         "git also can't do it, finds nothing instead. It could be the youngest commit in theory, but isn't"
-    )
+    );
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn needs_suffix() {
     assert!(
         matches!(err, spec::parse::Error::MissingColonSuffix),
         "git also can't do it, finds nothing instead. It could be the youngest commit in theory, but isn't"
-    )
+    );
 }
 
 #[test]

--- a/gix-revision/tests/spec/parse/mod.rs
+++ b/gix-revision/tests/spec/parse/mod.rs
@@ -78,7 +78,7 @@ impl Recorder {
 
     fn called(&mut self, f: Call) {
         self.calls += 1;
-        self.order.push(f)
+        self.order.push(f);
     }
 }
 

--- a/gix-revision/tests/spec/parse/navigate/caret_symbol.rs
+++ b/gix-revision/tests/spec/parse/navigate/caret_symbol.rs
@@ -58,7 +58,7 @@ fn followed_by_zero_is_peeling_to_commit() {
 #[test]
 fn explicitly_positive_numbers_are_invalid() {
     let err = try_parse("@^+1").unwrap_err();
-    assert!(matches!(err, spec::parse::Error::SignedNumber {input} if input == "+1"))
+    assert!(matches!(err, spec::parse::Error::SignedNumber {input} if input == "+1"));
 }
 
 #[test]

--- a/gix-revision/tests/spec/parse/navigate/tilde_symbol.rs
+++ b/gix-revision/tests/spec/parse/navigate/tilde_symbol.rs
@@ -5,7 +5,7 @@ use crate::spec::parse::{parse, try_parse};
 #[test]
 fn without_anchor_is_invalid() {
     let err = try_parse("~").unwrap_err();
-    assert!(matches!(err, spec::parse::Error::MissingTildeAnchor))
+    assert!(matches!(err, spec::parse::Error::MissingTildeAnchor));
 }
 
 #[test]

--- a/gix-revwalk/src/queue.rs
+++ b/gix-revwalk/src/queue.rs
@@ -109,7 +109,7 @@ impl<K: Ord, T> PriorityQueue<K, T> {
 
     /// Drop all items from the queue, without changing its capacity.
     pub fn clear(&mut self) {
-        self.0.clear()
+        self.0.clear();
     }
 }
 

--- a/gix-revwalk/tests/revwalk.rs
+++ b/gix-revwalk/tests/revwalk.rs
@@ -6,7 +6,7 @@ mod graph {
                 std::mem::size_of::<gix_revwalk::graph::Commit<()>>(),
                 48,
                 "We might see quite a lot of these, so they shouldn't grow unexpectedly"
-            )
+            );
         }
     }
 }

--- a/gix-status/src/index_as_worktree/recorder.rs
+++ b/gix-status/src/index_as_worktree/recorder.rs
@@ -42,6 +42,6 @@ impl<'index, T: Send, U: Send> VisitEntry<'index> for Recorder<'index, T, U> {
             entry_index,
             relative_path,
             status,
-        })
+        });
     }
 }

--- a/gix-status/src/index_as_worktree_with_renames/mod.rs
+++ b/gix-status/src/index_as_worktree_with_renames/mod.rs
@@ -195,7 +195,7 @@ pub(super) mod function {
                         if let Some(v) = entries_for_sorting.as_mut() {
                             v.push((change, location));
                         } else if let Some(change) = tracker.try_push_change(change, location.as_ref()) {
-                            collector.visit_entry(rewrite::change_to_entry(change, entries))
+                            collector.visit_entry(rewrite::change_to_entry(change, entries));
                         }
                     }
 
@@ -218,7 +218,7 @@ pub(super) mod function {
                                     if let Some(v) = entries_for_sorting.as_mut() {
                                         v.push(entry);
                                     } else {
-                                        collector.visit_entry(entry)
+                                        collector.visit_entry(entry);
                                     }
                                 }
                                 Some(src) => {

--- a/gix-status/src/index_as_worktree_with_renames/recorder.rs
+++ b/gix-status/src/index_as_worktree_with_renames/recorder.rs
@@ -12,6 +12,6 @@ impl<'index, T: Send, U: Send> VisitEntry<'index> for Recorder<'index, T, U> {
     type SubmoduleStatus = U;
 
     fn visit_entry(&mut self, entry: Entry<'index, Self::ContentChange, Self::SubmoduleStatus>) {
-        self.records.push(entry)
+        self.records.push(entry);
     }
 }

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -262,7 +262,7 @@ fn subomdule_typechange() {
             symlink_metadata_calls: 2,
             ..Default::default()
         }
-    )
+    );
 }
 
 #[test]

--- a/gix-status/tests/status/index_as_worktree_with_renames.rs
+++ b/gix-status/tests/status/index_as_worktree_with_renames.rs
@@ -96,7 +96,7 @@ fn changed_and_untracked_and_renamed() {
             num_similarity_checks_skipped_for_rename_tracking_due_to_limit: 0,
             num_similarity_checks_skipped_for_copy_tracking_due_to_limit: 0,
         })
-    )
+    );
 }
 
 #[test]

--- a/gix-transport/src/client/blocking_io/bufread_ext.rs
+++ b/gix-transport/src/client/blocking_io/bufread_ext.rs
@@ -63,7 +63,7 @@ impl<'a, T: ReadlineBufRead + ?Sized + 'a> ReadlineBufRead for Box<T> {
 
 impl<'a, T: ExtendedBufRead<'a> + ?Sized + 'a> ExtendedBufRead<'a> for Box<T> {
     fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>) {
-        self.deref_mut().set_progress_handler(handle_progress)
+        self.deref_mut().set_progress_handler(handle_progress);
     }
 
     fn peek_data_line(&mut self) -> Option<io::Result<Result<&[u8], Error>>> {
@@ -71,7 +71,7 @@ impl<'a, T: ExtendedBufRead<'a> + ?Sized + 'a> ExtendedBufRead<'a> for Box<T> {
     }
 
     fn reset(&mut self, version: Protocol) {
-        self.deref_mut().reset(version)
+        self.deref_mut().reset(version);
     }
 
     fn stopped_at(&self) -> Option<MessageKind> {
@@ -101,7 +101,7 @@ impl<'a, T: io::Read> ReadlineBufRead for gix_packetline::read::WithSidebands<'a
 
 impl<'a, T: io::Read> ExtendedBufRead<'a> for gix_packetline::read::WithSidebands<'a, T, HandleProgress<'a>> {
     fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>) {
-        self.set_progress_handler(handle_progress)
+        self.set_progress_handler(handle_progress);
     }
     fn peek_data_line(&mut self) -> Option<io::Result<Result<&[u8], Error>>> {
         match self.peek_data_line() {

--- a/gix-transport/src/client/blocking_io/http/mod.rs
+++ b/gix-transport/src/client/blocking_io/http/mod.rs
@@ -308,7 +308,7 @@ impl<H: Http> Transport<H> {
             headers.push(Cow::Owned(format!(
                 "Authorization: Basic {}",
                 base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"))
-            )))
+            )));
         }
         Ok(())
     }
@@ -480,7 +480,7 @@ impl<H: Http, B: Unpin> HeadersThenBody<H, B> {
     fn handle_headers(&mut self) -> std::io::Result<()> {
         if let Some(headers) = self.headers.take() {
             <Transport<H>>::check_content_type(self.service, "result", headers)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
         }
         Ok(())
     }
@@ -500,7 +500,7 @@ impl<H: Http, B: BufRead + Unpin> BufRead for HeadersThenBody<H, B> {
     }
 
     fn consume(&mut self, amt: usize) {
-        self.body.consume(amt)
+        self.body.consume(amt);
     }
 }
 
@@ -520,7 +520,7 @@ impl<H: Http, B: ReadlineBufRead + Unpin> ReadlineBufRead for HeadersThenBody<H,
 
 impl<'a, H: Http, B: ExtendedBufRead<'a> + Unpin> ExtendedBufRead<'a> for HeadersThenBody<H, B> {
     fn set_progress_handler(&mut self, handle_progress: Option<HandleProgress<'a>>) {
-        self.body.set_progress_handler(handle_progress)
+        self.body.set_progress_handler(handle_progress);
     }
 
     fn peek_data_line(&mut self) -> Option<std::io::Result<Result<&[u8], client::Error>>> {
@@ -531,7 +531,7 @@ impl<'a, H: Http, B: ExtendedBufRead<'a> + Unpin> ExtendedBufRead<'a> for Header
     }
 
     fn reset(&mut self, version: Protocol) {
-        self.body.reset(version)
+        self.body.reset(version);
     }
 
     fn stopped_at(&self) -> Option<MessageKind> {

--- a/gix-transport/src/client/blocking_io/http/redirect.rs
+++ b/gix-transport/src/client/blocking_io/http/redirect.rs
@@ -61,6 +61,6 @@ mod tests {
             ),
             "https://redirected.org/b/info/refs?something",
             "the tail stays the same if redirection happened"
-        )
+        );
     }
 }

--- a/gix-transport/src/client/blocking_io/ssh/program_kind.rs
+++ b/gix-transport/src/client/blocking_io/ssh/program_kind.rs
@@ -38,7 +38,7 @@ impl ProgramKind {
                 if desired_version != Protocol::V1 {
                     prepare = prepare
                         .args(["-o", "SendEnv=GIT_PROTOCOL"])
-                        .env("GIT_PROTOCOL", format!("version={}", desired_version as usize))
+                        .env("GIT_PROTOCOL", format!("version={}", desired_version as usize));
                 }
                 if let Some(port) = url.port {
                     prepare = prepare.arg(format!("-p{port}"));

--- a/gix-transport/src/client/blocking_io/ssh/tests.rs
+++ b/gix-transport/src/client/blocking_io/ssh/tests.rs
@@ -150,7 +150,7 @@ mod program_kind {
             assert!(matches!(
                 try_call(ProgramKind::Ssh, "ssh://-arg@host/p", Protocol::V2),
                 Err(ssh::invocation::Error::AmbiguousUserName { user }) if user == "-arg"
-            ))
+            ));
         }
 
         #[test]
@@ -158,7 +158,7 @@ mod program_kind {
             assert!(matches!(
                 try_call(ProgramKind::Ssh, "-arg@host:p/q", Protocol::V2),
                 Err(ssh::invocation::Error::AmbiguousUserName { user }) if user == "-arg"
-            ))
+            ));
         }
 
         #[test]

--- a/gix-transport/src/client/git/mod.rs
+++ b/gix-transport/src/client/git/mod.rs
@@ -104,14 +104,14 @@ mod message {
             assert_eq!(
                 git::message::connect(Service::UploadPack, Protocol::V1, b"hello/world", None, &[]),
                 "git-upload-pack hello/world\0"
-            )
+            );
         }
         #[test]
         fn version_2_without_host_and_version() {
             assert_eq!(
                 git::message::connect(Service::UploadPack, Protocol::V2, b"hello\\world", None, &[]),
                 "git-upload-pack hello\\world\0\0version=2\0"
-            )
+            );
         }
         #[test]
         fn version_2_without_host_and_version_and_exta_parameters() {
@@ -124,7 +124,7 @@ mod message {
                     &[("key", Some("value")), ("value-only", None)]
                 ),
                 "git-upload-pack /path/project.git\0\0version=2\0key=value\0value-only\0"
-            )
+            );
         }
         #[test]
         fn with_host_without_port() {
@@ -137,7 +137,7 @@ mod message {
                     &[]
                 ),
                 "git-upload-pack hello\\world\0host=host\0"
-            )
+            );
         }
         #[test]
         fn with_host_without_port_and_extra_parameters() {
@@ -150,7 +150,7 @@ mod message {
                     &[("key", Some("value")), ("value-only", None)]
                 ),
                 "git-upload-pack hello\\world\0host=host\0\0key=value\0value-only\0"
-            )
+            );
         }
         #[test]
         fn with_host_with_port() {
@@ -163,7 +163,7 @@ mod message {
                     &[]
                 ),
                 "git-upload-pack hello\\world\0host=host:404\0"
-            )
+            );
         }
 
         #[test]
@@ -178,7 +178,7 @@ mod message {
                 ),
                 "git-upload-pack --upload-pack=attack\0host=--proxy=other-attack:404\0",
                 "we explicitly allow possible `-arg` arguments to be passed to the git daemon - the remote must protect against exploitation, we don't want to prevent legitimate cases"
-            )
+            );
         }
     }
 }

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -73,7 +73,7 @@ async fn handshake_v1_and_request() -> crate::Result {
     let mut refs = Vec::new();
     #[allow(clippy::while_let_on_iterator)] // needed in async version of test
     while let Some(line) = lines.next().await {
-        refs.push(line?)
+        refs.push(line?);
     }
     #[allow(clippy::drop_non_drop)] // needed for non-async version
     drop(lines);
@@ -187,7 +187,7 @@ async fn push_v1_simulated() -> crate::Result {
         let mut info = Vec::new();
         #[allow(clippy::while_let_on_iterator)] // needed in async version of test
         while let Some(line) = lines.next().await {
-            info.push(line?)
+            info.push(line?);
         }
         assert_eq!(
             info,
@@ -351,7 +351,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
     let mut refs = Vec::new();
     #[allow(clippy::while_let_on_iterator)] // needed in async version of test
     while let Some(line) = lines.next().await {
-        refs.push(line?)
+        refs.push(line?);
     }
     assert_eq!(
         refs,

--- a/gix-traverse/src/tree/breadthfirst.rs
+++ b/gix-traverse/src/tree/breadthfirst.rs
@@ -74,7 +74,7 @@ pub(crate) mod impl_ {
                         Continue => {
                             delegate.pop_path_component();
                             delegate.push_back_tracked_path_component(entry.filename);
-                            state.next.push_back(entry.oid.to_owned())
+                            state.next.push_back(entry.oid.to_owned());
                         }
                         Cancel => {
                             return Err(Error::Cancelled);

--- a/gix-traverse/src/tree/recorder.rs
+++ b/gix-traverse/src/tree/recorder.rs
@@ -123,7 +123,7 @@ impl Visit for Recorder {
 
     fn pop_path_component(&mut self) {
         if let Some(Location::Path) = self.location {
-            self.pop_element()
+            self.pop_element();
         }
     }
 

--- a/gix-traverse/tests/tree/mod.rs
+++ b/gix-traverse/tests/tree/mod.rs
@@ -143,7 +143,7 @@ fn breadth_first_no_location() -> crate::Result<()> {
     )?;
 
     for path in recorder.records.into_iter().map(|e| e.filepath) {
-        assert_eq!(path, "", "path should be empty as it's not tracked at all")
+        assert_eq!(path, "", "path should be empty as it's not tracked at all");
     }
     Ok(())
 }

--- a/gix-url/tests/parse/invalid.rs
+++ b/gix-url/tests/parse/invalid.rs
@@ -5,17 +5,17 @@ use crate::parse::parse;
 
 #[test]
 fn relative_path_due_to_double_colon() {
-    assert_matches!(parse("invalid:://host.xz/path/to/repo.git/"), Err(RelativeUrl { .. }))
+    assert_matches!(parse("invalid:://host.xz/path/to/repo.git/"), Err(RelativeUrl { .. }));
 }
 
 #[test]
 fn ssh_missing_path() {
-    assert_matches!(parse("ssh://host.xz"), Err(MissingRepositoryPath { .. }))
+    assert_matches!(parse("ssh://host.xz"), Err(MissingRepositoryPath { .. }));
 }
 
 #[test]
 fn git_missing_path() {
-    assert_matches!(parse("git://host.xz"), Err(MissingRepositoryPath { .. }))
+    assert_matches!(parse("git://host.xz"), Err(MissingRepositoryPath { .. }));
 }
 
 #[test]
@@ -37,5 +37,5 @@ fn file_missing_host_path_separator() {
 
 #[test]
 fn missing_port_despite_indication() {
-    assert_matches!(parse("ssh://host.xz:"), Err(MissingRepositoryPath { .. }))
+    assert_matches!(parse("ssh://host.xz:"), Err(MissingRepositoryPath { .. }));
 }

--- a/gix-url/tests/parse/mod.rs
+++ b/gix-url/tests/parse/mod.rs
@@ -11,7 +11,7 @@ fn assert_url(url: &str, expected: gix_url::Url) -> Result<gix_url::Url, crate::
             actual.path
         );
         if actual.path.len() < 2 {
-            assert!(actual.path_is_root())
+            assert!(actual.path_is_root());
         }
     }
     Ok(expected)

--- a/gix-validate/src/tag.rs
+++ b/gix-validate/src/tag.rs
@@ -141,7 +141,7 @@ pub(crate) fn name_inner(input: &BStr, mode: Mode) -> Result<Option<BString>, na
                 }
 
                 if let Some(out) = out.as_mut() {
-                    out.push(*c)
+                    out.push(*c);
                 }
 
                 if byte_pos == last && input[component_end + 1..].ends_with_str(".lock") {

--- a/gix-validate/tests/path/mod.rs
+++ b/gix-validate/tests/path/mod.rs
@@ -319,7 +319,7 @@ mod component {
                         unreachable!("{invalid:?} should not validate successfully")
                     }
                     Err(err) => {
-                        assert!(matches!(err, Error::SymlinkedGitModules))
+                        assert!(matches!(err, Error::SymlinkedGitModules));
                     }
                 }
             }

--- a/gix-worktree-state/src/checkout/chunk.rs
+++ b/gix-worktree-state/src/checkout/chunk.rs
@@ -137,7 +137,7 @@ where
         match checkout_entry_handle_result(entry, entry_path, &mut errors, &mut collisions, files, bytes, ctx)? {
             entry::Outcome::Written { bytes } => {
                 bytes_written += bytes as u64;
-                files_in_chunk += 1
+                files_in_chunk += 1;
             }
             entry::Outcome::Delayed(delayed) => delayed_filter_results.push(delayed),
         }

--- a/gix-worktree-state/tests/state/checkout.rs
+++ b/gix-worktree-state/tests/state/checkout.rs
@@ -372,7 +372,7 @@ fn keep_going_collects_results() {
             outcome.errors.len(),
             2,
             "content changes due to non-deterministic nature of racy threads"
-        )
+        );
     } else {
         assert_eq!(
             outcome

--- a/gix-worktree-stream/src/from_tree/mod.rs
+++ b/gix-worktree-stream/src/from_tree/mod.rs
@@ -138,7 +138,7 @@ where
                 let file = std::fs::File::open(path)?;
                 protocol::write_stream(&mut buf, file, out)
             }
-        }?
+        }?;
     }
     Ok(())
 }

--- a/gix-worktree-stream/src/from_tree/traverse.rs
+++ b/gix-worktree-stream/src/from_tree/traverse.rs
@@ -122,7 +122,7 @@ where
     }
 
     fn pop_path_component(&mut self) {
-        self.pop_element()
+        self.pop_element();
     }
 
     fn visit_tree(&mut self, entry: &tree::EntryRef<'_>) -> Action {

--- a/gix-worktree/src/stack/delegate.rs
+++ b/gix-worktree/src/stack/delegate.rs
@@ -65,7 +65,7 @@ impl<'a, 'find> gix_fs::stack::Delegate for StackDelegate<'a, 'find> {
                     self.objects,
                     self.case,
                     &mut self.statistics.ignore,
-                )?
+                )?;
             }
             State::IgnoreStack(ignore) => ignore.push_directory(
                 stack.root(),
@@ -98,7 +98,7 @@ impl<'a, 'find> gix_fs::stack::Delegate for StackDelegate<'a, 'find> {
                     self.mode,
                     &mut self.statistics.delegate.num_mkdir_calls,
                     *unlink_on_collision,
-                )?
+                )?;
             }
             #[cfg(feature = "attributes")]
             State::AttributesAndIgnoreStack { .. } | State::AttributesStack(_) => {}

--- a/gix-worktree/src/stack/state/attributes.rs
+++ b/gix-worktree/src/stack/state/attributes.rs
@@ -167,7 +167,7 @@ impl Attributes {
         // Need one stack level per component so push and pop matches, but only if this isn't the root level which is never popped.
         if !added && self.info_attributes.is_none() {
             self.stack
-                .add_patterns_buffer(&[], "<empty dummy>".into(), None, &mut self.collection, true)
+                .add_patterns_buffer(&[], "<empty dummy>".into(), None, &mut self.collection, true);
         }
 
         // When reading the root, always the first call, we can try to also read the `.git/info/attributes` file which is

--- a/gix-worktree/src/stack/state/ignore.rs
+++ b/gix-worktree/src/stack/state/ignore.rs
@@ -188,7 +188,7 @@ impl Ignore {
                     }
                     Err(_) => {
                         // Need one stack level per component so push and pop matches.
-                        self.stack.patterns.push(Default::default())
+                        self.stack.patterns.push(Default::default());
                     }
                 }
             }
@@ -216,7 +216,7 @@ impl Ignore {
                         }
                         Err(_) => {
                             // Need one stack level per component so push and pop matches.
-                            self.stack.patterns.push(Default::default())
+                            self.stack.patterns.push(Default::default());
                         }
                     }
                 }

--- a/gix/examples/stats.rs
+++ b/gix/examples/stats.rs
@@ -124,11 +124,11 @@ mod visit {
                 Commit => self.num_submodules += 1,
                 Blob => {
                     self.count_bytes(entry.oid);
-                    self.num_blobs += 1
+                    self.num_blobs += 1;
                 }
                 BlobExecutable => {
                     self.count_bytes(entry.oid);
-                    self.num_blobs_exec += 1
+                    self.num_blobs_exec += 1;
                 }
                 Link => self.num_links += 1,
                 Tree => unreachable!("BUG"),

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -143,7 +143,7 @@ impl PrepareFetch {
             let mut fetch_opts = {
                 let mut opts = self.fetch_options.clone();
                 if !opts.extra_refspecs.contains(&head_refspec) {
-                    opts.extra_refspecs.push(head_refspec.clone())
+                    opts.extra_refspecs.push(head_refspec.clone());
                 }
                 if let Some(ref_name) = &self.ref_name {
                     opts.extra_refspecs.push(

--- a/gix/src/id.rs
+++ b/gix/src/id.rs
@@ -121,7 +121,7 @@ mod impls {
 
     impl<'a> std::hash::Hash for Id<'a> {
         fn hash<H: Hasher>(&self, state: &mut H) {
-            self.inner.hash(state)
+            self.inner.hash(state);
         }
     }
 
@@ -203,6 +203,6 @@ mod tests {
         assert!(
             actual <= ceiling,
             "size of oid shouldn't change without notice: {actual} <= {ceiling}"
-        )
+        );
     }
 }

--- a/gix/src/interrupt.rs
+++ b/gix/src/interrupt.rs
@@ -239,7 +239,7 @@ where
     }
 
     fn consume(&mut self, amt: usize) {
-        self.inner.consume(amt)
+        self.inner.consume(amt);
     }
 }
 

--- a/gix/src/object/tree/diff/for_each.rs
+++ b/gix/src/object/tree/diff/for_each.rs
@@ -243,19 +243,19 @@ where
     E: Into<Box<dyn std::error::Error + Sync + Send + 'static>>,
 {
     fn pop_front_tracked_path_and_set_current(&mut self) {
-        self.recorder.pop_front_tracked_path_and_set_current()
+        self.recorder.pop_front_tracked_path_and_set_current();
     }
 
     fn push_back_tracked_path_component(&mut self, component: &BStr) {
-        self.recorder.push_back_tracked_path_component(component)
+        self.recorder.push_back_tracked_path_component(component);
     }
 
     fn push_path_component(&mut self, component: &BStr) {
-        self.recorder.push_path_component(component)
+        self.recorder.push_path_component(component);
     }
 
     fn pop_path_component(&mut self) {
-        self.recorder.pop_path_component()
+        self.recorder.pop_path_component();
     }
 
     fn visit(&mut self, change: gix_diff::tree::visit::Change) -> gix_diff::tree::visit::Action {
@@ -314,15 +314,15 @@ mod tree_to_changes {
 
     impl gix_traverse::tree::Visit for Delegate<'_> {
         fn pop_front_tracked_path_and_set_current(&mut self) {
-            self.recorder.pop_front_tracked_path_and_set_current()
+            self.recorder.pop_front_tracked_path_and_set_current();
         }
 
         fn push_back_tracked_path_component(&mut self, component: &BStr) {
-            self.recorder.push_back_tracked_path_component(component)
+            self.recorder.push_back_tracked_path_component(component);
         }
 
         fn push_path_component(&mut self, component: &BStr) {
-            self.recorder.push_path_component(component)
+            self.recorder.push_path_component(component);
         }
 
         fn pop_path_component(&mut self) {

--- a/gix/src/remote/connection/fetch/negotiate.rs
+++ b/gix/src/remote/connection/fetch/negotiate.rs
@@ -241,7 +241,7 @@ pub(crate) fn add_wants(
                 want.remote
                     .as_name()
                     .expect("name available if this isn't an object id"),
-            )
+            );
         }
         let id_is_annotated_tag_we_have = id_on_remote
             .and_then(|id| repo.objects.header(id).ok().map(|h| (id, h)))
@@ -250,7 +250,7 @@ pub(crate) fn add_wants(
         if let Some(tag_on_remote) = id_is_annotated_tag_we_have {
             // Annotated tags are not handled at all by negotiators in the commit-graph - they only see commits and thus won't
             // ever add `have`s for tags. To correct for that, we add these haves here to avoid getting them sent again.
-            arguments.have(tag_on_remote)
+            arguments.have(tag_on_remote);
         }
     }
 }
@@ -273,11 +273,11 @@ fn mark_recent_complete_commits(
             if let Some(parent) = graph
                 .try_lookup_or_insert_commit(parent_id, |md| {
                     was_complete = md.flags.contains(Flags::COMPLETE);
-                    md.flags |= Flags::COMPLETE
+                    md.flags |= Flags::COMPLETE;
                 })?
                 .filter(|_| !was_complete)
             {
-                queue.insert(parent.commit_time, parent_id)
+                queue.insert(parent.commit_time, parent_id);
             }
         }
     }
@@ -298,7 +298,7 @@ fn mark_all_refs_in_repo(
         if let Some(commit) = graph
             .try_lookup_or_insert_commit(id, |md| {
                 is_complete = md.flags.contains(Flags::COMPLETE);
-                md.flags |= mark
+                md.flags |= mark;
             })?
             .filter(|_| !is_complete)
         {

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -284,7 +284,7 @@ pub(crate) fn update(
             mode,
             type_change,
             edit_index,
-        })
+        });
     }
 
     for (update_index, edit_index) in edit_indices_to_validate {

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -182,7 +182,7 @@ mod update {
                             new.id(),
                             remote_ref.target().id(),
                             "remote ref provides the id to set in the local reference"
-                        )
+                        );
                     }
                     _ => unreachable!("only updates"),
                 }

--- a/gix/src/repository/cache.rs
+++ b/gix/src/repository/cache.rs
@@ -24,7 +24,7 @@ impl crate::Repository {
     /// Use this method to avoid overwriting any existing value while assuring better performance in case no value is set.
     pub fn object_cache_size_if_unset(&mut self, bytes: usize) {
         if !self.objects.has_object_cache() {
-            self.object_cache_size(bytes)
+            self.object_cache_size(bytes);
         }
     }
 

--- a/gix/src/repository/init.rs
+++ b/gix/src/repository/init.rs
@@ -44,7 +44,7 @@ pub(crate) fn setup_objects(objects: &mut crate::OdbHandle, config: &crate::conf
             None => match config.static_pack_cache_limit_bytes {
                 None => objects.set_pack_cache(|| Box::<gix_pack::cache::lru::StaticLinkedList<64>>::default()),
                 Some(limit) => {
-                    objects.set_pack_cache(move || Box::new(gix_pack::cache::lru::StaticLinkedList::<64>::new(limit)))
+                    objects.set_pack_cache(move || Box::new(gix_pack::cache::lru::StaticLinkedList::<64>::new(limit)));
                 }
             },
             Some(0) => objects.unset_pack_cache(),

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -19,7 +19,7 @@ impl crate::Repository {
                 res.push(worktree::Proxy {
                     parent: self,
                     git_dir: worktree_git_dir,
-                })
+                });
             }
         }
         res.sort_by(|a, b| a.git_dir.cmp(&b.git_dir));

--- a/gix/src/revision/spec/parse/delegate/navigate.rs
+++ b/gix/src/revision/spec/parse/delegate/navigate.rs
@@ -140,7 +140,7 @@ impl<'repo> delegate::Navigate for Delegate<'repo> {
                                 // Technically this is letting the last one win, but so be it.
                                 self.paths[self.idx] = Some((path.to_owned(), mode));
                             }
-                            replacements.push((*obj, replace))
+                            replacements.push((*obj, replace));
                         }
                         Err(err) => errors.push((*obj, err)),
                     }
@@ -224,7 +224,7 @@ impl<'repo> delegate::Navigate for Delegate<'repo> {
                                         commits_searched: count,
                                         oid: oid.attach(repo).shorten_or_id(),
                                     },
-                                ))
+                                ));
                             }
                         }
                         Err(err) => errors.push((*oid, err.into())),

--- a/gix/tests/clone/mod.rs
+++ b/gix/tests/clone/mod.rs
@@ -345,7 +345,7 @@ mod blocking_io {
                             assert!(
                                 repo.find_reference(referent).is_ok(),
                                 "if we set up a symref, the target should exist by now"
-                            )
+                            );
                         }
                         TargetRef::Object(id) => {
                             assert!(repo.objects.exists(id), "part of the fetched pack");
@@ -374,7 +374,7 @@ mod blocking_io {
                                     !r.log_exists(),
                                     "symbolic refs don't have object ids, so they can't get \
                                       into the reflog as these need previous and new oid"
-                                )
+                                );
                             }
                         }
                     }
@@ -639,7 +639,7 @@ mod blocking_io {
     fn assure_index_entries_on_disk(index: &gix::worktree::Index, work_dir: &Path) {
         for entry in index.entries() {
             let entry_path = work_dir.join(gix_path::from_bstr(entry.path(index)));
-            assert!(entry_path.is_file(), "{entry_path:?} not found on disk")
+            assert!(entry_path.is_file(), "{entry_path:?} not found on disk");
         }
     }
 

--- a/gix/tests/object/mod.rs
+++ b/gix/tests/object/mod.rs
@@ -8,7 +8,7 @@ fn object_ref_size_in_memory() {
         std::mem::size_of::<gix::Object<'_>>(),
         56,
         "the size of this structure should not changed unexpectedly"
-    )
+    );
 }
 
 #[test]
@@ -17,5 +17,5 @@ fn oid_size_in_memory() {
         std::mem::size_of::<gix::Id<'_>>(),
         32,
         "the size of this structure should not changed unexpectedly"
-    )
+    );
 }

--- a/gix/tests/remote/fetch.rs
+++ b/gix/tests/remote/fetch.rs
@@ -621,10 +621,10 @@ mod blocking_and_async_io {
                     if dry_run {
                         match edit.change.new_value().expect("no deletions") {
                             gix_ref::TargetRef::Object(id) => {
-                                assert_eq!(id, mapping.remote.as_id().expect("no unborn"))
+                                assert_eq!(id, mapping.remote.as_id().expect("no unborn"));
                             }
                             gix_ref::TargetRef::Symbolic(target) => {
-                                assert_eq!(target.as_bstr(), mapping.remote.as_target().expect("no direct ref"))
+                                assert_eq!(target.as_bstr(), mapping.remote.as_target().expect("no direct ref"));
                             }
                         }
                         assert!(
@@ -642,7 +642,7 @@ mod blocking_and_async_io {
                                 );
                             }
                             gix_ref::TargetRef::Symbolic(target) => {
-                                assert_eq!(target.as_bstr(), mapping.remote.as_target().expect("no direct ref"))
+                                assert_eq!(target.as_bstr(), mapping.remote.as_target().expect("no direct ref"));
                             }
                         }
                     }

--- a/gix/tests/repository/config/config_snapshot/credential_helpers.rs
+++ b/gix/tests/repository/config/config_snapshot/credential_helpers.rs
@@ -108,14 +108,14 @@ mod baseline {
     }
 
     pub fn agrees_with(url: &str) {
-        agrees_with_inner(url, false, false)
+        agrees_with_inner(url, false, false);
     }
 
     pub fn agrees_with_but_drops_default_port_in_prompt(url: &str) {
-        agrees_with_inner(url, true, false)
+        agrees_with_inner(url, true, false);
     }
     pub fn agrees_with_but_lowercases_scheme_and_host(url: &str) {
-        agrees_with_inner(url, false, true)
+        agrees_with_inner(url, false, true);
     }
 }
 

--- a/gix/tests/repository/remote.rs
+++ b/gix/tests/repository/remote.rs
@@ -170,7 +170,7 @@ mod find_remote {
         let remote = repo.find_remote("origin").expect("present");
         assert_eq!(remote.url(Direction::Push).unwrap().path, ".");
         assert_eq!(remote.url(Direction::Fetch).unwrap().path, base_dir(&repo));
-        assert_eq!(remote.refspecs(Direction::Push), &[pushspec("refs/tags/*:refs/tags/*")])
+        assert_eq!(remote.refspecs(Direction::Push), &[pushspec("refs/tags/*:refs/tags/*")]);
     }
 
     #[test]
@@ -184,7 +184,7 @@ mod find_remote {
                 fetchspec("+refs/heads/*:refs/remotes/origin/*"),
                 fetchspec("refs/tags/*:refs/tags/*")
             ]
-        )
+        );
     }
 
     #[test]

--- a/gix/tests/repository/worktree.rs
+++ b/gix/tests/repository/worktree.rs
@@ -95,7 +95,7 @@ mod with_core_worktree_config {
             !repo.work_dir().expect("configured").exists(),
             "non-existing or invalid worktrees (this one is a file) are taken verbatim and \
             may lead to errors later - just like in `git` and we explicitly do not try to be smart about it"
-        )
+        );
     }
 
     #[test]

--- a/gix/tests/status/mod.rs
+++ b/gix/tests/status/mod.rs
@@ -38,7 +38,7 @@ mod index_worktree {
                 .status(gix::progress::Discard)?
                 .index_worktree_options_mut(|opts| {
                     opts.sorting =
-                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive)
+                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive);
                 })
                 .into_index_worktree_iter(Vec::new())?;
             let items: Vec<_> = status.by_ref().filter_map(Result::ok).collect();
@@ -53,7 +53,7 @@ mod index_worktree {
                 .status(gix::progress::Discard)?
                 .index_worktree_options_mut(|opts| {
                     opts.sorting =
-                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive)
+                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive);
                 })
                 .into_index_worktree_iter(Vec::new())?;
             let items: Vec<_> = status.filter_map(Result::ok).collect();
@@ -99,7 +99,7 @@ mod index_worktree {
                 .status(gix::progress::Discard)?
                 .index_worktree_options_mut(|opts| {
                     opts.sorting =
-                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive)
+                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive);
                 })
                 .into_index_worktree_iter(Vec::new())?;
             let items: Vec<_> = status.by_ref().filter_map(Result::ok).collect();
@@ -120,7 +120,7 @@ mod index_worktree {
                 .index_worktree_submodules(gix::status::Submodule::AsConfigured { check_dirty: true })
                 .index_worktree_options_mut(|opts| {
                     opts.sorting =
-                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive)
+                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive);
                 })
                 .into_index_worktree_iter(Vec::new())?
                 .next()

--- a/gix/tests/submodule/mod.rs
+++ b/gix/tests/submodule/mod.rs
@@ -91,7 +91,7 @@ mod open {
                         worktree.dot_git_exists(),
                         state.worktree_checkout,
                         "there is a way to check for indicators that a submodule worktree isn't checked out though"
-                    )
+                    );
                 }
                 #[cfg(feature = "status")]
                 for check_dirty in [false, true] {
@@ -113,7 +113,7 @@ mod open {
                         status.is_dirty(),
                         *_expected_is_dirty,
                         "none of these submodules are dirty, but some aren't checked out"
-                    )
+                    );
                 }
             }
             assert_eq!(

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -63,7 +63,7 @@ pub fn main() -> Result<()> {
     let mut trace = false;
     #[cfg(feature = "tracing")]
     {
-        trace = args.trace
+        trace = args.trace;
     }
     let object_hash = args.object_hash;
     let config = args.config;

--- a/src/plumbing/progress.rs
+++ b/src/plumbing/progress.rs
@@ -24,12 +24,12 @@ impl Display for Usage {
             NotPlanned(reason) => write!(f, "not planned || {reason}")?,
             Planned(note) => {
                 if !note.is_empty() {
-                    write!(f, "planned || {note}")?
+                    write!(f, "planned || {note}")?;
                 }
             }
             InUse(deviation) => {
                 if !deviation.is_empty() {
-                    write!(f, "❗️❗️❗️{deviation}")?
+                    write!(f, "❗️❗️❗️{deviation}")?;
                 }
             }
         }

--- a/tests/it/src/commands/copy_royal.rs
+++ b/tests/it/src/commands/copy_royal.rs
@@ -44,7 +44,7 @@ pub(super) mod function {
                         src = src.display()
                     )
                 })?;
-                std::fs::write(dst, remapped(&content))?
+                std::fs::write(dst, remapped(&content))?;
             }
         }
         Ok(())

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -516,7 +516,7 @@ fn scripted_fixture_read_only_with_args_inner(
     let failure_marker = script_result_directory.join("_invalid_state_due_to_script_failure_");
     if force_run || !script_result_directory.is_dir() || failure_marker.is_file() {
         if failure_marker.is_file() {
-            std::fs::remove_dir_all(&script_result_directory).map_err(|err| format!("Failed to remove '{script_result_directory:?}', please try to do that by hand. Original error: {err}"))?
+            std::fs::remove_dir_all(&script_result_directory).map_err(|err| format!("Failed to remove '{script_result_directory:?}', please try to do that by hand. Original error: {err}"))?;
         }
         std::fs::create_dir_all(&script_result_directory)?;
         let script_identity_for_archive = match args_in_hash {
@@ -534,7 +534,7 @@ fn scripted_fixture_read_only_with_args_inner(
                     archive_file_path.display(),
                     archive_id,
                     platform
-                )
+                );
             }
             Err(err) => {
                 if err.kind() != std::io::ErrorKind::NotFound {


### PR DESCRIPTION
Automatically apply it with clippy:

```
 cargo clippy --fix --all-targets --workspace -- -A clippy::all -W clippy::semicolon-if-nothing-returned
```

This would close the biggest pedantic clippy complaint in #874
