### PR TITLE
One fix of clippy::match_same_arms

### DIFF
--- a/gix-validate/src/tag.rs
+++ b/gix-validate/src/tag.rs
@@ -116,13 +116,6 @@ pub(crate) fn name_inner(input: &BStr, mode: Mode) -> Result<Option<BString>, na
                     return Err(name::Error::RepeatedSlash);
                 }
             }
-            b'.' if previous == b'/' => {
-                if let Some(out) = out.as_mut() {
-                    out.push(b'-');
-                } else {
-                    return Err(name::Error::StartsWithDot);
-                }
-            }
             c => {
                 if *c == b'/' {
                     component_start = component_end;


### PR DESCRIPTION
Clippy suggests to collapse identical match arms ([info](https://rust-lang.github.io/rust-clippy/master/index.html#/match_same_arms)), but i am not too certain it will create more readable code everywhere. Though, while looking at it, this instance clearly is an accidental dup.

