### PR TITLE
Slightly adjust internal `gix_path::env::git`-related organization

### DIFF
--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -83,9 +83,9 @@ pub(super) static EXE_NAME: &str = "git";
 pub(super) static EXE_INFO: Lazy<Option<BString>> = Lazy::new(exe_info);
 
 #[cfg(windows)]
-static NULL_DEVICE: &str = "NUL";
+const NULL_DEVICE: &str = "NUL";
 #[cfg(not(windows))]
-static NULL_DEVICE: &str = "/dev/null";
+const NULL_DEVICE: &str = "/dev/null";
 
 fn exe_info() -> Option<BString> {
     let mut cmd = git_cmd(EXE_NAME.into());

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -80,7 +80,7 @@ pub(super) const EXE_NAME: &str = "git";
 /// Invoke the git executable to obtain the origin configuration, which is cached and returned.
 ///
 /// The git executable is the one found in PATH or an alternative location.
-pub(super) static EXE_INFO: Lazy<Option<BString>> = Lazy::new(exe_info);
+pub(super) static GIT_HIGHEST_PRIORITY_CONFIG_PATH: Lazy<Option<BString>> = Lazy::new(exe_info);
 
 #[cfg(windows)]
 const NULL_DEVICE: &str = "NUL";
@@ -171,7 +171,7 @@ pub(super) fn install_config_path() -> Option<&'static BStr> {
             exec_path.push("gitconfig");
             return crate::os_string_into_bstring(exec_path.into()).ok();
         }
-        EXE_INFO.clone()
+        GIT_HIGHEST_PRIORITY_CONFIG_PATH.clone()
     });
     PATH.as_ref().map(AsRef::as_ref)
 }

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -73,9 +73,9 @@ where
 }
 
 #[cfg(windows)]
-pub(super) static EXE_NAME: &str = "git.exe";
+pub(super) const EXE_NAME: &str = "git.exe";
 #[cfg(not(windows))]
-pub(super) static EXE_NAME: &str = "git";
+pub(super) const EXE_NAME: &str = "git";
 
 /// Invoke the git executable to obtain the origin configuration, which is cached and returned.
 ///

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -551,9 +551,9 @@ mod exe_info {
 
         let maybe_path = exe_info();
         assert_eq!(
-        maybe_path, None,
-        "Should find no config path if the config would be local even in a `/tmp`-like dir (suppressed system config)"
-    );
+            maybe_path, None,
+            "Should find no config path if the config would be local even in a `/tmp`-like dir (suppressed system config)"
+        );
     }
 }
 

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -555,37 +555,37 @@ mod exe_info {
             "Should find no config path if the config would be local even in a `/tmp`-like dir (suppressed system config)"
         );
     }
-}
 
-#[test]
-fn first_file_from_config_with_origin() {
-    let macos =
-        "file:/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig\0credential.helper\0file:/Users/byron/.gitconfig\0push.default\0";
-    let win_msys = "file:C:/git-sdk-64/etc/gitconfig\0core.symlinks\0file:C:/git-sdk-64/etc/gitconfig\0core.autocrlf\0";
-    let win_cmd =
-        "file:C:/Program Files/Git/etc/gitconfig\0diff.astextplain.textconv\0file:C:/Program Files/Git/etc/gitconfig\0filter.lfs.clean\0";
-    let win_msys_old =
-        "file:C:\\ProgramData/Git/config\0diff.astextplain.textconv\0file:C:\\ProgramData/Git/config\0filter.lfs.clean\0";
-    let linux = "file:/home/parallels/.gitconfig\0core.excludesfile\0";
-    let bogus = "something unexpected";
-    let empty = "";
+    #[test]
+    fn first_file_from_config_with_origin() {
+        let macos =
+            "file:/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig\0credential.helper\0file:/Users/byron/.gitconfig\0push.default\0";
+        let win_msys = "file:C:/git-sdk-64/etc/gitconfig\0core.symlinks\0file:C:/git-sdk-64/etc/gitconfig\0core.autocrlf\0";
+        let win_cmd =
+            "file:C:/Program Files/Git/etc/gitconfig\0diff.astextplain.textconv\0file:C:/Program Files/Git/etc/gitconfig\0filter.lfs.clean\0";
+        let win_msys_old =
+            "file:C:\\ProgramData/Git/config\0diff.astextplain.textconv\0file:C:\\ProgramData/Git/config\0filter.lfs.clean\0";
+        let linux = "file:/home/parallels/.gitconfig\0core.excludesfile\0";
+        let bogus = "something unexpected";
+        let empty = "";
 
-    for (source, expected) in [
-        (
-            macos,
-            Some("/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig"),
-        ),
-        (win_msys, Some("C:/git-sdk-64/etc/gitconfig")),
-        (win_msys_old, Some("C:\\ProgramData/Git/config")),
-        (win_cmd, Some("C:/Program Files/Git/etc/gitconfig")),
-        (linux, Some("/home/parallels/.gitconfig")),
-        (bogus, None),
-        (empty, None),
-    ] {
-        assert_eq!(
-            super::first_file_from_config_with_origin(source.into()),
-            expected.map(Into::into)
-        );
+        for (source, expected) in [
+            (
+                macos,
+                Some("/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig"),
+            ),
+            (win_msys, Some("C:/git-sdk-64/etc/gitconfig")),
+            (win_msys_old, Some("C:\\ProgramData/Git/config")),
+            (win_cmd, Some("C:/Program Files/Git/etc/gitconfig")),
+            (linux, Some("/home/parallels/.gitconfig")),
+            (bogus, None),
+            (empty, None),
+        ] {
+            assert_eq!(
+                crate::env::git::first_file_from_config_with_origin(source.into()),
+                expected.map(Into::into)
+            );
+        }
     }
 }
 

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -560,7 +560,8 @@ mod exe_info {
     fn first_file_from_config_with_origin() {
         let macos =
             "file:/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig\0credential.helper\0file:/Users/byron/.gitconfig\0push.default\0";
-        let win_msys = "file:C:/git-sdk-64/etc/gitconfig\0core.symlinks\0file:C:/git-sdk-64/etc/gitconfig\0core.autocrlf\0";
+        let win_msys =
+            "file:C:/git-sdk-64/etc/gitconfig\0core.symlinks\0file:C:/git-sdk-64/etc/gitconfig\0core.autocrlf\0";
         let win_cmd =
             "file:C:/Program Files/Git/etc/gitconfig\0diff.astextplain.textconv\0file:C:/Program Files/Git/etc/gitconfig\0filter.lfs.clean\0";
         let win_msys_old =


### PR DESCRIPTION
This is a small follow-up to #1567. As suggested in https://github.com/Byron/gitoxide/pull/1567#issuecomment-2322846485, it moves the `first_file_from_config_with_origin` test case into the nested `exe_info` module, and it changes `NULL_DEVICE` from `static` to `const`.

This also changes `EXE_NAME`, which provides `git` or `git.exe` and never holds a longer path even when one is ultimately used, from `static` to `const`. While `EXE_NAME` is non-private, it is crate-internal via `pub(super)`, so this change is still non-breaking and non-user-facing.

In contrast, the static items `ALTERNATIVE_LOCATIONS` and `EXE_INFO` cannot be made `const`. No change is made to them. It may make sense in the future for `EXE_INFO` to hold an `Option<PathBuf>` rather than an `Option<BString>`; depending in part on the future direction of changes related to #1523 and #1567 or to the question of which scopes are eligible to inform `GitInstallation`, that may be required in the future. But nothing toward that is included here. 