### PR TITLE
Rename to `GIT_HIGHEST_SCOPE_CONFIG_PATH`

### DIFF
--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -80,7 +80,7 @@ pub(super) const EXE_NAME: &str = "git";
 /// Invoke the git executable to obtain the origin configuration, which is cached and returned.
 ///
 /// The git executable is the one found in PATH or an alternative location.
-pub(super) static GIT_HIGHEST_PRIORITY_CONFIG_PATH: Lazy<Option<BString>> = Lazy::new(exe_info);
+pub(super) static GIT_HIGHEST_SCOPE_CONFIG_PATH: Lazy<Option<BString>> = Lazy::new(exe_info);
 
 #[cfg(windows)]
 const NULL_DEVICE: &str = "NUL";
@@ -171,7 +171,7 @@ pub(super) fn install_config_path() -> Option<&'static BStr> {
             exec_path.push("gitconfig");
             return crate::os_string_into_bstring(exec_path.into()).ok();
         }
-        GIT_HIGHEST_PRIORITY_CONFIG_PATH.clone()
+        GIT_HIGHEST_SCOPE_CONFIG_PATH.clone()
     });
     PATH.as_ref().map(AsRef::as_ref)
 }


### PR DESCRIPTION
This renames the crate-internal static item with the cached path of the highest scope nonempty config, treated as associated with the `git` installation, from `GIT_HIGHEST_PRIORITY_CONFIG_PATH` to `GIT_HIGHEST_SCOPE_CONFIG_PATH`.

This reflects the propensity of "priority" to have the opposite of the intended meaning here, since configuration in this file stands to be superseded by configuration in any lower (i.e. any other) scope. See #1568 for context.

I think this change from "PRIORITY" to "SCOPE" in the name preserves the benefits of the change from `EXE_INFO` to `GIT_HIGHEST_PRIORITY_CONFIG_PATH` (dd2d666), while making clearer what is going on and avoiding misinterpretations.

