### PR TITLE
Omit system/global config in fixture scripts even amidst strange filenames

### DIFF
--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -907,9 +907,8 @@ mod tests {
         let output = cmd.output().expect("can run git");
         let stdout = output.stdout.to_str().expect("valid UTF-8");
         let status = output.status.code().expect("terminated normally");
-
-        assert_eq!(stdout, "", "should be no config variable to display");
-        assert_eq!(status, 1, "exit status should indicate config variable is absent");
+        assert_eq!(stdout, "", "should be no config variables to display");
+        assert_eq!(status, 0, "reading the config should nonetheless succeed");
 
         temp.close().expect("Test bug: Should be able to delete everything");
     }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -916,7 +916,7 @@ mod tests {
                 .expect("the file really exists")
                 .read_to_end(&mut buf)
                 .expect("can read contents");
-            assert_eq!(buf, CONFIG_DATA, "File {:?} should be created", path);
+            assert_eq!(buf, CONFIG_DATA, "File {path:?} should be created");
         }
     }
 

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -903,7 +903,10 @@ mod tests {
 
         // Create the files.
         for path in paths {
-            File::create_new(path)
+            File::options()
+                .write(true)
+                .create_new(true)
+                .open(path)
                 .expect("can create file")
                 .write_all(CONFIG_DATA)
                 .expect("can write contents");

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -938,8 +938,6 @@ mod tests {
         let status = output.status.code().expect("terminated normally");
         assert_eq!(stdout, "", "should be no config variables to display");
         assert_eq!(status, 0, "reading the config should nonetheless succeed");
-
-        temp.close().expect("Test bug: Should be able to delete everything");
     }
 
     #[test]

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -583,12 +583,16 @@ fn scripted_fixture_read_only_with_args_inner(
     Ok(script_result_directory)
 }
 
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_DEVICE: &str = "/dev/null";
+
 fn configure_command<'a>(
     cmd: &'a mut std::process::Command,
     args: &[String],
     script_result_directory: &Path,
 ) -> &'a mut std::process::Command {
-    let never_path = if cfg!(windows) { "-" } else { ":" };
     let mut msys_for_git_bash_on_windows = std::env::var("MSYS").unwrap_or_default();
     msys_for_git_bash_on_windows.push_str(" winsymlinks:nativestrict");
     cmd.args(args)
@@ -599,8 +603,8 @@ fn configure_command<'a>(
         .env_remove("GIT_ASKPASS")
         .env_remove("SSH_ASKPASS")
         .env("MSYS", msys_for_git_bash_on_windows)
-        .env("GIT_CONFIG_SYSTEM", never_path)
-        .env("GIT_CONFIG_GLOBAL", never_path)
+        .env("GIT_CONFIG_SYSTEM", NULL_DEVICE)
+        .env("GIT_CONFIG_GLOBAL", NULL_DEVICE)
         .env("GIT_TERMINAL_PROMPT", "false")
         .env("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000")
         .env("GIT_AUTHOR_EMAIL", "author@example.com")

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -872,8 +872,6 @@ impl<'a> Drop for Env<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::{Read, Write};
 
     #[test]
     fn parse_version() {
@@ -903,22 +901,12 @@ mod tests {
 
         // Create the files.
         for path in paths {
-            File::options()
-                .write(true)
-                .create_new(true)
-                .open(path)
-                .expect("can create file")
-                .write_all(CONFIG_DATA)
-                .expect("can write contents");
+            std::fs::write(path, CONFIG_DATA).expect("can write contents");
         }
 
         // Verify the files. This is mostly to show we really made a `\\?\...\NUL` on Windows.
         for path in paths {
-            let mut buf = Vec::with_capacity(CONFIG_DATA.len());
-            File::open(path)
-                .expect("the file really exists")
-                .read_to_end(&mut buf)
-                .expect("can read contents");
+            let buf = std::fs::read(path).expect("the file really exists");
             assert_eq!(buf, CONFIG_DATA, "File {path:?} should be created");
         }
     }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -885,13 +885,16 @@ mod tests {
         assert_eq!(git_version_from_bytes(b"git version 2.37.2\n").unwrap(), (2, 37, 2));
     }
 
-    fn check_configure_clears_scope(scope_env_var: &str, scope_option: &str) {
-        let temp = tempfile::TempDir::new().expect("can create temp dir");
+    fn check_configure_clears_scope(scope_env_key: &str, scope_option: &str) {
+        let scope_env_value = "gitconfig";
 
         #[cfg(windows)]
-        let names = ["config", "-"];
+        let names = [scope_env_value, "-"];
         #[cfg(not(windows))]
-        let names = ["config", "-", ":"];
+        let names = [scope_env_value, "-", ":"];
+
+        let temp = tempfile::TempDir::new().expect("can create temp dir");
+
         for name in names {
             File::create_new(temp.path().join(name))
                 .expect("can create file")
@@ -900,7 +903,7 @@ mod tests {
         }
 
         let mut cmd = std::process::Command::new("git");
-        cmd.env(scope_env_var, "config"); // configure_command() should override it.
+        cmd.env(scope_env_key, scope_env_value); // configure_command() should override it.
         let args = ["config", "-l", "--show-origin", scope_option].map(String::from);
         configure_command(&mut cmd, &args, temp.path());
 


### PR DESCRIPTION
Since 33be0e0 (#966), configuration from the system and global scopes is cleared in the environment used to run test fixture scripts by setting `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_GLOBAL`.

https://github.com/Byron/gitoxide/blob/dd65e7bd0adf7afeec377f47ba67970ae5126fa3/tests/tools/src/lib.rs#L591

https://github.com/Byron/gitoxide/blob/dd65e7bd0adf7afeec377f47ba67970ae5126fa3/tests/tools/src/lib.rs#L602-L603

This is usually effective, because there is usually not a file named `:` or `-`. However, these names are not treated specially, and they can exist, in which case configuration variables will be read from them. Because they would have to exist in the CWD of the fixture script, the impact is very limited. However, because tests (and thus their fixtures) often deliberately introduce edge cases, including unusual filenames, it is plausible for this problem to occur unintentionally.

Another factor that could lead to it is if such files are created accidentally, such as by passing `-` where it is meant to indicate stdin but not interpreted that way, or (though less likely) by using a `:` somewhere it is intended to be a separator when it is instead treated as a path. In particular, though I am not sure because they may just have been selected as valid but unlikely paths, it seems like those might have been the intentions of those names as they are currently used in `gix-testtools`. (The reason they do not have those meanings is that the  `:` is in an environment variable that is interpreted as a single path rather than a list of paths, and the `-` is in an environment variable rather than on the command line.)

[git(1) recommends](https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode) using the null device path for `GIT_CONFIG_SYSTEM` and/or `GIT_CONFIG_GLOBAL` when one wishes to prevent real configuration associated with those scopes from being read:

> `GIT_CONFIG_GLOBAL`
> `GIT_CONFIG_SYSTEM`
>
> Take the configuration from the given files instead from global or system-level configuration files. If `GIT_CONFIG_SYSTEM` is set, the system config file defined at build time (usually `/etc/gitconfig`) will not be read. Likewise, if `GIT_CONFIG_GLOBAL` is set, neither `$HOME/.gitconfig` nor `$XDG_CONFIG_HOME/git/config` will be read. Can be set to `/dev/null` to skip reading configuration files of the respective level.

In addition to being more reliable for the reasons described above, this has two more (also minor) advantages:

- It clearly expresses intent, since it achieves the effect more as the documentation recommends doing it.
- Reading the configuration with `git config` and specifying the scope explicitly with `--global` or `--system` no longer gives exit code 128 due to an attempt to open a nonexistent file.

This PR makes that change. For Windows, where `/dev/null` is not generally a usable path for the null device, it uses `NUL`.

This also adds tests that the system and global scopes are cleared and that attempts to access configuration variables avoid unusual results, for situations:

- Where they were already successfully cleared.
- Where weirdly named files (files named `:` or `-` depending on platform) would inject configuration for them until the changes here (those tests fail before the bugfix and pass after it, as expected).
- When an actual file called `NUL` exists on Windows in the directory being operated in. This is possible with `\\?\` paths, and the main point of testing this is to show that accessing the null device as `NUL` still works and is unaffected by such a file. Thus this is not just renaming the hypothetical file that would mess things up, but eliminating it.

Regarding that last point, the main goal of explicitly testing with a file called `NUL` is demonstrative. But there may be a practical benefit, in that it is possible to write code that wrongly opens such a file, if one starts out with `NUL` and joins it to the result of calling `canonicalize()`. The `canonicalize()` functions in Rust return UNC paths on Windows, which may be unexpected. (This, albeit deliberately, is how I made the file in the first place.)

It think testing with a file actually named `NUL` is not really necessary, and I am unsure if it's worthwhile to keep this or not, because the tests can be shorter without it. But another option, rather than removing that, would be to move these unit tests of private members in `tests/tools/src/lib.rs` from there to a newly created `tests/tools/src/tests.rs` module. Or both changes could be made. For now I've left the elaborated tests and also not (yet?) moved them to a different file. (Neither these tests nor anything affected by this PR should be confused with the integration tests introduced in #1560, which are inside `tests/tools/tests/`.)

Although the topic of this PR is somewhat conceptually related to that of some other recent PRs such as #1567, the small bug this is addressing and the changes it makes are independent of those. This PR introduces and uses a private `NULL_DEVICE` constant for the null device path, which is defined the same way as in the `gix-path` crate as of 9917d47 (#1568). But it doesn't necessarily make sense for `gix-path` to expose that, `gix-testtools` also does not already directly declare `gix-path` as a dependency, and I have not thought of a reasonable other gitoxide crate that ought to have, and commit to having, it. So at least for now I think the duplication is acceptable.