### PR TITLE
Omit other high-scoped config in fixtures

### DIFF
--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -603,7 +603,7 @@ fn configure_command<'a>(
         .env_remove("GIT_ASKPASS")
         .env_remove("SSH_ASKPASS")
         .env("MSYS", msys_for_git_bash_on_windows)
-        .env("GIT_CONFIG_SYSTEM", NULL_DEVICE)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_CONFIG_GLOBAL", NULL_DEVICE)
         .env("GIT_TERMINAL_PROMPT", "false")
         .env("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000")

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -921,7 +921,8 @@ mod tests {
         configure_command(&mut cmd, &args, temp.path());
 
         let output = cmd.output().expect("can run git");
-        let lines: Vec<_> = output.stdout
+        let lines: Vec<_> = output
+            .stdout
             .to_str()
             .expect("valid UTF-8")
             .lines()


### PR DESCRIPTION
As requested in https://github.com/Byron/gitoxide/pull/1570#issuecomment-2323236218, this has the `configure_command` helper function in `gix-testtools` use `GIT_CONFIG_NOSYSTEM` instead of `GIT_CONFIG_SYSTEM` to suppress Git configuration variables in scopes associated with the `git` installation, even when this includes a scope other than the system scope.

This is for the "unknown" scope in Apple Git. I am not aware of other practical cases where this applies, though if they exist then this should help with them too.

Due to having only sporadic and limited access to macOS outside of CI, I have not tested this locally on macOS. Because I think the `git` installation on CI runners is always a more recent version set up when customizing the image, I would not expect the consolidated and extended test to fail before the fix on CI.

If feasible, I suggest running the test locally on macOS at the first commit ([d576b32](https://github.com/Byron/gitoxide/pull/1571/commits/d576b321008d7e19180cfcd6a8d132352600bc91)) to confirm that it fails, and at or after the second commit ([a879d22](https://github.com/Byron/gitoxide/pull/1571/commits/a879d2214ae40be7692fa00360c8151bb8e2e88e)) to confirm that it passes. I do not know any reasonably reliable way to test this in the test suite on other systems; I don't think most builds of Git support such scopes, nor should the test suite actually add, remove, or alter existing configuration files that would affect other programs running on the system.

There is some more information in the commit messages. In particular, I consolidated the two existing tests (from #1570) and extended the resulting single test so that, in addition to effectively covering what was covered before, it tests that no other configuration from files is present in the output of `git config -l --show-origin` when `configure_command` is used. While `configure_command` adds configuration variables, they are in the command scope, rather than files. Excluding other files will automatically cover the "unknown" scope. It will also automatically cover the local scope. More details about this, including why I made it so even local scope variables will make the test fail, is included in the first commit message.