### PR TITLE
Append to preexisting `MSYS` env var even if ill-formed

### DIFF
--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -593,8 +593,8 @@ fn configure_command<'a>(
     args: &[String],
     script_result_directory: &Path,
 ) -> &'a mut std::process::Command {
-    let mut msys_for_git_bash_on_windows = std::env::var("MSYS").unwrap_or_default();
-    msys_for_git_bash_on_windows.push_str(" winsymlinks:nativestrict");
+    let mut msys_for_git_bash_on_windows = std::env::var_os("MSYS").unwrap_or_default();
+    msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
     cmd.args(args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -872,7 +872,6 @@ impl<'a> Drop for Env<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsStr;
 
     #[test]
     fn parse_version() {
@@ -932,45 +931,5 @@ mod tests {
         let status = output.status.code().expect("terminated normally");
         assert_eq!(lines, Vec::<&str>::new(), "should be no config variables from files");
         assert_eq!(status, 0, "reading the config should succeed");
-    }
-
-    #[test]
-    fn configure_command_msys() {
-        let temp = tempfile::TempDir::new().expect("can create temp dir");
-        let mut cmd = std::process::Command::new("not-actually-run");
-
-        let msys_option = configure_command(&mut cmd, &[], temp.path())
-            .get_envs()
-            .find(|(k, _)| *k == OsStr::new("MSYS"))
-            .expect("should customize MSYS variable")
-            .1
-            .expect("should set, not unset, MSYS variable")
-            .to_str()
-            .expect("valid UTF-8")
-            .trim_matches(' ');
-
-        assert_eq!(msys_option, "winsymlinks:nativestrict");
-    }
-
-    #[test]
-    fn configure_command_msys_extends() {
-        let old_msys = r"error_start:C:\gdb.exe";
-        let temp = tempfile::TempDir::new().expect("can create temp dir");
-        let mut cmd = std::process::Command::new("not-actually-run");
-        cmd.env("MSYS", old_msys);
-
-        let msys_options = configure_command(&mut cmd, &[], temp.path())
-            .get_envs()
-            .find(|(k, _)| *k == OsStr::new("MSYS"))
-            .expect("should customize MSYS variable")
-            .1
-            .expect("should set, not unset, MSYS variable")
-            .to_str()
-            .expect("valid UTF-8")
-            .split(' ') // Just spaces, not arbitrary whitespace.
-            .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>();
-
-        assert_eq!(msys_options, vec![old_msys, "winsymlinks:nativestrict"]);
     }
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -872,6 +872,7 @@ impl<'a> Drop for Env<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
 
     #[test]
     fn parse_version() {
@@ -931,5 +932,45 @@ mod tests {
         let status = output.status.code().expect("terminated normally");
         assert_eq!(lines, Vec::<&str>::new(), "should be no config variables from files");
         assert_eq!(status, 0, "reading the config should succeed");
+    }
+
+    #[test]
+    fn configure_command_msys() {
+        let temp = tempfile::TempDir::new().expect("can create temp dir");
+        let mut cmd = std::process::Command::new("not-actually-run");
+
+        let msys_option = configure_command(&mut cmd, &[], temp.path())
+            .get_envs()
+            .find(|(k, _)| *k == OsStr::new("MSYS"))
+            .expect("should customize MSYS variable")
+            .1
+            .expect("should set, not unset, MSYS variable")
+            .to_str()
+            .expect("valid UTF-8")
+            .trim_matches(' ');
+
+        assert_eq!(msys_option, "winsymlinks:nativestrict");
+    }
+
+    #[test]
+    fn configure_command_msys_extends() {
+        let old_msys = r"error_start:C:\gdb.exe";
+        let temp = tempfile::TempDir::new().expect("can create temp dir");
+        let mut cmd = std::process::Command::new("not-actually-run");
+        cmd.env("MSYS", old_msys);
+
+        let msys_options = configure_command(&mut cmd, &[], temp.path())
+            .get_envs()
+            .find(|(k, _)| *k == OsStr::new("MSYS"))
+            .expect("should customize MSYS variable")
+            .1
+            .expect("should set, not unset, MSYS variable")
+            .to_str()
+            .expect("valid UTF-8")
+            .split(' ') // Just spaces, not arbitrary whitespace.
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+
+        assert_eq!(msys_options, vec![old_msys, "winsymlinks:nativestrict"]);
     }
 }


### PR DESCRIPTION
Fixes #1574

When the `MSYS` variable is absent, we treat this the same as when it is present but empty. However, as described in #1574, an `MSYS` variable that is present but whose value contains an unpaired surrogate would also be replaced entirely, rather than appending to its old value. This changes that, to instead append, retaining whatever was there even if it was ill-formed Unicode.

An alternative change could be to panic when the old value is ill-formed Unicode. The change made here allows and appends to the old value, rather than panicking or keeping and documenting the previous behavior of discarding the old value, because the appended sequence ` winsymlinks:nativestrict` is effective at causing fixture scripts to attempt to create actual symlinks even if the preceding code point is an unpaired Unicode high surrogate.

---

To avoid confusion related to #1358, I tested without setting `GIX_TEST_IGNORE_ARCHIVES`, relying on how some fixtures must still run because archive generation is suppressed for them in `.gitignore` files. That failure would occur in connection with the `MSYS` variable even when run this way was observed in #1443 and #1444, but I have also verified that.

This PR adds and then removes tests, which were unsuitable for the reasons noted in #1578, and which I removed rather than attempting to fix due to the concerns in #1577 combined with there being little doubt, in this case, that the code using `OsString::push` works as it seems. If those abandoned tests are not wanted in the history, I have no objection to rebasing to remove those commits, which I would be pleased to do on request.

[**This gist**](https://gist.github.com/EliahKagan/fc6f81c4d0f1da5bd327772f3870f852) contains transcript of the manual verification done to decide on and check over this approach. The scripts run in a [normal environment](https://gist.github.com/EliahKagan/fc6f81c4d0f1da5bd327772f3870f852#file-1-no-msys-inherited-txt), as well as in an [environment in which the old value of `MSYS` has a trailing unpaired Unicode high surrogate](https://gist.github.com/EliahKagan/fc6f81c4d0f1da5bd327772f3870f852#file-2-ill-formed-msys-inherited-txt). Failures occur due to the [absence of `MSYS` when the code that sets it is removed](https://gist.github.com/EliahKagan/fc6f81c4d0f1da5bd327772f3870f852#file-3-no-msys-inherited-or-added-txt), which verifies both that this code does not break setting it, and that the appended space character and `winsymlinks` option takes effect properly even if it immediately follows an unpaired high surrogate that "tries" to combine with the next code point. [Testing with a `panic!` temporarily added](https://gist.github.com/EliahKagan/fc6f81c4d0f1da5bd327772f3870f852#file-4-with-panic-temporarily-added-to-check-value-txt), by the same technique as #1574, confirms that we really are concatenating.

All full test runs have an unrelated failure of `jj_realistic_needs_to_be_more_clever` locally, which is due to #1575 and can therefore be disregarded in the transcripts of local test runs here. Between tests, I removed generated fixture script output by using the technique discussed in #1435 of running `gix clean -xd -m '*generated*' -e`, which is shown in the gist transcripts. I did it that way rather than by running the stronger command `gix clean -xde` so the unpaired surrogate in the `MSYS` environment variable would not stall the build due to https://github.com/rust-lang/libz-sys/issues/215. The command used is strong enough, but to doubly ensure insufficient cleaning would not cause misinterpreted results, I ran the tests with the expected failure modification last of all the full runs, so that if left-over fixture output was going to cause tests to wrongly pass, then it would happen with the tests I was verifying should fail.