### PR TITLE
Don't read "installation" config from `GIT_CONFIG`

### DIFF
--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -140,8 +140,10 @@ fn git_cmd(executable: PathBuf) -> Command {
     // scope. Although `GIT_CONFIG_NOSYSTEM` will suppress this as well, passing --system omits it.
     cmd.args(["config", "-lz", "--show-origin", "--name-only"])
         .current_dir(cwd)
-        .env_remove("GIT_COMMON_DIR") // We are setting `GIT_DIR`.
         .env_remove("GIT_DISCOVERY_ACROSS_FILESYSTEM")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_COMMON_DIR")
         .env("GIT_DIR", NULL_DEVICE) // Avoid getting local-scope config.
         .env("GIT_WORK_TREE", NULL_DEVICE) // Avoid confusion when debugging.
         .stdin(Stdio::null())

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -140,6 +140,7 @@ fn git_cmd(executable: PathBuf) -> Command {
     // scope. Although `GIT_CONFIG_NOSYSTEM` will suppress this as well, passing --system omits it.
     cmd.args(["config", "-lz", "--show-origin", "--name-only"])
         .current_dir(cwd)
+        .env_remove("GIT_CONFIG")
         .env_remove("GIT_DISCOVERY_ACROSS_FILESYSTEM")
         .env_remove("GIT_OBJECT_DIRECTORY")
         .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -455,6 +455,13 @@ mod exe_info {
 
     #[test]
     #[serial]
+    fn tolerates_git_config_env_var() {
+        let _env = gix_testtools::Env::new().set("GIT_CONFIG", NULL_DEVICE);
+        check_exe_info();
+    }
+
+    #[test]
+    #[serial]
     fn same_result_with_broken_temp() {
         let with_unmodified_temp = exe_info();
 
@@ -478,6 +485,19 @@ mod exe_info {
         };
 
         assert_eq!(with_unmodified_env, with_oversanitized_env);
+    }
+
+    #[test]
+    #[serial]
+    fn same_result_with_git_config_env_var() {
+        let with_unmodified_env = exe_info();
+
+        let with_git_config_env_var = {
+            let _env = gix_testtools::Env::new().set("GIT_CONFIG", NULL_DEVICE);
+            exe_info()
+        };
+
+        assert_eq!(with_unmodified_env, with_git_config_env_var);
     }
 
     #[test]
@@ -553,6 +573,34 @@ mod exe_info {
         assert_eq!(
             maybe_path, None,
             "Should find no config path if the config would be local even in a `/tmp`-like dir (suppressed system config)"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn never_from_git_config_env_var() {
+        let repo = gix_testtools::scripted_fixture_read_only("local_config.sh").expect("script succeeds");
+
+        // FIXME: exe_info() changes directory, so this is not seen, which results in this test
+        // wrongly passing even if exe_info() does not really ensure GIT_CONFIG is ignore. So
+        // either make this path an absolute non-UNC path (non-UNC to ensure all versions of Git
+        // accept it) or use a newly created temporary file rather than the fixture.
+        let config_path = repo
+            .join(".git")
+            .join("config")
+            .to_str()
+            .expect("valid UTF-8")
+            .to_owned();
+
+        let _env = gix_testtools::Env::new()
+            .set("GIT_CONFIG_NOSYSTEM", "1")
+            .set("GIT_CONFIG_GLOBAL", NULL_DEVICE)
+            .set("GIT_CONFIG", config_path);
+
+        let maybe_path = exe_info();
+        assert_eq!(
+            maybe_path, None,
+            "Should find no config path from GIT_CONFIG (even if nonempty)"
         );
     }
 

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -581,11 +581,10 @@ mod exe_info {
     fn never_from_git_config_env_var() {
         let repo = gix_testtools::scripted_fixture_read_only("local_config.sh").expect("script succeeds");
 
-        // FIXME: exe_info() changes directory, so this is not seen, which results in this test
-        // wrongly passing even if exe_info() does not really ensure GIT_CONFIG is ignore. So
-        // either make this path an absolute non-UNC path (non-UNC to ensure all versions of Git
-        // accept it) or use a newly created temporary file rather than the fixture.
-        let config_path = repo
+        // Get an absolute path to a config file that is non-UNC if possible so any Git accepts it.
+        let config_path = std::env::current_dir()
+            .expect("got CWD")
+            .join(repo)
             .join(".git")
             .join("config")
             .to_str()


### PR DESCRIPTION
This makes it so `GIT_HIGHEST_SCOPE_CONFIG_PATH` never uses the value of the `GIT_CONFIG` environment variable. Previously it used it because `git config` uses it, treating it as though its value were an operand to `--file`. But no other `git` commands use it.

It was previously used in most situations when present, since it causes `git config -l` to list nothing else of any scope (even if very high scoped configuration is available). The main and possibly only significant situation where it was not used was the `EXEPATH` optimization on Windows (which in practice only occurs in Git Bash environments). I think this inconsistency--since it never has anything to do with whether a user would want `GIT_CONFIG` to have an effect--is one of the most significant reasons to omit it.

However, when reviewing this, I recommend considering if possible uses where a user would set `GIT_CONFIG` to view configuration from an arbitrary file with commands like `gix config`--even though it would not work from Git Bash--might be something people are doing. I have prefixed the commit message `fix:` but maybe I should have written `fix!:` for this reason? I am not sure. But as far as I know, this is not altering any behavior to become inconsistent with what was previously documented or otherwise stated.

There is more information in the commit messages, especially the one prefixed `fix:`, eb72d31a6. This also adds tests related to `GIT_CONFIG`, in the two commits that precede that, 340ff371d and f8e38d057.

I have also unset some other environment variables (that would only occasionally be set in the first place) besides `GIT_CONFIG`. This is in the first commit, 01a412feb, and it is for a different reason: it is to ensure that even if some version of `git` behaves weirdly, or if my understanding of its intended behavior is incorrect, then we still get the full effect of setting `GIT_DIR`. The commit message has more information about that. I mostly included that here rather than in a separate PR to avoid a merge conflict (or decreased code readability if the `remove_env` calls were to be merged in an unintuitive order).