### PR TITLE
Have CI check if we need to commit regenerated archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,13 @@ jobs:
         with:
           tool: nextest
       - name: "Test (nextest)"
+        env:
+          GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: 1
         run: cargo nextest run --all --no-fail-fast
       - name: Doctest
         run: cargo test --doc
+      - name: Check that tracked archives are up to date
+        run: git diff  # If this fails, the fix is usually to commit a regenerated archive.
 
   test-32bit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Doctest
         run: cargo test --doc
       - name: Check that tracked archives are up to date
-        run: git diff  # If this fails, the fix is usually to commit a regenerated archive.
+        run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
   test-32bit:
     runs-on: ubuntu-latest

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -569,7 +569,7 @@ fn scripted_fixture_read_only_with_args_inner(
                     output.stdout.as_bstr(),
                     output.stderr.as_bstr()
                 );
-                create_archive_if_not_on_ci(
+                create_archive_if_we_should(
                     &script_result_directory,
                     &archive_file_path,
                     script_identity_for_archive,
@@ -644,7 +644,7 @@ fn is_lfs_pointer_file(path: &Path) -> bool {
 
 /// The `script_identity` will be baked into the soon to be created `archive` as it identifies the script
 /// that created the contents of `source_dir`.
-fn create_archive_if_not_on_ci(source_dir: &Path, archive: &Path, script_identity: u32) -> std::io::Result<()> {
+fn create_archive_if_we_should(source_dir: &Path, archive: &Path, script_identity: u32) -> std::io::Result<()> {
     // On Windows, we fail to remove the meta_dir and can't do anything about it, which means tests will see more
     // in the directory than they should which makes them fail. It's probably a bad idea to generate archives on Windows
     // anyway. Either Unix is portable OR no archive is created anywhere. This also means that Windows users can't create

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -642,12 +642,12 @@ fn is_lfs_pointer_file(path: &Path) -> bool {
         .map_or(false, |_| buf.starts_with(PREFIX))
 }
 
-/// The `script_identity` will be baked into the soon to be created `archive` as it identitifies the script
+/// The `script_identity` will be baked into the soon to be created `archive` as it identifies the script
 /// that created the contents of `source_dir`.
 fn create_archive_if_not_on_ci(source_dir: &Path, archive: &Path, script_identity: u32) -> std::io::Result<()> {
-    // on windows, we fail to remove the meta_dir and can't do anything about it, which means tests will see more
-    // in the directory than they should which makes them fail. It's probably a bad idea to generate archives on windows
-    // anyway. Either unix is portable OR no archive is created anywhere. This also means that windows users can't create
+    // On Windows, we fail to remove the meta_dir and can't do anything about it, which means tests will see more
+    // in the directory than they should which makes them fail. It's probably a bad idea to generate archives on Windows
+    // anyway. Either Unix is portable OR no archive is created anywhere. This also means that Windows users can't create
     // archives, but that's not a deal-breaker.
     if cfg!(windows) || is_ci::cached() || is_excluded(archive) {
         return Ok(());

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -10,6 +10,7 @@
 
 use std::{
     collections::BTreeMap,
+    env,
     ffi::OsString,
     io::Read,
     path::{Path, PathBuf},
@@ -150,8 +151,8 @@ fn git_version_from_bytes(bytes: &[u8]) -> Result<(u8, u8, u8)> {
 
 /// Set the current working dir to `new_cwd` and return a type that returns to the previous working dir on drop.
 pub fn set_current_dir(new_cwd: impl AsRef<Path>) -> std::io::Result<AutoRevertToPreviousCWD> {
-    let cwd = std::env::current_dir()?;
-    std::env::set_current_dir(new_cwd)?;
+    let cwd = env::current_dir()?;
+    env::set_current_dir(new_cwd)?;
     Ok(AutoRevertToPreviousCWD(cwd))
 }
 
@@ -166,7 +167,7 @@ pub struct AutoRevertToPreviousCWD(PathBuf);
 
 impl Drop for AutoRevertToPreviousCWD {
     fn drop(&mut self) {
-        std::env::set_current_dir(&self.0).unwrap();
+        env::set_current_dir(&self.0).unwrap();
     }
 }
 
@@ -461,7 +462,7 @@ fn scripted_fixture_read_only_with_args_inner(
                 crc_digest.update(&std::fs::read(&script_path).unwrap_or_else(|err| {
                     panic!(
                         "file {script_path:?} in CWD {:?} could not be read: {err}",
-                        std::env::current_dir().expect("valid cwd"),
+                        env::current_dir().expect("valid cwd"),
                     )
                 }));
                 for arg in &args {
@@ -548,7 +549,7 @@ fn scripted_fixture_read_only_with_args_inner(
                         script_location.display()
                     );
                 }
-                let script_absolute_path = std::env::current_dir()?.join(script_path);
+                let script_absolute_path = env::current_dir()?.join(script_path);
                 let mut cmd = std::process::Command::new(&script_absolute_path);
                 let output = match configure_command(&mut cmd, &args, &script_result_directory).output() {
                     Ok(out) => out,
@@ -593,7 +594,7 @@ fn configure_command<'a>(
     args: &[String],
     script_result_directory: &Path,
 ) -> &'a mut std::process::Command {
-    let mut msys_for_git_bash_on_windows = std::env::var_os("MSYS").unwrap_or_default();
+    let mut msys_for_git_bash_on_windows = env::var_os("MSYS").unwrap_or_default();
     msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
     cmd.args(args)
         .stdout(std::process::Stdio::piped())
@@ -632,6 +633,14 @@ fn write_failure_marker(failure_marker: &Path) {
     std::fs::write(failure_marker, []).ok();
 }
 
+fn should_skip_all_archive_creation() -> bool {
+    // On Windows, we fail to remove the meta_dir and can't do anything about it, which means tests will see more
+    // in the directory than they should which makes them fail. It's probably a bad idea to generate archives on Windows
+    // anyway. Either Unix is portable OR no archive is created anywhere. This also means that Windows users can't create
+    // archives, but that's not a deal-breaker.
+    cfg!(windows) || (is_ci::cached() && !env::var_os("GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI").is_some())
+}
+
 fn is_lfs_pointer_file(path: &Path) -> bool {
     const PREFIX: &[u8] = b"version https://gix-lfs";
     let mut buf = [0_u8; PREFIX.len()];
@@ -645,11 +654,7 @@ fn is_lfs_pointer_file(path: &Path) -> bool {
 /// The `script_identity` will be baked into the soon to be created `archive` as it identifies the script
 /// that created the contents of `source_dir`.
 fn create_archive_if_we_should(source_dir: &Path, archive: &Path, script_identity: u32) -> std::io::Result<()> {
-    // On Windows, we fail to remove the meta_dir and can't do anything about it, which means tests will see more
-    // in the directory than they should which makes them fail. It's probably a bad idea to generate archives on Windows
-    // anyway. Either Unix is portable OR no archive is created anywhere. This also means that Windows users can't create
-    // archives, but that's not a deal-breaker.
-    if cfg!(windows) || is_ci::cached() || is_excluded(archive) {
+    if should_skip_all_archive_creation() || is_excluded(archive) {
         return Ok(());
     }
     if is_lfs_pointer_file(archive) {
@@ -702,7 +707,7 @@ fn is_excluded(archive: &Path) -> bool {
     let mut lut = EXCLUDE_LUT.lock();
     lut.as_mut()
         .and_then(|cache| {
-            let archive = std::env::current_dir().ok()?.join(archive);
+            let archive = env::current_dir().ok()?.join(archive);
             let relative_path = archive.strip_prefix(cache.base()).ok()?;
             cache
                 .at_path(
@@ -746,7 +751,7 @@ fn extract_archive(
         let mut buf = Vec::new();
         #[cfg_attr(feature = "xz", allow(unused_mut))]
         let mut input_archive = std::fs::File::open(archive)?;
-        if std::env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some() {
+        if env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
@@ -848,16 +853,16 @@ impl<'a> Env<'a> {
 
     /// Set `var` to `value`.
     pub fn set(mut self, var: &'a str, value: impl Into<String>) -> Self {
-        let prev = std::env::var_os(var);
-        std::env::set_var(var, value.into());
+        let prev = env::var_os(var);
+        env::set_var(var, value.into());
         self.altered_vars.push((var, prev));
         self
     }
 
     /// Unset `var`.
     pub fn unset(mut self, var: &'a str) -> Self {
-        let prev = std::env::var_os(var);
-        std::env::remove_var(var);
+        let prev = env::var_os(var);
+        env::remove_var(var);
         self.altered_vars.push((var, prev));
         self
     }
@@ -867,8 +872,8 @@ impl<'a> Drop for Env<'a> {
     fn drop(&mut self) {
         for (var, prev_value) in self.altered_vars.iter().rev() {
             match prev_value {
-                Some(value) => std::env::set_var(var, value),
-                None => std::env::remove_var(var),
+                Some(value) => env::set_var(var, value),
+                None => env::remove_var(var),
             }
         }
     }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -638,7 +638,7 @@ fn should_skip_all_archive_creation() -> bool {
     // in the directory than they should which makes them fail. It's probably a bad idea to generate archives on Windows
     // anyway. Either Unix is portable OR no archive is created anywhere. This also means that Windows users can't create
     // archives, but that's not a deal-breaker.
-    cfg!(windows) || (is_ci::cached() && !env::var_os("GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI").is_some())
+    cfg!(windows) || (is_ci::cached() && env::var_os("GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI").is_none())
 }
 
 fn is_lfs_pointer_file(path: &Path) -> bool {


### PR DESCRIPTION
This adds the ability of `gix-testtools` to generate archives of fixture output even when the environment is detected to be CI. This behavior is turned off by default, but enabled if `GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI` is set. A small amount of refactoring is included to avoid decreasing code readability while making this change.

Although there are a few plausible use cases for this, which along with other information are detailed in commit messages, the motivating use case is to let us use CI to find out if generated archives are out of date. This is something that has happened a number of times, and is not always immediately noticed, because it has had to be observed in the state of a repository after running tests locally.

On this project's CI, this newly recognized environment variable is:

- Left unset in the `test` job.
- Set in the `test-fast` jobs. The `test-fast` jobs will use existing generated archives if available, because `GIX_TEST_IGNORE_ARCHIVES` is not set for them, so this should only cause more work to be done on CI in situations where there something is wrong.

In addition to setting `GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI` for the `test-fast` jobs, this also adds a new step at the end to run `git diff --exit-code`. That actually detects if any new archives were create. This is because, in practice, as far as I know, they always end up being at least slightly different from whatever existed before for them, if anything.

There may be slightly more efficient ways to detect this, and maybe even slightly more reliable ways to detect it, but I think it makes sense to start with this way, because:

- As noted in commit messages, there are some other plausible applications of the new environment variable anyway, including if other projects that use `gix-testtools` ever want to use CI to generate their archives and save them as artifacts for reuse.
- This automates what is, in effect, the exact workflow that happens locally, for noticing that running the test suite produces a new or changed generated archive.

---

**As of now, CI will fail** on this PR, because there is an archive that needs to be regenerated. The new step can be expected [to fails with](https://github.com/EliahKagan/gitoxide/actions/runs/10803415921/job/29967218978):

```text
Run git diff --exit-code
  git diff --exit-code
  shell: /bin/bash -e {0}
  env:
    CARGO_TERM_COLOR: always
    CLICOLOR: 1
    CARGO_HOME: /Users/runner/.cargo
    CARGO_INCREMENTAL: 0
    CACHE_ON_FAILURE: false
diff --git a/gix-worktree-state/tests/fixtures/generated-archives/make_dangling_symlink_to_windows_reserved.tar b/gix-worktree-state/tests/fixtures/generated-archives/make_dangling_symlink_to_windows_reserved.tar
index 3d9c416..4d50761 100644
Binary files a/gix-worktree-state/tests/fixtures/generated-archives/make_dangling_symlink_to_windows_reserved.tar and b/gix-worktree-state/tests/fixtures/generated-archives/make_dangling_symlink_to_windows_reserved.tar differ
Error: Process completed with exit code 1.
```

If #1589 is merged to main, and then this PR is rebased onto main (or main is merged into it afterwards), CI here should pass.