### PR TITLE
In gix-testtools, use `ignore` and `index` via `gix_worktree`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,8 +2577,6 @@ dependencies = [
  "fs_extra",
  "gix-discover 0.32.0",
  "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ignore 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-index 0.33.1",
  "gix-lock 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-tempfile 14.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-worktree 0.34.1",

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -27,9 +27,6 @@ xz = ["dep:xz2"]
 [dependencies]
 gix-lock = "14.0.0"
 gix-discover = "0.32.0"
-# TODO(ST) remove once `gix-worktree` exports `index`.
-gix-ignore = "0.11.2"
-gix-index = "0.33.0"
 gix-worktree = "0.34.0"
 gix-fs = "0.11"
 gix-tempfile = { version = "^14.0.0", default-features = false, features = ["signals"] }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -67,11 +67,11 @@ static EXCLUDE_LUT: Lazy<Mutex<Option<gix_worktree::Stack>>> = Lazy::new(|| {
         let mut buf = Vec::with_capacity(512);
         let case = gix_fs::Capabilities::probe(&work_tree)
             .ignore_case
-            .then_some(gix_ignore::glob::pattern::Case::Fold)
+            .then_some(gix_worktree::ignore::glob::pattern::Case::Fold)
             .unwrap_or_default();
         let state = gix_worktree::stack::State::IgnoreStack(gix_worktree::stack::state::Ignore::new(
             Default::default(),
-            gix_ignore::Search::from_git_dir(&gix_dir, None, &mut buf).ok()?,
+            gix_worktree::ignore::Search::from_git_dir(&gix_dir, None, &mut buf).ok()?,
             None,
             gix_worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped,
         ));
@@ -707,7 +707,7 @@ fn is_excluded(archive: &Path) -> bool {
             cache
                 .at_path(
                     relative_path,
-                    Some(gix_index::entry::Mode::FILE),
+                    Some(gix_worktree::index::entry::Mode::FILE),
                     &gix_worktree::object::find::Never,
                 )
                 .ok()?


### PR DESCRIPTION
This removes the `gix-ignore` and `gix-index` direct dependencies of `gix-testtools`, by having `gix_testtools` use them through `gix-worktree`, accessing `gix_worktree::ignore` for `gix_ignore` and `gix_worktree::index` for `gix_index`.

The rationale is that various other `gix-*` dependencies were used this way already, and also that this specific change appears to have been planned, based on the TODO comment in ddaacda (#1413).

Just in case this were to have unanticipated ramifications, I've rerun the full test suite, after `gix clean -xde`, both with and without `GIX_TESTS_IGNORE_ARCHIVES=1`, locally on Ubuntu 22.04 LTS and Windows 10.

([On Windows 10](https://gist.github.com/EliahKagan/1aa24e5ba916ede6c9a1788d08c10aff) without using pre-generated archives, there are failures, but the failures are the same as in #1358 and https://github.com/Byron/gitoxide/issues/1358#issuecomment-2342635661 in [this gist](https://gist.github.com/EliahKagan/1ff070df2c144f26ffacc7c73ff14143), indicating that the changes in this PR have not broken Windows either.)