### PR TITLE
Make `configure_command` easier to call and comment about `MSYS`

### DIFF
--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -594,6 +594,9 @@ fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
     args: I,
     script_result_directory: &Path,
 ) -> &'a mut std::process::Command {
+    // For simplicity, we extend the `MSYS` variable from from our own environment. This disregards
+    // state from any prior `cmd.env("MSYS")` or `cmd.env_remove("MSYS")` calls. Such calls should
+    // either be avoided, or made after this function returns (but before spawning the command).
     let mut msys_for_git_bash_on_windows = env::var_os("MSYS").unwrap_or_default();
     msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
     cmd.args(args)

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -11,7 +11,7 @@
 use std::{
     collections::BTreeMap,
     env,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     io::Read,
     path::{Path, PathBuf},
     str::FromStr,
@@ -589,11 +589,15 @@ const NULL_DEVICE: &str = "NUL";
 #[cfg(not(windows))]
 const NULL_DEVICE: &str = "/dev/null";
 
-fn configure_command<'a>(
+fn configure_command<'a, I, S>(
     cmd: &'a mut std::process::Command,
-    args: &[String],
+    args: I,
     script_result_directory: &Path,
-) -> &'a mut std::process::Command {
+) -> &'a mut std::process::Command
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
     let mut msys_for_git_bash_on_windows = env::var_os("MSYS").unwrap_or_default();
     msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
     cmd.args(args)
@@ -925,10 +929,9 @@ mod tests {
         populate_ad_hoc_config_files(temp.path());
 
         let mut cmd = std::process::Command::new("git");
-        let args = ["config", "-l", "--show-origin"].map(String::from);
         cmd.env("GIT_CONFIG_SYSTEM", SCOPE_ENV_VALUE);
         cmd.env("GIT_CONFIG_GLOBAL", SCOPE_ENV_VALUE);
-        configure_command(&mut cmd, &args, temp.path());
+        configure_command(&mut cmd, ["config", "-l", "--show-origin"], temp.path());
 
         let output = cmd.output().expect("can run git");
         let lines: Vec<_> = output

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -589,15 +589,11 @@ const NULL_DEVICE: &str = "NUL";
 #[cfg(not(windows))]
 const NULL_DEVICE: &str = "/dev/null";
 
-fn configure_command<'a, I, S>(
+fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
     cmd: &'a mut std::process::Command,
     args: I,
     script_result_directory: &Path,
-) -> &'a mut std::process::Command
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
+) -> &'a mut std::process::Command {
     let mut msys_for_git_bash_on_windows = env::var_os("MSYS").unwrap_or_default();
     msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
     cmd.args(args)


### PR DESCRIPTION
No major design changes along the lines discussed in #1578 seemed like a decisive improvement; all of them had significant disadvantages. This instead:

- Makes `configure_command` take anything we can iterate to get arguments, rather than requiring a `&[String]`. This makes the current test simpler and easier to read, and should also help with future tests.
- Comments about how we don't heed `env` and `env_remove` calls on the `Command` object where `"MSYS"` is the key, since we take it from our environment directly and modify that.

There's slightly more thoughts in the commit messages. Also, I had trouble articulating why I thought 0e1e6a9 might be better here, since I don't usually prefer the more compact style, so maybe it's better without that change.