### PR TITLE
Double the fixture lock timeout

### DIFF
--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -511,7 +511,7 @@ fn scripted_fixture_read_only_with_args_inner(
 
     let _marker = gix_lock::Marker::acquire_to_hold_resource(
         script_basename,
-        gix_lock::acquire::Fail::AfterDurationWithBackoff(Duration::from_secs(3 * 60)),
+        gix_lock::acquire::Fail::AfterDurationWithBackoff(Duration::from_secs(6 * 60)),
         None,
     )?;
     let failure_marker = script_result_directory.join("_invalid_state_due_to_script_failure_");


### PR DESCRIPTION
Fixes #1605

As suggested in https://github.com/Byron/gitoxide/issues/1605#issuecomment-2370630099, this increases the lock timeout `gix-testtools` uses when it runs fixture scripts.

If 6 minutes is too long, I can experiment with intermediate values.

`Duration::from_mins` is still marked experimental in the standard library, so I've continued to use `Duration::from_secs` with `* 60` as before.