### PR TITLE
Tell github-linguist to count fixture shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,8 @@
 **/tests/fixtures/**/*.sh text crlf=input	eol=lf
 /justfile text crlf=input	eol=lf
 
+# have GitHub include fixture-making scripts when it counts code
+**/tests/fixtures/**/*.sh linguist-vendored=false
+
 # have GitHub treat the gix-packetline-blocking src copy as auto-generated
 gix-packetline-blocking/src/ linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
-generated-archives/*.tar* filter=lfs-disabled diff=lfs merge=lfs -text
+**/generated-archives/*.tar* filter=lfs-disabled diff=lfs merge=lfs -text
 
 # assure line feeds don't interfere with our working copy hash
-tests/fixtures/**/*.sh text crlf=input	eol=lf
+**/tests/fixtures/**/*.sh text crlf=input	eol=lf
 /justfile text crlf=input	eol=lf
 
 # have GitHub include fixture-making scripts when it counts code
-tests/fixtures/**/*.sh linguist-vendored=false
+**/tests/fixtures/**/*.sh linguist-vendored=false
 
 # have GitHub treat the gix-packetline-blocking src copy as auto-generated
 gix-packetline-blocking/src/ linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
-**/generated-archives/*.tar* filter=lfs-disabled diff=lfs merge=lfs -text
+generated-archives/*.tar* filter=lfs-disabled diff=lfs merge=lfs -text
 
 # assure line feeds don't interfere with our working copy hash
-**/tests/fixtures/**/*.sh text crlf=input	eol=lf
+tests/fixtures/**/*.sh text crlf=input	eol=lf
 /justfile text crlf=input	eol=lf
 
 # have GitHub include fixture-making scripts when it counts code
-**/tests/fixtures/**/*.sh linguist-vendored=false
+tests/fixtures/**/*.sh linguist-vendored=false
 
 # have GitHub treat the gix-packetline-blocking src copy as auto-generated
 gix-packetline-blocking/src/ linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,29 +12,9 @@ on:
       - '**/run-ci/**'
     tags-ignore:
       - '*'
-    paths:
-      - '.github/**'
-      - 'ci/**'
-      - 'etc/**'
-      - 'src/**'
-      - 'tests/**'
-      - 'cargo-*/**'
-      - 'gix*/**'
-      - '*.toml'
-      - Makefile
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/**'
-      - 'ci/**'
-      - 'etc/**'
-      - 'src/**'
-      - 'tests/**'
-      - 'cargo-*/**'
-      - 'gix*/**'
-      - '*.toml'
-      - Makefile
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
By default, github-linguist [treats source code files inside `tests/fixtures` directories as vendored](https://github.com/github-linguist/linguist/blob/9b50e9e46bc0fb2451f5deee612a36c386aae6cf/lib/linguist/vendor.yml#L342-L344), thereby declining to consider them when computing the percentage each language contributes to a repository:

```yml
# Test fixtures
- (^|/)[Tt]ests?/fixtures/
- (^|/)[Ss]pecs?/fixtures/
```

But in this repository, the shell scripts inside `tests/fixtures` are code that is part of the test suite. The effect of treating them as vendored is that only the comparably few shell scripts that are not test fixture scripts contribute to the language computation (and possibly other uses of github-linguist by various tooling? I am not sure).

Thus, the "Languages" bar on GitHub for this repository (or in forks) currently shows 97.5% Rust, 1.3% HTML, and 1.2% Other. But "Shell" should really be shown as a the second most prevalent language here, with a percentage significantly exceeding that of HTML.

[Running `github-linguist -b` locally](https://gist.github.com/EliahKagan/23d667cfdd2cffa38eff2579a86e4c11) verifies the situation.

Marking the affected files as *not* vendored, with the usual pattern we have been using to adjust their attributes in other ways, in the top-level `.gitattributes` file, fixes that. This PR makes that change.

This changes the output of `github-linguist` from:

```text
97.63%  7154452    Rust
1.32%   96933      HTML
0.94%   69205      Shell
0.10%   7100       Makefile
0.00%   108        Dockerfile
```

To:

```text
94.98%  7154452    Rust
3.64%   274106     Shell
1.29%   96933      HTML
0.09%   7100       Makefile
0.00%   108        Dockerfile
```

I have verified that `github-linguist` identifies all the expected files by running:

```sh
find . -name '*.sh' -printf '%P\n' | sort >a
github-linguist -b | grep -E '\.sh$' | sort >b
diff a b
```

(Where the reason for `-printf '%P\n'` was to omit the leading `./` that would otherwise stymie `diff`. I don't know if this is portable; I used GNU find.)

On the `count-sh` branch--the feature branch for this PR--that gives no output.

Regarding non-obvious specifics of the edit to `.gitattributes`:

- While I don't think the pattern `**/tests/fixtures/**/*.sh` confers a benefit over `tests/fixtures/**/*.sh`, I've used it because it was already in use.
- `linguist-vendored=false` (or `-linguist-vendored`) could be added to the previous line with this pattern, but I added a separate line instead because it not closely related to the other line, and because they both benefit from their own comments.
- Least importantly, I put it before the `linguist-generated=true` line for `gix-packetline-blocking/src/` because if `gix-packetline-blocking/src/` were somehow ever to gain fixture scripts--which is admittedly unlikely, since it is a `src` directory--then it should be clear that *those* would not contribute to the count. The order does not actually affect that, because one is setting <code>linguist-*vendored*</code> to `false`, while the other is setting <code>linguist-*generated*</code> to `true`. But I think this order is still clearer for that.