### PR TITLE
Only fuzz test PRs that run the test suite

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,7 +1,18 @@
 name: CIFuzz
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+    paths:
+      - '.github/**'
+      - 'ci/**'
+      - 'etc/**'
+      - 'src/**'
+      - 'tests/**'
+      - 'cargo-*/**'
+      - 'gix*/**'
+      - '*.toml'
+      - Makefile
   workflow_dispatch:
 jobs:
  Fuzzing:


### PR DESCRIPTION
This adds a `paths` restriction on the CIFuzz job to avoid the situation where a PR that doesn't modify anything that causes the usual tests to run on it would still run fuzz tests.

An example of a such a PR is #1607, where, as things are set up now, the CIFuzz job ran, taking 19 minutes, even though the only other CI jobs that needed to run there were the MSRV jobs. (I'm not entirely sure they need to run either, but it seems okay since they are rather light weight.)

Note that while #1608 also relates to a potential non-ideal CI-related behavior observed in #1607, that is unrelated to this, and this PR does *not* fix issue #1608.

This should still have CIFuzz run even when the only change a PR makes is to adjust how CI fuzzing itself works, because one of the patterns is matched by any change to any CI workflow file. In particular, this PR itself should be fuzzed under these rules.

