### PR TITLE
feat: add option to traverse commits from oldest to newest

### DIFF
--- a/examples/log.rs
+++ b/examples/log.rs
@@ -79,7 +79,7 @@ fn run(args: Args) -> anyhow::Result<()> {
         Sorting::BreadthFirst
     } else {
         // else if args.newest_first {
-        Sorting::ByCommitTimeNewestFirst
+        Sorting::ByCommitTime(Default::default())
     };
 
     let mut min_parents = args.min_parents.unwrap_or(0);

--- a/gitoxide-core/src/repository/commitgraph/list.rs
+++ b/gitoxide-core/src/repository/commitgraph/list.rs
@@ -30,7 +30,7 @@ pub(crate) mod function {
             .context("Need committish as starting point")?
             .id()
             .ancestors()
-            .sorting(Sorting::ByCommitTimeNewestFirst)
+            .sorting(Sorting::ByCommitTime(Default::default()))
             .all()?;
         for commit in commits {
             let commit = commit?;

--- a/gitoxide-core/src/repository/revision/list.rs
+++ b/gitoxide-core/src/repository/revision/list.rs
@@ -52,7 +52,7 @@ pub(crate) mod function {
             .context("Need committish as starting point")?
             .id()
             .ancestors()
-            .sorting(Sorting::ByCommitTimeNewestFirst)
+            .sorting(Sorting::ByCommitTime(Default::default()))
             .all()?;
 
         let mut vg = match text {

--- a/gix-traverse/src/commit/simple.rs
+++ b/gix-traverse/src/commit/simple.rs
@@ -2,7 +2,18 @@ use gix_date::SecondsSinceUnixEpoch;
 use gix_hash::ObjectId;
 use gix_hashtable::HashSet;
 use smallvec::SmallVec;
+use std::cmp::Reverse;
 use std::collections::VecDeque;
+
+#[derive(Default, Debug, Copy, Clone)]
+/// The order with which to prioritize the search
+pub enum CommitTimeOrder {
+    #[default]
+    /// sort commits by newest first
+    NewestFirst,
+    /// sort commits by oldest first
+    OldestFirst,
+}
 
 /// Specify how to sort commits during a [simple](super::Simple) traversal.
 ///
@@ -28,24 +39,27 @@ pub enum Sorting {
     /// as it avoids overlapping branches.
     #[default]
     BreadthFirst,
-    /// Commits are sorted by their commit time in descending order, that is newest first.
+    /// Commits are sorted by their commit time in the order specified, either newest or oldest first.
     ///
     /// The sorting applies to all currently queued commit ids and thus is full.
     ///
-    /// In the *sample history* the order would be `8, 7, 6, 5, 4, 3, 2, 1`
+    /// In the *sample history* the order would be `8, 7, 6, 5, 4, 3, 2, 1` for NewestFirst
+    /// Or `1, 2, 3, 4, 5, 6, 7, 8` for OldestFirst
     ///
     /// # Performance
     ///
     /// This mode benefits greatly from having an object_cache in `find()`
     /// to avoid having to lookup each commit twice.
-    ByCommitTimeNewestFirst,
-    /// This sorting is similar to `ByCommitTimeNewestFirst`, but adds a cutoff to not return commits older than
+    ByCommitTime(CommitTimeOrder),
+    /// This sorting is similar to `ByCommitTime`, but adds a cutoff to not return commits older than
     /// a given time, stopping the iteration once no younger commits is queued to be traversed.
     ///
     /// As the query is usually repeated with different cutoff dates, this search mode benefits greatly from an object cache.
     ///
     /// In the *sample history* and a cut-off date of 4, the returned list of commits would be `8, 7, 6, 4`
-    ByCommitTimeNewestFirstCutoffOlderThan {
+    ByCommitTimeCutoff {
+        /// The order in wich to prioritize lookups
+        order: CommitTimeOrder,
         /// The amount of seconds since unix epoch, the same value obtained by any `gix_date::Time` structure and the way git counts time.
         seconds: gix_date::SecondsSinceUnixEpoch,
     },
@@ -61,11 +75,14 @@ pub enum Error {
     ObjectDecode(#[from] gix_object::decode::Error),
 }
 
+use Result as Either;
+type QueueKey<T> = Either<T, Reverse<T>>;
+
 /// The state used and potentially shared by multiple graph traversals.
 #[derive(Clone)]
 pub(super) struct State {
     next: VecDeque<ObjectId>,
-    queue: gix_revwalk::PriorityQueue<SecondsSinceUnixEpoch, ObjectId>,
+    queue: gix_revwalk::PriorityQueue<QueueKey<SecondsSinceUnixEpoch>, ObjectId>,
     buf: Vec<u8>,
     seen: HashSet<ObjectId>,
     parents_buf: Vec<u8>,
@@ -77,10 +94,13 @@ mod init {
     use gix_date::SecondsSinceUnixEpoch;
     use gix_hash::{oid, ObjectId};
     use gix_object::{CommitRefIter, FindExt};
+    use std::cmp::Reverse;
+    use Err as Oldest;
+    use Ok as Newest;
 
     use super::{
         super::{simple::Sorting, Either, Info, ParentIds, Parents, Simple},
-        collect_parents, Error, State,
+        collect_parents, CommitTimeOrder, Error, State,
     };
 
     impl Default for State {
@@ -105,6 +125,14 @@ mod init {
         }
     }
 
+    fn order_time(i: i64, order: CommitTimeOrder) -> super::QueueKey<i64> {
+        if let CommitTimeOrder::NewestFirst = order {
+            Newest(i)
+        } else {
+            Oldest(Reverse(i))
+        }
+    }
+
     /// Builder
     impl<Find, Predicate> Simple<Find, Predicate>
     where
@@ -117,19 +145,23 @@ mod init {
                 Sorting::BreadthFirst => {
                     self.queue_to_vecdeque();
                 }
-                Sorting::ByCommitTimeNewestFirst | Sorting::ByCommitTimeNewestFirstCutoffOlderThan { .. } => {
+                Sorting::ByCommitTime(order) | Sorting::ByCommitTimeCutoff { order, .. } => {
                     let cutoff_time = self.sorting.cutoff_time();
                     let state = &mut self.state;
                     for commit_id in state.next.drain(..) {
                         let commit_iter = self.objects.find_commit_iter(&commit_id, &mut state.buf)?;
                         let time = commit_iter.committer()?.time.seconds;
-                        match cutoff_time {
-                            Some(cutoff_time) if time >= cutoff_time => {
-                                state.queue.insert(time, commit_id);
+                        let ordered_time = order_time(time, order);
+                        match (cutoff_time, order) {
+                            (Some(cutoff_time), CommitTimeOrder::NewestFirst) if time >= cutoff_time => {
+                                state.queue.insert(ordered_time, commit_id);
                             }
-                            Some(_) => {}
-                            None => {
-                                state.queue.insert(time, commit_id);
+                            (Some(cutoff_time), CommitTimeOrder::OldestFirst) if time <= cutoff_time => {
+                                state.queue.insert(ordered_time, commit_id);
+                            }
+                            (Some(_), _) => {}
+                            (None, _) => {
+                                state.queue.insert(ordered_time, commit_id);
                             }
                         }
                     }
@@ -254,10 +286,8 @@ mod init {
             } else {
                 match self.sorting {
                     Sorting::BreadthFirst => self.next_by_topology(),
-                    Sorting::ByCommitTimeNewestFirst => self.next_by_commit_date(None),
-                    Sorting::ByCommitTimeNewestFirstCutoffOlderThan { seconds } => {
-                        self.next_by_commit_date(seconds.into())
-                    }
+                    Sorting::ByCommitTime(order) => self.next_by_commit_date(order, None),
+                    Sorting::ByCommitTimeCutoff { seconds, order } => self.next_by_commit_date(order, seconds.into()),
                 }
             }
         }
@@ -267,7 +297,7 @@ mod init {
         /// If not topo sort, provide the cutoff date if present.
         fn cutoff_time(&self) -> Option<SecondsSinceUnixEpoch> {
             match self {
-                Sorting::ByCommitTimeNewestFirstCutoffOlderThan { seconds } => Some(*seconds),
+                Sorting::ByCommitTimeCutoff { seconds, .. } => Some(*seconds),
                 _ => None,
             }
         }
@@ -281,18 +311,21 @@ mod init {
     {
         fn next_by_commit_date(
             &mut self,
-            cutoff_older_than: Option<SecondsSinceUnixEpoch>,
+            order: CommitTimeOrder,
+            cutoff: Option<SecondsSinceUnixEpoch>,
         ) -> Option<Result<Info, Error>> {
             let state = &mut self.state;
 
-            let (commit_time, oid) = state.queue.pop()?;
+            let (commit_time, oid) = match state.queue.pop()? {
+                (Newest(t) | Oldest(Reverse(t)), o) => (t, o),
+            };
             let mut parents: ParentIds = Default::default();
             match super::super::find(self.cache.as_ref(), &self.objects, &oid, &mut state.buf) {
                 Ok(Either::CachedCommit(commit)) => {
                     if !collect_parents(&mut state.parent_ids, self.cache.as_ref(), commit.iter_parents()) {
                         // drop corrupt caches and try again with ODB
                         self.cache = None;
-                        return self.next_by_commit_date(cutoff_older_than);
+                        return self.next_by_commit_date(order, cutoff);
                     }
                     for (id, parent_commit_time) in state.parent_ids.drain(..) {
                         parents.push(id);
@@ -301,9 +334,19 @@ mod init {
                             continue;
                         }
 
-                        match cutoff_older_than {
-                            Some(cutoff_older_than) if parent_commit_time < cutoff_older_than => continue,
-                            Some(_) | None => state.queue.insert(parent_commit_time, id),
+                        let time = order_time(parent_commit_time, order);
+                        match (cutoff, order) {
+                            (Some(cutoff_older_than), CommitTimeOrder::NewestFirst)
+                                if parent_commit_time < cutoff_older_than =>
+                            {
+                                continue
+                            }
+                            (Some(cutoff_newer_than), CommitTimeOrder::OldestFirst)
+                                if parent_commit_time > cutoff_newer_than =>
+                            {
+                                continue
+                            }
+                            (Some(_) | None, _) => state.queue.insert(time, id),
                         }
                     }
                 }
@@ -323,9 +366,19 @@ mod init {
                                     .and_then(|parent| parent.committer().ok().map(|committer| committer.time.seconds))
                                     .unwrap_or_default();
 
-                                match cutoff_older_than {
-                                    Some(cutoff_older_than) if parent_commit_time < cutoff_older_than => continue,
-                                    Some(_) | None => state.queue.insert(parent_commit_time, id),
+                                let time = order_time(parent_commit_time, order);
+                                match (cutoff, order) {
+                                    (Some(cutoff_older_than), CommitTimeOrder::NewestFirst)
+                                        if parent_commit_time < cutoff_older_than =>
+                                    {
+                                        continue
+                                    }
+                                    (Some(cutoff_newer_than), CommitTimeOrder::OldestFirst)
+                                        if parent_commit_time > cutoff_newer_than =>
+                                    {
+                                        continue
+                                    }
+                                    (Some(_) | None, _) => state.queue.insert(time, id),
                                 }
                             }
                             Ok(_unused_token) => break,

--- a/gix-traverse/tests/commit/simple.rs
+++ b/gix-traverse/tests/commit/simple.rs
@@ -134,7 +134,7 @@ mod different_date_intermixed {
                 "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTimeNewestFirst)
+        .with_sorting(Sorting::ByCommitTime(Default::default()))
         .check()
     }
 }
@@ -186,7 +186,7 @@ mod different_date {
                 "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTimeNewestFirst)
+        .with_sorting(Sorting::ByCommitTime(Default::default()))
         .check()
     }
 }
@@ -247,7 +247,7 @@ mod same_date {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTimeNewestFirst)
+        .with_sorting(Sorting::ByCommitTime(Default::default()))
         .check()
     }
 
@@ -368,7 +368,7 @@ mod adjusted_dates {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTimeNewestFirst)
+        .with_sorting(Sorting::ByCommitTime(Default::default()))
         .check()
     }
 
@@ -379,7 +379,8 @@ mod adjusted_dates {
             &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
             &["bcb05040a6925f2ff5e10d3ae1f9264f2e8c43ac"], /* b1c1 */
         )
-        .with_sorting(Sorting::ByCommitTimeNewestFirstCutoffOlderThan {
+        .with_sorting(Sorting::ByCommitTimeCutoff {
+            order: Default::default(),
             seconds: 978393600, // =2001-01-02 00:00:00 +0000
         })
         .check()
@@ -394,7 +395,8 @@ mod adjusted_dates {
             Some(hex_to_id("9902e3c3e8f0c569b4ab295ddf473e6de763e1e7" /* c2 */)),
             &store,
         )
-        .sorting(Sorting::ByCommitTimeNewestFirstCutoffOlderThan {
+        .sorting(Sorting::ByCommitTimeCutoff {
+            order: Default::default(),
             seconds: 978393600, // =2001-01-02 00:00:00 +0000
         })?;
         assert_eq!(
@@ -415,7 +417,7 @@ mod adjusted_dates {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTimeNewestFirst)
+        .with_sorting(Sorting::ByCommitTime(Default::default()))
         .with_parents(Parents::First)
         .check()
     }

--- a/gix-traverse/tests/commit/simple.rs
+++ b/gix-traverse/tests/commit/simple.rs
@@ -92,7 +92,7 @@ impl TraversalAssertion<'_> {
 }
 
 mod different_date_intermixed {
-    use gix_traverse::commit::simple::Sorting;
+    use gix_traverse::commit::simple::{CommitTimeOrder, Sorting};
 
     use crate::commit::simple::TraversalAssertion;
 
@@ -114,6 +114,7 @@ mod different_date_intermixed {
                 "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check()
     }
 
@@ -134,13 +135,30 @@ mod different_date_intermixed {
                 "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTime(Default::default()))
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
+        .check()?;
+
+        TraversalAssertion::new_at(
+            "make_repos.sh",
+            "intermixed",
+            &["58912d92944087dcb09dca79cdd2a937cc158bed"], /* merge */
+            &[
+                "a9c28710e058af4e5163699960234adb9fb2abc7", /* b2c2 */
+                "b648f955b930ca95352fae6f22cb593ee0244b27", /* b2c1 */
+                "ad33ff2d0c4fc77d56b5fbff6f86f332fe792d83", /* c2 */
+                "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
+                "0f6632a5a7d81417488b86692b729e49c1b73056", /* b1c2 */
+                "77fd3c6832c0cd542f7a39f3af9250c3268db979", /* b1c1 */
+                "2dce37be587e07caef8c4a5ab60b423b13a8536a", /* c3 */
+            ],
+        )
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::OldestFirst))
         .check()
     }
 }
 
 mod different_date {
-    use gix_traverse::commit::simple::Sorting;
+    use gix_traverse::commit::simple::{CommitTimeOrder, Sorting};
 
     use crate::commit::simple::TraversalAssertion;
 
@@ -186,16 +204,34 @@ mod different_date {
                 "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTime(Default::default()))
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
+        .check()?;
+        TraversalAssertion::new_at(
+            "make_repos.sh",
+            "simple",
+            &["f49838d84281c3988eeadd988d97dd358c9f9dc4"], /* merge */
+            &[
+                "48e8dac19508f4238f06c8de2b10301ce64a641c", /* b2c2 */
+                "cb6a6befc0a852ac74d74e0354e0f004af29cb79", /* b2c1 */
+                "8cb5f13b66ce52a49399a2c49f537ee2b812369c", /* c4 */
+                "33aa07785dd667c0196064e3be3c51dd9b4744ef", /* c3 */
+                "ad33ff2d0c4fc77d56b5fbff6f86f332fe792d83", /* c2 */
+                "65d6af66f60b8e39fd1ba6a1423178831e764ec5", /* c1 */
+                "66a309480201c4157b0eae86da69f2d606aadbe7", /* b1c2 */
+                "80947acb398362d8236fcb8bf0f8a9dac640583f", /* b1c1 */
+                "0edb95c0c0d9933d88f532ec08fcd405d0eee882", /* c5 */
+            ],
+        )
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::OldestFirst))
         .check()
     }
 }
 
 /// Same dates are somewhat special as they show how sorting-details on priority queues affects ordering
 mod same_date {
-    use gix_traverse::commit::{simple::Sorting, Parents};
-
     use crate::{commit::simple::TraversalAssertion, hex_to_id};
+    use gix_traverse::commit::simple::CommitTimeOrder;
+    use gix_traverse::commit::{simple::Sorting, Parents};
 
     #[test]
     fn c4_breadth_first() -> crate::Result {
@@ -208,6 +244,7 @@ mod same_date {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check()
     }
 
@@ -229,6 +266,7 @@ mod same_date {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check()
     }
 
@@ -247,7 +285,23 @@ mod same_date {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTime(Default::default()))
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
+        .check()?;
+
+        TraversalAssertion::new(
+            "make_traversal_repo_for_commits_same_date.sh",
+            &["01ec18a3ebf2855708ad3c9d244306bc1fae3e9b"], /* m1b1 */
+            &[
+                "efd9a841189668f1bab5b8ebade9cd0a1b139a37", /* c5 */
+                "ce2e8ffaa9608a26f7b21afc1db89cadb54fd353", /* b1c2 */
+                "9556057aee5abb06912922e9f26c46386a816822", /* c4 */
+                "9152eeee2328073cf23dcf8e90c949170b711659", /* b1c1 */
+                "17d78c64cef6c33a10a604573fd2c429e477fd63", /* c3 */
+                "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7", /* c2 */
+                "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
+            ],
+        )
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::OldestFirst))
         .check()
     }
 
@@ -265,6 +319,7 @@ mod same_date {
             ],
         )
         .with_parents(Parents::First)
+        .with_sorting(Sorting::BreadthFirst)
         .check()
     }
 
@@ -285,6 +340,7 @@ mod same_date {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check()
     }
 
@@ -306,6 +362,7 @@ mod same_date {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check_with_predicate(|id| id != hex_to_id("9152eeee2328073cf23dcf8e90c949170b711659"))
     }
 
@@ -323,6 +380,7 @@ mod same_date {
                 "9152eeee2328073cf23dcf8e90c949170b711659", /* b1c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check_with_predicate(move |id| {
             if id == hex_to_id("9556057aee5abb06912922e9f26c46386a816822") {
                 assert!(!seen);
@@ -337,9 +395,9 @@ mod same_date {
 
 /// Some dates adjusted to be a year apart, but still 'c1' and 'c2' with the same date.
 mod adjusted_dates {
-    use gix_traverse::commit::{simple::Sorting, Parents, Simple};
-
     use crate::{commit::simple::TraversalAssertion, hex_to_id};
+    use gix_traverse::commit::simple::CommitTimeOrder;
+    use gix_traverse::commit::{simple::Sorting, Parents, Simple};
 
     #[test]
     fn head_breadth_first() -> crate::Result {
@@ -354,6 +412,7 @@ mod adjusted_dates {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
+        .with_sorting(Sorting::BreadthFirst)
         .check()
     }
 
@@ -368,57 +427,115 @@ mod adjusted_dates {
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTime(Default::default()))
-        .check()
-    }
-
-    #[test]
-    fn head_date_order_with_cutoff() -> crate::Result {
-        TraversalAssertion::new(
-            "make_traversal_repo_for_commits_with_dates.sh",
-            &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
-            &["bcb05040a6925f2ff5e10d3ae1f9264f2e8c43ac"], /* b1c1 */
-        )
-        .with_sorting(Sorting::ByCommitTimeCutoff {
-            order: Default::default(),
-            seconds: 978393600, // =2001-01-02 00:00:00 +0000
-        })
-        .check()
-    }
-
-    #[test]
-    fn date_order_with_cutoff_is_applied_to_starting_position() -> crate::Result {
-        let dir =
-            gix_testtools::scripted_fixture_read_only_standalone("make_traversal_repo_for_commits_with_dates.sh")?;
-        let store = gix_odb::at(dir.join(".git").join("objects"))?;
-        let iter = Simple::new(
-            Some(hex_to_id("9902e3c3e8f0c569b4ab295ddf473e6de763e1e7" /* c2 */)),
-            &store,
-        )
-        .sorting(Sorting::ByCommitTimeCutoff {
-            order: Default::default(),
-            seconds: 978393600, // =2001-01-02 00:00:00 +0000
-        })?;
-        assert_eq!(
-            iter.count(),
-            0,
-            "initial tips that don't pass cutoff value are not returned either"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn head_date_order_first_parent_only() -> crate::Result {
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
+        .check()?;
         TraversalAssertion::new(
             "make_traversal_repo_for_commits_with_dates.sh",
             &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
             &[
                 "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7", /* c2 */
                 "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
+                "bcb05040a6925f2ff5e10d3ae1f9264f2e8c43ac", /* b1c1 */
             ],
         )
-        .with_sorting(Sorting::ByCommitTime(Default::default()))
-        .with_parents(Parents::First)
+        .with_sorting(Sorting::ByCommitTime(CommitTimeOrder::OldestFirst))
         .check()
+    }
+
+    #[test]
+    fn head_date_order_with_cutoff() -> crate::Result {
+        for order in all_commit_time_orderings() {
+            TraversalAssertion::new(
+                "make_traversal_repo_for_commits_with_dates.sh",
+                &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
+                &["bcb05040a6925f2ff5e10d3ae1f9264f2e8c43ac"], /* b1c1 */
+            )
+            .with_sorting(Sorting::ByCommitTimeCutoff {
+                order,
+                seconds: 978393600, // =2001-01-02 00:00:00 +0000
+            })
+            .check()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn head_date_order_with_cutoff_disabled() -> crate::Result {
+        let very_early = 878393600; // an early date before any commit
+        TraversalAssertion::new(
+            "make_traversal_repo_for_commits_with_dates.sh",
+            &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
+            &[
+                "bcb05040a6925f2ff5e10d3ae1f9264f2e8c43ac", /* b1c1 */
+                "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7", /* c2 */
+                "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
+            ],
+        )
+        .with_sorting(Sorting::ByCommitTimeCutoff {
+            order: CommitTimeOrder::NewestFirst,
+            seconds: very_early,
+        })
+        .check()?;
+
+        TraversalAssertion::new(
+            "make_traversal_repo_for_commits_with_dates.sh",
+            &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
+            &[
+                "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7", /* c2 */
+                "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
+                "bcb05040a6925f2ff5e10d3ae1f9264f2e8c43ac", /* b1c1 */
+            ],
+        )
+        .with_sorting(Sorting::ByCommitTimeCutoff {
+            order: CommitTimeOrder::OldestFirst,
+            seconds: very_early,
+        })
+        .check()?;
+        Ok(())
+    }
+
+    #[test]
+    fn date_order_with_cutoff_is_applied_to_starting_position() -> crate::Result {
+        for order in all_commit_time_orderings() {
+            let dir =
+                gix_testtools::scripted_fixture_read_only_standalone("make_traversal_repo_for_commits_with_dates.sh")?;
+            let store = gix_odb::at(dir.join(".git").join("objects"))?;
+            let iter = Simple::new(
+                Some(hex_to_id("9902e3c3e8f0c569b4ab295ddf473e6de763e1e7" /* c2 */)),
+                &store,
+            )
+            .sorting(Sorting::ByCommitTimeCutoff {
+                order,
+                seconds: 978393600, // =2001-01-02 00:00:00 +0000
+            })?;
+            assert_eq!(
+                iter.count(),
+                0,
+                "initial tips that don't pass cutoff value are not returned either"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn head_date_order_first_parent_only() -> crate::Result {
+        for order in all_commit_time_orderings() {
+            TraversalAssertion::new(
+                "make_traversal_repo_for_commits_with_dates.sh",
+                &["288e509293165cb5630d08f4185bdf2445bf6170"], /* m1b1 */
+                &[
+                    "9902e3c3e8f0c569b4ab295ddf473e6de763e1e7", /* c2 */
+                    "134385f6d781b7e97062102c6a483440bfda2a03", /* c1 */
+                ],
+            )
+            .with_sorting(Sorting::ByCommitTime(order))
+            .with_parents(Parents::First)
+            .check()?;
+        }
+        Ok(())
+    }
+
+    fn all_commit_time_orderings() -> [CommitTimeOrder; 2] {
+        [CommitTimeOrder::NewestFirst, CommitTimeOrder::OldestFirst]
     }
 }

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -154,19 +154,19 @@ pub(crate) fn update(
                                                 .find_object(local_id)?
                                                 .try_into_commit()
                                                 .map_err(|_| ())
-                                                .and_then(|c| {
-                                                    c.committer().map(|a| a.time.seconds).map_err(|_| ())
-                                                }).and_then(|local_commit_time|
-                                                remote_id
-                                                    .to_owned()
-                                                    .ancestors(&repo.objects)
-                                                    .sorting(
-                                                        gix_traverse::commit::simple::Sorting::ByCommitTimeNewestFirstCutoffOlderThan {
-                                                            seconds: local_commit_time
-                                                        },
-                                                    )
-                                                    .map_err(|_| ())
-                                            );
+                                                .and_then(|c| c.committer().map(|a| a.time.seconds).map_err(|_| ()))
+                                                .and_then(|local_commit_time| {
+                                                    remote_id
+                                                        .to_owned()
+                                                        .ancestors(&repo.objects)
+                                                        .sorting(
+                                                            gix_traverse::commit::simple::Sorting::ByCommitTimeCutoff {
+                                                                order: Default::default(),
+                                                                seconds: local_commit_time,
+                                                            },
+                                                        )
+                                                        .map_err(|_| ())
+                                                });
                                             match ancestors {
                                                 Ok(mut ancestors) => {
                                                     ancestors.any(|cid| cid.map_or(false, |c| c.id == local_id))

--- a/gix/src/revision/spec/parse/delegate/navigate.rs
+++ b/gix/src/revision/spec/parse/delegate/navigate.rs
@@ -192,7 +192,7 @@ impl<'repo> delegate::Navigate for Delegate<'repo> {
                     match oid
                         .attach(repo)
                         .ancestors()
-                        .sorting(crate::revision::walk::Sorting::ByCommitTimeNewestFirst)
+                        .sorting(crate::revision::walk::Sorting::ByCommitTime(Default::default()))
                         .all()
                     {
                         Ok(iter) => {
@@ -245,7 +245,7 @@ impl<'repo> delegate::Navigate for Delegate<'repo> {
                                     .filter(|r| r.id().header().ok().map_or(false, |obj| obj.kind().is_commit()))
                                     .filter_map(|r| r.detach().peeled),
                             )
-                            .sorting(crate::revision::walk::Sorting::ByCommitTimeNewestFirst)
+                            .sorting(crate::revision::walk::Sorting::ByCommitTime(Default::default()))
                             .all()
                         {
                             Ok(iter) => {

--- a/gix/tests/id/mod.rs
+++ b/gix/tests/id/mod.rs
@@ -85,7 +85,7 @@ mod ancestors {
             let commits_by_commit_date = head
                 .ancestors()
                 .use_commit_graph(!use_commit_graph)
-                .sorting(gix::revision::walk::Sorting::ByCommitTimeNewestFirst)
+                .sorting(gix::revision::walk::Sorting::ByCommitTime(Default::default()))
                 .all()?
                 .map(|c| c.map(gix::revision::walk::Info::detach))
                 .collect::<Result<Vec<_>, _>>()?;
@@ -119,7 +119,7 @@ mod ancestors {
             let head = repo.head()?.into_peeled_id()?;
             let commits = head
                 .ancestors()
-                .sorting(gix::revision::walk::Sorting::ByCommitTimeNewestFirst) // assure we have time set
+                .sorting(gix::revision::walk::Sorting::ByCommitTime(Default::default())) // assure we have time set
                 .use_commit_graph(use_commit_graph)
                 .all()?
                 .collect::<Result<Vec<_>, _>>()?;
@@ -162,8 +162,11 @@ mod ancestors {
         for use_commit_graph in [false, true] {
             for sorting in [
                 gix::revision::walk::Sorting::BreadthFirst,
-                gix::revision::walk::Sorting::ByCommitTimeNewestFirst,
-                gix::revision::walk::Sorting::ByCommitTimeNewestFirstCutoffOlderThan { seconds: 0 },
+                gix::revision::walk::Sorting::ByCommitTime(Default::default()),
+                gix::revision::walk::Sorting::ByCommitTimeCutoff {
+                    order: Default::default(),
+                    seconds: 0,
+                },
             ] {
                 let commits_graph_order = head
                     .ancestors()

--- a/gix/tests/repository/shallow.rs
+++ b/gix/tests/repository/shallow.rs
@@ -44,6 +44,7 @@ fn yes() -> crate::Result {
 }
 
 mod traverse {
+    use gix_traverse::commit::simple::CommitTimeOrder;
     use serial_test::parallel;
 
     use crate::util::{hex_to_id, named_subrepo_opts};
@@ -53,8 +54,11 @@ mod traverse {
     fn boundary_is_detected_triggering_no_error() -> crate::Result {
         for sorting in [
             gix::revision::walk::Sorting::BreadthFirst,
-            gix::revision::walk::Sorting::ByCommitTimeNewestFirst,
-            gix::revision::walk::Sorting::ByCommitTimeNewestFirstCutoffOlderThan { seconds: 0 },
+            gix::revision::walk::Sorting::ByCommitTime(CommitTimeOrder::NewestFirst),
+            gix::revision::walk::Sorting::ByCommitTimeCutoff {
+                order: CommitTimeOrder::NewestFirst,
+                seconds: 0,
+            },
         ] {
             for toggle in [false, true] {
                 for name in ["shallow.git", "shallow"] {
@@ -97,7 +101,7 @@ mod traverse {
                     .head_id()?
                     .ancestors()
                     .use_commit_graph(toggle)
-                    .sorting(gix::revision::walk::Sorting::ByCommitTimeNewestFirst)
+                    .sorting(gix::revision::walk::Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
                     .all()?
                     .map(|c| c.map(|c| c.id))
                     .collect::<Result<_, _>>()?;


### PR DESCRIPTION
This change introduces an enum to control commit traversal order for Simple. Users can now choose between newest-first or oldest-first traversal. The default behavior remains newest-first, but it can be toggled by passing a CommitTimeOrder to a Sorting::ByCommitTime* variant.

This feature is particularly useful for searching early repository history, which should be orders of magnitude faster with this variant. In my benchmarking I was able to identify the original commit in a large mono-repo source tree using the new OldestFirst variant in 12ms down from 2.6s with NewestFirst.

The implementation logic remains largely agnostic to this change, with only minor adjustments in key areas as necessary.

The reversed order is achieved by inverting the PriorityQueue key with std::cmp::Reverse when an oldest-first traversal is requested. This is what allows the bulk of the original logic to remain unchanged.